### PR TITLE
Feat/runtime skill reload

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,25 +1,35 @@
-# Ori Runtime — Code Owners
+# Ori Runtime — CODEOWNERS
 #
-# GitHub enforces these rules automatically:
-# - A PR touching any file under /ori/ cannot be merged without maintainer approval
-# - A PR touching only /skills/ can be reviewed by any designated maintainer
+# This repo is safety-critical (physical actuation). Default every path to
+# maintainer review, then keep explicit sections for clarity.
 #
-# Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Reference:
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# ── Core Runtime — maintainer review required ──────────────────────────────────
-# Changes here affect physical hardware. Every line must be understood and approved.
-/ori/                   @AdeGneus
-/tests/                 @AdeGneus
-/pyproject.toml         @AdeGneus
-/requirements*.txt      @AdeGneus
-/requirements*.in       @AdeGneus
-/CLAUDE.md              @AdeGneus
-/AGENTS.md              @AdeGneus
-/PRINCIPLES.md          @AdeGneus
-/.github/               @AdeGneus
+# ── Default owner (no unowned paths) ──────────────────────────────────────────
+* @AdeGneus
 
-# ── Bundled Skills — maintainer review required ────────────────────────────────
-# Bundled skills use _load_hooks_direct() which bypasses the sandbox.
-# They ship with the runtime and are implicitly trusted. Core team review required.
-# Community skill contributions do NOT go here — they go to the Skills Hub repo.
-/skills/                @AdeGneus
+# ── Runtime core (physical behavior + safety) ─────────────────────────────────
+/ori/ @AdeGneus
+/tests/ @AdeGneus
+
+# ── Build + dependency supply chain ───────────────────────────────────────────
+/pyproject.toml @AdeGneus
+/requirements*.in @AdeGneus
+/requirements*.txt @AdeGneus
+
+# ── Runtime policy/spec docs (authoritative behavior) ────────────────────────
+/AGENTS.md @AdeGneus
+/CLAUDE.md @AdeGneus
+/PRINCIPLES.md @AdeGneus
+/README.md @AdeGneus
+/ori.yaml.example @AdeGneus
+/ori.yaml.phone.example @AdeGneus
+
+# ── CI / governance / automation ──────────────────────────────────────────────
+/.github/ @AdeGneus
+/scripts/ @AdeGneus
+
+# ── Bundled skills ship with runtime and are trusted code ────────────────────
+# Community skill submissions belong in the separate ori-skills repository.
+/skills/ @AdeGneus

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@
 
 [![License](https://img.shields.io/badge/license-Apache%202.0-1E6B4A?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-1E6B4A?style=flat-square)](https://python.org)
-[![Tests](https://img.shields.io/badge/tests-660%2B%20passing-1E6B4A?style=flat-square)](#testing)
+[![Tests](https://img.shields.io/badge/tests-790%2B%20passing-1E6B4A?style=flat-square)](#testing)
+[![Release](https://img.shields.io/badge/release-alpha-C8A951?style=flat-square)](#release-status)
 [![Platform](https://img.shields.io/badge/runs%20on-Raspberry%20Pi%20·%20Linux%20·%20macOS-C8A951?style=flat-square)](#)
 
 </div>
@@ -18,6 +19,25 @@
 > **IoT devices do not need more data. They need to reason about that data — and act on it.**
 
 Ori is an open-source **agentic IoT runtime** that gives physical devices **tiered autonomous reasoning** — from deterministic safety rules to local SLMs. This reasoning is governed by a **[Physical Actuation Trust](PRINCIPLES.md)** framework that defines exactly what an AI agent is permitted to do in the physical world, at what consequence level, and with what human oversight. Offline-first. No cloud required. Runs on a $55 Raspberry Pi.
+
+## Release Status
+
+**Current channel: Alpha (`0.1.x`)**
+
+- Runtime core is functional and publicly testable.
+- Safety invariants (tier guards, strict skill validation, sandbox boundaries) are CI-enforced on every PR.
+- APIs/config may still evolve between minor alpha releases.
+- Recommended use today: pilots, PoCs, and controlled deployments.
+
+Related repos in the org:
+
+- Runtime: `ori-platform/ori-runtime` (this repo)
+- Skills registry: `ori-platform/ori-skills`
+- CLI: `ori-platform/ori-cli`
+- Gateway: `ori-platform/ori-gateway`
+- SDK (Python): `ori-platform/ori-sdk-python`
+- Dashboard: `ori-platform/ori-dashboard`
+- Specs/RFCs: `ori-platform/ori-specs`
 
 ---
 
@@ -256,7 +276,11 @@ pytest tests/test_rule_engine.py -v           # Specific module
 pytest tests/ --cov=ori --cov-report=term-missing  # With coverage
 ```
 
-The test suite covers all layers — HAL adapters, event bus, rule engine (with AST safety validation), action dispatcher (all four tiers), skill loader, state store, and runtime. 660+ tests passing, 5 skipped (hardware-only).
+The test suite covers all layers — HAL adapters, event bus, rule engine (with AST safety validation), action dispatcher (all four tiers), skill loader, state store, and runtime. 790+ tests passing, 5 skipped (hardware-only).
+
+## Security
+
+See [SECURITY.md](SECURITY.md) for vulnerability reporting, supported versions, and disclosure policy.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,78 @@
+# Security Policy
+
+Ori Runtime controls physical systems. Security issues can have real-world consequences.
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| `0.1.x` (alpha) | Yes |
+| `<0.1.0` | No |
+
+## Reporting a Vulnerability
+
+Use GitHub's private vulnerability reporting for this repository:
+
+1. Go to the repository `Security` tab.
+2. Click `Report a vulnerability`.
+3. Submit details privately.
+
+If private reporting is unavailable, contact the repository owner directly via GitHub.
+
+Do not open public issues for undisclosed vulnerabilities.
+
+## What to Include
+
+Please include:
+
+- Affected component and file paths
+- Reproduction steps (minimal PoC)
+- Impact (confidentiality/integrity/availability/safety)
+- Whether physical actuation can be triggered or bypassed
+- Suggested remediation (if available)
+
+## Response Targets
+
+For valid reports:
+
+- Initial acknowledgment: within 72 hours
+- Triage and severity decision: within 7 days
+- Patch target:
+  - Critical/high: as soon as possible, usually within 14 days
+  - Medium/low: scheduled in normal release cadence
+
+## Disclosure Policy
+
+- Coordinate disclosure until a fix is available.
+- Public disclosure is expected only after fix release or explicit maintainer approval.
+- Security advisories and release notes will describe impact and mitigation.
+
+## Scope and Priorities
+
+Highest-priority findings include:
+
+- Tier C/Tier D enforcement bypasses
+- Skill sandbox escape or unsafe hook execution
+- Unsafe rule-expression execution or AST guard bypass
+- Unauthorized action execution via webhook/approval paths
+- Secrets exposure in repo, config handling, or logs
+- Supply-chain integrity issues in dependency/update paths
+
+## Safe Harbor
+
+Good-faith security research is welcome. We will not pursue action for:
+
+- Testing within this repository and your own infrastructure
+- Non-destructive proof-of-concept demonstrations
+- Responsible private disclosure under this policy
+
+Do not access or modify data/systems that you do not own or have permission to test.
+
+## Operational Safety Note
+
+If you discover an issue that can cause immediate physical harm, mark the report as urgent and clearly state:
+
+- Trigger conditions
+- Potential hazard
+- Suggested temporary mitigation
+

--- a/docs/alpha-release-notes.md
+++ b/docs/alpha-release-notes.md
@@ -1,0 +1,67 @@
+# Ori Runtime — Alpha Release Notes
+
+## Version
+
+`v0.1.0-alpha` (or current `0.1.x` alpha tag)
+
+## Summary
+
+Ori Runtime is now publicly available as an alpha release.
+
+This release focuses on the runtime foundation:
+
+- Deterministic + tiered reasoning/action architecture
+- Tier enforcement invariants for physical actuation trust
+- Strict skill validation and sandbox boundaries
+- Hardware adapter resilience with circuit-breaker protections
+- SMS/WhatsApp alert and approval workflow integration
+- Broad protocol support including GPIO/I2C/Serial/MQTT/OPC-UA/SolarmanV5/HTTP
+
+## Safety and Security
+
+- Tier guard regressions are blocked by CI invariants.
+- Skill capability strictness is CI-enforced.
+- Community skill hooks are sandboxed.
+- Tier C approval workflow remains mandatory.
+- Tier D safety path remains autonomous and non-LLM.
+
+See `SECURITY.md` for vulnerability reporting.
+
+## Alpha Scope
+
+Recommended:
+
+- PoCs
+- Pilot rollouts
+- Controlled production-adjacent trials
+
+Not yet guaranteed:
+
+- Full backward compatibility across alpha minors
+- Stable SDK/CLI contracts across every alpha update
+
+## Repository Topology
+
+- Runtime: `ori-platform/ori-runtime`
+- Skills registry: `ori-platform/ori-skills`
+- CLI: `ori-platform/ori-cli`
+- Gateway: `ori-platform/ori-gateway`
+- SDK: `ori-platform/ori-sdk-python`
+- Dashboard: `ori-platform/ori-dashboard`
+- Specs: `ori-platform/ori-specs`
+
+## Suggested GitHub Release Description
+
+```markdown
+Ori Runtime is now public in **alpha**.
+
+This release establishes the core runtime needed for physically trustworthy edge agents:
+
+- Tiered reasoning + action authority framework
+- Strict safety invariants with CI enforcement
+- Community-skill safety boundaries (validation + sandboxing)
+- Non-blocking async runtime with hardware circuit-breaker protection
+
+This is an alpha channel focused on pilots and controlled deployments.
+Expect iterative changes while companion repos (`ori-skills`, `ori-cli`, `ori-gateway`, `ori-sdk-python`, `ori-dashboard`) continue shipping.
+```


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
