### PR TITLE
chore(devx): add local runtime smoke script and ignore smoke artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ coverage.xml
 htmlcov/
 .mypy_cache/
 .ruff_cache/
+.smoke/
 
 # macOS
 .DS_Store

--- a/scripts/smoke-runtime-local.sh
+++ b/scripts/smoke-runtime-local.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+CONFIG_FILE="${1:-ori.local.yaml}"
+RUN_SECONDS="${2:-8}"
+LOG_FILE="${3:-ori-local.log}"
+DB_FILE="${4:-ori_local_smoke.db}"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "❌ Config file not found: $CONFIG_FILE"
+  exit 1
+fi
+
+if [[ ! -d ".venv" ]]; then
+  echo "❌ .venv not found. Create/activate your virtual env first."
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+export ORI_AUTOLOAD_DOTENV="${ORI_AUTOLOAD_DOTENV:-true}"
+
+rm -f "$LOG_FILE" "$DB_FILE"
+
+echo "▶ Running runtime smoke test"
+echo "  config:   $CONFIG_FILE"
+echo "  duration: ${RUN_SECONDS}s"
+echo "  log:      $LOG_FILE"
+
+python -m ori.runtime --config "$CONFIG_FILE" >"$LOG_FILE" 2>&1 &
+RUNTIME_PID=$!
+
+sleep "$RUN_SECONDS"
+kill -INT "$RUNTIME_PID" 2>/dev/null || true
+wait "$RUNTIME_PID" || true
+
+echo
+echo "▶ Key runtime lines"
+grep -E "config loaded|local SLM enabled|event loop ready|shutdown initiated|shutdown complete|reasoning pipeline failed" "$LOG_FILE" || true
+
+if grep -q "reasoning pipeline failed" "$LOG_FILE"; then
+  echo
+  echo "❌ Smoke test failed: reasoning pipeline error detected"
+  exit 2
+fi
+
+required=(
+  "config loaded"
+  "local SLM enabled"
+  "event loop ready"
+  "shutdown initiated"
+)
+
+missing=0
+for line in "${required[@]}"; do
+  if ! grep -q "$line" "$LOG_FILE"; then
+    echo "❌ Missing expected log line: $line"
+    missing=1
+  fi
+done
+
+if [[ "$missing" -ne 0 ]]; then
+  echo
+  echo "❌ Smoke test failed: missing required startup/shutdown markers"
+  exit 3
+fi
+
+if ! grep -q "shutdown complete" "$LOG_FILE"; then
+  echo "⚠️  shutdown complete marker not seen (short run). This is non-fatal for smoke."
+fi
+
+echo
+echo "✅ Smoke test passed"


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
