### PR TITLE
docs(release): centralize alpha notes and add v0.1.0-alpha.2 notes

### DIFF
--- a/docs/alpha-release-notes.md
+++ b/docs/alpha-release-notes.md
@@ -1,67 +1,7 @@
 # Ori Runtime — Alpha Release Notes
 
-## Version
+Moved to:
 
-`v0.1.0-alpha` (or current `0.1.x` alpha tag)
+- [`docs/releases/alpha-release-notes.md`](releases/alpha-release-notes.md)
 
-## Summary
-
-Ori Runtime is now publicly available as an alpha release.
-
-This release focuses on the runtime foundation:
-
-- Deterministic + tiered reasoning/action architecture
-- Tier enforcement invariants for physical actuation trust
-- Strict skill validation and sandbox boundaries
-- Hardware adapter resilience with circuit-breaker protections
-- SMS/WhatsApp alert and approval workflow integration
-- Broad protocol support including GPIO/I2C/Serial/MQTT/OPC-UA/SolarmanV5/HTTP
-
-## Safety and Security
-
-- Tier guard regressions are blocked by CI invariants.
-- Skill capability strictness is CI-enforced.
-- Community skill hooks are sandboxed.
-- Tier C approval workflow remains mandatory.
-- Tier D safety path remains autonomous and non-LLM.
-
-See `SECURITY.md` for vulnerability reporting.
-
-## Alpha Scope
-
-Recommended:
-
-- PoCs
-- Pilot rollouts
-- Controlled production-adjacent trials
-
-Not yet guaranteed:
-
-- Full backward compatibility across alpha minors
-- Stable SDK/CLI contracts across every alpha update
-
-## Repository Topology
-
-- Runtime: `ori-platform/ori-runtime`
-- Skills registry: `ori-platform/ori-skills`
-- CLI: `ori-platform/ori-cli`
-- Gateway: `ori-platform/ori-gateway`
-- SDK: `ori-platform/ori-sdk-python`
-- Dashboard: `ori-platform/ori-dashboard`
-- Specs: `ori-platform/ori-specs`
-
-## Suggested GitHub Release Description
-
-```markdown
-Ori Runtime is now public in **alpha**.
-
-This release establishes the core runtime needed for physically trustworthy edge agents:
-
-- Tiered reasoning + action authority framework
-- Strict safety invariants with CI enforcement
-- Community-skill safety boundaries (validation + sandboxing)
-- Non-blocking async runtime with hardware circuit-breaker protection
-
-This is an alpha channel focused on pilots and controlled deployments.
-Expect iterative changes while companion repos (`ori-skills`, `ori-cli`, `ori-gateway`, `ori-sdk-python`, `ori-dashboard`) continue shipping.
-```
+This compatibility file is kept so older links continue to resolve.

--- a/docs/releases/alpha-release-notes.md
+++ b/docs/releases/alpha-release-notes.md
@@ -1,0 +1,73 @@
+# Ori Runtime — Alpha Release Notes
+
+## Versioned Notes
+
+- [`v0.1.0-alpha.2`](v0.1.0-alpha.2.md) — latest alpha cut
+- [`v0.1.0-alpha.1`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha.1)
+- [`v0.1.0-alpha`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha)
+
+## Version
+
+`v0.1.0-alpha` (or current `0.1.x` alpha tag)
+
+## Summary
+
+Ori Runtime is now publicly available as an alpha release.
+
+This release focuses on the runtime foundation:
+
+- Deterministic + tiered reasoning/action architecture
+- Tier enforcement invariants for physical actuation trust
+- Strict skill validation and sandbox boundaries
+- Hardware adapter resilience with circuit-breaker protections
+- SMS/WhatsApp alert and approval workflow integration
+- Broad protocol support including GPIO/I2C/Serial/MQTT/OPC-UA/SolarmanV5/HTTP
+
+## Safety and Security
+
+- Tier guard regressions are blocked by CI invariants.
+- Skill capability strictness is CI-enforced.
+- Community skill hooks are sandboxed.
+- Tier C approval workflow remains mandatory.
+- Tier D safety path remains autonomous and non-LLM.
+
+See `SECURITY.md` for vulnerability reporting.
+
+## Alpha Scope
+
+Recommended:
+
+- PoCs
+- Pilot rollouts
+- Controlled production-adjacent trials
+
+Not yet guaranteed:
+
+- Full backward compatibility across alpha minors
+- Stable SDK/CLI contracts across every alpha update
+
+## Repository Topology
+
+- Runtime: `ori-platform/ori-runtime`
+- Skills registry: `ori-platform/ori-skills`
+- CLI: `ori-platform/ori-cli`
+- Gateway: `ori-platform/ori-gateway`
+- SDK: `ori-platform/ori-sdk-python`
+- Dashboard: `ori-platform/ori-dashboard`
+- Specs: `ori-platform/ori-specs`
+
+## Suggested GitHub Release Description
+
+```markdown
+Ori Runtime is now public in **alpha**.
+
+This release establishes the core runtime needed for physically trustworthy edge agents:
+
+- Tiered reasoning + action authority framework
+- Strict safety invariants with CI enforcement
+- Community-skill safety boundaries (validation + sandboxing)
+- Non-blocking async runtime with hardware circuit-breaker protection
+
+This is an alpha channel focused on pilots and controlled deployments.
+Expect iterative changes while companion repos (`ori-skills`, `ori-cli`, `ori-gateway`, `ori-sdk-python`, `ori-dashboard`) continue shipping.
+```

--- a/docs/releases/v0.1.0-alpha.2.md
+++ b/docs/releases/v0.1.0-alpha.2.md
@@ -1,0 +1,45 @@
+# Ori Runtime — v0.1.0-alpha.2 Release Notes
+
+## Release Type
+
+Alpha pre-release (`v0.1.0-alpha.2`)
+
+## Compare
+
+`v0.1.0-alpha.1...v0.1.0-alpha.2`
+
+https://github.com/ori-platform/ori-runtime/compare/v0.1.0-alpha.1...v0.1.0-alpha.2
+
+## Summary
+
+This alpha.2 cut packages runtime hardening and operator/developer usability
+improvements merged on `main` after `v0.1.0-alpha.1`.
+
+## Included Since v0.1.0-alpha.1
+
+- Local SLM path wired into runtime startup and reasoning flow.
+- Optional external GPIO watchdog loop added with HAL config support.
+- StateStore concurrency hardening:
+  - write-only lock split for write operations
+  - thread-local read connections for safe concurrent reads
+  - follow-up fixes for Python 3.12 stability and cross-thread close safety
+- Local runtime smoke testing helper script and smoke artifact ignores.
+- Documentation and config capability alignment cleanup.
+
+## Validation Snapshot
+
+- Local suite: `pytest tests/ -v -m "not hardware"` passed.
+- Local runtime smoke: `scripts/smoke-runtime-local.sh` passed.
+
+## Known Limitations (Alpha)
+
+- Gateway and cloud reasoning tiers are still planned wiring; local rule + local
+  SLM paths remain the primary operational runtime path.
+- API/config compatibility may still evolve across alpha minors.
+- Hardware-dependent behavior still requires deployment-specific validation on
+  target devices.
+
+## Next Milestone
+
+External perception integration contract (`ori.perception.v1`) with MQTT-first
+ingestion and a reference Tier-A PPE safety skill vertical slice.


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
