### PR TITLE
feat(hal): add mqtt_perception adapter with ori.perception.v1 validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ htmlcov/
 .mypy_cache/
 .ruff_cache/
 .smoke/
+*.log.*
 
 # macOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ triggers:
     action_tier: D # → cuts power. no waiting.
 ```
 
-Bundled skills: **pc-system-health** (runs on any laptop), **energy-anomaly-detector**, and **hvac-refrigerant-monitor**.
+Bundled skills: **pc-system-health** (runs on any laptop), **energy-anomaly-detector**, **hvac-refrigerant-monitor**, and **site-safety-ppe**.
 
 Community skills live at **[ori-platform/ori-skills](https://github.com/ori-platform/ori-skills)**. The runtime enforces strict skill validation and sandboxed hook loading for community-installed skills.
 

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -125,6 +125,36 @@ sensors:
   #   unit: kelvin
   #   poll_interval_ms: 300000
 
+  # ─── External perception stream via MQTT (optional) ───────────────────────
+  # Payload contract expected on topic:
+  # {
+  #   "schema": "ori.perception.v1",
+  #   "sensor_type": "ppe_hardhat_violation_score",
+  #   "value": 0.84,
+  #   "confidence": 0.91,
+  #   "timestamp_ms": 1710000000123,
+  #   "metadata": {
+  #     "zone_id": "line-3",
+  #     "camera_id": "cam-04",
+  #     "subject_id": "worker-17"
+  #   }
+  # }
+  # - id: ppe-hardhat-cam-04
+  #   type: ppe_hardhat_violation_score
+  #   protocol: mqtt_perception
+  #   broker_host: "192.168.1.20"
+  #   topic: "ori/perception/site-b/cam-04"
+  #   port: 1883
+  #   poll_interval_ms: 1000
+  #
+  # - id: ppe-vest-cam-04
+  #   type: ppe_vest_violation_score
+  #   protocol: mqtt_perception
+  #   broker_host: "192.168.1.20"
+  #   topic: "ori/perception/site-b/cam-04"
+  #   port: 1883
+  #   poll_interval_ms: 1000
+
 
 skills:
   - name: energy-anomaly-detector

--- a/ori/hal/mqtt_perception_adapter.py
+++ b/ori/hal/mqtt_perception_adapter.py
@@ -1,0 +1,175 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+from typing import Any
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError
+from ori.hal.mqtt_base import MqttCachedAdapter
+from ori.network.events import SensorReading
+
+_DEFAULT_PORT = 1883
+_CONTRACT_VERSION = "ori.perception.v1"
+_SUPPORTED_SENSOR_TYPES = frozenset(
+    {
+        "ppe_hardhat_violation_score",
+        "ppe_vest_violation_score",
+    }
+)
+
+
+def _clamp_quality(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+class MqttPerceptionAdapter(MqttCachedAdapter):
+    """MQTT adapter for external perception streams using ori.perception.v1."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._sensor_type: str = ""
+        self._topic: str = ""
+
+    async def connect(self, config: dict) -> None:
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        if sensor_type not in _SUPPORTED_SENSOR_TYPES:
+            raise AdapterConnectionError(
+                f"MqttPerceptionAdapter: unsupported sensor_type '{sensor_type}'. "
+                f"Supported: {sorted(_SUPPORTED_SENSOR_TYPES)}"
+            )
+        topic = str(config.get("topic", "")).strip()
+        if not topic:
+            raise AdapterConnectionError(
+                "MqttPerceptionAdapter: 'topic' is required in sensor config."
+            )
+
+        self._sensor_type = sensor_type
+        self._topic = topic
+
+        await self._connect_mqtt(
+            config=config,
+            topics=[topic],
+            default_port=_DEFAULT_PORT,
+            listener_name=f"perception-listener:{topic}",
+        )
+
+    async def _handle_message(self, topic: str, payload: Any) -> None:
+        parsed = self._parse_payload(payload)
+        payload_sensor_type = str(parsed.get("sensor_type", "")).strip()
+        if payload_sensor_type != self._sensor_type:
+            return
+
+        value = float(parsed["value"])
+        self._cache_value(topic, value, parsed)
+
+    async def read(self, sensor_id: str) -> SensorReading:
+        self._ensure_aiomqtt_available()
+        if not self._connected:
+            raise AdapterReadError(
+                "MqttPerceptionAdapter: not connected — call connect() first"
+            )
+        if self._breaker is None:
+            raise AdapterReadError(
+                "MqttPerceptionAdapter: circuit breaker is not initialized"
+            )
+
+        async with self._breaker:
+            cached = self._cache.get(self._topic)
+            if cached is None:
+                raise AdapterReadError(
+                    "MqttPerceptionAdapter: no perception message cached yet"
+                )
+
+            value, timestamp_ms, raw_payload = cached
+            payload = raw_payload if isinstance(raw_payload, dict) else {}
+            confidence = _clamp_quality(float(payload.get("confidence", 0.0)))
+            payload_ts = payload.get("timestamp_ms")
+            if isinstance(payload_ts, (int, float)):
+                timestamp_ms = int(payload_ts)
+            meta = payload.get("metadata", {})
+            metadata = meta if isinstance(meta, dict) else {}
+
+            return SensorReading(
+                sensor_id=sensor_id,
+                sensor_type=self._sensor_type,
+                value=float(value),
+                unit="score",
+                timestamp=timestamp_ms,
+                quality=confidence,
+                metadata={
+                    **metadata,
+                    "source": "mqtt_perception",
+                    "schema": _CONTRACT_VERSION,
+                    "topic": self._topic,
+                    "broker_host": self._broker_host,
+                    "port": self._port,
+                },
+            )
+
+    async def close(self) -> None:
+        await self._close_mqtt()
+
+    def _parse_payload(self, payload: Any) -> dict[str, Any]:
+        if isinstance(payload, (bytes, bytearray)):
+            text = bytes(payload).decode("utf-8", errors="replace").strip()
+        else:
+            text = str(payload).strip()
+        if not text:
+            raise AdapterReadError("Perception payload is empty")
+
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterReadError(
+                f"Perception payload is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise AdapterReadError("Perception payload must be a JSON object")
+
+        schema = str(parsed.get("schema", "")).strip()
+        if schema != _CONTRACT_VERSION:
+            raise AdapterReadError(
+                f"Perception payload schema must be '{_CONTRACT_VERSION}'"
+            )
+
+        sensor_type = str(parsed.get("sensor_type", "")).strip()
+        if sensor_type not in _SUPPORTED_SENSOR_TYPES:
+            raise AdapterReadError(
+                f"Perception payload has unsupported sensor_type '{sensor_type}'"
+            )
+
+        value = parsed.get("value", parsed.get("violation_score"))
+        if not isinstance(value, (int, float)):
+            raise AdapterReadError("Perception payload field 'value' must be numeric")
+        if float(value) < 0.0 or float(value) > 1.0:
+            raise AdapterReadError("Perception payload 'value' must be within 0.0..1.0")
+        parsed["value"] = float(value)
+
+        confidence = parsed.get("confidence")
+        if not isinstance(confidence, (int, float)):
+            raise AdapterReadError(
+                "Perception payload field 'confidence' must be numeric"
+            )
+        if float(confidence) < 0.0 or float(confidence) > 1.0:
+            raise AdapterReadError(
+                "Perception payload 'confidence' must be within 0.0..1.0"
+            )
+        parsed["confidence"] = float(confidence)
+
+        if "timestamp_ms" not in parsed:
+            parsed["timestamp_ms"] = int(time.time() * 1000)
+        elif not isinstance(parsed.get("timestamp_ms"), (int, float)):
+            raise AdapterReadError(
+                "Perception payload field 'timestamp_ms' must be numeric"
+            )
+
+        metadata = parsed.get("metadata")
+        if metadata is not None and not isinstance(metadata, dict):
+            raise AdapterReadError(
+                "Perception payload field 'metadata' must be a mapping"
+            )
+        if metadata is None:
+            parsed["metadata"] = {}
+
+        return parsed

--- a/ori/hal/protocol_registry.py
+++ b/ori/hal/protocol_registry.py
@@ -12,6 +12,7 @@ SUPPORTED_SENSOR_PROTOCOLS: frozenset[str] = frozenset(
         "serial",
         "growatt",
         "victron",
+        "mqtt_perception",
         "usb_serial",
         "http",
         "opcua",
@@ -41,6 +42,10 @@ def make_adapter(protocol: str) -> BaseAdapter:
         from ori.hal.victron_adapter import VictronAdapter
 
         return VictronAdapter()
+    if protocol == "mqtt_perception":
+        from ori.hal.mqtt_perception_adapter import MqttPerceptionAdapter
+
+        return MqttPerceptionAdapter()
     if protocol == "serial":
         from ori.hal.serial_adapter import SerialAdapter
 

--- a/ori/reasoning/elevator.py
+++ b/ori/reasoning/elevator.py
@@ -273,7 +273,10 @@ class IntelligenceElevator:
             from ori.skills.hooks_api import HookContext
 
             hook_ctx = HookContext.build(
-                event, state_store, getattr(skill, "name", "unknown")
+                event,
+                state_store,
+                getattr(skill, "name", "unknown"),
+                skill_config=getattr(skill, "config", None),
             )
             try:
                 skill.hooks.pre_trigger_eval(hook_ctx)
@@ -672,7 +675,10 @@ class IntelligenceElevator:
                 from ori.skills.hooks_api import HookContext
 
                 pt_ctx = HookContext.build(
-                    event, state_store, getattr(skill, "name", "unknown")
+                    event,
+                    state_store,
+                    getattr(skill, "name", "unknown"),
+                    skill_config=getattr(skill, "config", None),
                 )
                 pt_ctx.trigger_name = rule_res.rule_name if rule_res.matched else ""
 

--- a/ori/skills/hooks_api.py
+++ b/ori/skills/hooks_api.py
@@ -10,6 +10,7 @@ from ori.network.events import OriEvent
 
 class HookHistoryAdapter:
     """Synchronous adapter to wrap StateStore for skill hooks."""
+
     def __init__(self, store: Any):
         self._store = store
 
@@ -71,6 +72,7 @@ class HookHistoryAdapter:
 
 class HookStateAdapter:
     """Provides key-value persistence specifically isolated to the active skill."""
+
     def __init__(self, store: Any, skill_name: str):
         self._store = store
         self._skill_name = skill_name
@@ -89,15 +91,31 @@ class HookStateAdapter:
 @dataclass
 class HookContext:
     """Context block provided to synchronous skill hooks."""
+
+    event: OriEvent | None
     trigger_name: str
     readings: dict[str, Any]
     history: HookHistoryAdapter
     state: HookStateAdapter
     timestamp: int
+    config: dict[str, Any] = field(default_factory=dict)
     derived: dict[str, Any] = field(default_factory=dict)
 
+    @property
+    def reading(self) -> Any:
+        """Convenience accessor for hook compatibility."""
+        if self.event is None:
+            return None
+        return self.event.reading
+
     @classmethod
-    def build(cls, event: OriEvent, store: Any, skill_name: str) -> "HookContext":
+    def build(
+        cls,
+        event: OriEvent,
+        store: Any,
+        skill_name: str,
+        skill_config: dict[str, Any] | None = None,
+    ) -> "HookContext":
         readings = {}
         if event and event.reading:
             readings[event.reading.sensor_id] = event.reading.value
@@ -106,9 +124,11 @@ class HookContext:
                 readings.update(event.reading.metadata)
 
         return cls(
+            event=event,
             trigger_name="",
             readings=readings,
             history=HookHistoryAdapter(store),
             state=HookStateAdapter(store, skill_name),
-            timestamp=event.timestamp if event else int(time.time() * 1000)
+            timestamp=event.timestamp if event else int(time.time() * 1000),
+            config=skill_config if isinstance(skill_config, dict) else {},
         )

--- a/skills/site-safety-ppe/hooks.py
+++ b/skills/site-safety-ppe/hooks.py
@@ -1,0 +1,53 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hooks for site-safety-ppe skill."""
+
+
+def _as_float(value, default):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def pre_trigger_eval(context):
+    """Expose sensor-specific score names and threshold config to rule context."""
+    event = getattr(context, "event", None)
+    reading = getattr(event, "reading", None)
+    if reading is None:
+        return
+
+    sensor_type = str(getattr(reading, "sensor_type", "")).strip()
+    if sensor_type in {"ppe_hardhat_violation_score", "ppe_vest_violation_score"}:
+        context.derived[sensor_type] = _as_float(getattr(reading, "value", 0.0), 0.0)
+
+    cfg = getattr(context, "config", {}) or {}
+    context.derived["violation_score_threshold"] = _as_float(
+        cfg.get("violation_score_threshold", 0.7), 0.7
+    )
+    context.derived["min_detection_quality"] = _as_float(
+        cfg.get("min_detection_quality", 0.6), 0.6
+    )
+
+
+def post_reasoning(result, ctx):
+    """Enrich alert text with zone and camera context from perception metadata."""
+    if ctx.event and ctx.event.reading:
+        meta = ctx.event.reading.metadata
+        parts = []
+        if meta.get("zone_id"):
+            parts.append(f"Zone: {meta['zone_id']}")
+        if meta.get("camera_id"):
+            parts.append(f"Camera: {meta['camera_id']}")
+        if meta.get("subject_id"):
+            parts.append(f"Worker ref: {meta['subject_id']}")
+
+        cfg = getattr(ctx, "config", {}) or {}
+        score_t = _as_float(cfg.get("violation_score_threshold", 0.7), 0.7)
+        quality_t = _as_float(cfg.get("min_detection_quality", 0.6), 0.6)
+        parts.append(f"Gate: score>{score_t:.2f}, quality>{quality_t:.2f}")
+
+        if parts:
+            result.text = result.text + "\n" + "  |  ".join(parts)
+    return result

--- a/skills/site-safety-ppe/skill.yaml
+++ b/skills/site-safety-ppe/skill.yaml
@@ -1,0 +1,73 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+name: site-safety-ppe
+version: 0.1.0
+author: wasiubakare
+description: >
+  PPE safety monitoring skill for hardhat and vest violations from external
+  perception pipelines.
+license: Apache-2.0
+signature: ed25519:PENDING
+
+sensors_required:
+  - type: ppe_hardhat_violation_score
+    protocol: mqtt_perception
+  - type: ppe_vest_violation_score
+    protocol: mqtt_perception
+
+# Trigger conditions intentionally gate on both violation score AND quality.
+#
+# quality reflects the perception adapter's confidence in the detection
+# (mapped from the ori.perception.v1 payload's confidence field).
+# A high violation score from a low-quality detection — caused by poor
+# lighting, camera occlusion, or a degraded model — should not generate
+# an operator alert.
+#
+# Recommended thresholds for v1 deployments:
+#   violation score > 0.7  — strong signal that a violation is present
+#   quality > 0.6          — detection confidence sufficient to act on
+#
+# Both thresholds are configurable in skill config if the deployment
+# environment requires adjustment.
+triggers:
+  - name: hardhat_violation_detected
+    condition: "ppe_hardhat_violation_score > violation_score_threshold and quality > min_detection_quality"
+    cooldown_seconds: 120
+    escalate_to: local_slm
+    action_tier: A
+
+  - name: vest_violation_detected
+    condition: "ppe_vest_violation_score > violation_score_threshold and quality > min_detection_quality"
+    cooldown_seconds: 120
+    escalate_to: local_slm
+    action_tier: A
+
+prompts:
+  hardhat_violation_detected: |
+    Hardhat PPE violation score: {value}
+    Detection quality: {quality}
+    Evaluate whether this is likely a true missing-hardhat safety violation.
+    Give 2 short operator actions in plain language.
+
+  vest_violation_detected: |
+    Safety vest PPE violation score: {value}
+    Detection quality: {quality}
+    Evaluate whether this is likely a true missing-vest safety violation.
+    Give 2 short operator actions in plain language.
+
+actions:
+  available:
+    - name: alert_whatsapp
+      tier: A
+    - name: alert_sms
+      tier: A
+    - name: log_to_dashboard
+      tier: A
+  defaults:
+    hardhat_violation_detected: [alert_whatsapp, log_to_dashboard]
+    vest_violation_detected: [alert_whatsapp, log_to_dashboard]
+
+config:
+  violation_score_threshold: 0.7
+  min_detection_quality: 0.6

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -391,6 +391,16 @@ actions:
         cfg = Config.load(yaml_path)
         assert cfg.sensors[0].protocol == "victron"
 
+    def test_accepts_mqtt_perception_protocol(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._base_yaml(
+                "  - id: ppe-hardhat-cam-01\n    type: ppe_hardhat_violation_score\n    protocol: mqtt_perception\n    poll_interval_ms: 1000"
+            ),
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.sensors[0].protocol == "mqtt_perception"
+
     def test_accepts_opcua_protocol(self, tmp_path):
         yaml_path = _write_yaml(
             tmp_path,

--- a/tests/test_mqtt_perception_adapter.py
+++ b/tests/test_mqtt_perception_adapter.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
+from ori.hal.mqtt_perception_adapter import MqttPerceptionAdapter
+
+
+def _config(
+    sensor_type: str = "ppe_hardhat_violation_score",
+    topic: str = "ori/perception/site-b/cam-01",
+    failure_threshold: int = 3,
+) -> dict:
+    return {
+        "sensor_id": "ppe-hardhat-cam-01",
+        "sensor_type": sensor_type,
+        "broker_host": "192.168.1.20",
+        "port": 1883,
+        "topic": topic,
+        "circuit_breaker": {
+            "failure_threshold": failure_threshold,
+            "recovery_timeout_s": 300,
+            "success_threshold": 2,
+        },
+    }
+
+
+class _FakeTopic:
+    def __init__(self, value: str):
+        self._value = value
+
+    def __str__(self) -> str:
+        return self._value
+
+
+class _FakeMessage:
+    def __init__(self, topic: str, payload: bytes | str):
+        self.topic = _FakeTopic(topic)
+        self.payload = payload
+
+
+class _FakeMessageStream:
+    def __init__(self, queue: asyncio.Queue):
+        self._queue = queue
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._queue.get()
+
+
+class _FakeClient:
+    def __init__(self, *, hostname: str, port: int, **kwargs):
+        self.hostname = hostname
+        self.port = port
+        self.kwargs = kwargs
+        self.subscriptions: list[str] = []
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        self.closed = True
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscriptions.append(topic)
+
+    @property
+    def messages(self):
+        return _FakeMessageStream(self._queue)
+
+    async def emit(self, topic: str, payload: bytes | str) -> None:
+        await self._queue.put(_FakeMessage(topic, payload))
+
+
+class TestMqttPerceptionAdapter:
+    @pytest.mark.asyncio
+    async def test_graceful_import_failure(self):
+        adapter = MqttPerceptionAdapter()
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", False),
+            patch("ori.hal.mqtt_base._aiomqtt", None),
+        ):
+            with pytest.raises(AdapterConnectionError, match="aiomqtt"):
+                await adapter.connect(_config())
+            assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_connect_stores_config(self):
+        adapter = MqttPerceptionAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(topic="ori/perception/site-b/cam-07")
+            await adapter.connect(cfg)
+            assert adapter.is_connected is True
+            assert adapter._sensor_type == "ppe_hardhat_violation_score"
+            assert adapter._topic == "ori/perception/site-b/cam-07"
+            assert isinstance(adapter._client, _FakeClient)
+            assert adapter._client.subscriptions == ["ori/perception/site-b/cam-07"]
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_read_valid_payload_maps_quality_and_metadata(self):
+        adapter = MqttPerceptionAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config()
+            await adapter.connect(cfg)
+            payload = {
+                "schema": "ori.perception.v1",
+                "sensor_type": "ppe_hardhat_violation_score",
+                "value": 0.88,
+                "confidence": 0.92,
+                "timestamp_ms": 1710000000123,
+                "metadata": {
+                    "zone_id": "line-3",
+                    "camera_id": "cam-01",
+                    "subject_id": "worker-7",
+                },
+            }
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("ppe-hardhat-cam-01")
+            assert reading.sensor_type == "ppe_hardhat_violation_score"
+            assert reading.value == pytest.approx(0.88)
+            assert reading.quality == pytest.approx(0.92)
+            assert reading.timestamp == 1710000000123
+            assert reading.metadata["source"] == "mqtt_perception"
+            assert reading.metadata["schema"] == "ori.perception.v1"
+            assert reading.metadata["zone_id"] == "line-3"
+            assert reading.metadata["camera_id"] == "cam-01"
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_mismatched_sensor_type_is_ignored(self):
+        adapter = MqttPerceptionAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(sensor_type="ppe_hardhat_violation_score")
+            await adapter.connect(cfg)
+            payload = {
+                "schema": "ori.perception.v1",
+                "sensor_type": "ppe_vest_violation_score",
+                "value": 0.93,
+                "confidence": 0.9,
+                "metadata": {},
+            }
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            with pytest.raises(AdapterReadError, match="no perception message cached"):
+                await adapter.read("ppe-hardhat-cam-01")
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_integration(self):
+        adapter = MqttPerceptionAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config(failure_threshold=2))
+
+            with pytest.raises(AdapterReadError, match="no perception message cached"):
+                await adapter.read("ppe-hardhat-cam-01")
+            assert adapter._breaker is not None
+            assert adapter._breaker.state == CircuitState.CLOSED
+
+            with pytest.raises(AdapterReadError, match="no perception message cached"):
+                await adapter.read("ppe-hardhat-cam-01")
+            assert adapter._breaker.state == CircuitState.OPEN
+
+            with pytest.raises(AdapterReadError, match="circuit breaker OPEN"):
+                await adapter.read("ppe-hardhat-cam-01")
+
+            await adapter.close()

--- a/tests/test_ppe_skill.py
+++ b/tests/test_ppe_skill.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from ori.network.events import OriEvent, ReasoningResult, SensorReading
+from ori.reasoning.rule_engine import RuleEngine
+from ori.skills.hooks_api import HookContext
+from ori.skills.loader import SkillLoader
+
+
+def _skill_dir() -> Path:
+    return Path(__file__).parent.parent / "skills" / "site-safety-ppe"
+
+
+def _load_skill():
+    return SkillLoader().load_one(_skill_dir())
+
+
+def _event(
+    *,
+    sensor_id: str,
+    sensor_type: str,
+    value: float,
+    quality: float,
+    metadata: dict | None = None,
+) -> OriEvent:
+    reading = SensorReading(
+        sensor_id=sensor_id,
+        sensor_type=sensor_type,
+        value=value,
+        unit="score",
+        timestamp=1710000000123,
+        quality=quality,
+        metadata=metadata or {},
+    )
+    return OriEvent.from_reading(reading, "site-b-ppe-01")
+
+
+def _build_rule_context(skill, event):
+    ctx = dict(skill.config)
+    hook_ctx = HookContext.build(event, None, skill.name, skill_config=skill.config)
+    skill.hooks.pre_trigger_eval(hook_ctx)
+    ctx.update(hook_ctx.derived)
+    return ctx
+
+
+def test_skill_loads():
+    skill = _load_skill()
+    assert skill.name == "site-safety-ppe"
+    assert len(skill.triggers) == 2
+
+
+def test_triggers_gate_on_quality():
+    skill = _load_skill()
+    hardhat = next(t for t in skill.triggers if t.name == "hardhat_violation_detected")
+    vest = next(t for t in skill.triggers if t.name == "vest_violation_detected")
+    assert "quality > min_detection_quality" in hardhat.condition
+    assert "quality > min_detection_quality" in vest.condition
+
+
+@pytest.mark.asyncio
+async def test_low_quality_detection_does_not_match():
+    skill = _load_skill()
+    trigger = next(t for t in skill.triggers if t.name == "hardhat_violation_detected")
+    event = _event(
+        sensor_id="ppe-hardhat-cam-01",
+        sensor_type="ppe_hardhat_violation_score",
+        value=0.95,
+        quality=0.4,
+    )
+    result = await RuleEngine().evaluate(
+        event,
+        [trigger],
+        context=_build_rule_context(skill, event),
+    )
+    assert result.matched is False
+
+
+@pytest.mark.asyncio
+async def test_high_quality_detection_matches():
+    skill = _load_skill()
+    trigger = next(t for t in skill.triggers if t.name == "hardhat_violation_detected")
+    event = _event(
+        sensor_id="ppe-hardhat-cam-01",
+        sensor_type="ppe_hardhat_violation_score",
+        value=0.95,
+        quality=0.93,
+    )
+    result = await RuleEngine().evaluate(
+        event,
+        [trigger],
+        context=_build_rule_context(skill, event),
+    )
+    assert result.matched is True
+    assert result.rule_name == "hardhat_violation_detected"
+
+
+@pytest.mark.asyncio
+async def test_thresholds_are_configurable_without_yaml_edit():
+    skill = _load_skill()
+    skill.config["violation_score_threshold"] = 0.95
+    skill.config["min_detection_quality"] = 0.9
+    trigger = next(t for t in skill.triggers if t.name == "hardhat_violation_detected")
+    event = _event(
+        sensor_id="ppe-hardhat-cam-01",
+        sensor_type="ppe_hardhat_violation_score",
+        value=0.9,
+        quality=0.95,
+    )
+    result = await RuleEngine().evaluate(
+        event,
+        [trigger],
+        context=_build_rule_context(skill, event),
+    )
+    assert result.matched is False
+
+
+def test_hooks_add_zone_camera_subject_context():
+    skill = _load_skill()
+    result = ReasoningResult(
+        text="PPE violation detected.",
+        tier="local_slm",
+        model="stub",
+        tokens_used=0,
+        latency_ms=0,
+    )
+    event = _event(
+        sensor_id="ppe-hardhat-cam-01",
+        sensor_type="ppe_hardhat_violation_score",
+        value=0.9,
+        quality=0.91,
+        metadata={
+            "zone_id": "line-3",
+            "camera_id": "cam-01",
+            "subject_id": "worker-12",
+        },
+    )
+    ctx = HookContext.build(event, None, skill.name, skill_config=skill.config)
+    updated = skill.hooks.post_reasoning(result, ctx)
+    assert "Zone: line-3" in updated.text
+    assert "Camera: cam-01" in updated.text
+    assert "Worker ref: worker-12" in updated.text


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
