### PR TITLE
feat(hal): add zigbee and lorawan mqtt-bridge adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ For the full architectural specification, read [`CLAUDE.md`](CLAUDE.md). For the
 | MQTT                 | ✅     | WiFi-connected sensors/devices via an MQTT broker (commonly Mosquitto). |
 | OPC-UA               | ✅     | Industrial PLCs (IEC 62541)                                             |
 | SolarmanV5 (Growatt) | ✅     | Smart inverter integration                                              |
-| Zigbee / LoRaWAN     | 🗓️     | Smart home and rural long-range sensors                                 |
+| Zigbee               | ✅     | Smart-home sensors via MQTT bridge (for example zigbee2mqtt)            |
+| LoRaWAN              | ✅     | Rural long-range uplink sensors via MQTT brokers (TTN/ChirpStack)       |
 
 ✅ = Implemented &nbsp;&nbsp; 🗓️ = Roadmap
 

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -132,6 +132,31 @@ sensors:
   #   unit: kelvin
   #   poll_interval_ms: 300000
 
+  # ─── Zigbee smart-home sensor via MQTT bridge (optional) ──────────────────
+  # Requires zigbee2mqtt (or equivalent) publishing JSON payloads.
+  # - id: living-room-temp
+  #   type: temperature
+  #   protocol: zigbee
+  #   broker_host: "192.168.1.55"
+  #   topic: "zigbee2mqtt/living-room"
+  #   port: 1883
+  #   # value_path defaults from sensor type mapping; override if needed:
+  #   # value_path: "temperature"
+  #   # quality_path: "quality"
+  #   poll_interval_ms: 2000
+
+  # ─── LoRaWAN uplink sensor via MQTT broker (optional) ─────────────────────
+  # Works with TTN/ChirpStack MQTT uplink events using configurable JSON paths.
+  # - id: field-temperature
+  #   type: lorawan_temperature
+  #   protocol: lorawan
+  #   broker_host: "192.168.1.88"
+  #   topic: "v3/app@ttn/devices/device-01/up"
+  #   port: 1883
+  #   # value_path defaults from sensor type mapping; override for your payload:
+  #   # value_path: "uplink_message.decoded_payload.temperature"
+  #   poll_interval_ms: 5000
+
   # ─── External perception stream via MQTT (optional) ───────────────────────
   # Payload contract expected on topic:
   # {

--- a/ori/hal/lorawan_adapter.py
+++ b/ori/hal/lorawan_adapter.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+from typing import Any
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError
+from ori.hal.mqtt_base import MqttCachedAdapter
+from ori.network.events import SensorReading
+
+_DEFAULT_PORT = 1883
+
+# Supports common LoRaWAN uplink payload shapes with overridable value_path.
+_SENSOR_MAP: dict[str, tuple[str, str]] = {
+    "lorawan_temperature": ("decoded_payload.temperature", "celsius"),
+    "lorawan_humidity": ("decoded_payload.humidity", "percent"),
+    "lorawan_battery_percent": ("decoded_payload.battery", "percent"),
+    "lorawan_soil_moisture": ("decoded_payload.soil_moisture", "percent"),
+    "lorawan_tank_level": ("decoded_payload.tank_level", "percent"),
+    "lorawan_signal_rssi": ("rx_metadata.0.rssi", "dbm"),
+    "lorawan_signal_snr": ("rx_metadata.0.snr", "db"),
+}
+
+
+def _clamp_quality(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _extract_path(data: Any, path: str) -> Any:
+    current = data
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                raise AdapterReadError(
+                    f"LoraWanAdapter: path '{path}' not found in payload"
+                )
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            try:
+                index = int(part)
+            except ValueError as exc:
+                raise AdapterReadError(
+                    f"LoraWanAdapter: path '{path}' expects numeric list index, got '{part}'"
+                ) from exc
+            if index < 0 or index >= len(current):
+                raise AdapterReadError(
+                    f"LoraWanAdapter: list index {index} out of range for path '{path}'"
+                )
+            current = current[index]
+            continue
+        raise AdapterReadError(
+            f"LoraWanAdapter: cannot traverse path '{path}' through {type(current).__name__}"
+        )
+    return current
+
+
+def _coerce_value(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        token = value.strip()
+        if not token:
+            raise AdapterReadError("LoraWanAdapter: empty value string")
+        try:
+            return float(token)
+        except ValueError as exc:
+            raise AdapterReadError(
+                f"LoraWanAdapter: value is not numeric: {value!r}"
+            ) from exc
+    raise AdapterReadError(
+        f"LoraWanAdapter: unsupported value type {type(value).__name__} in payload"
+    )
+
+
+class LoraWanAdapter(MqttCachedAdapter):
+    """LoRaWAN sensor adapter via MQTT uplink brokers (TTN/ChirpStack)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._sensor_type: str = ""
+        self._topic: str = ""
+        self._value_path: str = ""
+        self._quality_path: str = ""
+        self._unit: str = ""
+
+    async def connect(self, config: dict) -> None:
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        if not sensor_type:
+            raise AdapterConnectionError("LoraWanAdapter: 'sensor_type' is required")
+
+        default_path, default_unit = _SENSOR_MAP.get(sensor_type, ("", ""))
+        value_path = str(config.get("value_path", default_path)).strip()
+        unit = str(config.get("unit", default_unit)).strip()
+        if not value_path:
+            raise AdapterConnectionError(
+                "LoraWanAdapter: unsupported sensor_type without value_path override. "
+                f"Known sensor types: {sorted(_SENSOR_MAP)}"
+            )
+
+        topic = str(config.get("topic", "")).strip()
+        if not topic:
+            raise AdapterConnectionError(
+                "LoraWanAdapter: 'topic' is required (e.g. v3/<app>@ttn/devices/<dev>/up)"
+            )
+
+        self._sensor_type = sensor_type
+        self._topic = topic
+        self._value_path = value_path
+        self._quality_path = str(config.get("quality_path", "")).strip()
+        self._unit = unit
+
+        await self._connect_mqtt(
+            config=config,
+            topics=[topic],
+            default_port=_DEFAULT_PORT,
+            listener_name=f"lorawan-listener:{topic}",
+        )
+
+    async def _handle_message(self, topic: str, payload: Any) -> None:
+        parsed = self._parse_payload(payload)
+        raw_value = self._extract_with_variants(parsed, self._value_path)
+        value = _coerce_value(raw_value)
+
+        quality = 1.0
+        if self._quality_path:
+            raw_quality = self._extract_with_variants(parsed, self._quality_path)
+            quality = _clamp_quality(float(_coerce_value(raw_quality)))
+
+        payload_ts_ms = int(time.time() * 1000)
+        for path in (
+            "timestamp_ms",
+            "received_at",
+            "time",
+            "uplink_message.received_at",
+            "metadata.timestamp_ms",
+        ):
+            try:
+                ts_value = self._extract_with_variants(parsed, path)
+            except AdapterReadError:
+                continue
+            if isinstance(ts_value, (int, float)):
+                ts_int = int(ts_value)
+                payload_ts_ms = ts_int * 1000 if ts_int < 10_000_000_000 else ts_int
+                break
+
+        self._cache_value(
+            topic,
+            value,
+            {
+                "payload": parsed,
+                "quality": quality,
+                "timestamp_ms": payload_ts_ms,
+            },
+        )
+
+    async def read(self, sensor_id: str) -> SensorReading:
+        self._ensure_aiomqtt_available()
+        if not self._connected:
+            raise AdapterReadError(
+                "LoraWanAdapter: not connected — call connect() first"
+            )
+        if self._breaker is None:
+            raise AdapterReadError("LoraWanAdapter: circuit breaker is not initialized")
+
+        async with self._breaker:
+            cached = self._cache.get(self._topic)
+            if cached is None:
+                raise AdapterReadError("LoraWanAdapter: no MQTT data cached yet")
+
+            value, timestamp_ms, raw_payload = cached
+            quality = 1.0
+            payload = raw_payload
+            if isinstance(raw_payload, dict):
+                payload = raw_payload.get("payload", raw_payload)
+                quality = _clamp_quality(float(raw_payload.get("quality", 1.0)))
+                ts = raw_payload.get("timestamp_ms")
+                if isinstance(ts, (int, float)):
+                    timestamp_ms = int(ts)
+
+            return SensorReading(
+                sensor_id=sensor_id,
+                sensor_type=self._sensor_type,
+                value=float(value),
+                unit=self._unit,
+                timestamp=timestamp_ms,
+                quality=quality,
+                metadata={
+                    "source": "lorawan",
+                    "topic": self._topic,
+                    "value_path": self._value_path,
+                    "broker_host": self._broker_host,
+                    "port": self._port,
+                    "raw_payload": payload,
+                },
+            )
+
+    async def close(self) -> None:
+        await self._close_mqtt()
+
+    @staticmethod
+    def _parse_payload(payload: Any) -> dict[str, Any]:
+        if isinstance(payload, (bytes, bytearray)):
+            text = bytes(payload).decode("utf-8", errors="replace").strip()
+        else:
+            text = str(payload).strip()
+        if not text:
+            raise AdapterReadError("LoraWanAdapter: empty MQTT payload")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterReadError(
+                f"LoraWanAdapter: payload is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise AdapterReadError("LoraWanAdapter: payload must be a JSON object")
+        return parsed
+
+    @staticmethod
+    def _candidate_paths(path: str) -> list[str]:
+        candidates = [path]
+        if path.startswith("decoded_payload."):
+            suffix = path.removeprefix("decoded_payload.")
+            candidates.extend(
+                [
+                    f"uplink_message.decoded_payload.{suffix}",
+                    f"object.{suffix}",
+                ]
+            )
+        if path.startswith("rx_metadata."):
+            suffix = path.removeprefix("rx_metadata.")
+            candidates.append(f"uplink_message.rx_metadata.{suffix}")
+        return candidates
+
+    def _extract_with_variants(self, payload: dict[str, Any], path: str) -> Any:
+        last_error: AdapterReadError | None = None
+        for candidate in self._candidate_paths(path):
+            try:
+                return _extract_path(payload, candidate)
+            except AdapterReadError as exc:
+                last_error = exc
+        if last_error is not None:
+            raise last_error
+        raise AdapterReadError(f"LoraWanAdapter: value path '{path}' is invalid")

--- a/ori/hal/protocol_registry.py
+++ b/ori/hal/protocol_registry.py
@@ -12,6 +12,8 @@ SUPPORTED_SENSOR_PROTOCOLS: frozenset[str] = frozenset(
         "serial",
         "growatt",
         "victron",
+        "zigbee",
+        "lorawan",
         "mqtt_perception",
         "usb_serial",
         "http",
@@ -43,6 +45,14 @@ def make_adapter(protocol: str) -> BaseAdapter:
         from ori.hal.victron_adapter import VictronAdapter
 
         return VictronAdapter()
+    if protocol == "zigbee":
+        from ori.hal.zigbee_adapter import ZigbeeAdapter
+
+        return ZigbeeAdapter()
+    if protocol == "lorawan":
+        from ori.hal.lorawan_adapter import LoraWanAdapter
+
+        return LoraWanAdapter()
     if protocol == "mqtt_perception":
         from ori.hal.mqtt_perception_adapter import MqttPerceptionAdapter
 

--- a/ori/hal/zigbee_adapter.py
+++ b/ori/hal/zigbee_adapter.py
@@ -1,0 +1,218 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+from typing import Any
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError
+from ori.hal.mqtt_base import MqttCachedAdapter
+from ori.network.events import SensorReading
+
+_DEFAULT_PORT = 1883
+
+# Common zigbee2mqtt fields for smart-home sensors.
+_SENSOR_MAP: dict[str, tuple[str, str]] = {
+    "temperature": ("temperature", "celsius"),
+    "humidity": ("humidity", "percent"),
+    "illuminance": ("illuminance", "lux"),
+    "battery_percent": ("battery", "percent"),
+    "power_watt": ("power", "watt"),
+    "energy_kwh": ("energy", "kilowatt_hour"),
+    "motion": ("occupancy", "ratio"),
+    "contact": ("contact", "ratio"),
+    "water_leak": ("water_leak", "ratio"),
+}
+
+
+def _clamp_quality(value: float) -> float:
+    return max(0.0, min(1.0, value))
+
+
+def _extract_path(data: Any, path: str) -> Any:
+    current = data
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                raise AdapterReadError(
+                    f"ZigbeeAdapter: path '{path}' not found in payload"
+                )
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            try:
+                index = int(part)
+            except ValueError as exc:
+                raise AdapterReadError(
+                    f"ZigbeeAdapter: path '{path}' expects numeric list index, got '{part}'"
+                ) from exc
+            if index < 0 or index >= len(current):
+                raise AdapterReadError(
+                    f"ZigbeeAdapter: list index {index} out of range for path '{path}'"
+                )
+            current = current[index]
+            continue
+        raise AdapterReadError(
+            f"ZigbeeAdapter: cannot traverse path '{path}' through {type(current).__name__}"
+        )
+    return current
+
+
+def _coerce_value(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in {"true", "on", "open", "detected", "yes", "wet"}:
+            return 1.0
+        if token in {"false", "off", "closed", "clear", "no", "dry"}:
+            return 0.0
+        try:
+            return float(token)
+        except ValueError as exc:
+            raise AdapterReadError(
+                f"ZigbeeAdapter: value is not numeric/boolean: {value!r}"
+            ) from exc
+    raise AdapterReadError(
+        f"ZigbeeAdapter: unsupported value type {type(value).__name__} in payload"
+    )
+
+
+class ZigbeeAdapter(MqttCachedAdapter):
+    """Zigbee sensor adapter via MQTT bridge (zigbee2mqtt or equivalent)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._sensor_type: str = ""
+        self._topic: str = ""
+        self._value_path: str = ""
+        self._quality_path: str = ""
+        self._unit: str = ""
+
+    async def connect(self, config: dict) -> None:
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        if not sensor_type:
+            raise AdapterConnectionError("ZigbeeAdapter: 'sensor_type' is required")
+
+        default_path, default_unit = _SENSOR_MAP.get(sensor_type, ("", ""))
+        value_path = str(config.get("value_path", default_path)).strip()
+        unit = str(config.get("unit", default_unit)).strip()
+        if not value_path:
+            raise AdapterConnectionError(
+                "ZigbeeAdapter: unsupported sensor_type without value_path override. "
+                f"Known sensor types: {sorted(_SENSOR_MAP)}"
+            )
+
+        topic = str(config.get("topic", "")).strip()
+        if not topic:
+            raise AdapterConnectionError(
+                "ZigbeeAdapter: 'topic' is required (e.g. zigbee2mqtt/living-room)"
+            )
+
+        self._sensor_type = sensor_type
+        self._topic = topic
+        self._value_path = value_path
+        self._quality_path = str(config.get("quality_path", "")).strip()
+        self._unit = unit
+
+        await self._connect_mqtt(
+            config=config,
+            topics=[topic],
+            default_port=_DEFAULT_PORT,
+            listener_name=f"zigbee-listener:{topic}",
+        )
+
+    async def _handle_message(self, topic: str, payload: Any) -> None:
+        parsed = self._parse_payload(payload)
+        raw_value = _extract_path(parsed, self._value_path)
+        value = _coerce_value(raw_value)
+
+        quality = 1.0
+        if self._quality_path:
+            raw_quality = _extract_path(parsed, self._quality_path)
+            quality = _clamp_quality(float(_coerce_value(raw_quality)))
+
+        payload_ts_ms = int(time.time() * 1000)
+        for path in ("timestamp_ms", "metadata.timestamp_ms", "last_seen"):
+            try:
+                ts_value = _extract_path(parsed, path)
+            except AdapterReadError:
+                continue
+            if isinstance(ts_value, (int, float)):
+                ts_int = int(ts_value)
+                payload_ts_ms = ts_int * 1000 if ts_int < 10_000_000_000 else ts_int
+                break
+
+        self._cache_value(
+            topic,
+            value,
+            {
+                "payload": parsed,
+                "quality": quality,
+                "timestamp_ms": payload_ts_ms,
+            },
+        )
+
+    async def read(self, sensor_id: str) -> SensorReading:
+        self._ensure_aiomqtt_available()
+        if not self._connected:
+            raise AdapterReadError(
+                "ZigbeeAdapter: not connected — call connect() first"
+            )
+        if self._breaker is None:
+            raise AdapterReadError("ZigbeeAdapter: circuit breaker is not initialized")
+
+        async with self._breaker:
+            cached = self._cache.get(self._topic)
+            if cached is None:
+                raise AdapterReadError("ZigbeeAdapter: no MQTT data cached yet")
+
+            value, timestamp_ms, raw_payload = cached
+            quality = 1.0
+            payload = raw_payload
+            if isinstance(raw_payload, dict):
+                payload = raw_payload.get("payload", raw_payload)
+                quality = _clamp_quality(float(raw_payload.get("quality", 1.0)))
+                ts = raw_payload.get("timestamp_ms")
+                if isinstance(ts, (int, float)):
+                    timestamp_ms = int(ts)
+
+            return SensorReading(
+                sensor_id=sensor_id,
+                sensor_type=self._sensor_type,
+                value=float(value),
+                unit=self._unit,
+                timestamp=timestamp_ms,
+                quality=quality,
+                metadata={
+                    "source": "zigbee",
+                    "topic": self._topic,
+                    "value_path": self._value_path,
+                    "broker_host": self._broker_host,
+                    "port": self._port,
+                    "raw_payload": payload,
+                },
+            )
+
+    async def close(self) -> None:
+        await self._close_mqtt()
+
+    @staticmethod
+    def _parse_payload(payload: Any) -> dict[str, Any]:
+        if isinstance(payload, (bytes, bytearray)):
+            text = bytes(payload).decode("utf-8", errors="replace").strip()
+        else:
+            text = str(payload).strip()
+        if not text:
+            raise AdapterReadError("ZigbeeAdapter: empty MQTT payload")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterReadError(
+                f"ZigbeeAdapter: payload is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise AdapterReadError("ZigbeeAdapter: payload must be a JSON object")
+        return parsed

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -391,6 +391,26 @@ actions:
         cfg = Config.load(yaml_path)
         assert cfg.sensors[0].protocol == "victron"
 
+    def test_accepts_zigbee_protocol(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._base_yaml(
+                "  - id: living-room-temp\n    type: temperature\n    protocol: zigbee\n    poll_interval_ms: 1000"
+            ),
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.sensors[0].protocol == "zigbee"
+
+    def test_accepts_lorawan_protocol(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._base_yaml(
+                "  - id: field-temp\n    type: lorawan_temperature\n    protocol: lorawan\n    poll_interval_ms: 5000"
+            ),
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.sensors[0].protocol == "lorawan"
+
     def test_accepts_mqtt_perception_protocol(self, tmp_path):
         yaml_path = _write_yaml(
             tmp_path,

--- a/tests/test_lorawan_adapter.py
+++ b/tests/test_lorawan_adapter.py
@@ -1,0 +1,198 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
+from ori.hal.lorawan_adapter import LoraWanAdapter
+
+
+def _config(
+    *,
+    sensor_type: str = "lorawan_temperature",
+    topic: str = "v3/app@ttn/devices/device-01/up",
+    failure_threshold: int = 3,
+    extra: dict | None = None,
+) -> dict:
+    base = {
+        "sensor_id": "field-temp",
+        "sensor_type": sensor_type,
+        "broker_host": "192.168.1.88",
+        "port": 1883,
+        "topic": topic,
+        "circuit_breaker": {
+            "failure_threshold": failure_threshold,
+            "recovery_timeout_s": 300,
+            "success_threshold": 2,
+        },
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+class _FakeTopic:
+    def __init__(self, value: str):
+        self._value = value
+
+    def __str__(self) -> str:
+        return self._value
+
+
+class _FakeMessage:
+    def __init__(self, topic: str, payload: bytes | str):
+        self.topic = _FakeTopic(topic)
+        self.payload = payload
+
+
+class _FakeMessageStream:
+    def __init__(self, queue: asyncio.Queue):
+        self._queue = queue
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._queue.get()
+
+
+class _FakeClient:
+    def __init__(self, *, hostname: str, port: int, **kwargs):
+        self.hostname = hostname
+        self.port = port
+        self.kwargs = kwargs
+        self.subscriptions: list[str] = []
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        self.closed = True
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscriptions.append(topic)
+
+    @property
+    def messages(self):
+        return _FakeMessageStream(self._queue)
+
+    async def emit(self, topic: str, payload: bytes | str) -> None:
+        await self._queue.put(_FakeMessage(topic, payload))
+
+
+class TestLoraWanAdapter:
+    @pytest.mark.asyncio
+    async def test_graceful_import_failure(self):
+        adapter = LoraWanAdapter()
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", False),
+            patch("ori.hal.mqtt_base._aiomqtt", None),
+        ):
+            with pytest.raises(AdapterConnectionError, match="aiomqtt"):
+                await adapter.connect(_config())
+            assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_read_from_ttn_uplink_shape(self):
+        adapter = LoraWanAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(sensor_type="lorawan_temperature")
+            await adapter.connect(cfg)
+            payload = {
+                "uplink_message": {
+                    "decoded_payload": {"temperature": 32.4, "humidity": 77.1},
+                    "rx_metadata": [{"rssi": -89, "snr": 5.2}],
+                    "received_at": "2026-04-12T08:00:00Z",
+                }
+            }
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("field-temp")
+            assert reading.sensor_type == "lorawan_temperature"
+            assert reading.value == pytest.approx(32.4)
+            assert reading.unit == "celsius"
+            assert reading.metadata["source"] == "lorawan"
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_read_signal_rssi(self):
+        adapter = LoraWanAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(sensor_type="lorawan_signal_rssi")
+            await adapter.connect(cfg)
+            payload = {"rx_metadata": [{"rssi": -101.5, "snr": 2.1}]}
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("field-temp")
+            assert reading.value == pytest.approx(-101.5)
+            assert reading.unit == "dbm"
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_value_and_quality_paths(self):
+        adapter = LoraWanAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(
+                sensor_type="lorawan_tank_level",
+                extra={
+                    "value_path": "object.level",
+                    "quality_path": "object.quality",
+                    "unit": "percent",
+                },
+            )
+            await adapter.connect(cfg)
+            payload = {"object": {"level": 66.0, "quality": 0.87}}
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("field-temp")
+            assert reading.value == pytest.approx(66.0)
+            assert reading.quality == pytest.approx(0.87)
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_integration(self):
+        adapter = LoraWanAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config(failure_threshold=2))
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("field-temp")
+            assert adapter._breaker is not None
+            assert adapter._breaker.state == CircuitState.CLOSED
+
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("field-temp")
+            assert adapter._breaker.state == CircuitState.OPEN
+
+            with pytest.raises(AdapterReadError, match="circuit breaker OPEN"):
+                await adapter.read("field-temp")
+            await adapter.close()

--- a/tests/test_zigbee_adapter.py
+++ b/tests/test_zigbee_adapter.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
+from ori.hal.zigbee_adapter import ZigbeeAdapter
+
+
+def _config(
+    *,
+    sensor_type: str = "temperature",
+    topic: str = "zigbee2mqtt/living-room",
+    failure_threshold: int = 3,
+    extra: dict | None = None,
+) -> dict:
+    base = {
+        "sensor_id": "living-room-temp",
+        "sensor_type": sensor_type,
+        "broker_host": "192.168.1.55",
+        "port": 1883,
+        "topic": topic,
+        "circuit_breaker": {
+            "failure_threshold": failure_threshold,
+            "recovery_timeout_s": 300,
+            "success_threshold": 2,
+        },
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+class _FakeTopic:
+    def __init__(self, value: str):
+        self._value = value
+
+    def __str__(self) -> str:
+        return self._value
+
+
+class _FakeMessage:
+    def __init__(self, topic: str, payload: bytes | str):
+        self.topic = _FakeTopic(topic)
+        self.payload = payload
+
+
+class _FakeMessageStream:
+    def __init__(self, queue: asyncio.Queue):
+        self._queue = queue
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._queue.get()
+
+
+class _FakeClient:
+    def __init__(self, *, hostname: str, port: int, **kwargs):
+        self.hostname = hostname
+        self.port = port
+        self.kwargs = kwargs
+        self.subscriptions: list[str] = []
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        self.closed = True
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscriptions.append(topic)
+
+    @property
+    def messages(self):
+        return _FakeMessageStream(self._queue)
+
+    async def emit(self, topic: str, payload: bytes | str) -> None:
+        await self._queue.put(_FakeMessage(topic, payload))
+
+
+class TestZigbeeAdapter:
+    @pytest.mark.asyncio
+    async def test_graceful_import_failure(self):
+        adapter = ZigbeeAdapter()
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", False),
+            patch("ori.hal.mqtt_base._aiomqtt", None),
+        ):
+            with pytest.raises(AdapterConnectionError, match="aiomqtt"):
+                await adapter.connect(_config())
+            assert adapter.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_read_temperature_from_json_payload(self):
+        adapter = ZigbeeAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(sensor_type="temperature")
+            await adapter.connect(cfg)
+            payload = {
+                "temperature": 28.6,
+                "humidity": 62.4,
+                "last_seen": 1710001111,
+                "quality": 0.93,
+            }
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("living-room-temp")
+            assert reading.sensor_type == "temperature"
+            assert reading.value == pytest.approx(28.6)
+            assert reading.unit == "celsius"
+            assert reading.quality == pytest.approx(1.0)
+            assert reading.metadata["source"] == "zigbee"
+            assert reading.metadata["topic"] == cfg["topic"]
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_custom_value_and_quality_paths(self):
+        adapter = ZigbeeAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config(
+                sensor_type="motion",
+                extra={"value_path": "state.motion", "quality_path": "state.conf"},
+            )
+            await adapter.connect(cfg)
+            payload = {"state": {"motion": True, "conf": 0.78}}
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(cfg["topic"], json.dumps(payload).encode())
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("living-room-temp")
+            assert reading.value == pytest.approx(1.0)
+            assert reading.quality == pytest.approx(0.78)
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_no_data_yet_raises(self):
+        adapter = ZigbeeAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config())
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("living-room-temp")
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_integration(self):
+        adapter = ZigbeeAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config(failure_threshold=2))
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("living-room-temp")
+            assert adapter._breaker is not None
+            assert adapter._breaker.state == CircuitState.CLOSED
+
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("living-room-temp")
+            assert adapter._breaker.state == CircuitState.OPEN
+
+            with pytest.raises(AdapterReadError, match="circuit breaker OPEN"):
+                await adapter.read("living-room-temp")
+            await adapter.close()


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
