### PR TITLE
docs(release): add v0.1.0-alpha.3 release notes

### DIFF
--- a/docs/releases/alpha-release-notes.md
+++ b/docs/releases/alpha-release-notes.md
@@ -2,7 +2,8 @@
 
 ## Versioned Notes
 
-- [`v0.1.0-alpha.2`](v0.1.0-alpha.2.md) — latest alpha cut
+- [`v0.1.0-alpha.3`](v0.1.0-alpha.3.md) — latest alpha cut
+- [`v0.1.0-alpha.2`](v0.1.0-alpha.2.md)
 - [`v0.1.0-alpha.1`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha.1)
 - [`v0.1.0-alpha`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha)
 

--- a/docs/releases/v0.1.0-alpha.3.md
+++ b/docs/releases/v0.1.0-alpha.3.md
@@ -1,0 +1,50 @@
+# Ori Runtime — v0.1.0-alpha.3 Release Notes
+
+## Release Type
+
+Alpha pre-release (`v0.1.0-alpha.3`)
+
+## Compare
+
+`v0.1.0-alpha.2...v0.1.0-alpha.3`
+
+https://github.com/ori-platform/ori-runtime/compare/v0.1.0-alpha.2...v0.1.0-alpha.3
+
+## Summary
+
+This alpha.3 cut extends protocol and perception coverage for field and edge
+deployments while preserving runtime safety invariants.
+
+## Included Since v0.1.0-alpha.2
+
+- External perception ingestion contract wired via `mqtt_perception`:
+  - strict `ori.perception.v1` payload validation
+  - confidence-to-quality mapping
+  - reference PPE skill with explicit quality-gated triggers
+- SMART drive-health adapter (`smart`) with:
+  - `pySMART` first path
+  - `smartctl` JSON fallback
+  - circuit-breaker integration
+- Zigbee + LoRaWAN support via MQTT bridge adapters:
+  - `zigbee` protocol (zigbee2mqtt-style payloads)
+  - `lorawan` protocol (TTN/ChirpStack uplink payloads)
+- Updated examples/docs for new protocol paths.
+
+## Validation Snapshot
+
+- Full runtime suite passed:
+  - `pytest tests/ -v`
+  - Result: `848 passed, 5 skipped`
+
+## Known Limitations (Alpha)
+
+- Zigbee and LoRaWAN are MQTT-bridge integrations, not direct radio-stack
+  control from Ori runtime.
+- Gateway/cloud reasoning tiers remain planned wiring; local rule + local SLM
+  paths are the primary production path today.
+- API/config contracts may still evolve across alpha minor releases.
+
+## Next Milestone
+
+- Hardening package/deploy flows for mixed-protocol edge fleets (Pi, PC, phone).
+- Continue gateway integration for cross-device reasoning paths.


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
