### PR TITLE
Feat/hal extension

### DIFF
--- a/ori/hal/psutil_adapter.py
+++ b/ori/hal/psutil_adapter.py
@@ -37,6 +37,9 @@ _SUPPORTED = frozenset(
         "disk_read_count",
         "net_bytes_sent_mb",
         "net_bytes_recv_mb",
+        "net_listening_sockets",
+        "net_established_connections",
+        "active_terminal_users",
         "battery_drain_rate",
         "sleep_blocking_process",
     }
@@ -86,7 +89,9 @@ class PsutilAdapter(BaseAdapter):
             )
         self._sensor_id = config.get("sensor_id", "")
         self._sensor_type = sensor_type
-        self._breaker = HardwareCircuitBreaker(getattr(self, "adapter_name", type(self).__name__), config)
+        self._breaker = HardwareCircuitBreaker(
+            getattr(self, "adapter_name", type(self).__name__), config
+        )
         self._connected = True
 
     async def close(self) -> None:
@@ -149,6 +154,12 @@ class PsutilAdapter(BaseAdapter):
             return self._net(sensor_id, "sent")
         if t == "net_bytes_recv_mb":
             return self._net(sensor_id, "recv")
+        if t == "net_listening_sockets":
+            return self._net_connections_reading(sensor_id, "LISTEN")
+        if t == "net_established_connections":
+            return self._net_connections_reading(sensor_id, "ESTABLISHED")
+        if t == "active_terminal_users":
+            return self._active_terminal_users(sensor_id)
         raise AdapterReadError(f"Unknown sensor type: {t}")
 
     # ── System resources ──────────────────────────────────────────────────────
@@ -378,6 +389,113 @@ class PsutilAdapter(BaseAdapter):
             unit="megabytes",
             timestamp=_now_ms(),
             quality=1.0,
+        )
+
+    def _permission_degraded_reading(
+        self, sensor_id: str, sensor_type: str, exc: Exception
+    ) -> SensorReading:
+        return SensorReading(
+            sensor_id=sensor_id,
+            sensor_type=sensor_type,
+            value=0.0,
+            unit="count",
+            timestamp=_now_ms(),
+            quality=0.3,
+            metadata={
+                "source": "psutil",
+                "coverage": "partial",
+                "permission_denied": True,
+                "note": "Run with elevated permissions for full socket visibility",
+                "error": str(exc),
+            },
+        )
+
+    @staticmethod
+    def _extract_port(addr: object) -> int | None:
+        if hasattr(addr, "port"):
+            try:
+                return int(getattr(addr, "port"))
+            except (TypeError, ValueError):
+                return None
+        if isinstance(addr, tuple) and len(addr) >= 2:
+            try:
+                return int(addr[1])
+            except (TypeError, ValueError):
+                return None
+        return None
+
+    def _net_connections_reading(self, sensor_id: str, status: str) -> SensorReading:
+        sensor_type = (
+            "net_listening_sockets"
+            if status == "LISTEN"
+            else "net_established_connections"
+        )
+        try:
+            connections = psutil.net_connections(kind="inet")
+        except (psutil.AccessDenied, PermissionError, OSError) as exc:
+            return self._permission_degraded_reading(sensor_id, sensor_type, exc)
+
+        filtered = [c for c in connections if getattr(c, "status", "") == status]
+        ports: list[int] = []
+        pids: list[int] = []
+        for conn in filtered:
+            port = self._extract_port(getattr(conn, "laddr", None))
+            if port is not None:
+                ports.append(port)
+            pid = getattr(conn, "pid", None)
+            if isinstance(pid, int):
+                pids.append(pid)
+
+        return SensorReading(
+            sensor_id=sensor_id,
+            sensor_type=sensor_type,
+            value=float(len(filtered)),
+            unit="count",
+            timestamp=_now_ms(),
+            quality=1.0,
+            metadata={
+                "source": "psutil",
+                "coverage": "full",
+                "status_filter": status,
+                "total_inet_connections": len(connections),
+                "listener_ports" if status == "LISTEN" else "local_ports": sorted(
+                    set(ports)
+                ),
+                "sample_pids": sorted(set(pids))[:10],
+            },
+        )
+
+    def _active_terminal_users(self, sensor_id: str) -> SensorReading:
+        sensor_type = "active_terminal_users"
+        try:
+            users = psutil.users()
+        except (psutil.AccessDenied, PermissionError, OSError) as exc:
+            return self._permission_degraded_reading(sensor_id, sensor_type, exc)
+
+        sessions: list[dict] = []
+        for user in users:
+            sessions.append(
+                {
+                    "name": str(getattr(user, "name", "")),
+                    "terminal": str(getattr(user, "terminal", "")),
+                    "host": str(getattr(user, "host", "")),
+                }
+            )
+
+        usernames = [s["name"] for s in sessions if s["name"]]
+        return SensorReading(
+            sensor_id=sensor_id,
+            sensor_type=sensor_type,
+            value=float(len(sessions)),
+            unit="count",
+            timestamp=_now_ms(),
+            quality=1.0,
+            metadata={
+                "source": "psutil",
+                "coverage": "full",
+                "sessions": sessions,
+                "usernames": usernames,
+            },
         )
 
     # ── Battery drain rate (calculated, async) ────────────────────────────────

--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -472,14 +472,20 @@ class ActionDispatcher:
             # Backward compatibility for older test doubles/overrides that
             # patched _listen_for_response with a no-arg coroutine.
             listen_coro = self._listen_for_response()  # type: ignore[call-arg]
+        listen_task = asyncio.create_task(
+            listen_coro,
+            name=f"approval:{action}",
+        )
         try:
             operator_response = await asyncio.wait_for(
-                listen_coro,
+                listen_task,
                 # Keep a small guard margin around provider-side timeout logic.
                 timeout=float(approval_timeout_seconds) + 1.0,
             )
         except asyncio.TimeoutError:
             timed_out = True
+            if not listen_task.done():
+                listen_task.cancel()
             logger.warning(
                 "ActionDispatcher: approval timeout for action=%r after %ds — "
                 "executing safe_default=%r",

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -614,7 +614,7 @@ class OriRuntime:
                         try:
                             # Immediate wake on shutdown instead of sleeping blindly
                             await asyncio.wait_for(
-                                asyncio.shield(self._shutdown_event.wait()),
+                                self._shutdown_event.wait(),
                                 timeout=WATCHDOG_PING_INTERVAL,
                             )
                         except asyncio.TimeoutError:
@@ -658,7 +658,7 @@ class OriRuntime:
                 pin.off()
                 try:
                     await asyncio.wait_for(
-                        asyncio.shield(self._shutdown_event.wait()),
+                        self._shutdown_event.wait(),
                         timeout=ping_interval_s,
                     )
                 except asyncio.TimeoutError:
@@ -680,24 +680,38 @@ class OriRuntime:
     async def _heartbeat_loop(self, device_id: str) -> None:
         """Log a heartbeat every 5 minutes to confirm the runtime is alive.
 
-        Uses ``asyncio.wait_for`` on a shielded shutdown-event wait so that
-        the loop wakes immediately on shutdown rather than being cancelled
-        mid-sleep.  This produces a clean exit log line instead of a silent
-        ``CancelledError``.
+        The heartbeat reports:
+        - managed runtime background tasks (pollers/watchdog/compaction/etc.)
+        - pending reasoning tasks
+        - pending approval-wait tasks
+        - total active asyncio tasks
         """
         while not self._shutdown_event.is_set():
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._shutdown_event.wait()),
+                    self._shutdown_event.wait(),
                     timeout=300.0,
                 )
                 break  # shutdown was signalled during the wait — exit cleanly
             except asyncio.TimeoutError:
                 pass  # 5 minutes elapsed normally — log heartbeat
             active = [t for t in asyncio.all_tasks() if not t.done()]
+            managed = [t for t in self._background_tasks if not t.done()]
+            reasoning_pending = 0
+            approval_pending = 0
+            for task in active:
+                name = task.get_name()
+                if name.startswith("reason:"):
+                    reasoning_pending += 1
+                elif name.startswith("approval:"):
+                    approval_pending += 1
             logger.info(
-                "[heartbeat] device=%s active_tasks=%d",
+                "[heartbeat] device=%s managed_tasks=%d reasoning_pending=%d "
+                "approval_pending=%d active_tasks=%d",
                 device_id,
+                len(managed),
+                reasoning_pending,
+                approval_pending,
                 len(active),
             )
         logger.debug("[heartbeat] loop exited cleanly")
@@ -707,7 +721,7 @@ class OriRuntime:
         while not self._shutdown_event.is_set():
             try:
                 await asyncio.wait_for(
-                    asyncio.shield(self._shutdown_event.wait()),
+                    self._shutdown_event.wait(),
                     timeout=300.0,
                 )
                 break  # shutdown was signalled

--- a/ori/skills/hooks_api.py
+++ b/ori/skills/hooks_api.py
@@ -77,10 +77,22 @@ class HookStateAdapter:
         self._store = store
         self._skill_name = skill_name
 
+    def _read(self, fn_name: str, *args: Any) -> Any:
+        """Execute a StateStore sync read helper across store API versions."""
+        if not self._store:
+            return None
+        fn = getattr(self._store, fn_name, None)
+        if fn is None:
+            return None
+        run_read = getattr(self._store, "_run_read_with_conn", None)
+        if callable(run_read):
+            return run_read(fn, *args)
+        return fn(*args)
+
     def get(self, key: str) -> Optional[str]:
         if not self._store or not self._skill_name:
             return None
-        return self._store._get_skill_state_sync(self._skill_name, key)
+        return self._read("_get_skill_state_sync", self._skill_name, key)
 
     def set(self, key: str, value: str) -> None:
         if not self._store or not self._skill_name:

--- a/ori/skills/loader.py
+++ b/ori/skills/loader.py
@@ -644,7 +644,8 @@ class SkillLoader:
                     skill=skill,
                     state_store=state_store,
                     dispatcher=dispatcher,
-                )
+                ),
+                name=f"reason:{skill.name}:{trigger.name}",
             )
 
         # Give the handler a useful name for logging

--- a/skills/pc-network-threat-monitor/hooks.py
+++ b/skills/pc-network-threat-monitor/hooks.py
@@ -1,0 +1,224 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hooks for pc-network-threat-monitor skill."""
+
+
+def _as_float(value, default):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _as_int(value, default):
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+def _as_int_set(values):
+    if not isinstance(values, list):
+        return set()
+    output = set()
+    for value in values:
+        try:
+            output.add(int(value))
+        except (TypeError, ValueError):
+            continue
+    return output
+
+
+def _as_lower_str_set(values):
+    if not isinstance(values, list):
+        return set()
+    output = set()
+    for value in values:
+        text = str(value).strip().lower()
+        if text:
+            output.add(text)
+    return output
+
+
+def _state_get_float(context, key, default=0.0):
+    return _as_float(context.state.get(key), default)
+
+
+def _state_get_int(context, key, default=0):
+    return _as_int(context.state.get(key), default)
+
+
+def _state_set(context, key, value):
+    context.state.set(key, str(value))
+
+
+def pre_trigger_eval(context):
+    """Compute derived cyber anomaly metrics from current reading + state."""
+    cfg = getattr(context, "config", {}) or {}
+    min_quality = _as_float(cfg.get("min_quality", 0.8), 0.8)
+    warmup_polls = max(0, _as_int(cfg.get("baseline_warmup_polls", 5), 5))
+    correlation_window_ms = (
+        max(1, _as_int(cfg.get("correlation_window_seconds", 600), 600)) * 1000
+    )
+    listener_delta_threshold = _as_float(cfg.get("listener_delta_threshold", 1), 1)
+    established_delta_threshold = _as_float(
+        cfg.get("established_delta_threshold", 20),
+        20,
+    )
+    user_delta_threshold = _as_float(cfg.get("user_delta_threshold", 1), 1)
+
+    known_ports = _as_int_set(cfg.get("known_listener_ports", []))
+    known_users = _as_lower_str_set(cfg.get("known_terminal_users", []))
+
+    context.derived["min_quality"] = min_quality
+    context.derived["listener_delta_threshold"] = listener_delta_threshold
+    context.derived["established_delta_threshold"] = established_delta_threshold
+    context.derived["established_ratio_threshold"] = _as_float(
+        cfg.get("established_ratio_threshold", 2.5),
+        2.5,
+    )
+    context.derived["user_delta_threshold"] = user_delta_threshold
+    context.derived["tier_c_established_ratio"] = _as_float(
+        cfg.get("tier_c_established_ratio", 4.0),
+        4.0,
+    )
+    context.derived["tier_c_user_delta"] = _as_float(cfg.get("tier_c_user_delta", 1), 1)
+
+    context.derived["listener_delta"] = 0.0
+    context.derived["established_delta"] = 0.0
+    context.derived["established_ratio_24h"] = 0.0
+    context.derived["user_delta"] = 0.0
+
+    event = getattr(context, "event", None)
+    reading = getattr(event, "reading", None)
+    if reading is None:
+        context.derived["warmup_complete"] = 0
+        context.derived["recent_listener_spike"] = 0
+        context.derived["recent_user_spike"] = 0
+        return
+
+    now_ts = _as_int(getattr(context, "timestamp", 0), 0)
+    poll_count = _state_get_int(context, "poll_count", 0) + 1
+    _state_set(context, "poll_count", poll_count)
+    warmup_complete = 1 if poll_count > warmup_polls else 0
+    context.derived["warmup_complete"] = warmup_complete
+
+    sensor_type = str(getattr(reading, "sensor_type", "")).strip()
+    current_value = _as_float(getattr(reading, "value", 0.0), 0.0)
+    quality = _as_float(getattr(reading, "quality", 0.0), 0.0)
+
+    if sensor_type == "net_listening_sockets":
+        ports = []
+        metadata = getattr(reading, "metadata", {}) or {}
+        for port in metadata.get("listener_ports", []):
+            try:
+                ports.append(int(port))
+            except (TypeError, ValueError):
+                continue
+
+        adjusted_listeners = current_value
+        if ports:
+            adjusted_listeners = float(sum(1 for p in ports if p not in known_ports))
+
+        prev = _state_get_float(
+            context,
+            "last_net_listening_sockets",
+            adjusted_listeners,
+        )
+        delta = max(0.0, adjusted_listeners - prev) if warmup_complete else 0.0
+
+        context.derived["net_listening_sockets"] = adjusted_listeners
+        context.derived["listener_delta"] = delta
+        _state_set(context, "last_net_listening_sockets", adjusted_listeners)
+
+        if (
+            warmup_complete
+            and quality >= min_quality
+            and delta >= listener_delta_threshold
+        ):
+            _state_set(context, "last_listener_spike_ts", now_ts)
+
+    elif sensor_type == "net_established_connections":
+        prev = _state_get_float(
+            context, "last_net_established_connections", current_value
+        )
+        delta = max(0.0, current_value - prev) if warmup_complete else 0.0
+
+        baseline = context.history.avg_hours(reading.sensor_id, 24)
+        baseline_value = _as_float(baseline, 0.0)
+        ratio = (
+            current_value / baseline_value
+            if baseline_value > 0.0
+            else (current_value if current_value > 0 else 0.0)
+        )
+
+        context.derived["net_established_connections"] = current_value
+        context.derived["established_delta"] = delta
+        context.derived["established_ratio_24h"] = ratio
+        _state_set(context, "last_net_established_connections", current_value)
+
+        if (
+            warmup_complete
+            and quality >= min_quality
+            and delta >= established_delta_threshold
+        ):
+            _state_set(context, "last_established_spike_ts", now_ts)
+
+    elif sensor_type == "active_terminal_users":
+        sessions = []
+        metadata = getattr(reading, "metadata", {}) or {}
+        if isinstance(metadata.get("sessions"), list):
+            sessions = metadata["sessions"]
+
+        adjusted_users = current_value
+        if sessions:
+            filtered = []
+            for session in sessions:
+                name = str(session.get("name", "")).strip().lower()
+                if name and name not in known_users:
+                    filtered.append(session)
+            adjusted_users = float(len(filtered))
+
+        prev = _state_get_float(context, "last_active_terminal_users", adjusted_users)
+        delta = max(0.0, adjusted_users - prev) if warmup_complete else 0.0
+
+        context.derived["active_terminal_users"] = adjusted_users
+        context.derived["user_delta"] = delta
+        _state_set(context, "last_active_terminal_users", adjusted_users)
+
+        if warmup_complete and quality >= min_quality and delta >= user_delta_threshold:
+            _state_set(context, "last_user_spike_ts", now_ts)
+
+    listener_ts = _state_get_int(context, "last_listener_spike_ts", 0)
+    user_ts = _state_get_int(context, "last_user_spike_ts", 0)
+    context.derived["recent_listener_spike"] = (
+        1 if listener_ts > 0 and (now_ts - listener_ts) <= correlation_window_ms else 0
+    )
+    context.derived["recent_user_spike"] = (
+        1 if user_ts > 0 and (now_ts - user_ts) <= correlation_window_ms else 0
+    )
+
+
+def post_reasoning(result, ctx):
+    """Add compact host context to operator-facing text."""
+    event = getattr(ctx, "event", None)
+    reading = getattr(event, "reading", None)
+    if reading is None:
+        return result
+
+    metadata = getattr(reading, "metadata", {}) or {}
+    parts = []
+    if reading.sensor_type == "net_listening_sockets":
+        ports = metadata.get("listener_ports", [])
+        if isinstance(ports, list) and ports:
+            parts.append(f"Listener ports: {', '.join(str(p) for p in ports[:6])}")
+
+    if reading.sensor_type == "active_terminal_users":
+        usernames = metadata.get("usernames", [])
+        if isinstance(usernames, list) and usernames:
+            parts.append(f"Active users: {', '.join(str(u) for u in usernames[:6])}")
+
+    if parts:
+        result.text = result.text + "\n" + "  |  ".join(parts)
+    return result

--- a/skills/pc-network-threat-monitor/skill.yaml
+++ b/skills/pc-network-threat-monitor/skill.yaml
@@ -1,0 +1,102 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+name: pc-network-threat-monitor
+version: 0.1.0
+author: wasiubakare
+description: >
+  Host behavioral anomaly detection for suspicious listener/socket/session
+  changes on PC deployments.
+license: Apache-2.0
+signature: ed25519:PENDING
+
+sensors_required:
+  - type: net_listening_sockets
+    protocol: psutil
+  - type: net_established_connections
+    protocol: psutil
+  - type: active_terminal_users
+    protocol: psutil
+
+# This skill performs host behavioral anomaly detection from psutil telemetry.
+# It does not claim deterministic malware family or zero-day classification.
+#
+# Tier C defaults are intentionally conservative at launch:
+# alert + log only. Do not add terminate_process defaults until baseline false
+# positive rates are measured in production.
+triggers:
+  - name: suspicious_new_listener
+    condition: "sensor_type == 'net_listening_sockets' and warmup_complete == 1 and quality >= min_quality and listener_delta >= listener_delta_threshold"
+    cooldown_seconds: 120
+    escalate_to: local_slm
+    action_tier: A
+
+  - name: suspicious_connection_surge
+    condition: "sensor_type == 'net_established_connections' and warmup_complete == 1 and quality >= min_quality and established_delta >= established_delta_threshold and established_ratio_24h >= established_ratio_threshold"
+    cooldown_seconds: 120
+    escalate_to: local_slm
+    action_tier: A
+
+  - name: suspicious_terminal_user_increase
+    condition: "sensor_type == 'active_terminal_users' and warmup_complete == 1 and quality >= min_quality and user_delta >= user_delta_threshold"
+    cooldown_seconds: 180
+    escalate_to: local_slm
+    action_tier: A
+
+  - name: probable_c2_or_shell_foothold
+    condition: "warmup_complete == 1 and quality >= min_quality and recent_listener_spike == 1 and ((sensor_type == 'net_established_connections' and established_delta >= established_delta_threshold and established_ratio_24h >= tier_c_established_ratio) or (sensor_type == 'active_terminal_users' and user_delta >= tier_c_user_delta))"
+    cooldown_seconds: 300
+    escalate_to: rule
+    action_tier: C
+    approval_timeout_seconds: 300
+    safe_default_action: log_to_dashboard
+
+prompts:
+  suspicious_new_listener: |
+    A new network listener appeared on the host.
+    Evaluate whether this matches host behavioral indicators of post-exploitation
+    foothold behavior or expected local services.
+    Give 2 short operator actions in plain language.
+
+  suspicious_connection_surge: |
+    Outbound established connections surged compared to baseline.
+    Evaluate whether this matches host behavioral indicators of command-and-
+    control or benign burst traffic.
+    Give 2 short operator actions in plain language.
+
+  suspicious_terminal_user_increase: |
+    Active terminal sessions increased unexpectedly.
+    Evaluate whether this looks like authorized maintenance or suspicious shell
+    access behavior.
+    Give 2 short operator actions in plain language.
+
+  probable_c2_or_shell_foothold: |
+    Correlated host behavioral indicators were observed: recent listener spike
+    plus elevated connection/session activity.
+    Assess whether this warrants containment proposal to the operator.
+    Give 2 short operator actions in plain language.
+
+actions:
+  available:
+    - name: alert_whatsapp
+      tier: A
+    - name: log_to_dashboard
+      tier: A
+  defaults:
+    suspicious_new_listener: [alert_whatsapp, log_to_dashboard]
+    suspicious_connection_surge: [alert_whatsapp, log_to_dashboard]
+    suspicious_terminal_user_increase: [alert_whatsapp, log_to_dashboard]
+    probable_c2_or_shell_foothold: [alert_whatsapp, log_to_dashboard]
+
+config:
+  min_quality: 0.8
+  baseline_warmup_polls: 5
+  correlation_window_seconds: 600
+  listener_delta_threshold: 1
+  established_delta_threshold: 20
+  established_ratio_threshold: 2.5
+  user_delta_threshold: 1
+  tier_c_established_ratio: 4.0
+  tier_c_user_delta: 1
+  known_listener_ports: [5432, 3306, 6379, 8080, 9090]
+  known_terminal_users: [admin, deploy]

--- a/tests/test_network_threat_skill.py
+++ b/tests/test_network_threat_skill.py
@@ -1,0 +1,289 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from ori.network.events import OriEvent, SensorReading
+from ori.reasoning.rule_engine import RuleEngine
+from ori.skills.hooks_api import HookContext
+from ori.skills.loader import SkillLoader
+
+
+class _Store:
+    def __init__(self) -> None:
+        self._history: dict[str, list[SensorReading]] = {}
+        self._state: dict[tuple[str, str], str] = {}
+
+    def add_history(self, sensor_id: str, reading: SensorReading) -> None:
+        self._history.setdefault(sensor_id, []).insert(0, reading)
+
+    def _get_history_sync(self, sensor_id: str, limit: int) -> list[SensorReading]:
+        return self._history.get(sensor_id, [])[:limit]
+
+    def _avg_last_hours_sync(self, sensor_id: str, _hours: int) -> float | None:
+        rows = self._history.get(sensor_id, [])
+        if not rows:
+            return None
+        return sum(r.value for r in rows) / len(rows)
+
+    def _get_skill_state_sync(self, skill_name: str, key: str) -> str | None:
+        return self._state.get((skill_name, key))
+
+    def _set_skill_state_sync(self, skill_name: str, key: str, value: str) -> None:
+        self._state[(skill_name, key)] = value
+
+
+def _skill_dir() -> Path:
+    return Path(__file__).parent.parent / "skills" / "pc-network-threat-monitor"
+
+
+def _load_skill():
+    return SkillLoader().load_one(_skill_dir())
+
+
+def _event(
+    *,
+    sensor_id: str,
+    sensor_type: str,
+    value: float,
+    quality: float = 1.0,
+    metadata: dict | None = None,
+    timestamp: int = 1_710_000_000_123,
+) -> OriEvent:
+    reading = SensorReading(
+        sensor_id=sensor_id,
+        sensor_type=sensor_type,
+        value=value,
+        unit="count",
+        timestamp=timestamp,
+        quality=quality,
+        metadata=metadata or {},
+    )
+    return OriEvent.from_reading(reading, "pc-cyber-01")
+
+
+def _prepare_context(skill, event, store: _Store):
+    hook_ctx = HookContext.build(event, store, skill.name, skill_config=skill.config)
+    skill.hooks.pre_trigger_eval(hook_ctx)
+    context = dict(skill.config)
+    context.update(hook_ctx.derived)
+    return hook_ctx, context
+
+
+@pytest.mark.asyncio
+async def test_skill_loads_with_valid_tiers():
+    skill = _load_skill()
+    assert skill.name == "pc-network-threat-monitor"
+    assert len(skill.triggers) == 4
+    assert {t.action_tier for t in skill.triggers} == {"A", "C"}
+
+
+@pytest.mark.asyncio
+async def test_tier_c_trigger_has_safe_default_action():
+    skill = _load_skill()
+    trigger = next(
+        t for t in skill.triggers if t.name == "probable_c2_or_shell_foothold"
+    )
+    assert trigger.action_tier == "C"
+    assert trigger.safe_default_action == "log_to_dashboard"
+    defaults = skill.actions.get("defaults", {})
+    assert defaults["probable_c2_or_shell_foothold"] == [
+        "alert_whatsapp",
+        "log_to_dashboard",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_warmup_polls_suppress_delta_triggers():
+    skill = _load_skill()
+    trigger = next(t for t in skill.triggers if t.name == "suspicious_new_listener")
+    store = _Store()
+
+    for idx in range(5):
+        event = _event(
+            sensor_id="net-listeners-01",
+            sensor_type="net_listening_sockets",
+            value=2.0,
+            metadata={"listener_ports": [22, 5432]},
+            timestamp=1_710_000_000_123 + idx,
+        )
+        _, ctx = _prepare_context(skill, event, store)
+        result = await RuleEngine().evaluate(event, [trigger], context=ctx)
+        assert result.matched is False
+        assert ctx["warmup_complete"] == 0
+
+
+@pytest.mark.asyncio
+async def test_hooks_compute_listener_delta_after_warmup():
+    skill = _load_skill()
+    store = _Store()
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+    store._set_skill_state_sync(skill.name, "last_net_listening_sockets", "1")
+
+    event = _event(
+        sensor_id="net-listeners-01",
+        sensor_type="net_listening_sockets",
+        value=3.0,
+        metadata={"listener_ports": [22, 5432, 31337]},
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    assert ctx["warmup_complete"] == 1
+    assert ctx["net_listening_sockets"] == pytest.approx(2.0)
+    assert ctx["listener_delta"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_hooks_apply_known_listener_allowlist():
+    skill = _load_skill()
+    store = _Store()
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+
+    event = _event(
+        sensor_id="net-listeners-01",
+        sensor_type="net_listening_sockets",
+        value=3.0,
+        metadata={"listener_ports": [5432, 8080, 9001]},
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    assert ctx["net_listening_sockets"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_hooks_apply_known_terminal_users_allowlist():
+    skill = _load_skill()
+    store = _Store()
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+
+    event = _event(
+        sensor_id="active-users-01",
+        sensor_type="active_terminal_users",
+        value=3.0,
+        metadata={
+            "sessions": [
+                {"name": "admin", "terminal": "pts/0"},
+                {"name": "deploy", "terminal": "pts/1"},
+                {"name": "analyst", "terminal": "pts/2"},
+            ]
+        },
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    assert ctx["active_terminal_users"] == pytest.approx(1.0)
+
+
+@pytest.mark.asyncio
+async def test_rule_matches_suspicious_new_listener():
+    skill = _load_skill()
+    store = _Store()
+    trigger = next(t for t in skill.triggers if t.name == "suspicious_new_listener")
+
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+    store._set_skill_state_sync(skill.name, "last_net_listening_sockets", "1")
+
+    event = _event(
+        sensor_id="net-listeners-01",
+        sensor_type="net_listening_sockets",
+        value=3.0,
+        metadata={"listener_ports": [22, 5432, 31337]},
+        quality=0.95,
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    result = await RuleEngine().evaluate(event, [trigger], context=ctx)
+    assert result.matched is True
+
+
+@pytest.mark.asyncio
+async def test_rule_matches_probable_c2_or_shell_foothold_when_correlated():
+    skill = _load_skill()
+    store = _Store()
+    trigger = next(
+        t for t in skill.triggers if t.name == "probable_c2_or_shell_foothold"
+    )
+
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+    store._set_skill_state_sync(skill.name, "last_net_established_connections", "10")
+    store._set_skill_state_sync(skill.name, "last_listener_spike_ts", "1710000000000")
+
+    baseline_sensor_id = "net-established-01"
+    store.add_history(
+        baseline_sensor_id,
+        SensorReading(
+            sensor_id=baseline_sensor_id,
+            sensor_type="net_established_connections",
+            value=10.0,
+            unit="count",
+            timestamp=1_709_999_900_000,
+            quality=1.0,
+        ),
+    )
+
+    event = _event(
+        sensor_id=baseline_sensor_id,
+        sensor_type="net_established_connections",
+        value=60.0,
+        quality=0.95,
+        timestamp=1_710_000_000_123,
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    result = await RuleEngine().evaluate(event, [trigger], context=ctx)
+    assert result.matched is True
+
+
+@pytest.mark.asyncio
+async def test_low_quality_readings_do_not_trigger_alerts():
+    skill = _load_skill()
+    store = _Store()
+    trigger = next(t for t in skill.triggers if t.name == "suspicious_new_listener")
+
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+    store._set_skill_state_sync(skill.name, "last_net_listening_sockets", "1")
+
+    event = _event(
+        sensor_id="net-listeners-01",
+        sensor_type="net_listening_sockets",
+        value=3.0,
+        metadata={"listener_ports": [22, 5432, 31337]},
+        quality=0.3,
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    result = await RuleEngine().evaluate(event, [trigger], context=ctx)
+    assert result.matched is False
+
+
+@pytest.mark.asyncio
+async def test_no_correlation_does_not_fire_tier_c():
+    skill = _load_skill()
+    store = _Store()
+    trigger = next(
+        t for t in skill.triggers if t.name == "probable_c2_or_shell_foothold"
+    )
+
+    store._set_skill_state_sync(skill.name, "poll_count", "6")
+    store._set_skill_state_sync(skill.name, "last_net_established_connections", "10")
+    # Explicitly absent listener spike
+    store._set_skill_state_sync(skill.name, "last_listener_spike_ts", "0")
+
+    baseline_sensor_id = "net-established-01"
+    store.add_history(
+        baseline_sensor_id,
+        SensorReading(
+            sensor_id=baseline_sensor_id,
+            sensor_type="net_established_connections",
+            value=10.0,
+            unit="count",
+            timestamp=1_709_999_900_000,
+            quality=1.0,
+        ),
+    )
+
+    event = _event(
+        sensor_id=baseline_sensor_id,
+        sensor_type="net_established_connections",
+        value=60.0,
+        quality=0.95,
+        timestamp=1_710_000_000_123,
+    )
+    _, ctx = _prepare_context(skill, event, store)
+    result = await RuleEngine().evaluate(event, [trigger], context=ctx)
+    assert result.matched is False

--- a/tests/test_psutil_adapter.py
+++ b/tests/test_psutil_adapter.py
@@ -3,12 +3,13 @@
 
 import shutil
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import psutil
 import pytest
 
-from ori.hal.base import AdapterConnectionError
+from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
 from ori.hal.psutil_adapter import PsutilAdapter
 from ori.network.events import SensorReading
 
@@ -356,6 +357,103 @@ class TestNetwork:
             value_min=0.0,
             quality_min=1.0,
         )
+
+    async def test_net_listening_sockets_counts_listen_only(self):
+        connections = [
+            SimpleNamespace(status="LISTEN", laddr=("127.0.0.1", 5432), pid=111),
+            SimpleNamespace(status="ESTABLISHED", laddr=("10.0.0.2", 443), pid=222),
+            SimpleNamespace(status="LISTEN", laddr=("127.0.0.1", 8080), pid=333),
+        ]
+        adapter = await _make_adapter("net_listening_sockets")
+        with patch("psutil.net_connections", return_value=connections):
+            r = await adapter.read("net_listening_sockets")
+        _assert_reading(
+            r,
+            "net_listening_sockets",
+            "net_listening_sockets",
+            "count",
+            value_min=0.0,
+            quality_min=1.0,
+        )
+        assert r.value == 2.0
+        assert r.metadata["listener_ports"] == [5432, 8080]
+        assert r.metadata["sample_pids"] == [111, 333]
+        assert r.metadata["coverage"] == "full"
+
+    async def test_net_established_connections_counts_established_only(self):
+        connections = [
+            SimpleNamespace(status="LISTEN", laddr=("127.0.0.1", 5432), pid=111),
+            SimpleNamespace(status="ESTABLISHED", laddr=("10.0.0.2", 443), pid=222),
+            SimpleNamespace(status="ESTABLISHED", laddr=("10.0.0.2", 8443), pid=444),
+        ]
+        adapter = await _make_adapter("net_established_connections")
+        with patch("psutil.net_connections", return_value=connections):
+            r = await adapter.read("net_established_connections")
+        _assert_reading(
+            r,
+            "net_established_connections",
+            "net_established_connections",
+            "count",
+            value_min=0.0,
+            quality_min=1.0,
+        )
+        assert r.value == 2.0
+        assert r.metadata["local_ports"] == [443, 8443]
+        assert r.metadata["sample_pids"] == [222, 444]
+        assert r.metadata["coverage"] == "full"
+
+    async def test_active_terminal_users_counts_sessions(self):
+        sessions = [
+            SimpleNamespace(name="admin", terminal="ttys000", host="localhost"),
+            SimpleNamespace(name="deploy", terminal="ttys001", host="localhost"),
+        ]
+        adapter = await _make_adapter("active_terminal_users")
+        with patch("psutil.users", return_value=sessions):
+            r = await adapter.read("active_terminal_users")
+        _assert_reading(
+            r,
+            "active_terminal_users",
+            "active_terminal_users",
+            "count",
+            value_min=0.0,
+            quality_min=1.0,
+        )
+        assert r.value == 2.0
+        assert r.metadata["usernames"] == ["admin", "deploy"]
+        assert len(r.metadata["sessions"]) == 2
+
+    async def test_net_connections_access_denied_returns_low_quality_reading(self):
+        adapter = await _make_adapter("net_listening_sockets")
+        with patch(
+            "psutil.net_connections",
+            side_effect=psutil.AccessDenied(pid=100, name="netstat"),
+        ):
+            r = await adapter.read("net_listening_sockets")
+        assert r.sensor_type == "net_listening_sockets"
+        assert r.value == 0.0
+        assert r.quality == pytest.approx(0.3)
+        assert r.metadata["coverage"] == "partial"
+        assert r.metadata["permission_denied"] is True
+        assert "elevated permissions" in r.metadata["note"]
+
+    async def test_cyber_sensor_failures_trip_circuit_breaker(self):
+        adapter = await _make_adapter("net_established_connections")
+        with patch(
+            "psutil.net_connections",
+            side_effect=RuntimeError("boom"),
+        ):
+            with pytest.raises(AdapterReadError):
+                await adapter.read("net_established_connections")
+            with pytest.raises(AdapterReadError):
+                await adapter.read("net_established_connections")
+            with pytest.raises(AdapterReadError):
+                await adapter.read("net_established_connections")
+            with pytest.raises(AdapterReadError):
+                await adapter.read("net_established_connections")
+            with pytest.raises(AdapterReadError):
+                await adapter.read("net_established_connections")
+        assert adapter._breaker.state == CircuitState.OPEN
+        assert adapter._breaker.failure_count >= adapter._breaker.failure_threshold
 
 
 # ─── Battery drain rate ───────────────────────────────────────────────────────

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -555,7 +555,7 @@ class TestRegister:
         # patch asyncio.create_task to capture the coroutine
         created_coros = []
 
-        def fake_create_task(coro):
+        def fake_create_task(coro, **_kwargs):
             created_coros.append(coro)
             # Schedule it so it actually runs
             return asyncio.ensure_future(coro)
@@ -584,7 +584,7 @@ class TestRegister:
 
         task_calls = []
 
-        def fake_create_task(coro):
+        def fake_create_task(coro, **_kwargs):
             task_calls.append(coro)
             return asyncio.ensure_future(coro)
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [x] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
