### PR TITLE
docs: standardize claims to offline-capable safety core

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,8 @@ the architecture.
 ## What this project is
 
 Ori is an agentic IoT runtime. It reads physical sensor data and takes
-autonomous actions based on LLM reasoning. It runs offline on a Raspberry Pi.
+autonomous actions based on LLM reasoning. It has an offline-capable safety
+core and runs on a Raspberry Pi.
 
 The key concept that every contributor must understand before touching code:
 
@@ -221,14 +222,14 @@ by the runtime. It provides dynamic, sandboxed access to sensor data
 and persistent state. **Never** access the StateStore or database
 directly from hooks — always go through these adapters.
 
-| Property | Type | Description |
-| --- | --- | --- |
-| `context.readings` | `dict[str, Any]` | Current sensor values keyed by sensor_id |
-| `context.history` | `HookHistoryAdapter` | Parameterised history queries (see below) |
-| `context.state` | `HookStateAdapter` | Skill-isolated key-value persistence |
-| `context.timestamp` | `int` | Event timestamp (unix milliseconds) |
-| `context.derived` | `dict[str, Any]` | Writable dict for computed values |
-| `context.trigger_name` | `str` | Name of the trigger that fired |
+| Property               | Type                 | Description                               |
+| ---------------------- | -------------------- | ----------------------------------------- |
+| `context.readings`     | `dict[str, Any]`     | Current sensor values keyed by sensor_id  |
+| `context.history`      | `HookHistoryAdapter` | Parameterised history queries (see below) |
+| `context.state`        | `HookStateAdapter`   | Skill-isolated key-value persistence      |
+| `context.timestamp`    | `int`                | Event timestamp (unix milliseconds)       |
+| `context.derived`      | `dict[str, Any]`     | Writable dict for computed values         |
+| `context.trigger_name` | `str`                | Name of the trigger that fired            |
 
 **HookHistoryAdapter methods:**
 

--- a/PRINCIPLES.md
+++ b/PRINCIPLES.md
@@ -5,43 +5,50 @@ The design philosophy governing every architectural decision in this codebase is
 When you write code or review a pull request, ask yourself if it survives these lenses:
 
 ## 1. The Lens of Actuation Trust
-*Physical trust is earned, not assumed.*
 
-This codebase implements a **Physical Actuation Trust** framework. This is what makes Ori categorically different from every existing IoT platform and LLM agent framework. An AI agent acting in the physical world must earn the authority to act progressively. Ori's Action Tier Framework — Informational (Tier A) → Soft Physical (Tier B) → Hard Physical (Tier C) → Safety-Critical (Tier D) — is not a safety bolt-on. It is the fundamental model through which the runtime demonstrates trustworthiness. 
+_Physical trust is earned, not assumed._
+
+This codebase implements a **Physical Actuation Trust** framework. This is what makes Ori categorically different from every existing IoT platform and LLM agent framework. An AI agent acting in the physical world must earn the authority to act progressively. Ori's Action Tier Framework — Informational (Tier A) → Soft Physical (Tier B) → Hard Physical (Tier C) → Safety-Critical (Tier D) — is not a safety bolt-on. It is the fundamental model through which the runtime demonstrates trustworthiness.
 
 Furthermore, trust requires **Continuous Humility**. The operator's context always supersedes the agent's generalization. When an operator rejects a Tier C proposal, Ori explicitly logs that rejection to causal memory. Trust is won by proving that human correction permanently alters the machine's future behaviour.
 
 See also: The Lens of Explicit Authority Boundaries — which governs how learned behaviour interacts with actuation permissions.
 
 ## 2. The Lens of Constraint
-*Designed for the world's majority condition.*
 
-Ori was designed for the world's majority condition, not its exception. Unreliable power, intermittent connectivity, constrained hardware budgets, and limited cloud access describe the majority of the world's physical infrastructure — including industrial sites in Europe and the United States. 
+_Designed for the world's majority condition._
+
+Ori was designed for the world's majority condition, not its exception. Unreliable power, intermittent connectivity, constrained hardware budgets, and limited cloud access describe the majority of the world's physical infrastructure — including industrial sites in Europe and the United States.
 
 Systems designed for abundance fail in constraint. Systems designed for constraint work everywhere. This means we optimize for the $55 Raspberry Pi (or repurposed Android phone), not the $500 industrial edge server. We embrace the realities of intermittent power supplies and unreliable network interfaces.
 
 ## 3. The Lens of Inviolable Safety
-*The deterministic layer is absolute.*
+
+_The deterministic layer is absolute._
 
 The Tier D deterministic rule engine fires before any LLM is consulted. It cannot be disabled. It cannot be overridden by an external skill. It cannot be bypassed by a misconfigured action tier. This is not a configuration option — it is an architectural invariant enforced at every layer of the system. An LLM that hallucinates cannot cause a physical safety failure, because it never reaches the physical control layer without passing through deterministic validation first.
 
 ## 4. The Lens of Assumed Failure
-*Hardware lies. Software freezes. Power dies.*
+
+_Hardware lies. Software freezes. Power dies._
 
 Traditional IoT assumes perfect conditions and throws a fatal stack trace when hardware disconnects. Ori is built on the assumption that the physical world is hostile. Systems must degrade gracefully, not fail categorically. When the power supply drops, Ori throttles its intelligence — disabling LLMs but keeping safety rules alive. When an I2C sensor wire shorts, the HAL circuit breaker isolates the fault so the other sensors survive. Ori expects failure, and is engineered to survive it autonomously.
 
 ## 5. The Lens of Offline-First
-*Offline-first is the requirement, not a feature.*
 
-Most of the world's physical infrastructure does not have reliable internet connectivity. Building an agent runtime that requires the cloud for continuous reasoning is building for the wrong world. The Intelligence Elevator runs Tier 1 deterministic rules and Tier 2 local SLM inference without any external network connection. Cloud LLM is Tier 4 — a localized enhancement, not a fundamental dependency. Every safety-critical function must execute cleanly at 2:00 AM during a power and internet outage.
+_Offline-first is the requirement, not a feature._
+
+Most of the world's physical infrastructure does not have reliable internet connectivity. Building an agent runtime that requires the cloud for continuous reasoning is building for the wrong world. The Intelligence Elevator keeps an offline-capable safety core through Tier 1 deterministic rules and local Tier 2 reasoning. Cloud LLM is Tier 4 — a localized enhancement, not a fundamental dependency. Every safety-critical function must execute cleanly at 2:00 AM during a power and internet outage.
 
 ## 6. The Lens of Explicit Capability
-*The skill is the atomic unit of trust.*
+
+_The skill is the atomic unit of trust._
 
 Every autonomous capability Ori possesses is declared, versioned, signed, and auditable. A skill that is not declared cannot execute. An action that is not in the skill's capability declaration cannot be taken. The sandbox enforces this at the import level. The action tier framework enforces this at the execution level. Community skills are cryptographically signed. The trust model is explicit and machine-verifiable.
 
 ## 7. The Lens of Explicit Authority Boundaries
-*Learning improves reasoning. It never grants permissions.*
+
+_Learning improves reasoning. It never grants permissions._
 
 Learning is allowed to improve recommendations, context, deduplication, and prioritization. Learning is not allowed to silently grant new actuation authority.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 > **IoT devices do not need more data. They need to reason about that data — and act on it.**
 
-Ori is an open-source **agentic IoT runtime** that gives physical devices **tiered autonomous reasoning** — from deterministic safety rules to local SLMs. This reasoning is governed by a **[Physical Actuation Trust](PRINCIPLES.md)** framework that defines exactly what an AI agent is permitted to do in the physical world, at what consequence level, and with what human oversight. Offline-first and cloud-optional. Runs on a $55 Raspberry Pi.
+Ori is an open-source **agentic IoT runtime** that gives physical devices **tiered autonomous reasoning** — from deterministic safety rules to local SLMs. This reasoning is governed by a **[Physical Actuation Trust](PRINCIPLES.md)** framework that defines exactly what an AI agent is permitted to do in the physical world, at what consequence level, and with what human oversight. Offline-first with an offline-capable safety core; gateway/cloud escalation is optional. Runs on a $55 Raspberry Pi.
 
 Built for the world's majority condition — unreliable power, intermittent connectivity, constrained hardware. Systems designed for constraint work everywhere.
 
@@ -56,7 +56,7 @@ Every existing IoT platform does the same thing: collect data, apply a threshold
         Estimated failure: 2 weeks.
         I've sent a service reminder to your WhatsApp."
 
-         — sent autonomously, from a $55 Pi, with no internet
+         — sent autonomously from a $55 Pi, without requiring cloud inference for safety decisions
 
 ✅ Ori (Tier B): "Grid voltage dropped to 174V. I have switched to
 inverter power automatically." ← Acted. Then told you.
@@ -78,7 +78,7 @@ Ori is not a monitoring system with a language model attached. It is an agent th
 ## What Ori Is Not
 
 - Not a monitoring dashboard like Grafana — Ori acts, not just displays
-- Not a cloud IoT platform like AWS IoT Core — Ori can run fully offline (Tier 1 + Tier 2), with optional gateway/cloud escalation
+- Not a cloud IoT platform like AWS IoT Core — Ori keeps an offline-capable safety core (Tier 1 + local Tier 2), with optional gateway/cloud escalation when connected
 - Not a notification system — alerts are Tier A, the least of what Ori does
 - Not just a rules engine — Ori pairs deterministic safety rules with LLM reasoning
 
@@ -151,7 +151,7 @@ Ori runs a paired decision system on every sensor event:
 
 ```text
 Tier 1  RULE ENGINE    microseconds · always available  · safety triggers
-Tier 2  LOCAL SLM      3-8 seconds  · fully offline     · everyday reasoning
+Tier 2  LOCAL SLM      3-8 seconds  · offline-capable   · everyday reasoning
 Tier 3  GATEWAY LLM    1-3 seconds  · LAN only          · cross-device reasoning
 Tier 4  CLOUD LLM      2-5 seconds  · internet          · deep analysis + reports
 ```


### PR DESCRIPTION


## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
