### PR TITLE
feat: implement coap and mqtt generic telemetry adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,6 +221,7 @@ ori/
 │   │   ├── gpio_adapter.py
 │   │   ├── i2c_adapter.py
 │   │   ├── serial_adapter.py
+│   │   ├── mqtt_adapter.py    ← Generic MQTT telemetry adapter
 │   │   └── psutil_adapter.py  ← PC-Ori, no hardware needed
 │   │
 │   ├── network/               ← Network Layer (Layer 2)
@@ -249,6 +250,8 @@ ori/
 │   │   ├── sms.py             ← Africa's Talking (PRIMARY for Nigeria)
 │   │   ├── relay.py           ← Physical relay control (GPIO output)
 │   │   ├── modbus_control.py  ← Modbus write commands (industrial)
+│   │   ├── alert_failover.py  ← Failover alert transport wrapper
+│   │   ├── coap.py            ← CoAP action executor for constrained devices
 │   │   └── logger.py
 │   │
 │   └── state/
@@ -345,7 +348,8 @@ class ActionDispatcher:
             return await self._approval_workflow(action, context, result)
 
     async def _approval_workflow(self, action, context, result) -> ActionResult:
-        # 1. Send WhatsApp/SMS with reasoning + proposed action
+        # 1. Send WhatsApp/SMS with reasoning + proposed action via AlertFailoverSender
+        #    (tries primary channel first, falls back to secondary on failure)
         # 2. Wait for YES/NO within approval_timeout_seconds (default: 300)
         # 3. YES → execute action
         # 4. NO or timeout → execute safe_default_action, log override
@@ -523,6 +527,16 @@ actions:
   relay:
     enabled: false # true when physical relay is wired
     gpio_pin: 26
+  coap:
+    enabled: false
+    timeout_s: 2.0
+    retries: 1
+    allowed_hosts: ["192.168.1.70"]
+    commands:
+      open_bypass_valve:
+        uri: "coap://192.168.1.70/actuators/bypass"
+        method: POST
+        payload: '{"state":"open"}'
 
 logging:
   level: INFO

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ For the full architectural specification, read [`CLAUDE.md`](CLAUDE.md). For the
 | Modbus RTU (RS485)   | ✅     | Industrial energy meters, PLCs, motor drives                           |
 | psutil               | ✅     | PC and server health monitoring (any laptop)                           |
 | MQTT                 | ✅     | WiFi-connected sensors/devices via an MQTT broker (commonly Mosquitto) |
+| CoAP (actuation)     | ✅     | Constrained-device command path for low-overhead control endpoints     |
 | OPC-UA               | ✅     | Industrial PLCs (IEC 62541)                                            |
 | SolarmanV5 (Growatt) | ✅     | Smart inverter integration                                             |
 | Zigbee               | ✅     | Smart-home sensors via MQTT bridge (for example zigbee2mqtt)           |
@@ -190,6 +191,9 @@ Ori is designed for [physical actuation trust](PRINCIPLES.md). The safety archit
 - **Sandboxed skill hooks** — community skills cannot import arbitrary modules. The sandbox enforces an explicit allowlist at import time
 - **Hardware circuit breakers** — failing sensor buses are auto-isolated using a three-state (CLOSED → OPEN → HALF_OPEN) circuit breaker so one bad sensor doesn't crash the runtime
 - **Approval workflows for hard physical actions** — Tier C actions always require operator approval via WhatsApp/SMS. No config flag to skip it
+- **Alert transport failover** — approval requests use the configured primary channel first, then fail over to the secondary channel if delivery fails
+
+For constrained deployments, a common pattern is MQTT for continuous telemetry plus CoAP for low-overhead command delivery.
 
 For the full set of security invariants, see [`AGENTS.md`](AGENTS.md#security-invariants--never-violate-these).
 

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -157,6 +157,18 @@ sensors:
   #   # value_path: "uplink_message.decoded_payload.temperature"
   #   poll_interval_ms: 5000
 
+  # ─── Generic MQTT telemetry sensor (optional) ─────────────────────────────
+  # Use this when a device publishes JSON measurements to a broker.
+  # - id: chiller-supply-temp
+  #   type: temperature
+  #   protocol: mqtt
+  #   broker_host: "192.168.1.20"
+  #   topic: "plant/chiller-1/supply"
+  #   value_path: "reading.value"
+  #   quality_path: "reading.quality"
+  #   unit: celsius
+  #   poll_interval_ms: 2000
+
   # ─── External perception stream via MQTT (optional) ───────────────────────
   # Payload contract expected on topic:
   # {
@@ -249,6 +261,19 @@ actions:
     enabled: false                   # CHANGE TO true ONLY WHEN RELAY IS WIRED
     gpio_pin: 26                     # BCM pin number connected to relay IN
     active_high: true
+
+  # CoAP command transport (optional; constrained-device actuation path)
+  # CoAP commands are executed through `coap_command` actions in skills.
+  coap:
+    enabled: false
+    timeout_s: 2.0
+    retries: 1
+    allowed_hosts: ["192.168.1.70"]  # required when enabled
+    commands:
+      open_bypass_valve:
+        uri: "coap://192.168.1.70/actuators/bypass"
+        method: POST
+        payload: '{"state":"open"}'
 
 
 hal:

--- a/ori/actions/alert_failover.py
+++ b/ori/actions/alert_failover.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Failover alert transport wrapper used by approval workflows.
+
+Primary usage:
+- send Tier C approval requests via preferred channel
+- fall back to the secondary channel on transport failure
+- listen for operator responses on both channels concurrently
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class AlertFailoverSender:
+    """Wraps SMS and WhatsApp senders with primary/secondary failover."""
+
+    def __init__(
+        self,
+        *,
+        primary_channel: str,
+        sms_sender: Any,
+        whatsapp_sender: Any,
+    ) -> None:
+        self._primary_channel = str(primary_channel or "sms").strip().lower()
+        self._sms_sender = sms_sender
+        self._whatsapp_sender = whatsapp_sender
+
+        if self._primary_channel not in {"sms", "whatsapp"}:
+            logger.warning(
+                "AlertFailoverSender: unknown primary channel %r; defaulting to sms",
+                self._primary_channel,
+            )
+            self._primary_channel = "sms"
+
+    @property
+    def _ordered_senders(self) -> list[tuple[str, Any]]:
+        primary = (
+            ("sms", self._sms_sender)
+            if self._primary_channel == "sms"
+            else ("whatsapp", self._whatsapp_sender)
+        )
+        secondary = (
+            ("whatsapp", self._whatsapp_sender)
+            if primary[0] == "sms"
+            else ("sms", self._sms_sender)
+        )
+        return [primary, secondary]
+
+    async def send(self, message: str, to_number: str) -> bool:
+        """Send via primary transport; fall back to secondary on failure."""
+        for channel_name, sender in self._ordered_senders:
+            if sender is None:
+                continue
+            try:
+                ok = await sender.send(message=message, to_number=to_number)
+            except Exception:
+                logger.exception(
+                    "AlertFailoverSender: send failed on channel=%s",
+                    channel_name,
+                )
+                ok = False
+            if ok:
+                return True
+        return False
+
+    async def listen_for_response(
+        self,
+        from_number: str,
+        timeout_seconds: int,
+    ) -> str | None:
+        """Wait for first response from either transport listener."""
+        listeners: list[tuple[str, Any]] = []
+        for channel_name, sender in self._ordered_senders:
+            if sender is None:
+                continue
+            listener = getattr(sender, "listen_for_response", None)
+            if callable(listener):
+                listeners.append((channel_name, listener))
+
+        if not listeners:
+            return None
+
+        deadline = time.monotonic() + max(1, int(timeout_seconds))
+        pending: set[asyncio.Task[str | None]] = set()
+        for channel_name, listener in listeners:
+            pending.add(
+                asyncio.create_task(
+                    self._listen_safe(
+                        channel_name=channel_name,
+                        listener=listener,
+                        from_number=from_number,
+                        timeout_seconds=timeout_seconds,
+                    ),
+                    name=f"approval-listen:{channel_name}",
+                )
+            )
+
+        try:
+            while pending:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+
+                done, pending = await asyncio.wait(
+                    pending,
+                    timeout=remaining,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
+                    break
+
+                for task in done:
+                    response = task.result()
+                    if response is not None:
+                        for other in pending:
+                            other.cancel()
+                        await asyncio.gather(*pending, return_exceptions=True)
+                        return response
+        finally:
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        return None
+
+    async def _listen_safe(
+        self,
+        *,
+        channel_name: str,
+        listener: Any,
+        from_number: str,
+        timeout_seconds: int,
+    ) -> str | None:
+        try:
+            return await listener(
+                from_number=from_number,
+                timeout_seconds=timeout_seconds,
+            )
+        except TypeError:
+            try:
+                return await listener(from_number, timeout_seconds)
+            except Exception:
+                logger.exception(
+                    "AlertFailoverSender: %s listener failed",
+                    channel_name,
+                )
+                return None
+        except Exception:
+            logger.exception(
+                "AlertFailoverSender: %s listener failed",
+                channel_name,
+            )
+            return None

--- a/ori/actions/coap.py
+++ b/ori/actions/coap.py
@@ -1,0 +1,189 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""CoAP action executor for constrained-device actuation commands."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+try:
+    import aiocoap as _aiocoap  # type: ignore[import-untyped]
+
+    _AIOCOAP_AVAILABLE = True
+except ImportError:
+    _aiocoap = None
+    _AIOCOAP_AVAILABLE = False
+
+_ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "DELETE"})
+
+
+def _as_bool(value: object, default: bool = False) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    token = str(value).strip().lower()
+    if token in {"1", "true", "yes", "on"}:
+        return True
+    if token in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+class CoAPAction:
+    """Dispatch command payloads to CoAP endpoints with strict allowlisting."""
+
+    def __init__(self, config: dict | None = None) -> None:
+        cfg = config if isinstance(config, dict) else {}
+        self._enabled = _as_bool(cfg.get("enabled", False))
+        self._timeout_s = max(0.2, float(cfg.get("timeout_s", 2.0)))
+        self._retries = max(0, int(cfg.get("retries", 1)))
+        self._commands = cfg.get("commands", {}) or {}
+
+        allowed_hosts = cfg.get("allowed_hosts", []) or []
+        self._allowed_hosts = {
+            str(host).strip().lower() for host in allowed_hosts if str(host).strip()
+        }
+
+        if self._enabled and not _AIOCOAP_AVAILABLE:
+            logger.warning(
+                "CoAPAction: aiocoap is not installed — CoAP command delivery disabled."
+            )
+
+    async def execute_command(
+        self,
+        command_name: str,
+        payload_override: str | None = None,
+    ) -> bool:
+        """Execute a named command from ``actions.coap.commands``."""
+        if not self._enabled:
+            logger.debug("CoAPAction: disabled, skipping command=%r", command_name)
+            return False
+
+        if not _AIOCOAP_AVAILABLE or _aiocoap is None:
+            logger.warning(
+                "CoAPAction: aiocoap missing — cannot execute command=%r",
+                command_name,
+            )
+            return False
+
+        if not isinstance(self._commands, dict):
+            logger.error("CoAPAction: actions.coap.commands must be a mapping")
+            return False
+
+        spec = self._commands.get(command_name)
+        if not isinstance(spec, dict):
+            logger.error(
+                "CoAPAction: unknown command=%r. Define it under actions.coap.commands.",
+                command_name,
+            )
+            return False
+
+        uri = str(spec.get("uri", "")).strip()
+        method = str(spec.get("method", "POST")).strip().upper()
+        payload = (
+            payload_override
+            if payload_override is not None
+            else spec.get("payload", "")
+        )
+        payload_bytes = self._encode_payload(payload)
+
+        if not self._validate_target(uri=uri, method=method):
+            return False
+
+        for attempt in range(self._retries + 1):
+            ok = await self._send_once(uri=uri, method=method, payload=payload_bytes)
+            if ok:
+                return True
+            if attempt < self._retries:
+                await asyncio.sleep(min(1.0, 0.2 * (2**attempt)))
+
+        return False
+
+    def _validate_target(self, *, uri: str, method: str) -> bool:
+        if method not in _ALLOWED_METHODS:
+            logger.error(
+                "CoAPAction: invalid method=%r (allowed=%s)",
+                method,
+                sorted(_ALLOWED_METHODS),
+            )
+            return False
+
+        parsed = urlparse(uri)
+        if parsed.scheme not in {"coap", "coaps"}:
+            logger.error("CoAPAction: uri must use coap/coaps scheme, got %r", uri)
+            return False
+        host = (parsed.hostname or "").strip().lower()
+        if not host:
+            logger.error("CoAPAction: uri host is required")
+            return False
+
+        # SSRF/actuation-boundary hardening: explicit host allowlist is required.
+        if not self._allowed_hosts:
+            logger.error(
+                "CoAPAction: actions.coap.allowed_hosts is empty while CoAP is enabled"
+            )
+            return False
+        if host not in self._allowed_hosts:
+            logger.error(
+                "CoAPAction: host %r is not in actions.coap.allowed_hosts",
+                host,
+            )
+            return False
+
+        return True
+
+    async def _send_once(self, *, uri: str, method: str, payload: bytes) -> bool:
+        assert _aiocoap is not None
+        context = None
+        try:
+            context = await _aiocoap.Context.create_client_context()
+            code = getattr(_aiocoap, method, None)
+            if code is None:
+                logger.error("CoAPAction: method constant missing for %r", method)
+                return False
+
+            request = _aiocoap.Message(code=code, uri=uri, payload=payload)
+            response = await asyncio.wait_for(
+                context.request(request).response,
+                timeout=self._timeout_s,
+            )
+            response_code = str(response.code)
+            if response_code.startswith("2."):
+                return True
+            logger.warning(
+                "CoAPAction: non-success response for uri=%s code=%s",
+                uri,
+                response_code,
+            )
+            return False
+        except asyncio.TimeoutError:
+            logger.warning("CoAPAction: timeout sending CoAP command to %s", uri)
+            return False
+        except Exception:
+            logger.exception("CoAPAction: failed sending CoAP command to %s", uri)
+            return False
+        finally:
+            if context is not None:
+                try:
+                    await context.shutdown()
+                except Exception:
+                    logger.debug("CoAPAction: context shutdown failed", exc_info=True)
+
+    @staticmethod
+    def _encode_payload(payload: object) -> bytes:
+        if payload is None:
+            return b""
+        if isinstance(payload, (bytes, bytearray)):
+            return bytes(payload)
+        if isinstance(payload, (dict, list)):
+            return json.dumps(payload, separators=(",", ":"), ensure_ascii=True).encode(
+                "utf-8"
+            )
+        return str(payload).encode("utf-8")

--- a/ori/config.py
+++ b/ori/config.py
@@ -81,6 +81,7 @@ class ActionChannelConfig:
     whatsapp: dict = field(default_factory=dict)
     sms: dict = field(default_factory=dict)
     relay: dict = field(default_factory=dict)
+    coap: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -143,9 +144,13 @@ class Config:
         logging_cfg = _parse_logging(data.get("logging"))
 
         if not actions.operator_contact or "${" in actions.operator_contact:
-            logger.warning("[config] actions.operator_contact is missing or not properly interpolated. Tier C emergency actions will fail.")
+            logger.warning(
+                "[config] actions.operator_contact is missing or not properly interpolated. Tier C emergency actions will fail."
+            )
         if actions.secondary_contact and "${" in actions.secondary_contact:
-            logger.warning("[config] actions.secondary_contact contains uninterpolated variable. Escalations may fail.")
+            logger.warning(
+                "[config] actions.secondary_contact contains uninterpolated variable. Escalations may fail."
+            )
 
         whatsapp_enabled = (
             str(actions.whatsapp.get("enabled", "")).lower() == "true"
@@ -401,6 +406,50 @@ def _parse_actions(data: Any) -> ActionChannelConfig:
                 f"a safety action. Check ori.yaml."
             )
 
+    coap_raw = data.get("coap") or {}
+    if not isinstance(coap_raw, dict):
+        raise ConfigValidationError("'actions.coap' must be a mapping when provided.")
+    coap = dict(coap_raw)
+
+    coap_enabled = (
+        str(coap.get("enabled", "")).lower() == "true" or coap.get("enabled") is True
+    )
+    if coap_enabled:
+        commands = coap.get("commands") or {}
+        if not isinstance(commands, dict):
+            raise ConfigValidationError(
+                "actions.coap.commands must be a mapping when coap is enabled."
+            )
+        for command_name, spec in commands.items():
+            if not isinstance(spec, dict):
+                raise ConfigValidationError(
+                    f"actions.coap.commands.{command_name} must be a mapping."
+                )
+            uri = str(spec.get("uri", "")).strip()
+            method = str(spec.get("method", "POST")).strip().upper()
+            if not uri:
+                raise ConfigValidationError(
+                    f"actions.coap.commands.{command_name}.uri is required."
+                )
+            if not uri.startswith(("coap://", "coaps://")):
+                raise ConfigValidationError(
+                    f"actions.coap.commands.{command_name}.uri must start with coap:// or coaps://."
+                )
+            if method not in {"GET", "POST", "PUT", "DELETE"}:
+                raise ConfigValidationError(
+                    f"actions.coap.commands.{command_name}.method must be one of GET/POST/PUT/DELETE."
+                )
+
+        allowed_hosts = coap.get("allowed_hosts") or []
+        if (
+            not isinstance(allowed_hosts, list)
+            or len(allowed_hosts) == 0
+            or not all(isinstance(host, str) and host.strip() for host in allowed_hosts)
+        ):
+            raise ConfigValidationError(
+                "actions.coap.allowed_hosts must be a non-empty list of hostnames/IPs when coap is enabled."
+            )
+
     return ActionChannelConfig(
         primary_alert_channel=primary,
         operator_contact=str(data.get("operator_contact") or ""),
@@ -408,17 +457,28 @@ def _parse_actions(data: Any) -> ActionChannelConfig:
         whatsapp=data.get("whatsapp") or {},
         sms=data.get("sms") or {},
         relay=relay,
+        coap=coap,
     )
 
 
 def _parse_hal(data: Any) -> HalConfig:
     """Parse the HAL block gracefully, enforcing safe defaults on failure."""
-    default_cb = {"failure_threshold": 5, "recovery_timeout_s": 300, "success_threshold": 2}
-    default_external_watchdog = {"enabled": False, "gpio_pin": 17, "ping_interval_s": 30}
+    default_cb = {
+        "failure_threshold": 5,
+        "recovery_timeout_s": 300,
+        "success_threshold": 2,
+    }
+    default_external_watchdog = {
+        "enabled": False,
+        "gpio_pin": 17,
+        "ping_interval_s": 30,
+    }
 
     if not isinstance(data, dict):
         if data is not None:
-            logger.warning("[config] 'hal' config missing or not a dict. Falling back to default circuit breaker.")
+            logger.warning(
+                "[config] 'hal' config missing or not a dict. Falling back to default circuit breaker."
+            )
         return HalConfig(
             circuit_breaker=default_cb,
             external_watchdog=default_external_watchdog,
@@ -427,7 +487,9 @@ def _parse_hal(data: Any) -> HalConfig:
     cb_data = data.get("circuit_breaker")
     if not isinstance(cb_data, dict):
         if cb_data is not None:
-            logger.warning("[config] 'hal.circuit_breaker' missing or not a dict. Falling back to default circuit breaker.")
+            logger.warning(
+                "[config] 'hal.circuit_breaker' missing or not a dict. Falling back to default circuit breaker."
+            )
         cb_out = default_cb
     else:
         try:
@@ -437,7 +499,9 @@ def _parse_hal(data: Any) -> HalConfig:
                 "success_threshold": int(cb_data.get("success_threshold", 2)),
             }
         except (ValueError, TypeError):
-            logger.warning("[config] 'hal.circuit_breaker' has invalid types. Falling back to default circuit breaker.")
+            logger.warning(
+                "[config] 'hal.circuit_breaker' has invalid types. Falling back to default circuit breaker."
+            )
             cb_out = default_cb
         else:
             if cb_out["failure_threshold"] < 1:
@@ -490,7 +554,9 @@ def _parse_hal(data: Any) -> HalConfig:
 def _parse_logging(data: Any) -> LoggingConfig:
     if not isinstance(data, dict):
         if data is not None:
-            logger.warning("[config] 'logging' section is not a mapping. Using defaults.")
+            logger.warning(
+                "[config] 'logging' section is not a mapping. Using defaults."
+            )
         return LoggingConfig()
 
     try:
@@ -506,7 +572,7 @@ def _parse_logging(data: Any) -> LoggingConfig:
         max_bytes=max_bytes,
         backup_count=backup_count,
         log_action_decisions=bool(data.get("log_action_decisions", True)),
-        log_approval_workflow=bool(data.get("log_approval_workflow", True))
+        log_approval_workflow=bool(data.get("log_approval_workflow", True)),
     )
 
 

--- a/ori/hal/mqtt_adapter.py
+++ b/ori/hal/mqtt_adapter.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generic MQTT telemetry adapter (subscribe + cache read pattern)."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError
+from ori.hal.mqtt_base import MqttCachedAdapter
+from ori.network.events import SensorReading
+
+_DEFAULT_PORT = 1883
+
+
+def _extract_path(data: Any, path: str) -> Any:
+    current = data
+    for part in path.split("."):
+        if isinstance(current, dict):
+            if part not in current:
+                raise AdapterReadError(
+                    f"MqttAdapter: path '{path}' not found in payload"
+                )
+            current = current[part]
+            continue
+        if isinstance(current, list):
+            try:
+                idx = int(part)
+            except ValueError as exc:
+                raise AdapterReadError(
+                    f"MqttAdapter: path '{path}' expects numeric list index at '{part}'"
+                ) from exc
+            if idx < 0 or idx >= len(current):
+                raise AdapterReadError(
+                    f"MqttAdapter: list index {idx} out of range for '{path}'"
+                )
+            current = current[idx]
+            continue
+        raise AdapterReadError(
+            f"MqttAdapter: cannot traverse path '{path}' through {type(current).__name__}"
+        )
+    return current
+
+
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    token = str(value).strip()
+    if not token:
+        raise AdapterReadError("MqttAdapter: empty value")
+    try:
+        return float(token)
+    except ValueError as exc:
+        raise AdapterReadError(f"MqttAdapter: value is not numeric: {value!r}") from exc
+
+
+def _clamp_quality(value: float) -> float:
+    return max(0.0, min(1.0, float(value)))
+
+
+class MqttAdapter(MqttCachedAdapter):
+    """Subscribe to one MQTT topic and return cached numeric sensor readings."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._sensor_type: str = ""
+        self._topic: str = ""
+        self._value_path: str = "value"
+        self._quality_path: str = ""
+        self._unit: str = ""
+
+    async def connect(self, config: dict) -> None:
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        if not sensor_type:
+            raise AdapterConnectionError("MqttAdapter: 'sensor_type' is required")
+
+        topic = str(config.get("topic", "")).strip()
+        if not topic:
+            raise AdapterConnectionError("MqttAdapter: 'topic' is required")
+
+        self._sensor_type = sensor_type
+        self._topic = topic
+        self._value_path = str(config.get("value_path", "value")).strip()
+        self._quality_path = str(config.get("quality_path", "")).strip()
+        self._unit = str(config.get("unit", "")).strip()
+
+        await self._connect_mqtt(
+            config=config,
+            topics=[topic],
+            default_port=_DEFAULT_PORT,
+            listener_name=f"mqtt-listener:{topic}",
+        )
+
+    async def _handle_message(self, topic: str, payload: Any) -> None:
+        parsed = self._parse_payload(payload)
+        raw_value = _extract_path(parsed, self._value_path)
+        value = _coerce_float(raw_value)
+
+        quality = 1.0
+        if self._quality_path:
+            raw_quality = _extract_path(parsed, self._quality_path)
+            quality = _clamp_quality(_coerce_float(raw_quality))
+
+        timestamp_ms = int(time.time() * 1000)
+        self._cache_value(
+            topic,
+            value,
+            {
+                "payload": parsed,
+                "quality": quality,
+                "timestamp_ms": timestamp_ms,
+            },
+        )
+
+    async def read(self, sensor_id: str) -> SensorReading:
+        self._ensure_aiomqtt_available()
+        if not self._connected:
+            raise AdapterReadError("MqttAdapter: not connected — call connect() first")
+        if self._breaker is None:
+            raise AdapterReadError("MqttAdapter: circuit breaker is not initialized")
+
+        async with self._breaker:
+            cached = self._cache.get(self._topic)
+            if cached is None:
+                raise AdapterReadError("MqttAdapter: no MQTT data cached yet")
+
+            value, timestamp_ms, raw_payload = cached
+            quality = 1.0
+            payload = raw_payload
+            if isinstance(raw_payload, dict):
+                payload = raw_payload.get("payload", raw_payload)
+                quality = _clamp_quality(float(raw_payload.get("quality", 1.0)))
+                ts = raw_payload.get("timestamp_ms")
+                if isinstance(ts, (int, float)):
+                    timestamp_ms = int(ts)
+
+            return SensorReading(
+                sensor_id=sensor_id,
+                sensor_type=self._sensor_type,
+                value=float(value),
+                unit=self._unit,
+                timestamp=timestamp_ms,
+                quality=quality,
+                metadata={
+                    "source": "mqtt",
+                    "topic": self._topic,
+                    "value_path": self._value_path,
+                    "broker_host": self._broker_host,
+                    "port": self._port,
+                    "raw_payload": payload,
+                },
+            )
+
+    async def close(self) -> None:
+        await self._close_mqtt()
+
+    @staticmethod
+    def _parse_payload(payload: Any) -> dict[str, Any]:
+        if isinstance(payload, (bytes, bytearray)):
+            text = bytes(payload).decode("utf-8", errors="replace").strip()
+        else:
+            text = str(payload).strip()
+        if not text:
+            raise AdapterReadError("MqttAdapter: empty MQTT payload")
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise AdapterReadError(
+                f"MqttAdapter: payload is not valid JSON: {exc}"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise AdapterReadError("MqttAdapter: payload must be a JSON object")
+        return parsed

--- a/ori/hal/protocol_registry.py
+++ b/ori/hal/protocol_registry.py
@@ -14,6 +14,7 @@ SUPPORTED_SENSOR_PROTOCOLS: frozenset[str] = frozenset(
         "victron",
         "zigbee",
         "lorawan",
+        "mqtt",
         "mqtt_perception",
         "usb_serial",
         "http",
@@ -53,6 +54,10 @@ def make_adapter(protocol: str) -> BaseAdapter:
         from ori.hal.lorawan_adapter import LoraWanAdapter
 
         return LoraWanAdapter()
+    if protocol == "mqtt":
+        from ori.hal.mqtt_adapter import MqttAdapter
+
+        return MqttAdapter()
     if protocol == "mqtt_perception":
         from ori.hal.mqtt_perception_adapter import MqttPerceptionAdapter
 

--- a/ori/reasoning/elevator.py
+++ b/ori/reasoning/elevator.py
@@ -46,6 +46,7 @@ class SkillContext:
     skill: Any  # Skill instance (loader.py step 14)
     event: OriEvent
     state_store: Any  # StateStore
+    trigger_name: str = ""
 
 
 def _now_ms() -> int:
@@ -726,7 +727,12 @@ class IntelligenceElevator:
                     )
                     actions = ["log_to_dashboard"]
 
-            context = SkillContext(skill=skill, event=event, state_store=state_store)
+            context = SkillContext(
+                skill=skill,
+                event=event,
+                state_store=state_store,
+                trigger_name=rule_res.rule_name if rule_res.matched else "",
+            )
             for action in actions:
                 await dispatcher.dispatch(
                     action=action,
@@ -792,7 +798,10 @@ class IntelligenceElevator:
                     actions.append("alert_sms")
 
             context = SkillContext(
-                skill=skill, event=synthetic_event, state_store=state_store
+                skill=skill,
+                event=synthetic_event,
+                state_store=state_store,
+                trigger_name="sensor.invalid_value",
             )
             for action in actions:
                 await dispatcher.dispatch(

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -21,6 +21,8 @@ import uuid
 from pathlib import Path
 from typing import Any
 
+from ori.actions.alert_failover import AlertFailoverSender
+from ori.actions.coap import CoAPAction
 from ori.actions.logger import LoggerAction
 from ori.actions.process_manager import ProcessManagerAction
 from ori.actions.relay import RelayAction
@@ -180,6 +182,7 @@ class OriRuntime:
         # ── Step C: Instantiate action executors and ActionDispatcher ─────────
         whatsapp_action = WhatsAppAction(provider=TwilioProvider())
         sms_action = SMSAction(state_store=self._state_store)
+        coap_action = CoAPAction(config=config.actions.coap)
         self._sms_action = sms_action
         logger_action = LoggerAction()
         process_manager_action = ProcessManagerAction()
@@ -226,7 +229,11 @@ class OriRuntime:
                 break
 
         primary_alert_channel = config.actions.primary_alert_channel
-        alert_sender = sms_action if primary_alert_channel == "sms" else whatsapp_action
+        alert_sender = AlertFailoverSender(
+            primary_channel=primary_alert_channel,
+            sms_sender=sms_action,
+            whatsapp_sender=whatsapp_action,
+        )
         causal_cfg = (
             config.reasoning.causal_memory
             if isinstance(config.reasoning.causal_memory, dict)
@@ -300,6 +307,28 @@ class OriRuntime:
         dispatcher.register_executor(
             "reset_kernel_subsystem", _exec_reset_kernel_subsystem
         )
+
+        async def _exec_coap_command(action: str, ctx: SkillContext) -> bool:
+            command_name, payload_override = _coap_command_from_context(ctx)
+            if not command_name:
+                logger.warning(
+                    "[runtime] coap_command requested but no command was resolved from trigger=%r "
+                    "(expected skill.config.coap.trigger_commands or event metadata coap_command)",
+                    getattr(ctx, "trigger_name", ""),
+                )
+                return False
+            ok = await coap_action.execute_command(
+                command_name=command_name,
+                payload_override=payload_override,
+            )
+            if not ok:
+                logger.warning(
+                    "[runtime] coap_command execution failed for command=%r",
+                    command_name,
+                )
+            return ok
+
+        dispatcher.register_executor("coap_command", _exec_coap_command)
 
         # log_to_dashboard — override built-in with device_id from config
         async def _exec_log_to_dashboard(action: str, *_: Any) -> None:
@@ -981,6 +1010,56 @@ def _kernel_subsystem_from_context(ctx: SkillContext) -> str:
         if isinstance(value, str) and value.strip():
             return value.strip()
     return ""
+
+
+def _coap_command_from_context(ctx: SkillContext) -> tuple[str, str | None]:
+    """Resolve CoAP command from event metadata and skill config.
+
+    Resolution order:
+    1. event.context["coap_command"] / ["coap_payload"]
+    2. reading.metadata["coap_command"] / ["coap_payload"]
+    3. skill.config.coap.trigger_commands[trigger_name]
+    4. skill.config.coap.default_command
+    """
+    if not ctx or not ctx.event:
+        return "", None
+
+    command_name = ""
+    payload_override: str | None = None
+
+    event_ctx = ctx.event.context if isinstance(ctx.event.context, dict) else {}
+    if isinstance(event_ctx.get("coap_command"), str):
+        command_name = str(event_ctx["coap_command"]).strip()
+    if event_ctx.get("coap_payload") is not None:
+        payload_override = str(event_ctx.get("coap_payload"))
+
+    reading = ctx.event.reading
+    metadata = reading.metadata if reading is not None else {}
+    if not command_name and isinstance(metadata.get("coap_command"), str):
+        command_name = str(metadata["coap_command"]).strip()
+    if payload_override is None and metadata.get("coap_payload") is not None:
+        payload_override = str(metadata.get("coap_payload"))
+
+    skill_cfg = getattr(getattr(ctx, "skill", None), "config", {}) or {}
+    if isinstance(skill_cfg, dict):
+        coap_cfg = skill_cfg.get("coap") or {}
+        if isinstance(coap_cfg, dict):
+            trigger_commands = coap_cfg.get("trigger_commands") or {}
+            if (
+                not command_name
+                and isinstance(trigger_commands, dict)
+                and isinstance(getattr(ctx, "trigger_name", ""), str)
+            ):
+                trigger_name = ctx.trigger_name.strip()
+                mapped = trigger_commands.get(trigger_name)
+                if isinstance(mapped, str) and mapped.strip():
+                    command_name = mapped.strip()
+            if not command_name:
+                default_command = coap_cfg.get("default_command")
+                if isinstance(default_command, str) and default_command.strip():
+                    command_name = default_command.strip()
+
+    return command_name, payload_override
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -158,30 +158,38 @@ class StateStore:
         self._db_path = db_path
         self._conn: Optional[sqlite3.Connection] = None
         self._write_lock = asyncio.Lock()
+        self._lifecycle_lock = asyncio.Lock()
 
     # ─── Lifecycle ────────────────────────────────────────────────────────────
 
     async def open(self) -> None:
         """Open the database connection and apply DDL migrations."""
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._open_sync)
+        async with self._lifecycle_lock:
+            if self._conn is not None:
+                return
+            loop = asyncio.get_running_loop()
+            conn = await loop.run_in_executor(None, self._open_sync)
+            self._conn = conn
 
-    def _open_sync(self) -> None:
-        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
-        self._conn.row_factory = sqlite3.Row
-        self._conn.execute("PRAGMA journal_mode=WAL;")
-        self._conn.execute("PRAGMA foreign_keys=ON;")
-        self._migrate_sync()
+    def _open_sync(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL;")
+        conn.execute("PRAGMA foreign_keys=ON;")
+        self._migrate_sync(conn)
+        return conn
 
     async def close(self) -> None:
-        if self._conn is not None:
-            loop = asyncio.get_running_loop()
-            await loop.run_in_executor(None, self._conn.close)
-            self._conn = None
+        async with self._lifecycle_lock:
+            async with self._write_lock:
+                conn = self._conn
+                self._conn = None
+            if conn is not None:
+                loop = asyncio.get_running_loop()
+                await loop.run_in_executor(None, conn.close)
 
-    def _migrate_sync(self) -> None:
-        assert self._conn is not None
-        self._conn.executescript(_DDL)
+    def _migrate_sync(self, conn: sqlite3.Connection) -> None:
+        conn.executescript(_DDL)
         # Add columns that may be missing from databases created before this
         # migration.  SQLite does not support ALTER TABLE ADD COLUMN IF NOT EXISTS
         # so duplicate-column errors are handled explicitly.
@@ -193,13 +201,23 @@ class StateStore:
             ("proposed_action", "TEXT"),
         ]
         for col, typedef in _new_reasoning_cols:
-            self._add_column_if_missing("reasoning_log", col, typedef)
-        self._conn.commit()
+            self._add_column_if_missing_on_conn(conn, "reasoning_log", col, typedef)
+        conn.commit()
 
     def _add_column_if_missing(self, table: str, column: str, typedef: str) -> None:
+        """Backward-compatible helper used by tests and migrations."""
         assert self._conn is not None
+        self._add_column_if_missing_on_conn(self._conn, table, column, typedef)
+
+    def _add_column_if_missing_on_conn(
+        self,
+        conn: sqlite3.Connection,
+        table: str,
+        column: str,
+        typedef: str,
+    ) -> None:
         try:
-            self._conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {typedef}")
+            conn.execute(f"ALTER TABLE {table} ADD COLUMN {column} {typedef}")
         except sqlite3.OperationalError as exc:
             msg = str(exc).lower()
             if "duplicate column name" in msg:
@@ -214,8 +232,19 @@ class StateStore:
 
     async def _run_read(self, fn, *args):
         """Run a synchronous read callable in the executor without write lock."""
+        if self._db_path == ":memory:":
+            # In-memory SQLite cannot be shared with short-lived read
+            # connections, so route reads through the primary connection
+            # under the write lock to avoid cross-thread misuse.
+            return await self._run_write(self._run_read_on_primary_conn, fn, *args)
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, partial(self._run_read_with_conn, fn, *args))
+        return await loop.run_in_executor(
+            None, partial(self._run_read_with_conn, fn, *args)
+        )
+
+    def _run_read_on_primary_conn(self, fn, *args):
+        assert self._conn is not None
+        return fn(self._conn, *args)
 
     def _run_read_with_conn(self, fn, *args):
         conn, close_when_done = self._open_read_conn_sync()
@@ -451,7 +480,9 @@ class StateStore:
         self, sensor_id: str, start_ms: int, end_ms: int
     ) -> list[tuple[int, float]]:
         """Fetch chart data from the appropriate compaction tier."""
-        return await self._run_read(self._get_timeseries_sync, sensor_id, start_ms, end_ms)
+        return await self._run_read(
+            self._get_timeseries_sync, sensor_id, start_ms, end_ms
+        )
 
     def _get_timeseries_sync(
         self, conn: sqlite3.Connection, sensor_id: str, start_ms: int, end_ms: int
@@ -745,7 +776,9 @@ class StateStore:
     async def store_causal_memory(
         self, pattern_key: str, resolution: str, confidence: float
     ) -> None:
-        await self._run_write(self._store_causal_sync, pattern_key, resolution, confidence)
+        await self._run_write(
+            self._store_causal_sync, pattern_key, resolution, confidence
+        )
 
     def _store_causal_sync(
         self, pattern_key: str, resolution: str, confidence: float
@@ -886,7 +919,9 @@ class StateStore:
         timestamp_ms: int,
     ) -> str:
         value_bucket = round(float(value) * 2.0) / 2.0
-        dt = datetime.datetime.fromtimestamp(timestamp_ms / 1000.0, tz=datetime.timezone.utc)
+        dt = datetime.datetime.fromtimestamp(
+            timestamp_ms / 1000.0, tz=datetime.timezone.utc
+        )
         two_hour_bucket = (dt.hour // 2) * 2
         day_of_week = dt.weekday()
         raw = (

--- a/tests/test_alert_failover.py
+++ b/tests/test_alert_failover.py
@@ -1,0 +1,77 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ori.actions.alert_failover import AlertFailoverSender
+
+
+class TestAlertFailoverSender:
+    @pytest.mark.asyncio
+    async def test_send_uses_primary_first(self):
+        sms = AsyncMock()
+        sms.send = AsyncMock(return_value=True)
+        whatsapp = AsyncMock()
+        whatsapp.send = AsyncMock(return_value=True)
+
+        sender = AlertFailoverSender(
+            primary_channel="sms",
+            sms_sender=sms,
+            whatsapp_sender=whatsapp,
+        )
+        ok = await sender.send("hello", "+2340000000")
+        assert ok is True
+        sms.send.assert_awaited_once()
+        whatsapp.send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_send_falls_back_to_secondary(self):
+        sms = AsyncMock()
+        sms.send = AsyncMock(return_value=False)
+        whatsapp = AsyncMock()
+        whatsapp.send = AsyncMock(return_value=True)
+
+        sender = AlertFailoverSender(
+            primary_channel="sms",
+            sms_sender=sms,
+            whatsapp_sender=whatsapp,
+        )
+        ok = await sender.send("hello", "+2340000000")
+        assert ok is True
+        sms.send.assert_awaited_once()
+        whatsapp.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_listen_returns_first_non_none_response(self):
+        sms = AsyncMock()
+        sms.listen_for_response = AsyncMock(return_value=None)
+        whatsapp = AsyncMock()
+        whatsapp.listen_for_response = AsyncMock(return_value="YES")
+
+        sender = AlertFailoverSender(
+            primary_channel="sms",
+            sms_sender=sms,
+            whatsapp_sender=whatsapp,
+        )
+        response = await sender.listen_for_response(
+            from_number="+2340000000",
+            timeout_seconds=3,
+        )
+        assert response == "YES"
+        sms.listen_for_response.assert_awaited_once()
+        whatsapp.listen_for_response.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_listen_without_compatible_senders_returns_none(self):
+        sender = AlertFailoverSender(
+            primary_channel="sms",
+            sms_sender=object(),
+            whatsapp_sender=object(),
+        )
+        response = await sender.listen_for_response(
+            from_number="+2340000000",
+            timeout_seconds=1,
+        )
+        assert response is None

--- a/tests/test_coap_action.py
+++ b/tests/test_coap_action.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ori.actions.coap import CoAPAction
+
+
+def _config() -> dict:
+    return {
+        "enabled": True,
+        "timeout_s": 0.5,
+        "retries": 1,
+        "allowed_hosts": ["192.168.1.70"],
+        "commands": {
+            "open_bypass_valve": {
+                "uri": "coap://192.168.1.70/actuators/bypass",
+                "method": "POST",
+                "payload": {"state": "open"},
+            }
+        },
+    }
+
+
+class _FakeResponse:
+    def __init__(self, code: str):
+        self.code = code
+
+
+class _FakeRequester:
+    def __init__(self, response):
+        self.response = response
+
+
+class _FakeContext:
+    def __init__(self, response):
+        self._response = response
+        self.messages = []
+        self.shutdown_called = False
+
+    def request(self, message):
+        self.messages.append(message)
+        return _FakeRequester(self._response)
+
+    async def shutdown(self):
+        self.shutdown_called = True
+
+
+class _FakeMessage:
+    def __init__(self, code, uri, payload):
+        self.code = code
+        self.uri = uri
+        self.payload = payload
+
+
+class TestCoAPAction:
+    @pytest.mark.asyncio
+    async def test_disabled_returns_false(self):
+        action = CoAPAction({"enabled": False})
+        assert await action.execute_command("open_bypass_valve") is False
+
+    @pytest.mark.asyncio
+    async def test_missing_aiocoap_returns_false(self):
+        action = CoAPAction(_config())
+        with (
+            patch("ori.actions.coap._AIOCOAP_AVAILABLE", False),
+            patch("ori.actions.coap._aiocoap", None),
+        ):
+            assert await action.execute_command("open_bypass_valve") is False
+
+    @pytest.mark.asyncio
+    async def test_successful_command(self):
+        action = CoAPAction(_config())
+        fake_context = _FakeContext(asyncio.Future())
+        fake_context._response.set_result(_FakeResponse("2.04 Changed"))
+        fake_aiocoap = SimpleNamespace(
+            POST="POST",
+            GET="GET",
+            PUT="PUT",
+            DELETE="DELETE",
+            Message=_FakeMessage,
+            Context=SimpleNamespace(
+                create_client_context=staticmethod(
+                    lambda: _completed_future(fake_context)
+                )
+            ),
+        )
+
+        with (
+            patch("ori.actions.coap._AIOCOAP_AVAILABLE", True),
+            patch("ori.actions.coap._aiocoap", fake_aiocoap),
+        ):
+            ok = await action.execute_command("open_bypass_valve")
+            assert ok is True
+            assert len(fake_context.messages) == 1
+            req = fake_context.messages[0]
+            assert req.uri == "coap://192.168.1.70/actuators/bypass"
+            assert req.code == "POST"
+            assert b'"state":"open"' in req.payload
+            assert fake_context.shutdown_called is True
+
+    @pytest.mark.asyncio
+    async def test_disallowed_host_refused(self):
+        cfg = _config()
+        cfg["commands"]["open_bypass_valve"]["uri"] = "coap://10.0.0.8/relay"
+        action = CoAPAction(cfg)
+        assert await action.execute_command("open_bypass_valve") is False
+
+    @pytest.mark.asyncio
+    async def test_non_success_response_returns_false(self):
+        action = CoAPAction(_config())
+        fake_context = _FakeContext(asyncio.Future())
+        fake_context._response.set_result(_FakeResponse("4.01 Unauthorized"))
+        fake_aiocoap = SimpleNamespace(
+            POST="POST",
+            GET="GET",
+            PUT="PUT",
+            DELETE="DELETE",
+            Message=_FakeMessage,
+            Context=SimpleNamespace(
+                create_client_context=staticmethod(
+                    lambda: _completed_future(fake_context)
+                )
+            ),
+        )
+        with (
+            patch("ori.actions.coap._AIOCOAP_AVAILABLE", True),
+            patch("ori.actions.coap._aiocoap", fake_aiocoap),
+        ):
+            assert await action.execute_command("open_bypass_valve") is False
+
+
+def _completed_future(value):
+    fut = asyncio.Future()
+    fut.set_result(value)
+    return fut

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -421,6 +421,16 @@ actions:
         cfg = Config.load(yaml_path)
         assert cfg.sensors[0].protocol == "mqtt_perception"
 
+    def test_accepts_mqtt_protocol(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._base_yaml(
+                "  - id: chiller-supply\n    type: temperature\n    protocol: mqtt\n    poll_interval_ms: 1000"
+            ),
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.sensors[0].protocol == "mqtt"
+
     def test_accepts_opcua_protocol(self, tmp_path):
         yaml_path = _write_yaml(
             tmp_path,
@@ -440,6 +450,71 @@ actions:
         )
         cfg = Config.load(yaml_path)
         assert cfg.sensors[0].protocol == "smart"
+
+    def test_accepts_coap_action_config(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+device:
+  id: dev-01
+  name: Test
+  location: Lagos
+sensors: []
+skills: []
+reasoning:
+  default_tier: local
+  local_model: x
+  model_path: /tmp
+  offline_fallback: rule
+gateway:
+  enabled: false
+  broker_url: mqtt://localhost
+actions:
+  primary_alert_channel: sms
+  coap:
+    enabled: true
+    allowed_hosts: ["192.168.1.70"]
+    commands:
+      open_bypass_valve:
+        uri: coap://192.168.1.70/actuators/bypass
+        method: POST
+        payload: '{"state":"open"}'
+""",
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.actions.coap["enabled"] is True
+        assert "open_bypass_valve" in cfg.actions.coap["commands"]
+
+    def test_rejects_coap_enabled_without_allowlist(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+device:
+  id: dev-01
+  name: Test
+  location: Lagos
+sensors: []
+skills: []
+reasoning:
+  default_tier: local
+  local_model: x
+  model_path: /tmp
+  offline_fallback: rule
+gateway:
+  enabled: false
+  broker_url: mqtt://localhost
+actions:
+  primary_alert_channel: sms
+  coap:
+    enabled: true
+    commands:
+      open_bypass_valve:
+        uri: coap://192.168.1.70/actuators/bypass
+        method: POST
+""",
+        )
+        with pytest.raises(ConfigValidationError, match="allowed_hosts"):
+            Config.load(yaml_path)
 
 
 # ─── SkillConfig / action_tier validation ─────────────────────────────────────

--- a/tests/test_mqtt_adapter.py
+++ b/tests/test_mqtt_adapter.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
+from ori.hal.mqtt_adapter import MqttAdapter
+
+
+def _config(
+    *,
+    sensor_type: str = "temperature",
+    topic: str = "plant/chiller/supply",
+    failure_threshold: int = 3,
+) -> dict:
+    return {
+        "sensor_id": "chiller-temp-01",
+        "sensor_type": sensor_type,
+        "broker_host": "192.168.1.20",
+        "port": 1883,
+        "topic": topic,
+        "value_path": "reading.value",
+        "quality_path": "reading.quality",
+        "unit": "celsius",
+        "circuit_breaker": {
+            "failure_threshold": failure_threshold,
+            "recovery_timeout_s": 300,
+            "success_threshold": 2,
+        },
+    }
+
+
+class _FakeTopic:
+    def __init__(self, value: str):
+        self._value = value
+
+    def __str__(self) -> str:
+        return self._value
+
+
+class _FakeMessage:
+    def __init__(self, topic: str, payload: bytes | str):
+        self.topic = _FakeTopic(topic)
+        self.payload = payload
+
+
+class _FakeMessageStream:
+    def __init__(self, queue: asyncio.Queue):
+        self._queue = queue
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self._queue.get()
+
+
+class _FakeClient:
+    def __init__(self, *, hostname: str, port: int, **kwargs):
+        self.hostname = hostname
+        self.port = port
+        self.kwargs = kwargs
+        self.subscriptions: list[str] = []
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self.closed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, _exc_type, _exc, _tb):
+        self.closed = True
+
+    async def subscribe(self, topic: str) -> None:
+        self.subscriptions.append(topic)
+
+    @property
+    def messages(self):
+        return _FakeMessageStream(self._queue)
+
+    async def emit(self, topic: str, payload: bytes | str) -> None:
+        await self._queue.put(_FakeMessage(topic, payload))
+
+
+class TestMqttAdapter:
+    @pytest.mark.asyncio
+    async def test_graceful_import_failure(self):
+        adapter = MqttAdapter()
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", False),
+            patch("ori.hal.mqtt_base._aiomqtt", None),
+        ):
+            with pytest.raises(AdapterConnectionError, match="aiomqtt"):
+                await adapter.connect(_config())
+
+    @pytest.mark.asyncio
+    async def test_cached_read(self):
+        adapter = MqttAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            cfg = _config()
+            await adapter.connect(cfg)
+            assert isinstance(adapter._client, _FakeClient)
+            await adapter._client.emit(
+                cfg["topic"],
+                b'{"reading":{"value":27.4,"quality":0.91}}',
+            )
+            await asyncio.sleep(0)
+
+            reading = await adapter.read("chiller-temp-01")
+            assert reading.sensor_type == "temperature"
+            assert reading.value == pytest.approx(27.4)
+            assert reading.quality == pytest.approx(0.91)
+            assert reading.unit == "celsius"
+            assert reading.metadata["source"] == "mqtt"
+            assert reading.metadata["topic"] == cfg["topic"]
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_no_data_yet(self):
+        adapter = MqttAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config())
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("chiller-temp-01")
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_invalid_payload_path_is_ignored(self):
+        adapter = MqttAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config())
+            assert isinstance(adapter._client, _FakeClient)
+
+            # Missing reading.value path -> listener logs and skips cache write.
+            await adapter._client.emit("plant/chiller/supply", b'{"bad":true}')
+            await asyncio.sleep(0)
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("chiller-temp-01")
+            await adapter.close()
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_integration(self):
+        adapter = MqttAdapter()
+        fake_aiomqtt = SimpleNamespace(Client=_FakeClient)
+
+        with (
+            patch("ori.hal.mqtt_base._AIOMQTT_AVAILABLE", True),
+            patch("ori.hal.mqtt_base._aiomqtt", fake_aiomqtt),
+        ):
+            await adapter.connect(_config(failure_threshold=2))
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("chiller-temp-01")
+            assert adapter._breaker is not None
+            assert adapter._breaker.state == CircuitState.CLOSED
+
+            with pytest.raises(AdapterReadError, match="no MQTT data cached yet"):
+                await adapter.read("chiller-temp-01")
+            assert adapter._breaker.state == CircuitState.OPEN
+
+            with pytest.raises(AdapterReadError, match="circuit breaker OPEN"):
+                await adapter.read("chiller-temp-01")
+            await adapter.close()

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -23,6 +23,7 @@ from ori.reasoning.elevator import SkillContext
 from ori.runtime import (
     OriRuntime,
     _build_local_llm,
+    _coap_command_from_context,
     _maybe_autoload_dotenv,
     _process_target_from_context,
     _resolve_local_model_file,
@@ -729,6 +730,60 @@ class TestProcessTargetResolution:
             }
         )
         assert _process_target_from_context(ctx) == (2, "B")
+
+
+class TestCoapCommandResolution:
+    def test_prefers_event_context(self):
+        reading = SensorReading(
+            sensor_id="s-1",
+            sensor_type="temperature",
+            value=1.0,
+            unit="celsius",
+            timestamp=1_700_000_000_000,
+            quality=1.0,
+        )
+        event = OriEvent.from_reading(reading, "dev-01")
+        event.context = {
+            "coap_command": "open_bypass_valve",
+            "coap_payload": '{"state":"open"}',
+        }
+        ctx = SkillContext(
+            skill=SimpleNamespace(config={}),
+            event=event,
+            state_store=None,
+            trigger_name="trigger-a",
+        )
+        command, payload = _coap_command_from_context(ctx)
+        assert command == "open_bypass_valve"
+        assert payload == '{"state":"open"}'
+
+    def test_uses_skill_trigger_mapping(self):
+        reading = SensorReading(
+            sensor_id="s-1",
+            sensor_type="temperature",
+            value=1.0,
+            unit="celsius",
+            timestamp=1_700_000_000_000,
+            quality=1.0,
+        )
+        event = OriEvent.from_reading(reading, "dev-01")
+        ctx = SkillContext(
+            skill=SimpleNamespace(
+                config={
+                    "coap": {
+                        "trigger_commands": {
+                            "probable_c2_or_shell_foothold": "isolate_vlan",
+                        }
+                    }
+                }
+            ),
+            event=event,
+            state_store=None,
+            trigger_name="probable_c2_or_shell_foothold",
+        )
+        command, payload = _coap_command_from_context(ctx)
+        assert command == "isolate_vlan"
+        assert payload is None
 
 
 class TestWebhookIngest:


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
