### PR TITLE
feat(network): update webhook auth to accept query

### DIFF
--- a/ori/network/sms_webhook.py
+++ b/ori/network/sms_webhook.py
@@ -91,7 +91,8 @@ class SMSWebhookServer:
             if url.path != self._path:
                 await self._respond(writer, 404, "not found")
                 return
-            if self._token and not self._authorized(request.headers):
+            query = parse_qs(url.query, keep_blank_values=True)
+            if self._token and not self._authorized(request.headers, query):
                 await self._respond(writer, 401, "unauthorized")
                 return
 
@@ -147,13 +148,22 @@ class SMSWebhookServer:
 
         return _HttpRequest(method=method, path=path, headers=headers, body=body)
 
-    def _authorized(self, headers: dict[str, str]) -> bool:
+    def _authorized(
+        self, headers: dict[str, str], query: dict[str, list[str]] | None = None
+    ) -> bool:
         token_header = headers.get("x-ori-webhook-token", "")
         if token_header == self._token:
             return True
         auth = headers.get("authorization", "")
         if auth.lower().startswith("bearer "):
             return auth[7:].strip() == self._token
+        if query:
+            token_values = query.get("token") or []
+            if token_values and token_values[0] == self._token:
+                logger.warning(
+                    "SMSWebhookServer: authenticated inbound webhook via query token fallback"
+                )
+                return True
         return False
 
     def _decode_payload(self, headers: dict[str, str], body: bytes) -> dict[str, Any]:

--- a/tests/test_sms_webhook.py
+++ b/tests/test_sms_webhook.py
@@ -31,9 +31,8 @@ class _FakeWriter:
 async def test_authorized_accepts_header_and_bearer():
     server = SMSWebhookServer(sms_action=AsyncMock(), token="secret-token")
     assert server._authorized({"x-ori-webhook-token": "secret-token"}) is True
-    assert (
-        server._authorized({"authorization": "Bearer secret-token"}) is True
-    )
+    assert server._authorized({"authorization": "Bearer secret-token"}) is True
+    assert server._authorized({}, {"token": ["secret-token"]}) is True
     assert server._authorized({"x-ori-webhook-token": "wrong"}) is False
 
 
@@ -112,6 +111,33 @@ async def test_handle_client_returns_200_for_valid_request():
             path="/webhooks/sms/africastalking",
             headers={
                 "x-ori-webhook-token": "secret-token",
+                "content-type": "application/x-www-form-urlencoded",
+            },
+            body=b"from=%2B2348000000000&text=YES",
+        )
+    )
+    reader = asyncio.StreamReader()
+    writer = _FakeWriter()
+
+    await server._handle_client(reader, writer)
+
+    text = writer.buffer.decode("utf-8", errors="replace")
+    assert "200 OK" in text
+    sms_action.ingest_incoming_webhook.assert_awaited_once_with(
+        {"from": "+2348000000000", "text": "YES"}
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_client_accepts_query_token_fallback():
+    sms_action = AsyncMock()
+    sms_action.ingest_incoming_webhook.return_value = True
+    server = SMSWebhookServer(sms_action=sms_action, token="secret-token")
+    server._read_request = AsyncMock(
+        return_value=_HttpRequest(
+            method="POST",
+            path="/webhooks/sms/africastalking?token=secret-token",
+            headers={
                 "content-type": "application/x-www-form-urlencoded",
             },
             body=b"from=%2B2348000000000&text=YES",


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
