### PR TITLE
docs(release): add v0.1.0-alpha.4 notes

### DIFF
--- a/docs/releases/alpha-release-notes.md
+++ b/docs/releases/alpha-release-notes.md
@@ -2,7 +2,8 @@
 
 ## Versioned Notes
 
-- [`v0.1.0-alpha.3`](v0.1.0-alpha.3.md) — latest alpha cut
+- [`v0.1.0-alpha.4`](v0.1.0-alpha.4.md) — latest alpha cut
+- [`v0.1.0-alpha.3`](v0.1.0-alpha.3.md)
 - [`v0.1.0-alpha.2`](v0.1.0-alpha.2.md)
 - [`v0.1.0-alpha.1`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha.1)
 - [`v0.1.0-alpha`](https://github.com/ori-platform/ori-runtime/releases/tag/v0.1.0-alpha)

--- a/docs/releases/v0.1.0-alpha.4.md
+++ b/docs/releases/v0.1.0-alpha.4.md
@@ -1,0 +1,54 @@
+# Ori Runtime — v0.1.0-alpha.4 Release Notes
+
+## Release Type
+
+Alpha pre-release (`v0.1.0-alpha.4`)
+
+## Compare
+
+`v0.1.0-alpha.3...v0.1.0-alpha.4`
+
+https://github.com/ori-platform/ori-runtime/compare/v0.1.0-alpha.3...v0.1.0-alpha.4
+
+## Summary
+
+This alpha.4 cut hardens runtime contracts and operational safety behavior
+while extending protocol and local validation coverage.
+
+## Included Since v0.1.0-alpha.3
+
+- MQTT + CoAP runtime expansion:
+  - generic MQTT telemetry adapter wiring
+  - CoAP command/action path support
+- SMS webhook auth hardening:
+  - query token fallback support for constrained webhook deployments
+- Runtime contract correctness fixes:
+  - deterministic event source + fingerprint propagation
+  - deduplicator wiring in poll path with cleanup in compaction loop
+  - elevator tier-floor handling from trigger `escalate_to`
+  - per-trigger Tier C approval timeout propagation
+  - prompt placeholder substitution + untrusted input sanitization path hardening
+- Documentation and principles updates:
+  - explicit authority-boundary lens added
+  - product wording normalized to “offline-capable safety core”
+- Developer experience:
+  - live PC health smoke report script improvements
+  - Termux model download URL correction for local setup reliability
+
+## Validation Snapshot
+
+- Full runtime suite passed:
+  - `pytest tests/ -v`
+  - Result: `901 passed, 5 skipped`
+
+## Known Limitations (Alpha)
+
+- Gateway/cloud reasoning tiers remain planned wiring; rule + local SLM paths
+  are the primary runtime path today.
+- Skill sandboxing remains Python-level restriction, not OS-level isolation.
+- API/config contracts can still evolve between alpha minor releases.
+
+## Next Milestone
+
+- Finalize cross-repo contract publication in `ori-specs` and align runtime,
+  gateway, CLI, and skills-hub against the shared versioned interfaces.


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
