### PR TITLE
Chore/precommit bootstrap enforcement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
@@ -41,6 +43,13 @@ jobs:
           else
             FROM_REF="${{ github.event.before }}"
             TO_REF="${{ github.sha }}"
+          fi
+          # Some event refs may not exist in shallow/partial clones.
+          # If either commit is unavailable, fall back to all-files mode.
+          if ! git cat-file -e "${FROM_REF}^{commit}" 2>/dev/null || ! git cat-file -e "${TO_REF}^{commit}" 2>/dev/null; then
+            echo "Pre-commit refs unavailable in checkout (from=$FROM_REF to=$TO_REF); running all-files."
+            pre-commit run --show-diff-on-failure --all-files
+            exit $?
           fi
           if echo "$FROM_REF" | grep -Eq '^0+$'; then
             echo "Running pre-commit on all files (no valid base ref)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,18 +31,24 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev]"
 
-      - name: Lint — ruff
-        run: ruff check ori/ tests/ skills/
-
-      - name: Check license headers
+      - name: Pre-commit (lint + format + hygiene)
+        env:
+          SKIP: no-commit-to-branch
         run: |
-          missing=$(grep -rL "SPDX-License-Identifier: Apache-2.0" ori/ tests/ --include="*.py" || true)
-          if [ -n "$missing" ]; then
-            echo "❌ Missing Apache-2.0 license header in:"
-            echo "$missing"
-            exit 1
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            FROM_REF="${{ github.event.pull_request.base.sha }}"
+            TO_REF="${{ github.event.pull_request.head.sha }}"
+          else
+            FROM_REF="${{ github.event.before }}"
+            TO_REF="${{ github.sha }}"
           fi
-          echo "✅ All Python files have license headers"
+          if echo "$FROM_REF" | grep -Eq '^0+$'; then
+            echo "Running pre-commit on all files (no valid base ref)"
+            pre-commit run --show-diff-on-failure --all-files
+          else
+            echo "Running pre-commit from $FROM_REF to $TO_REF"
+            pre-commit run --show-diff-on-failure --from-ref "$FROM_REF" --to-ref "$TO_REF"
+          fi
 
       - name: Guard Tier Escalation Invariants
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,16 +6,19 @@
 #
 # This is opt-in for contributors. CI enforces the same checks unconditionally.
 
+minimum_pre_commit_version: "3.7.0"
+default_install_hook_types: [pre-commit, pre-push, commit-msg]
+
 repos:
   # ── Ruff: lint + format ──────────────────────────────────────────────────────
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.9
     hooks:
       - id: ruff
-        args: [--fix]
-        files: ^(ori|tests|skills)/.*\.py$
+        args: [--fix, --exit-non-zero-on-fix]
+        files: ^(ori|tests|skills|scripts)/.*\.py$
       - id: ruff-format
-        files: ^(ori|tests|skills)/.*\.py$
+        files: ^(ori|tests|skills|scripts)/.*\.py$
 
   # ── License header check ─────────────────────────────────────────────────────
   - repo: local
@@ -30,10 +33,11 @@ repos:
             import pathlib
             import sys
 
+            roots = {"ori", "tests", "skills", "scripts"}
             missing = [
                 str(f)
                 for f in pathlib.Path(".").rglob("*.py")
-                if any(p in str(f) for p in ["ori/", "tests/"])
+                if f.parts and f.parts[0] in roots
                 and "SPDX-License-Identifier: Apache-2.0" not in f.read_text()
             ]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -263,6 +263,12 @@ Identify which [extension point](AGENTS.md) your change fits into:
 ### 4. Write Tests and Submit
 
 ```bash
+# First-time setup (deps + hooks + baseline formatting)
+bash scripts/bootstrap.sh
+
+# Run full quality gate locally (before pushing)
+pre-commit run --all-files
+
 # Run tests
 pytest tests/ -v
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ git clone https://github.com/ori-platform/ori-runtime.git
 cd ori-runtime
 python3 -m venv .venv
 source .venv/bin/activate
-pip install --upgrade pip          # required: old pip (<22) can't handle pyproject.toml editable installs
-pip install -e ".[dev]"
+
+# One-command dev bootstrap (deps + hooks + formatting baseline)
+bash scripts/bootstrap.sh
 
 # Verify everything works
 pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
+    "pre-commit>=3.7",
     "black>=24.0",
     "ruff>=0.4",
     "mypy>=1.10",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT_DIR}"
+
+if [[ -n "${VIRTUAL_ENV:-}" ]]; then
+  PYTHON_BIN="${VIRTUAL_ENV}/bin/python"
+else
+  PYTHON_BIN="${PYTHON_BIN:-python3}"
+fi
+
+if ! command -v "${PYTHON_BIN}" >/dev/null 2>&1; then
+  echo "Error: Python executable not found: ${PYTHON_BIN}" >&2
+  exit 1
+fi
+
+echo "Using Python: $(${PYTHON_BIN} --version)"
+
+echo "Installing/upgrading project dependencies..."
+"${PYTHON_BIN}" -m pip install --upgrade pip
+"${PYTHON_BIN}" -m pip install -e ".[dev]"
+
+echo "Installing git hooks..."
+"${PYTHON_BIN}" -m pre_commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg
+
+echo "Running pre-commit baseline pass..."
+if ! "${PYTHON_BIN}" -m pre_commit run --all-files; then
+  echo "pre-commit reported fixes or issues; re-running to verify clean state..."
+  "${PYTHON_BIN}" -m pre_commit run --all-files
+fi
+
+cat <<'MSG'
+Bootstrap complete.
+
+Next steps:
+  1) Run tests: pytest tests/ -v
+  2) Start runtime: python -m ori.runtime --config ori.yaml
+MSG


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [ ] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
