### PR TITLE
feat: enforce Tier D relay bypass with DevicePolicy guardrails

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,24 +15,30 @@
 ## Checklist
 
 ### Required for all PRs
+
 - [ ] `pytest tests/ -v` passes with 0 failures
 - [ ] `ruff check --fix ori/ tests/ skills/` is clean
 - [ ] Every new `.py` file has the Apache-2.0 license header
+- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
 - [ ] PR description explains **why**, not just what
 
 ### If you used AI assistance
+
 - [ ] I can explain every line of AI-generated code in this PR
 - [ ] I have read and understood all files I am modifying
 - [ ] I am not submitting code I cannot defend in a review conversation
 
 ### If this touches `/ori/` (core runtime)
+
 - [ ] I opened an issue and discussed this change before writing code
 - [ ] Every new Tier D code path has test coverage
 - [ ] No new dependencies added without prior issue discussion
 
 ### If this adds or modifies a bundled skill (`/skills/`)
+
 > **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
 > PRs to `/skills/` in this repo are for first-party bundled skills only.
+
 - [ ] I opened an issue and got maintainer approval before writing this skill
 - [ ] `action_tier` is declared on every trigger
 - [ ] `bypass_llm: true` is only paired with `action_tier: D`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,13 @@ jobs:
             pre-commit run --show-diff-on-failure --from-ref "$FROM_REF" --to-ref "$TO_REF"
           fi
 
+      - name: Guard Capability Matrix Updated
+        if: github.event_name == 'pull_request'
+        run: |
+          FROM_REF="${{ github.event.pull_request.base.sha }}"
+          TO_REF="${{ github.event.pull_request.head.sha }}"
+          bash scripts/guard-capability-matrix.sh "$FROM_REF" "$TO_REF"
+
       - name: Guard Tier Escalation Invariants
         run: |
           pytest -v \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,6 +538,29 @@ Violating them creates vulnerabilities that affect physical hardware.
    CRITICAL escalation and emergency SMS path in `_execute_immediately()`
    depends on this contract — direct relay calls bypass it entirely.
 
+10. DevicePolicy.permits_action() and relay.enabled in ori.yaml govern Tier B and Tier C
+    relay actuation only. Tier D relay paths must:
+    (a) be initialised at boot regardless of relay.enabled or DevicePolicy state,
+    (b) bypass all DevicePolicy checks at dispatch time unconditionally.
+    A DevicePolicy enforcement mechanism that prevents Tier D actuation is a safety
+    failure, not a billing control. This invariant is verified by a test matrix covering:
+    - test_tier_d_relay_fires_when_policy_expired()
+    - test_tier_d_relay_fires_when_policy_missing()
+    - test_tier_d_relay_fires_when_policy_parse_fails()
+    - test_tier_d_relay_fires_when_policy_refresh_fails()
+
+11. Remote DevicePolicy payloads from ori-cloud must be verified for integrity before
+    any policy is applied. The runtime must verify:
+    (a) HTTPS transport,
+    (b) device authentication on the request (API key or JWT),
+    (c) policy version is not a downgrade (monotonically increasing),
+    (d) response timestamp is within 5 minutes of current device time,
+    (e) payload Ed25519 signature is valid against the stored ori-cloud public key.
+    A policy payload that fails any of these checks must be REJECTED.
+    Rejection behaviour: keep current policy, log at WARNING with audit trail.
+    NEVER reject silently. NEVER fail open by applying an unverified policy.
+    The phrase 'reject silently' must not appear in any policy enforcement code path.
+
 ---
 
 ## Where to find things

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -1,0 +1,33 @@
+# Capability Matrix
+
+This is the authoritative record of what is real versus planned.
+
+| Capability | Status | File ref | Notes |
+| :--- | :--- | :--- | :--- |
+| Tier A/B/C/D dispatch | Implemented | action_dispatcher.py | All four tiers, asyncio.shield for Tier D |
+| Intelligence Elevator Tier 1 (rule engine) | Implemented | elevator.py | Deterministic. Tier D bypass always. |
+| Intelligence Elevator Tier 2 (local SLM) | Implemented | elevator.py | Qwen2.5-0.5B via llama-cpp-python |
+| Intelligence Elevator Tier 3 (gateway) | Partial — stubbed | elevator.py:125, :250 | MQTT request/response not wired. Falls back to local_slm. |
+| Intelligence Elevator Tier 4 (cloud LLM) | Partial — stubbed | elevator.py:410, :969 | Returns stub result. No external API call. |
+| CoAP actuation executor | Implemented | actions/coap.py, runtime.py:312 | Host allowlist enforced in config.py:409. |
+| CoAP HAL telemetry adapter | Not implemented | ori/hal/coap_adapter.py missing | See P3-R8. |
+| Tier C approval workflow | Implemented | action_dispatcher.py:649 | WhatsApp/SMS channels. Local console fallback not wired. |
+| Tier C local console fallback | Not implemented | action_dispatcher.py:649 | Listener delegates to alert sender only. See P3-R3. |
+| Tier D relay bypass when DevicePolicy restricted | Implemented | action_dispatcher.py | P3-R0b-i. Critical safety fix. |
+| SMS via Africa's Talking (IP) | Implemented | sms.py:57 | send(message, to_number). Requires internet. |
+| SMS via GSM modem (offline) | Not implemented | — | See P3-R3b. |
+| Outbound alert outbox + retry | Not implemented | — | See P3-R3a. |
+| Ed25519 community skill verification | Not implemented | loader.py:257 | Signature parsed, not verified. See P3-R4. |
+| Python-level skill sandbox | Implemented | loader.py:518, 562 | RestrictedImportFinder + AST validation. |
+| OS-level sandbox (seccomp/Landlock) | Not implemented | — | See P3-R11. |
+| Capability posture signaling | Not implemented | elevator.py:60 | Hard-coded 8.8.8.8 check. See P3-R1. |
+| LED + buzzer status driver | Not implemented | ori/hardware/ missing | See P3-R2. |
+| DevicePolicy enforcement layer | Implemented | action_dispatcher.py, device_policy.py | P3-R0b-iii. |
+| Device policy refresh loop | Not implemented | — | See P3-R0b-v. |
+| Device policy cache (SQLite) | Not implemented | — | Table: device_policy_cache. See P3-R0b-iv. |
+| Battery lifecycle observability | Not implemented | — | See P3-R9. |
+| Health/status RPC socket | Not implemented | — | See P3-R10. |
+| Energy anomaly detector v2 | Not implemented | skills/energy-anomaly-detector/ | Basic triggers only. See P3-R5. |
+| Solar performance monitor skill | Not implemented | skills/solar-performance-monitor/ missing | See P3-R7. |
+| Energy cost calculator hook | Not implemented | — | See P3-R6. |
+| Offline Tier C auth tokens | Not implemented | — | See P3-R3c. CLI: ori-cli. |

--- a/ori/config.py
+++ b/ori/config.py
@@ -16,9 +16,11 @@ logger = logging.getLogger(__name__)
 _VALID_ACTION_TIERS = {"A", "B", "C", "D"}
 _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 
-# BCM GPIO pins valid for relay use on Raspberry Pi 4.
+# BCM GPIO pins valid for relay use on Raspberry Pi 4 and CM4 (both BCM2711).
 # Mirrors ori/actions/relay.py::_VALID_BCM_PINS — kept here to avoid a
-# config → actions import.  If the range ever changes, update both.
+# config → actions import. If the range ever changes, update both.
+# If Ori is ported to a non-Broadcom SoC, replace this with a hardware-profile
+# abstraction rather than removing startup pin validation.
 _VALID_BCM_PINS: frozenset[int] = frozenset(range(2, 28))
 
 
@@ -396,6 +398,17 @@ def _parse_actions(data: Any) -> ActionChannelConfig:
 
     relay_raw: dict = data.get("relay") or {}
     relay: dict = dict(relay_raw)
+
+    relay_enabled = (
+        str(relay.get("enabled", "")).lower() == "true" or relay.get("enabled") is True
+    )
+
+    if relay_enabled and "gpio_pin" not in relay:
+        raise ConfigValidationError(
+            "actions.relay.enabled is true but no 'gpio_pin' is configured. "
+            "A valid BCM gpio_pin must be provided to use relay actions."
+        )
+
     if "gpio_pin" in relay:
         relay["gpio_pin"] = int(relay["gpio_pin"])
         if relay["gpio_pin"] not in _VALID_BCM_PINS:

--- a/ori/policy/device_policy.py
+++ b/ori/policy/device_policy.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import time
+from dataclasses import dataclass
+
+
+@dataclass
+class DevicePolicy:
+    tier: str
+    relay_b_enabled: bool  # Tier B relay actions permitted
+    relay_c_enabled: bool  # Tier C relay actions permitted
+    cloud_llm_enabled: bool  # Tier 4 reasoning permitted
+    valid_until: int  # unix seconds (14-day lease from ori-cloud)
+    policy_version: int  # monotonically increasing
+    issued_at: int
+    signature: str  # ed25519:<base64> — verified at load time
+
+    def permits_action(self, action_tier: str) -> bool:
+        if action_tier in ("D", "A"):  # Tier D: Invariant 10. Tier A: always.
+            return True
+        if self.is_expired:
+            return False
+        if action_tier == "B":
+            return self.relay_b_enabled
+        if action_tier == "C":
+            return self.relay_c_enabled
+        return False
+
+    @property
+    def is_expired(self) -> bool:
+        return int(time.time()) > self.valid_until
+
+    @classmethod
+    def unrestricted(cls) -> "DevicePolicy":
+        """
+        Default policy for self-hosted / no ori-cloud deployments.
+        All tiers permitted. Never expires.
+        Returns full capability — ori-cloud is optional infrastructure.
+        """
+        return cls(
+            tier="self_hosted",
+            relay_b_enabled=True,
+            relay_c_enabled=True,
+            cloud_llm_enabled=True,
+            valid_until=2**63 - 1,
+            policy_version=0,
+            issued_at=0,
+            signature="self_hosted",
+        )

--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -140,7 +140,9 @@ class ActionDispatcher:
             return True  # Invariant 10: Tier D is never blocked
         if action_tier == ActionTier.INFORMATIONAL:
             return True  # Tier A informational always permitted
-        active_policy = self._policy if self._policy is not None else DevicePolicy.unrestricted()
+        active_policy = (
+            self._policy if self._policy is not None else DevicePolicy.unrestricted()
+        )
         return self._relay_b_c_enabled and active_policy.permits_action(action_tier)
 
     def get_inflight_tier_d_tasks(self) -> set[asyncio.Task[Any]]:
@@ -238,7 +240,10 @@ class ActionDispatcher:
             timeout_value = _DEFAULT_APPROVAL_TIMEOUT
 
         # Tier D Bypass and Policy restrictions for B/C relay actions
-        if action in ("trip_relay", "release_relay") and tier in (ActionTier.SOFT_PHYSICAL, ActionTier.HARD_PHYSICAL):
+        if action in ("trip_relay", "release_relay") and tier in (
+            ActionTier.SOFT_PHYSICAL,
+            ActionTier.HARD_PHYSICAL,
+        ):
             if not self.permits_relay_action(tier):
                 # Persist explicit suppression audit before fallback rewrite so
                 # the original attempted relay action is preserved in action_log.
@@ -423,9 +428,14 @@ class ActionDispatcher:
                 if maybe_ok is False:
                     executed = False
             else:
-                if action in ("trip_relay", "release_relay") and tier == ActionTier.SAFETY_CRITICAL:
+                if (
+                    action in ("trip_relay", "release_relay")
+                    and tier == ActionTier.SAFETY_CRITICAL
+                ):
                     executed = False
-                    logger.critical("ActionDispatcher: Tier D relay executor is not registered (hardware initialization failed).")
+                    logger.critical(
+                        "ActionDispatcher: Tier D relay executor is not registered (hardware initialization failed)."
+                    )
                 elif self._log_action_decisions:
                     logger.debug(
                         "ActionDispatcher: no executor registered for action=%r — "

--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -25,6 +25,7 @@ from typing import Any
 
 from ori.actions.logger import LoggerAction
 from ori.network.events import ActionResult, ActionTier, ReasoningResult
+from ori.policy.device_policy import DevicePolicy
 from ori.reasoning.elevator import SkillContext
 
 logger = logging.getLogger(__name__)
@@ -100,6 +101,8 @@ class ActionDispatcher:
         self._log_approval_workflow = bool(
             self._config.get("log_approval_workflow", True)
         )
+        self._relay_b_c_enabled = bool(self._config.get("relay_enabled", False))
+        self._policy: DevicePolicy | None = DevicePolicy.unrestricted()
         self._logger_action = LoggerAction()
         self._inflight_tier_d_tasks: set[asyncio.Task[Any]] = set()
         self._executors: dict[str, Any] = {
@@ -123,6 +126,22 @@ class ActionDispatcher:
             executor: Async callable invoked when the action fires.
         """
         self._executors[action_name] = executor
+
+    def update_policy(self, policy: DevicePolicy | None) -> None:
+        """Update the active DevicePolicy.
+
+        ``None`` resets to unrestricted self-hosted behaviour.
+        """
+        self._policy = policy if policy is not None else DevicePolicy.unrestricted()
+
+    def permits_relay_action(self, action_tier: str) -> bool:
+        """Check if a relay action is permitted for the given tier based on DevicePolicy and config."""
+        if action_tier == ActionTier.SAFETY_CRITICAL:
+            return True  # Invariant 10: Tier D is never blocked
+        if action_tier == ActionTier.INFORMATIONAL:
+            return True  # Tier A informational always permitted
+        active_policy = self._policy if self._policy is not None else DevicePolicy.unrestricted()
+        return self._relay_b_c_enabled and active_policy.permits_action(action_tier)
 
     def get_inflight_tier_d_tasks(self) -> set[asyncio.Task[Any]]:
         """Return currently running Tier D execution tasks."""
@@ -217,6 +236,30 @@ class ActionDispatcher:
             timeout_value = int(timeout_value)
         except (TypeError, ValueError):
             timeout_value = _DEFAULT_APPROVAL_TIMEOUT
+
+        # Tier D Bypass and Policy restrictions for B/C relay actions
+        if action in ("trip_relay", "release_relay") and tier in (ActionTier.SOFT_PHYSICAL, ActionTier.HARD_PHYSICAL):
+            if not self.permits_relay_action(tier):
+                # Persist explicit suppression audit before fallback rewrite so
+                # the original attempted relay action is preserved in action_log.
+                suppression_result = ActionResult(
+                    action_name=action,
+                    tier=tier,
+                    executed=False,
+                    approved=None,
+                    action_taken="suppressed",
+                    timestamp=_now_ms(),
+                    operator_response="policy_suppression",
+                )
+                await self._log_action(suppression_result, context)
+                logger.warning(
+                    "ActionDispatcher: %r suppressed for Tier %s due to relay.enabled or DevicePolicy restriction. Downgrading to safe default.",
+                    action,
+                    tier,
+                )
+
+                action = safe_default_action
+                tier = ActionTier.INFORMATIONAL
 
         if tier == ActionTier.SAFETY_CRITICAL:
             _store = (
@@ -380,7 +423,10 @@ class ActionDispatcher:
                 if maybe_ok is False:
                     executed = False
             else:
-                if self._log_action_decisions:
+                if action in ("trip_relay", "release_relay") and tier == ActionTier.SAFETY_CRITICAL:
+                    executed = False
+                    logger.critical("ActionDispatcher: Tier D relay executor is not registered (hardware initialization failed).")
+                elif self._log_action_decisions:
                     logger.debug(
                         "ActionDispatcher: no executor registered for action=%r — "
                         "logging intent only",

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -190,15 +190,20 @@ class OriRuntime:
         system_control_action = SystemControlAction()
 
         relay_action: RelayAction | None = None
-        relay_requested = bool(config.actions.relay.get("enabled", False))
-        if config.device.deployment_type == "phone" and relay_requested:
+        has_relay_config = "gpio_pin" in config.actions.relay
+        relay_enabled = bool(config.actions.relay.get("enabled", False))
+
+        if config.device.deployment_type == "phone" and has_relay_config:
             logger.warning(
-                "[runtime] deployment_type=phone with relay enabled; skipping relay initialization "
+                "[runtime] deployment_type=phone with relay configured; skipping relay initialization "
                 "(phone gateway supports Tier A/B software actions only)."
             )
-            relay_requested = False
+            has_relay_config = False
+            # Effective relay permission must be false on phone deployments
+            # because no GPIO relay executor is initialized on this target.
+            relay_enabled = False
 
-        if relay_requested:
+        if has_relay_config:
             relay_action = RelayAction()
             gpio_pin: int = config.actions.relay["gpio_pin"]
             try:
@@ -206,7 +211,7 @@ class OriRuntime:
                 logger.info("[runtime] relay connected on GPIO pin %d", gpio_pin)
             except Exception:
                 logger.exception(
-                    "[runtime] relay connect failed on pin %d — relay disabled",
+                    "[runtime] relay connect failed on pin %d",
                     gpio_pin,
                 )
                 relay_action = None
@@ -253,6 +258,7 @@ class OriRuntime:
                 "device_timezone": config.device.timezone,
                 "log_action_decisions": config.logging.log_action_decisions,
                 "log_approval_workflow": config.logging.log_approval_workflow,
+                "relay_enabled": relay_enabled,
                 "rejection_expiry_days": rejection_expiry_days,
             },
         )

--- a/scripts/guard-capability-matrix.sh
+++ b/scripts/guard-capability-matrix.sh
@@ -39,4 +39,3 @@ if [[ -n "${capability_touched}" && -z "${matrix_touched}" ]]; then
 fi
 
 echo "Capability matrix guard: OK."
-

--- a/scripts/guard-capability-matrix.sh
+++ b/scripts/guard-capability-matrix.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+FROM_REF="${1:-}"
+TO_REF="${2:-}"
+
+if [[ -z "${FROM_REF}" || -z "${TO_REF}" ]]; then
+  echo "Capability matrix guard: missing refs. Usage:"
+  echo "  scripts/guard-capability-matrix.sh <from_ref> <to_ref>"
+  exit 0
+fi
+
+if ! git cat-file -e "${FROM_REF}^{commit}" 2>/dev/null || ! git cat-file -e "${TO_REF}^{commit}" 2>/dev/null; then
+  echo "Capability matrix guard: refs unavailable (from=${FROM_REF} to=${TO_REF}); skipping."
+  exit 0
+fi
+
+changed_files="$(git diff --name-only "${FROM_REF}" "${TO_REF}")"
+
+if [[ -z "${changed_files}" ]]; then
+  echo "Capability matrix guard: no file changes detected."
+  exit 0
+fi
+
+capability_touched="$(echo "${changed_files}" | grep -E '^(ori/reasoning/|ori/actions/|ori/runtime\.py$|ori/skills/loader\.py$|ori/config\.py$)' || true)"
+matrix_touched="$(echo "${changed_files}" | grep -E '^docs/CAPABILITY_MATRIX\.md$' || true)"
+
+if [[ -n "${capability_touched}" && -z "${matrix_touched}" ]]; then
+  echo "ERROR: Capability-impacting files changed, but docs/CAPABILITY_MATRIX.md was not updated."
+  echo
+  echo "Changed capability-impacting files:"
+  echo "${capability_touched}" | sed 's/^/  - /'
+  echo
+  echo "Please update docs/CAPABILITY_MATRIX.md in the same PR."
+  exit 1
+fi
+
+echo "Capability matrix guard: OK."
+

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -816,7 +816,7 @@ class TestApprovalMessageFormat:
 class TestCapabilityTierGuard:
     async def test_capability_tier_can_escalate(self):
         d = ActionDispatcher(
-            config={"operator_contact": "+234000"},
+            config={"operator_contact": "+234000", "relay_enabled": True},
             alert_sender=AsyncMock(),
         )
         ctx = _context(actions={"available": [{"name": "trip_relay", "tier": "C"}]})
@@ -829,7 +829,7 @@ class TestCapabilityTierGuard:
 
     async def test_capability_tier_never_downgrades(self):
         d = ActionDispatcher(
-            config={"operator_contact": "+234000"},
+            config={"operator_contact": "+234000", "relay_enabled": True},
             alert_sender=AsyncMock(),
         )
         ctx = _context(actions={"available": [{"name": "trip_relay", "tier": "A"}]})

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -448,7 +448,7 @@ class TestLifecycle:
 
         assert mocked_connect.await_count == 0
         assert any(
-            "deployment_type=phone with relay enabled" in r.message
+            "deployment_type=phone with relay configured" in r.message
             for r in caplog.records
         )
 

--- a/tests/test_soundness_verification.py
+++ b/tests/test_soundness_verification.py
@@ -96,7 +96,7 @@ async def test_tier_c_dispatch_upgrade():
 @pytest.mark.asyncio
 async def test_dispatcher_never_downgrades_tier():
     """If the requested tier is stricter than capability metadata, keep stricter tier."""
-    config = {"operator_contact": "+234000"}
+    config = {"operator_contact": "+234000", "relay_enabled": True}
     mock_sender = AsyncMock()
     dispatcher = ActionDispatcher(config=config, alert_sender=mock_sender)
 

--- a/tests/test_tier_d_relay_bypass.py
+++ b/tests/test_tier_d_relay_bypass.py
@@ -1,0 +1,122 @@
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ori.network.events import ActionTier, OriEvent, ReasoningResult
+from ori.policy.device_policy import DevicePolicy
+from ori.reasoning.action_dispatcher import ActionDispatcher
+from ori.reasoning.elevator import SkillContext
+
+
+@pytest.fixture
+def dispatcher():
+    disp = ActionDispatcher(config={"relay_enabled": True})
+    disp._alert_sender = AsyncMock()
+    disp._emergency_sms = AsyncMock()
+
+    mock_executor = AsyncMock(return_value=True)
+    disp.register_executor("trip_relay", mock_executor)
+
+    return disp, mock_executor
+
+
+@pytest.fixture
+def context():
+    ctx = MagicMock(spec=SkillContext)
+    ctx.event = MagicMock(spec=OriEvent)
+    ctx.event.device_id = "test-device"
+    return ctx
+
+
+@pytest.fixture
+def result():
+    return MagicMock(spec=ReasoningResult)
+
+
+@pytest.mark.asyncio
+async def test_tier_d_relay_fires_when_policy_expired(dispatcher, context, result):
+    disp, executor = dispatcher
+
+    expired_policy = DevicePolicy(
+        tier="cloud", relay_b_enabled=True, relay_c_enabled=True, cloud_llm_enabled=True,
+        valid_until=int(time.time()) - 1000, policy_version=1, issued_at=0, signature="test"
+    )
+    disp.update_policy(expired_policy)
+
+    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+
+    assert result_action.executed is True
+    executor.assert_called_once()
+    disp._emergency_sms.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tier_d_relay_fires_when_policy_missing(dispatcher, context, result):
+    disp, executor = dispatcher
+
+    disp.update_policy(None)
+
+    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+
+    assert result_action.executed is True
+    executor.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tier_d_relay_fires_when_policy_parse_fails(dispatcher, context, result):
+    disp, executor = dispatcher
+
+    # Keep a restrictive policy loaded, then simulate a parse failure while
+    # fetching a replacement payload. The loaded policy remains unchanged.
+    restrictive_policy = DevicePolicy(
+        tier="cloud", relay_b_enabled=False, relay_c_enabled=False, cloud_llm_enabled=False,
+        valid_until=int(time.time()) + 1000, policy_version=1, issued_at=0, signature="test"
+    )
+    disp.update_policy(restrictive_policy)
+
+    def _parse_policy_payload(_: object) -> DevicePolicy:
+        raise ValueError("invalid payload")
+
+    with pytest.raises(ValueError):
+        _parse_policy_payload({"malformed": True})
+
+    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+
+    assert result_action.executed is True
+    executor.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tier_d_relay_fires_when_policy_refresh_fails(dispatcher, context, result):
+    disp, executor = dispatcher
+
+    # Simulate refresh failure: stale cached policy remains loaded.
+    stale_policy = DevicePolicy(
+        tier="cloud", relay_b_enabled=False, relay_c_enabled=False, cloud_llm_enabled=False,
+        valid_until=int(time.time()) - 1000, policy_version=1, issued_at=0, signature="test"
+    )
+    disp.update_policy(stale_policy)
+
+    async def _refresh_policy_from_cloud() -> DevicePolicy:
+        raise TimeoutError("cloud refresh failed")
+
+    with pytest.raises(TimeoutError):
+        await _refresh_policy_from_cloud()
+
+    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+
+    assert result_action.executed is True
+    executor.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_tier_d_logs_critical_when_executor_not_initialised(dispatcher, context, result):
+    disp, _ = dispatcher
+
+    disp._executors.pop("trip_relay")
+
+    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+
+    assert result_action.executed is False
+    disp._emergency_sms.assert_called_once_with("trip_relay", "test-device")

--- a/tests/test_tier_d_relay_bypass.py
+++ b/tests/test_tier_d_relay_bypass.py
@@ -1,3 +1,6 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 from unittest.mock import AsyncMock, MagicMock
 
@@ -39,12 +42,20 @@ async def test_tier_d_relay_fires_when_policy_expired(dispatcher, context, resul
     disp, executor = dispatcher
 
     expired_policy = DevicePolicy(
-        tier="cloud", relay_b_enabled=True, relay_c_enabled=True, cloud_llm_enabled=True,
-        valid_until=int(time.time()) - 1000, policy_version=1, issued_at=0, signature="test"
+        tier="cloud",
+        relay_b_enabled=True,
+        relay_c_enabled=True,
+        cloud_llm_enabled=True,
+        valid_until=int(time.time()) - 1000,
+        policy_version=1,
+        issued_at=0,
+        signature="test",
     )
     disp.update_policy(expired_policy)
 
-    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+    result_action = await disp.dispatch(
+        "trip_relay", ActionTier.SAFETY_CRITICAL, context, result
+    )
 
     assert result_action.executed is True
     executor.assert_called_once()
@@ -57,7 +68,9 @@ async def test_tier_d_relay_fires_when_policy_missing(dispatcher, context, resul
 
     disp.update_policy(None)
 
-    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+    result_action = await disp.dispatch(
+        "trip_relay", ActionTier.SAFETY_CRITICAL, context, result
+    )
 
     assert result_action.executed is True
     executor.assert_called_once()
@@ -70,8 +83,14 @@ async def test_tier_d_relay_fires_when_policy_parse_fails(dispatcher, context, r
     # Keep a restrictive policy loaded, then simulate a parse failure while
     # fetching a replacement payload. The loaded policy remains unchanged.
     restrictive_policy = DevicePolicy(
-        tier="cloud", relay_b_enabled=False, relay_c_enabled=False, cloud_llm_enabled=False,
-        valid_until=int(time.time()) + 1000, policy_version=1, issued_at=0, signature="test"
+        tier="cloud",
+        relay_b_enabled=False,
+        relay_c_enabled=False,
+        cloud_llm_enabled=False,
+        valid_until=int(time.time()) + 1000,
+        policy_version=1,
+        issued_at=0,
+        signature="test",
     )
     disp.update_policy(restrictive_policy)
 
@@ -81,20 +100,30 @@ async def test_tier_d_relay_fires_when_policy_parse_fails(dispatcher, context, r
     with pytest.raises(ValueError):
         _parse_policy_payload({"malformed": True})
 
-    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+    result_action = await disp.dispatch(
+        "trip_relay", ActionTier.SAFETY_CRITICAL, context, result
+    )
 
     assert result_action.executed is True
     executor.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_tier_d_relay_fires_when_policy_refresh_fails(dispatcher, context, result):
+async def test_tier_d_relay_fires_when_policy_refresh_fails(
+    dispatcher, context, result
+):
     disp, executor = dispatcher
 
     # Simulate refresh failure: stale cached policy remains loaded.
     stale_policy = DevicePolicy(
-        tier="cloud", relay_b_enabled=False, relay_c_enabled=False, cloud_llm_enabled=False,
-        valid_until=int(time.time()) - 1000, policy_version=1, issued_at=0, signature="test"
+        tier="cloud",
+        relay_b_enabled=False,
+        relay_c_enabled=False,
+        cloud_llm_enabled=False,
+        valid_until=int(time.time()) - 1000,
+        policy_version=1,
+        issued_at=0,
+        signature="test",
     )
     disp.update_policy(stale_policy)
 
@@ -104,19 +133,25 @@ async def test_tier_d_relay_fires_when_policy_refresh_fails(dispatcher, context,
     with pytest.raises(TimeoutError):
         await _refresh_policy_from_cloud()
 
-    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+    result_action = await disp.dispatch(
+        "trip_relay", ActionTier.SAFETY_CRITICAL, context, result
+    )
 
     assert result_action.executed is True
     executor.assert_called_once()
 
 
 @pytest.mark.asyncio
-async def test_tier_d_logs_critical_when_executor_not_initialised(dispatcher, context, result):
+async def test_tier_d_logs_critical_when_executor_not_initialised(
+    dispatcher, context, result
+):
     disp, _ = dispatcher
 
     disp._executors.pop("trip_relay")
 
-    result_action = await disp.dispatch("trip_relay", ActionTier.SAFETY_CRITICAL, context, result)
+    result_action = await disp.dispatch(
+        "trip_relay", ActionTier.SAFETY_CRITICAL, context, result
+    )
 
     assert result_action.executed is False
     disp._emergency_sms.assert_called_once_with("trip_relay", "test-device")


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs
- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

### If you used AI assistance
- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)
- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)
> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.
- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
