### PR TITLE
Alert outbox retry

### DIFF
--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -16,7 +16,7 @@ This is the authoritative record of what is real versus planned.
 | Tier D relay bypass when DevicePolicy restricted | Implemented | action_dispatcher.py | P3-R0b-i. Critical safety fix. |
 | SMS via Africa's Talking (IP) | Implemented | sms.py:57 | send(message, to_number). Requires internet. |
 | SMS via GSM modem (offline) | Not implemented | — | See P3-R3b. |
-| Outbound alert outbox + retry | Not implemented | — | See P3-R3a. |
+| Outbound alert outbox + retry | Implemented | runtime.py, state/store.py | Store-and-retry queue with Tier D critical escalation and non-Tier-D abandon threshold. |
 | Ed25519 community skill verification | Not implemented | loader.py:257 | Signature parsed, not verified. See P3-R4. |
 | Python-level skill sandbox | Implemented | loader.py:518, 562 | RestrictedImportFinder + AST validation. |
 | OS-level sandbox (seccomp/Landlock) | Not implemented | — | See P3-R11. |

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -14,9 +14,11 @@ Or via the CLI entry point::
 """
 
 import asyncio
+import hashlib
 import logging
 import os
 import signal
+import time
 from pathlib import Path
 from typing import Any
 
@@ -49,6 +51,10 @@ WATCHDOG_TIMEOUT = 60  # seconds — kernel reboots if no ping within this windo
 EXTERNAL_WATCHDOG_GPIO = 17  # BCM pin for optional external watchdog heartbeat
 EXTERNAL_WATCHDOG_PING_S = 30  # heartbeat interval for external watchdog devices
 TIER_D_DRAIN_TIMEOUT = 5.0  # seconds — wait for in-flight Tier D tasks on shutdown
+ALERT_OUTBOX_RETRY_INTERVAL_S = 30.0
+ALERT_OUTBOX_BATCH_SIZE = 50
+ALERT_OUTBOX_MAX_ATTEMPTS_NON_TIER_D = 10
+ALERT_OUTBOX_TIER_D_CRITICAL_THRESHOLD = 3
 
 
 class OriRuntime:
@@ -267,14 +273,38 @@ class OriRuntime:
         # alert_whatsapp executor
         async def _exec_alert_whatsapp(action: str, ctx: SkillContext) -> None:
             msg = _message_from_context(ctx, action)
-            await whatsapp_action.send(message=msg, to_number=_operator_contact)
+            action_tier = _resolve_action_declared_tier(ctx, action)
+            trigger_name = _resolve_trigger_name(ctx)
+            original_ts = _resolve_original_ts(ctx)
+            return await self._send_or_queue_alert(
+                channel="whatsapp",
+                message=msg,
+                recipient=_operator_contact,
+                action_tier=action_tier,
+                trigger_name=trigger_name,
+                original_ts=original_ts,
+                sms_action=sms_action,
+                whatsapp_action=whatsapp_action,
+            )
 
         dispatcher.register_executor("alert_whatsapp", _exec_alert_whatsapp)
 
         # alert_sms executor
         async def _exec_alert_sms(action: str, ctx: SkillContext) -> None:
             msg = _message_from_context(ctx, action)
-            await sms_action.send(message=msg, to_number=_operator_contact)
+            action_tier = _resolve_action_declared_tier(ctx, action)
+            trigger_name = _resolve_trigger_name(ctx)
+            original_ts = _resolve_original_ts(ctx)
+            return await self._send_or_queue_alert(
+                channel="sms",
+                message=msg,
+                recipient=_operator_contact,
+                action_tier=action_tier,
+                trigger_name=trigger_name,
+                original_ts=original_ts,
+                sms_action=sms_action,
+                whatsapp_action=whatsapp_action,
+            )
 
         dispatcher.register_executor("alert_sms", _exec_alert_sms)
 
@@ -487,6 +517,12 @@ class OriRuntime:
         self._background_tasks.append(
             asyncio.create_task(
                 self._compaction_loop(self._deduplicator), name="compaction"
+            )
+        )
+        self._background_tasks.append(
+            asyncio.create_task(
+                self._alert_delivery_loop(sms_action, whatsapp_action),
+                name="alert-outbox",
             )
         )
         webhook_task = await self._start_sms_webhook_if_enabled(config)
@@ -800,6 +836,192 @@ class OriRuntime:
                         "[compaction] deduplicator cleanup failed — will retry"
                     )
 
+    async def _send_or_queue_alert(
+        self,
+        *,
+        channel: str,
+        message: str,
+        recipient: str,
+        action_tier: str,
+        trigger_name: str,
+        original_ts: int,
+        sms_action: SMSAction,
+        whatsapp_action: WhatsAppAction,
+    ) -> bool:
+        """Attempt immediate delivery; enqueue on failure.
+
+        Returns True if delivered immediately or queued successfully.
+        Returns False only if queueing also fails.
+        """
+        if not recipient:
+            logger.warning(
+                "[runtime] %s alert skipped: operator_contact not configured", channel
+            )
+            return False
+
+        delivered = False
+        try:
+            if channel == "sms":
+                delivered = await sms_action.send(message=message, to_number=recipient)
+            elif channel == "whatsapp":
+                delivered = await whatsapp_action.send(
+                    message=message, to_number=recipient
+                )
+            else:
+                logger.error("[runtime] unknown alert channel=%r", channel)
+                return False
+        except Exception:
+            logger.exception(
+                "[runtime] unexpected %s send failure; falling back to outbox queue",
+                channel,
+            )
+            delivered = False
+
+        if delivered:
+            return True
+
+        if self._state_store is None:
+            logger.error(
+                "[runtime] alert delivery failed and StateStore is unavailable; dropping alert"
+            )
+            return False
+
+        alert_id = _build_alert_id(
+            channel=channel,
+            recipient=recipient,
+            message=message,
+            action_tier=action_tier,
+            trigger_name=trigger_name,
+            original_ts=original_ts,
+        )
+        inserted = await self._state_store.enqueue_alert(
+            alert_id=alert_id,
+            channel=channel,
+            recipient=recipient,
+            message=message,
+            action_tier=action_tier,
+            trigger_name=trigger_name,
+            original_ts=original_ts,
+        )
+        if inserted:
+            logger.info(
+                "[runtime] queued failed %s alert id=%s tier=%s trigger=%s original_ts=%d",
+                channel,
+                alert_id,
+                action_tier,
+                trigger_name,
+                original_ts,
+            )
+        else:
+            logger.debug(
+                "[runtime] alert already queued id=%s channel=%s", alert_id, channel
+            )
+        return True
+
+    async def _alert_delivery_loop(
+        self,
+        sms_action: SMSAction,
+        whatsapp_action: WhatsAppAction,
+    ) -> None:
+        """Retry queued outbound alerts until delivered (or abandoned for non-Tier D)."""
+        while not self._shutdown_event.is_set():
+            try:
+                await asyncio.wait_for(
+                    self._shutdown_event.wait(),
+                    timeout=ALERT_OUTBOX_RETRY_INTERVAL_S,
+                )
+                break
+            except asyncio.TimeoutError:
+                pass
+
+            if self._state_store is None:
+                continue
+
+            try:
+                pending = await self._state_store.get_retryable_alerts(
+                    ALERT_OUTBOX_BATCH_SIZE
+                )
+            except Exception:
+                logger.exception("[runtime] alert outbox fetch failed")
+                continue
+
+            for alert in pending:
+                try:
+                    channel = str(alert["channel"])
+                    message = str(alert["message"])
+                    recipient = str(alert["recipient"])
+                    action_tier = str(alert["action_tier"]).upper()
+                    attempt_count = int(alert.get("attempt_count", 0))
+                    alert_id = str(alert["alert_id"])
+                except Exception:
+                    logger.exception("[runtime] malformed outbox row: %r", alert)
+                    continue
+
+                delivered = False
+                try:
+                    if channel == "sms":
+                        delivered = await sms_action.send(
+                            message=message,
+                            to_number=recipient,
+                        )
+                    elif channel == "whatsapp":
+                        delivered = await whatsapp_action.send(
+                            message=message,
+                            to_number=recipient,
+                        )
+                    else:
+                        logger.error(
+                            "[runtime] alert outbox has unknown channel=%r id=%s",
+                            channel,
+                            alert_id,
+                        )
+                except Exception:
+                    logger.exception(
+                        "[runtime] alert outbox send failed for id=%s channel=%s",
+                        alert_id,
+                        channel,
+                    )
+
+                if delivered:
+                    await self._state_store.mark_alert_delivered(alert_id)
+                    logger.info(
+                        "[runtime] delivered queued alert id=%s channel=%s after %d attempt(s)",
+                        alert_id,
+                        channel,
+                        attempt_count + 1,
+                    )
+                    continue
+
+                await self._state_store.mark_alert_attempt_failed(alert_id)
+                attempts_after = attempt_count + 1
+                logger.warning(
+                    "[runtime] retry failed for queued alert id=%s channel=%s tier=%s attempt=%d",
+                    alert_id,
+                    channel,
+                    action_tier,
+                    attempts_after,
+                )
+
+                if action_tier == "D":
+                    if attempts_after >= ALERT_OUTBOX_TIER_D_CRITICAL_THRESHOLD:
+                        logger.critical(
+                            "[runtime] Tier D notification delivery still failing id=%s "
+                            "channel=%s attempts=%d (will keep retrying)",
+                            alert_id,
+                            channel,
+                            attempts_after,
+                        )
+                    continue
+
+                if attempts_after >= ALERT_OUTBOX_MAX_ATTEMPTS_NON_TIER_D:
+                    await self._state_store.mark_alert_abandoned(alert_id)
+                    logger.warning(
+                        "[runtime] abandoning queued alert id=%s channel=%s after %d attempts",
+                        alert_id,
+                        channel,
+                        attempts_after,
+                    )
+
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -813,6 +1035,56 @@ def _message_from_context(ctx: SkillContext, fallback: str) -> str:
             f"{r.value} {r.unit}"
         )
     return fallback
+
+
+def _resolve_trigger_name(ctx: SkillContext) -> str:
+    if ctx and isinstance(getattr(ctx, "trigger_name", ""), str):
+        trigger_name = ctx.trigger_name.strip()
+        if trigger_name:
+            return trigger_name
+    if ctx and ctx.event and isinstance(getattr(ctx.event, "sensor_id", ""), str):
+        return ctx.event.sensor_id
+    return ""
+
+
+def _resolve_original_ts(ctx: SkillContext) -> int:
+    if ctx and ctx.event:
+        try:
+            return int(ctx.event.timestamp)
+        except Exception:
+            pass
+    return int(time.time() * 1000)
+
+
+def _resolve_action_declared_tier(ctx: SkillContext, action_name: str) -> str:
+    """Resolve declared tier for an action from skill capability metadata."""
+    if ctx and hasattr(ctx, "skill") and hasattr(ctx.skill, "actions"):
+        available = None
+        if isinstance(ctx.skill.actions, dict):
+            available = ctx.skill.actions.get("available")
+        if isinstance(available, list):
+            for item in available:
+                if not isinstance(item, dict):
+                    continue
+                if str(item.get("name", "")) != action_name:
+                    continue
+                tier = str(item.get("tier", "")).upper().strip()
+                if tier in {"A", "B", "C", "D"}:
+                    return tier
+    return "A"
+
+
+def _build_alert_id(
+    *,
+    channel: str,
+    recipient: str,
+    message: str,
+    action_tier: str,
+    trigger_name: str,
+    original_ts: int,
+) -> str:
+    raw = f"{channel}|{recipient}|{action_tier}|{trigger_name}|{original_ts}|{message}"
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
 
 
 def _is_truthy(value: Any) -> bool:

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -112,6 +112,23 @@ CREATE TABLE IF NOT EXISTS inbound_messages (
 CREATE INDEX IF NOT EXISTS idx_inbound_lookup
     ON inbound_messages (channel, from_number, received_at, consumed_at);
 
+CREATE TABLE IF NOT EXISTS alert_outbox (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    alert_id        TEXT    NOT NULL UNIQUE,
+    channel         TEXT    NOT NULL,   -- 'sms' | 'whatsapp'
+    recipient       TEXT    NOT NULL,
+    message         TEXT    NOT NULL,
+    action_tier     TEXT    NOT NULL,   -- 'A' | 'B' | 'C' | 'D'
+    trigger_name    TEXT    NOT NULL DEFAULT '',
+    original_ts     INTEGER NOT NULL,
+    attempt_count   INTEGER NOT NULL DEFAULT 0,
+    last_attempt_ts INTEGER,
+    status          TEXT    NOT NULL DEFAULT 'pending' -- 'pending' | 'failed' | 'delivered' | 'abandoned'
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_outbox_status_tier_ts
+    ON alert_outbox (status, action_tier, original_ts ASC);
+
 CREATE TABLE IF NOT EXISTS sensor_history_5min (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     sensor_id TEXT NOT NULL,
@@ -651,6 +668,156 @@ class StateStore:
         )
         self._conn.commit()
         return str(row["message"])
+
+    # ─── alert_outbox ─────────────────────────────────────────────────────────
+
+    async def enqueue_alert(
+        self,
+        *,
+        alert_id: str,
+        channel: str,
+        recipient: str,
+        message: str,
+        action_tier: str,
+        trigger_name: str,
+        original_ts: int,
+    ) -> bool:
+        """Insert an outbound alert row into alert_outbox.
+
+        Returns:
+            True if a new row was inserted, False if a row with alert_id already
+            exists (deduplicated by UNIQUE constraint).
+        """
+        return await self._run_write(
+            self._enqueue_alert_sync,
+            alert_id,
+            channel,
+            recipient,
+            message,
+            action_tier,
+            trigger_name,
+            original_ts,
+        )
+
+    def _enqueue_alert_sync(
+        self,
+        alert_id: str,
+        channel: str,
+        recipient: str,
+        message: str,
+        action_tier: str,
+        trigger_name: str,
+        original_ts: int,
+    ) -> bool:
+        assert self._conn is not None
+        cur = self._conn.execute(
+            """
+            INSERT INTO alert_outbox
+                (alert_id, channel, recipient, message, action_tier, trigger_name, original_ts, status)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 'pending')
+            ON CONFLICT(alert_id) DO NOTHING
+            """,
+            (
+                alert_id,
+                channel,
+                recipient,
+                message,
+                action_tier,
+                trigger_name,
+                original_ts,
+            ),
+        )
+        self._conn.commit()
+        return int(cur.rowcount) > 0
+
+    async def get_retryable_alerts(self, limit: int = 50) -> list[dict]:
+        """Fetch pending/failed outbox alerts in oldest-first order."""
+        return await self._run_read(self._get_retryable_alerts_sync, limit)
+
+    def _get_retryable_alerts_sync(
+        self,
+        conn: sqlite3.Connection,
+        limit: int,
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT alert_id, channel, recipient, message, action_tier,
+                   trigger_name, original_ts, attempt_count, last_attempt_ts, status
+            FROM alert_outbox
+            WHERE status IN ('pending', 'failed')
+            ORDER BY original_ts ASC, id ASC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    async def mark_alert_delivered(
+        self, alert_id: str, delivered_ts_ms: int | None = None
+    ) -> None:
+        await self._run_write(
+            self._mark_alert_delivered_sync,
+            alert_id,
+            delivered_ts_ms if delivered_ts_ms is not None else _now_ms(),
+        )
+
+    def _mark_alert_delivered_sync(self, alert_id: str, delivered_ts_ms: int) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            UPDATE alert_outbox
+            SET status = 'delivered',
+                last_attempt_ts = ?
+            WHERE alert_id = ?
+            """,
+            (delivered_ts_ms, alert_id),
+        )
+        self._conn.commit()
+
+    async def mark_alert_attempt_failed(
+        self, alert_id: str, failed_ts_ms: int | None = None
+    ) -> None:
+        await self._run_write(
+            self._mark_alert_attempt_failed_sync,
+            alert_id,
+            failed_ts_ms if failed_ts_ms is not None else _now_ms(),
+        )
+
+    def _mark_alert_attempt_failed_sync(self, alert_id: str, failed_ts_ms: int) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            UPDATE alert_outbox
+            SET attempt_count = attempt_count + 1,
+                last_attempt_ts = ?,
+                status = 'failed'
+            WHERE alert_id = ?
+            """,
+            (failed_ts_ms, alert_id),
+        )
+        self._conn.commit()
+
+    async def mark_alert_abandoned(
+        self, alert_id: str, abandoned_ts_ms: int | None = None
+    ) -> None:
+        await self._run_write(
+            self._mark_alert_abandoned_sync,
+            alert_id,
+            abandoned_ts_ms if abandoned_ts_ms is not None else _now_ms(),
+        )
+
+    def _mark_alert_abandoned_sync(self, alert_id: str, abandoned_ts_ms: int) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            UPDATE alert_outbox
+            SET status = 'abandoned',
+                last_attempt_ts = ?
+            WHERE alert_id = ?
+            """,
+            (abandoned_ts_ms, alert_id),
+        )
+        self._conn.commit()
 
     # ─── reasoning_log ───────────────────────────────────────────────────────
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1318,3 +1318,155 @@ class TestWebhookServerStartup:
             await asyncio.gather(runtime.start(), _stop())
 
         cls.assert_not_called()
+
+
+class TestAlertOutbox:
+    async def test_send_or_queue_alert_queues_when_send_fails(self, tmp_path):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "outbox-queue.db"))
+        await runtime._state_store.open()
+
+        sms_action = AsyncMock()
+        sms_action.send.return_value = False
+        whatsapp_action = AsyncMock()
+        whatsapp_action.send.return_value = False
+
+        try:
+            handled = await runtime._send_or_queue_alert(
+                channel="sms",
+                message="alert message",
+                recipient="+2340000000000",
+                action_tier="A",
+                trigger_name="high_draw",
+                original_ts=1234567890,
+                sms_action=sms_action,
+                whatsapp_action=whatsapp_action,
+            )
+            assert handled is True
+            queued = await runtime._state_store.get_retryable_alerts(limit=10)
+            assert len(queued) == 1
+            assert queued[0]["channel"] == "sms"
+            assert queued[0]["status"] == "pending"
+        finally:
+            await runtime._state_store.close()
+
+    async def test_alert_delivery_loop_delivers_queued_alert(
+        self, tmp_path, monkeypatch
+    ):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "outbox-deliver.db"))
+        await runtime._state_store.open()
+        monkeypatch.setattr("ori.runtime.ALERT_OUTBOX_RETRY_INTERVAL_S", 0.01)
+
+        await runtime._state_store.enqueue_alert(
+            alert_id="deliver-1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+
+        async def _send_and_stop(*, message: str, to_number: str) -> bool:
+            runtime._shutdown_event.set()
+            return True
+
+        sms_action = AsyncMock()
+        sms_action.send.side_effect = _send_and_stop
+        whatsapp_action = AsyncMock()
+        whatsapp_action.send.return_value = True
+
+        try:
+            await runtime._alert_delivery_loop(sms_action, whatsapp_action)
+            remaining = await runtime._state_store.get_retryable_alerts(limit=10)
+            assert remaining == []
+        finally:
+            await runtime._state_store.close()
+
+    async def test_alert_delivery_loop_tier_d_never_abandons(
+        self, tmp_path, monkeypatch
+    ):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "outbox-tierd.db"))
+        await runtime._state_store.open()
+        monkeypatch.setattr("ori.runtime.ALERT_OUTBOX_RETRY_INTERVAL_S", 0.01)
+
+        await runtime._state_store.enqueue_alert(
+            alert_id="tierd-1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="D",
+            trigger_name="critical",
+            original_ts=1234,
+        )
+        await runtime._state_store.mark_alert_attempt_failed("tierd-1")
+        await runtime._state_store.mark_alert_attempt_failed("tierd-1")
+
+        async def _fail_and_stop(*, message: str, to_number: str) -> bool:
+            runtime._shutdown_event.set()
+            return False
+
+        sms_action = AsyncMock()
+        sms_action.send.side_effect = _fail_and_stop
+        whatsapp_action = AsyncMock()
+        whatsapp_action.send.return_value = False
+
+        try:
+            await runtime._alert_delivery_loop(sms_action, whatsapp_action)
+            rows = await runtime._state_store.get_retryable_alerts(limit=10)
+            assert len(rows) == 1
+            assert rows[0]["status"] == "failed"
+            assert rows[0]["attempt_count"] == 3
+        finally:
+            await runtime._state_store.close()
+
+    async def test_alert_delivery_loop_abandons_non_tier_d_at_threshold(
+        self, tmp_path, monkeypatch
+    ):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "outbox-abandon.db"))
+        await runtime._state_store.open()
+        monkeypatch.setattr("ori.runtime.ALERT_OUTBOX_RETRY_INTERVAL_S", 0.01)
+
+        await runtime._state_store.enqueue_alert(
+            alert_id="aband-1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+        for _ in range(9):
+            await runtime._state_store.mark_alert_attempt_failed("aband-1")
+
+        async def _fail_and_stop(*, message: str, to_number: str) -> bool:
+            runtime._shutdown_event.set()
+            return False
+
+        sms_action = AsyncMock()
+        sms_action.send.side_effect = _fail_and_stop
+        whatsapp_action = AsyncMock()
+        whatsapp_action.send.return_value = False
+
+        try:
+            await runtime._alert_delivery_loop(sms_action, whatsapp_action)
+            retryable = await runtime._state_store.get_retryable_alerts(limit=10)
+            assert retryable == []
+
+            row = await runtime._state_store._run_read(
+                lambda conn: conn.execute(
+                    """
+                    SELECT status, attempt_count
+                    FROM alert_outbox
+                    WHERE alert_id = ?
+                    """,
+                    ("aband-1",),
+                ).fetchone()
+            )
+            assert row["status"] == "abandoned"
+            assert row["attempt_count"] == 10
+        finally:
+            await runtime._state_store.close()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -89,6 +89,7 @@ class TestLifecycle:
             "action_log",
             "causal_memory",
             "skill_state",
+            "alert_outbox",
         } <= names
 
     async def test_open_is_idempotent(self, tmp_path):
@@ -289,6 +290,102 @@ class TestActionLog:
     async def test_get_action_log_empty(self, store):
         log = await store.get_action_log()
         assert log == []
+
+
+# ─── alert_outbox ─────────────────────────────────────────────────────────────
+
+
+class TestAlertOutbox:
+    async def test_enqueue_and_fetch_retryable(self, store):
+        inserted = await store.enqueue_alert(
+            alert_id="a1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+        assert inserted is True
+
+        rows = await store.get_retryable_alerts(limit=10)
+        assert len(rows) == 1
+        assert rows[0]["alert_id"] == "a1"
+        assert rows[0]["status"] == "pending"
+        assert rows[0]["attempt_count"] == 0
+
+    async def test_enqueue_deduplicates_by_alert_id(self, store):
+        first = await store.enqueue_alert(
+            alert_id="dup-1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+        second = await store.enqueue_alert(
+            alert_id="dup-1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+        assert first is True
+        assert second is False
+
+        rows = await store.get_retryable_alerts(limit=10)
+        assert len(rows) == 1
+
+    async def test_mark_failed_increments_attempt_count(self, store):
+        await store.enqueue_alert(
+            alert_id="f1",
+            channel="whatsapp",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="B",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+
+        await store.mark_alert_attempt_failed("f1")
+        rows = await store.get_retryable_alerts(limit=10)
+        assert len(rows) == 1
+        assert rows[0]["status"] == "failed"
+        assert rows[0]["attempt_count"] == 1
+        assert rows[0]["last_attempt_ts"] is not None
+
+    async def test_mark_delivered_removes_from_retryable(self, store):
+        await store.enqueue_alert(
+            alert_id="d1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+
+        await store.mark_alert_delivered("d1")
+        rows = await store.get_retryable_alerts(limit=10)
+        assert rows == []
+
+    async def test_mark_abandoned_removes_from_retryable(self, store):
+        await store.enqueue_alert(
+            alert_id="ab1",
+            channel="sms",
+            recipient="+2340000000000",
+            message="msg",
+            action_tier="A",
+            trigger_name="high_draw",
+            original_ts=1234,
+        )
+
+        await store.mark_alert_abandoned("ab1")
+        rows = await store.get_retryable_alerts(limit=10)
+        assert rows == []
 
 
 # ─── causal_memory ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
