### PR TITLE
feat: verify community skill

### DIFF
--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -2,32 +2,32 @@
 
 This is the authoritative record of what is real versus planned.
 
-| Capability | Status | File ref | Notes |
-| :--- | :--- | :--- | :--- |
-| Tier A/B/C/D dispatch | Implemented | action_dispatcher.py | All four tiers, asyncio.shield for Tier D |
-| Intelligence Elevator Tier 1 (rule engine) | Implemented | elevator.py | Deterministic. Tier D bypass always. |
-| Intelligence Elevator Tier 2 (local SLM) | Implemented | elevator.py | Qwen2.5-0.5B via llama-cpp-python |
-| Intelligence Elevator Tier 3 (gateway) | Partial — stubbed | elevator.py:125, :250 | MQTT request/response not wired. Falls back to local_slm. |
-| Intelligence Elevator Tier 4 (cloud LLM) | Partial — stubbed | elevator.py:410, :969 | Returns stub result. No external API call. |
-| CoAP actuation executor | Implemented | actions/coap.py, runtime.py:312 | Host allowlist enforced in config.py:409. |
-| CoAP HAL telemetry adapter | Not implemented | ori/hal/coap_adapter.py missing | See P3-R8. |
-| Tier C approval workflow | Implemented | action_dispatcher.py:649 | WhatsApp/SMS channels. Local console fallback not wired. |
-| Tier C local console fallback | Not implemented | action_dispatcher.py:649 | Listener delegates to alert sender only. See P3-R3. |
-| Tier D relay bypass when DevicePolicy restricted | Implemented | action_dispatcher.py | P3-R0b-i. Critical safety fix. |
-| SMS via Africa's Talking (IP) | Implemented | sms.py:57 | send(message, to_number). Requires internet. |
-| SMS via GSM modem (offline) | Not implemented | — | See P3-R3b. |
-| Outbound alert outbox + retry | Implemented | runtime.py, state/store.py | Store-and-retry queue with Tier D critical escalation and non-Tier-D abandon threshold. |
-| Ed25519 community skill verification | Not implemented | loader.py:257 | Signature parsed, not verified. See P3-R4. |
-| Python-level skill sandbox | Implemented | loader.py:518, 562 | RestrictedImportFinder + AST validation. |
-| OS-level sandbox (seccomp/Landlock) | Not implemented | — | See P3-R11. |
-| Capability posture signaling | Not implemented | elevator.py:60 | Hard-coded 8.8.8.8 check. See P3-R1. |
-| LED + buzzer status driver | Not implemented | ori/hardware/ missing | See P3-R2. |
-| DevicePolicy enforcement layer | Implemented | action_dispatcher.py, device_policy.py | P3-R0b-iii. |
-| Device policy refresh loop | Not implemented | — | See P3-R0b-v. |
-| Device policy cache (SQLite) | Not implemented | — | Table: device_policy_cache. See P3-R0b-iv. |
-| Battery lifecycle observability | Not implemented | — | See P3-R9. |
-| Health/status RPC socket | Not implemented | — | See P3-R10. |
-| Energy anomaly detector v2 | Not implemented | skills/energy-anomaly-detector/ | Basic triggers only. See P3-R5. |
-| Solar performance monitor skill | Not implemented | skills/solar-performance-monitor/ missing | See P3-R7. |
-| Energy cost calculator hook | Not implemented | — | See P3-R6. |
-| Offline Tier C auth tokens | Not implemented | — | See P3-R3c. CLI: ori-cli. |
+| Capability                                       | Status            | File ref                                  | Notes                                                                                                                 |
+| :----------------------------------------------- | :---------------- | :---------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| Tier A/B/C/D dispatch                            | Implemented       | action_dispatcher.py                      | All four tiers, asyncio.shield for Tier D                                                                             |
+| Intelligence Elevator Tier 1 (rule engine)       | Implemented       | elevator.py                               | Deterministic. Tier D bypass always.                                                                                  |
+| Intelligence Elevator Tier 2 (local SLM)         | Implemented       | elevator.py                               | Qwen2.5-0.5B via llama-cpp-python                                                                                     |
+| Intelligence Elevator Tier 3 (gateway)           | Partial — stubbed | elevator.py:125, :250                     | MQTT request/response not wired. Falls back to local_slm.                                                             |
+| Intelligence Elevator Tier 4 (cloud LLM)         | Partial — stubbed | elevator.py:410, :969                     | Returns stub result. No external API call.                                                                            |
+| CoAP actuation executor                          | Implemented       | actions/coap.py, runtime.py:312           | Host allowlist enforced in config.py:409.                                                                             |
+| CoAP HAL telemetry adapter                       | Not implemented   | ori/hal/coap_adapter.py missing           | See P3-R8.                                                                                                            |
+| Tier C approval workflow                         | Implemented       | action_dispatcher.py:649                  | WhatsApp/SMS channels. Local console fallback not wired.                                                              |
+| Tier C local console fallback                    | Not implemented   | action_dispatcher.py:649                  | Listener delegates to alert sender only. See P3-R3.                                                                   |
+| Tier D relay bypass when DevicePolicy restricted | Implemented       | action_dispatcher.py                      | P3-R0b-i. Critical safety fix.                                                                                        |
+| SMS via Africa's Talking (IP)                    | Implemented       | sms.py:57                                 | send(message, to_number). Requires internet.                                                                          |
+| SMS via GSM modem (offline)                      | Not implemented   | —                                         | See P3-R3b.                                                                                                           |
+| Outbound alert outbox + retry                    | Implemented       | runtime.py, state/store.py                | Store-and-retry queue with Tier D critical escalation and non-Tier-D abandon threshold.                               |
+| Ed25519 community skill verification             | Implemented       | skills/loader.py, skills/signing.py       | Community skills require valid `ed25519:<base64>` signature against Hub trust anchor; bundled local skills unchanged. |
+| Python-level skill sandbox                       | Implemented       | loader.py:518, 562                        | RestrictedImportFinder + AST validation.                                                                              |
+| OS-level sandbox (seccomp/Landlock)              | Not implemented   | —                                         | See P3-R11.                                                                                                           |
+| Capability posture signaling                     | Not implemented   | elevator.py:60                            | Hard-coded 8.8.8.8 check. See P3-R1.                                                                                  |
+| LED + buzzer status driver                       | Not implemented   | ori/hardware/ missing                     | See P3-R2.                                                                                                            |
+| DevicePolicy enforcement layer                   | Implemented       | action_dispatcher.py, device_policy.py    | P3-R0b-iii.                                                                                                           |
+| Device policy refresh loop                       | Not implemented   | —                                         | See P3-R0b-v.                                                                                                         |
+| Device policy cache (SQLite)                     | Not implemented   | —                                         | Table: device_policy_cache. See P3-R0b-iv.                                                                            |
+| Battery lifecycle observability                  | Not implemented   | —                                         | See P3-R9.                                                                                                            |
+| Health/status RPC socket                         | Not implemented   | —                                         | See P3-R10.                                                                                                           |
+| Energy anomaly detector v2                       | Not implemented   | skills/energy-anomaly-detector/           | Basic triggers only. See P3-R5.                                                                                       |
+| Solar performance monitor skill                  | Not implemented   | skills/solar-performance-monitor/ missing | See P3-R7.                                                                                                            |
+| Energy cost calculator hook                      | Not implemented   | —                                         | See P3-R6.                                                                                                            |
+| Offline Tier C auth tokens                       | Not implemented   | —                                         | See P3-R3c. CLI: ori-cli.                                                                                             |

--- a/ori/skills/loader.py
+++ b/ori/skills/loader.py
@@ -28,11 +28,14 @@ from typing import Any
 import yaml
 
 from ori.network.events import OriEvent
+from ori.skills.sandbox import SkillSecurityError
+from ori.skills.signing import verify_community_skill_signature
 
 logger = logging.getLogger(__name__)
 
 _VALID_TIERS = frozenset({"A", "B", "C", "D"})
 _TRIGGER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_HUB_ROOT_PUBLIC_KEY_B64 = "PENDING_REPLACE_AT_HUB_LAUNCH"
 
 
 # ── Exceptions ────────────────────────────────────────────────────────────────
@@ -231,6 +234,12 @@ class SkillLoader:
                 logger.error(
                     "SkillLoader: validation failed for %s — %s", child.name, exc
                 )
+            except SkillSecurityError as exc:
+                logger.error(
+                    "SkillLoader: security validation failed for %s — %s",
+                    child.name,
+                    exc,
+                )
             except Exception:
                 logger.exception(
                     "SkillLoader: unexpected error loading skill from %s", child
@@ -273,6 +282,7 @@ class SkillLoader:
             raw.get("name", "<unknown>"),
             trigger_names=[t.name for t in triggers],
         )
+        self._verify_community_signature(raw, skill_dir)
         hooks = self._load_hooks(skill_dir)
 
         return Skill(
@@ -285,6 +295,25 @@ class SkillLoader:
             actions=raw.get("actions") or {},
             config=raw.get("config") or {},
             hooks=hooks,
+        )
+
+    def _verify_community_signature(
+        self,
+        raw: dict[str, Any],
+        skill_dir: Path,
+    ) -> None:
+        """Verify signatures for community-installed skills only."""
+        if self._is_bundled_skill(skill_dir):
+            return
+
+        if _HUB_ROOT_PUBLIC_KEY_B64 == "PENDING_REPLACE_AT_HUB_LAUNCH":
+            raise SkillSecurityError(
+                "community skill verification trust anchor is not configured"
+            )
+
+        verify_community_skill_signature(
+            raw_skill=raw,
+            trust_anchor_public_key_b64=_HUB_ROOT_PUBLIC_KEY_B64,
         )
 
     def _validate_skill_metadata(

--- a/ori/skills/signing.py
+++ b/ori/skills/signing.py
@@ -1,0 +1,85 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ed25519 signature helpers for community skill verification."""
+
+import base64
+import json
+from typing import Any
+
+from ori.skills.sandbox import SkillSecurityError
+
+
+def canonical_skill_payload(raw_skill: dict[str, Any]) -> bytes:
+    """Build canonical bytes for signature verification.
+
+    The signature field itself is excluded from the signed payload.
+    """
+    canonical_obj = {k: v for k, v in raw_skill.items() if k != "signature"}
+    canonical_json = json.dumps(
+        canonical_obj,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return canonical_json.encode("utf-8")
+
+
+def verify_community_skill_signature(
+    raw_skill: dict[str, Any],
+    trust_anchor_public_key_b64: str,
+) -> None:
+    """Verify a community skill signature against the configured trust anchor.
+
+    Raises:
+        SkillSecurityError: If signature/trust anchor is missing, malformed,
+            or verification fails.
+    """
+    signature_field = str(raw_skill.get("signature") or "").strip()
+    if not signature_field:
+        raise SkillSecurityError("missing required 'signature' field")
+
+    if ":" not in signature_field:
+        raise SkillSecurityError(
+            "invalid signature format. Expected 'ed25519:<base64_signature>'"
+        )
+    scheme, signature_b64 = signature_field.split(":", 1)
+    if scheme.lower() != "ed25519":
+        raise SkillSecurityError(
+            "unsupported signature scheme. Expected 'ed25519:<base64_signature>'"
+        )
+    if not signature_b64.strip():
+        raise SkillSecurityError("signature payload is empty")
+
+    trust_anchor_public_key_b64 = str(trust_anchor_public_key_b64 or "").strip()
+    if not trust_anchor_public_key_b64:
+        raise SkillSecurityError("community skill verification trust anchor is empty")
+
+    try:
+        signature_bytes = base64.b64decode(signature_b64.encode("ascii"), validate=True)
+    except Exception as exc:
+        raise SkillSecurityError("invalid base64 signature payload") from exc
+
+    try:
+        public_key_bytes = base64.b64decode(
+            trust_anchor_public_key_b64.encode("ascii"),
+            validate=True,
+        )
+    except Exception as exc:
+        raise SkillSecurityError("invalid trust anchor public key encoding") from exc
+
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+    except Exception as exc:
+        raise SkillSecurityError(
+            "cryptography Ed25519 support is unavailable on this runtime"
+        ) from exc
+
+    payload_bytes = canonical_skill_payload(raw_skill)
+    try:
+        key = Ed25519PublicKey.from_public_bytes(public_key_bytes)
+        key.verify(signature_bytes, payload_bytes)
+    except Exception as exc:
+        raise SkillSecurityError(
+            "community skill signature verification failed"
+        ) from exc

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import base64
 import textwrap
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+import yaml
 
 from ori.network.event_bus import EventBus
 from ori.network.events import OriEvent, SensorReading
@@ -17,6 +19,18 @@ from ori.skills.loader import (
     Trigger,
     _CooldownTracker,
 )
+from ori.skills.sandbox import SkillSecurityError
+from ori.skills.signing import canonical_skill_payload
+
+try:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+        Ed25519PrivateKey,
+    )
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+except Exception:  # pragma: no cover - environment without cryptography support
+    Ed25519PrivateKey = None
+    Encoding = None
+    PublicFormat = None
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -24,6 +38,14 @@ from ori.skills.loader import (
 def _write_skill_yaml(skill_dir: Path, content: str) -> None:
     skill_dir.mkdir(parents=True, exist_ok=True)
     (skill_dir / "skill.yaml").write_text(textwrap.dedent(content))
+
+
+def _write_skill_yaml_mapping(skill_dir: Path, content: dict) -> None:
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    (skill_dir / "skill.yaml").write_text(
+        yaml.safe_dump(content, sort_keys=False),
+        encoding="utf-8",
+    )
 
 
 def _minimal_yaml(
@@ -72,6 +94,33 @@ def _make_event(sensor_type: str = "current_clamp", value: float = 6.0) -> OriEv
         quality=1.0,
     )
     return OriEvent.from_reading(reading, "dev-01")
+
+
+def _community_skill_mapping(name: str = "community-skill") -> dict:
+    return {
+        "name": name,
+        "version": "0.1.0",
+        "author": "community-author",
+        "sensors_required": [{"type": "current_clamp", "protocol": "i2c"}],
+        "triggers": [
+            {
+                "name": "over_threshold",
+                "condition": "value > 5.0",
+                "cooldown_seconds": 10,
+                "action_tier": "A",
+            }
+        ],
+        "actions": {
+            "available": [{"name": "alert_whatsapp", "tier": "A"}],
+            "defaults": {"over_threshold": ["alert_whatsapp"]},
+        },
+    }
+
+
+def _sign_skill(raw_skill: dict, private_key: Ed25519PrivateKey) -> str:  # type: ignore
+    payload = canonical_skill_payload(raw_skill)
+    signature = private_key.sign(payload)
+    return "ed25519:" + base64.b64encode(signature).decode("ascii")
 
 
 # ─── Trigger dataclass ────────────────────────────────────────────────────────
@@ -238,6 +287,103 @@ class TestLoadOne:
         loader = SkillLoader()
         with pytest.raises(FileNotFoundError):
             loader.load_one(skill_dir)
+
+    @pytest.mark.skipif(
+        Ed25519PrivateKey is None,
+        reason="cryptography ed25519 is unavailable",
+    )
+    def test_loads_valid_signed_community_skill(self, tmp_path, monkeypatch):
+        skill_dir = tmp_path / "community-valid"
+        raw = _community_skill_mapping()
+        private_key = Ed25519PrivateKey.generate()
+        public_key_b64 = base64.b64encode(
+            private_key.public_key().public_bytes(
+                encoding=Encoding.Raw,
+                format=PublicFormat.Raw,
+            )
+        ).decode("ascii")
+        raw["signature"] = _sign_skill(raw, private_key)
+        _write_skill_yaml_mapping(skill_dir, raw)
+
+        monkeypatch.setattr(
+            "ori.skills.loader._HUB_ROOT_PUBLIC_KEY_B64",
+            public_key_b64,
+        )
+        loader = SkillLoader()
+        with patch.object(loader, "_is_bundled_skill", return_value=False):
+            skill = loader.load_one(skill_dir)
+        assert skill.name == raw["name"]
+
+    @pytest.mark.skipif(
+        Ed25519PrivateKey is None,
+        reason="cryptography ed25519 is unavailable",
+    )
+    def test_rejects_tampered_community_skill(self, tmp_path, monkeypatch):
+        skill_dir = tmp_path / "community-tampered"
+        raw = _community_skill_mapping()
+        private_key = Ed25519PrivateKey.generate()
+        public_key_b64 = base64.b64encode(
+            private_key.public_key().public_bytes(
+                encoding=Encoding.Raw,
+                format=PublicFormat.Raw,
+            )
+        ).decode("ascii")
+        raw["signature"] = _sign_skill(raw, private_key)
+        raw["version"] = "0.2.0"  # tamper after signature
+        _write_skill_yaml_mapping(skill_dir, raw)
+
+        monkeypatch.setattr(
+            "ori.skills.loader._HUB_ROOT_PUBLIC_KEY_B64",
+            public_key_b64,
+        )
+        loader = SkillLoader()
+        with patch.object(loader, "_is_bundled_skill", return_value=False):
+            with pytest.raises(
+                SkillSecurityError,
+                match="signature verification failed",
+            ):
+                loader.load_one(skill_dir)
+
+    def test_rejects_missing_community_signature(self, tmp_path, monkeypatch):
+        skill_dir = tmp_path / "community-missing-signature"
+        raw = _community_skill_mapping()
+        _write_skill_yaml_mapping(skill_dir, raw)
+        monkeypatch.setattr(
+            "ori.skills.loader._HUB_ROOT_PUBLIC_KEY_B64",
+            "dGVzdA==",
+        )
+        loader = SkillLoader()
+        with patch.object(loader, "_is_bundled_skill", return_value=False):
+            with pytest.raises(
+                SkillSecurityError,
+                match="missing required 'signature' field",
+            ):
+                loader.load_one(skill_dir)
+
+    def test_rejects_invalid_signature_scheme(self, tmp_path, monkeypatch):
+        skill_dir = tmp_path / "community-invalid-scheme"
+        raw = _community_skill_mapping()
+        raw["signature"] = "rsa:abc"
+        _write_skill_yaml_mapping(skill_dir, raw)
+        monkeypatch.setattr(
+            "ori.skills.loader._HUB_ROOT_PUBLIC_KEY_B64",
+            "dGVzdA==",
+        )
+        loader = SkillLoader()
+        with patch.object(loader, "_is_bundled_skill", return_value=False):
+            with pytest.raises(
+                SkillSecurityError,
+                match="unsupported signature scheme",
+            ):
+                loader.load_one(skill_dir)
+
+    def test_bundled_unsigned_skill_still_loads(self, tmp_path):
+        skill_dir = tmp_path / "bundled-unsigned"
+        _write_skill_yaml(skill_dir, _minimal_yaml(name="bundled-unsigned"))
+        loader = SkillLoader()
+        with patch.object(loader, "_is_bundled_skill", return_value=True):
+            skill = loader.load_one(skill_dir)
+        assert skill.name == "bundled-unsigned"
 
 
 # ─── SkillLoader validation ───────────────────────────────────────────────────
@@ -542,6 +688,26 @@ class TestLoadAll:
         names = {s.name for s in skills}
         assert "real-skill" in names
         assert "template" not in names
+
+    def test_security_failed_skill_is_skipped(self, tmp_path):
+        _write_skill_yaml(tmp_path / "good-skill", _minimal_yaml(name="good-skill"))
+        _write_skill_yaml(
+            tmp_path / "bad-community-skill",
+            _minimal_yaml(name="bad-community-skill"),
+        )
+        loader = SkillLoader()
+        original_load_one = loader.load_one
+
+        def _fake_load_one(path):
+            if Path(path).name == "bad-community-skill":
+                raise SkillSecurityError("signature verification failed")
+            return original_load_one(path)
+
+        with patch.object(loader, "load_one", side_effect=_fake_load_one):
+            skills = loader.load_all(str(tmp_path))
+
+        assert len(skills) == 1
+        assert skills[0].name == "good-skill"
 
 
 # ─── SkillLoader.register — EventBus handler ─────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [x] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
