### PR TITLE
feat: implement offline tier C auth tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,34 +201,56 @@ class ReasoningResult:
 
 ```bash
 ori/
+├── AGENTS.md
 ├── CLAUDE.md
+├── PRINCIPLES.md
 ├── README.md
 ├── CONTRIBUTING.md
+├── SECURITY.md
 ├── LICENSE
 ├── pyproject.toml
+├── requirements.in
 ├── requirements.txt
+├── requirements-dev.in
 ├── requirements-dev.txt
 ├── ori.yaml.example
+├── ori.linux.yaml.example
+├── ori.yaml.phone.example
+│
+├── docs/
+│   ├── CAPABILITY_MATRIX.md
+│   ├── linux-setup.md
+│   └── releases/
+│
+├── scripts/
+│   └── guard-capability-matrix.sh
 │
 ├── ori/
 │   ├── __init__.py
 │   ├── runtime.py             ← main event loop — build last
 │   ├── config.py              ← ori.yaml loader and validator
+│   ├── time_utils.py
 │   │
 │   ├── hal/                   ← Hardware Abstraction Layer (Layer 1)
 │   │   ├── __init__.py
 │   │   ├── base.py
-│   │   ├── gpio_adapter.py
 │   │   ├── i2c_adapter.py
 │   │   ├── serial_adapter.py
 │   │   ├── mqtt_adapter.py    ← Generic MQTT telemetry adapter
-│   │   └── psutil_adapter.py  ← PC-Ori, no hardware needed
+│   │   ├── psutil_adapter.py  ← PC-Ori, no hardware needed
+│   │   ├── smart_adapter.py
+│   │   ├── http_adapter.py
+│   │   ├── opcua_adapter.py
+│   │   ├── victron_adapter.py
+│   │   ├── growatt_adapter.py
+│   │   └── ... (LoRaWAN, Zigbee, USB-Serial, MQTT perception adapters)
 │   │
 │   ├── network/               ← Network Layer (Layer 2)
 │   │   ├── __init__.py
 │   │   ├── events.py          ← OriEvent + SensorReading + ActionResult — BUILD FIRST
 │   │   ├── event_bus.py
-│   │   └── deduplicator.py
+│   │   ├── deduplicator.py
+│   │   └── sms_webhook.py
 │   │
 │   ├── reasoning/             ← Intelligence Elevator + Action Tiers (Layer 4)
 │   │   ├── __init__.py
@@ -236,22 +258,37 @@ ori/
 │   │   ├── rule_engine.py     ← deterministic rules — BUILD BEFORE LLM
 │   │   ├── local_llm.py       ← llama-cpp-python wrapper
 │   │   ├── causal_memory.py   ← SQLite pattern cache
+│   │   ├── capability_posture.py
 │   │   └── action_dispatcher.py ← ACTION TIER ROUTER — the agent's executor
+│   │
+│   ├── hardware/
+│   │   ├── __init__.py
+│   │   └── led_indicator.py
+│   │
+│   ├── policy/
+│   │   ├── device_policy.py
+│   │   └── remote_fetch.py
+│   │
+│   ├── security/
+│   │   ├── __init__.py
+│   │   └── offline_tokens.py
 │   │
 │   ├── skills/                ← Skills loader (Layer 5)
 │   │   ├── __init__.py
 │   │   ├── loader.py
 │   │   ├── hooks_api.py
-│   │   └── sandbox.py
+│   │   ├── sandbox.py
+│   │   └── signing.py
 │   │
 │   ├── actions/               ← Action executors (called by action_dispatcher)
 │   │   ├── __init__.py
 │   │   ├── whatsapp.py        ← Twilio / WhatsApp Cloud API
 │   │   ├── sms.py             ← Africa's Talking (PRIMARY for Nigeria)
 │   │   ├── relay.py           ← Physical relay control (GPIO output)
-│   │   ├── modbus_control.py  ← Modbus write commands (industrial)
 │   │   ├── alert_failover.py  ← Failover alert transport wrapper
 │   │   ├── coap.py            ← CoAP action executor for constrained devices
+│   │   ├── process_manager.py
+│   │   ├── system_control.py
 │   │   └── logger.py
 │   │
 │   └── state/
@@ -265,22 +302,28 @@ ori/
 │   ├── energy-anomaly-detector/
 │   │   ├── skill.yaml
 │   │   └── hooks.py
+│   ├── hvac-refrigerant-monitor/
+│   │   ├── skill.yaml
+│   │   └── hooks.py
+│   ├── pc-network-threat-monitor/
+│   │   ├── skill.yaml
+│   │   └── hooks.py
+│   ├── site-safety-ppe/
+│   │   ├── skill.yaml
+│   │   └── hooks.py
 │   └── pc-system-health/
 │       ├── skill.yaml
 │       └── hooks.py           ← uses HookContext dynamic API
 │
 └── tests/
     ├── __init__.py
-    ├── test_events.py
-    ├── test_rule_engine.py         ← includes AST whitelist validation tests
     ├── test_action_dispatcher.py
-    ├── test_circuit_breaker.py
-    ├── test_deduplicator.py
     ├── test_config.py
     ├── test_elevator.py
-    ├── test_event_bus.py
-    ├── test_store.py
-    └── ... (23 test modules total)
+    ├── test_led_indicator.py
+    ├── test_remote_policy_fetch.py
+    ├── test_offline_tokens.py
+    └── ... (full suite in tests/)
 ```
 
 ---

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -31,7 +31,7 @@ This is the authoritative record of what is real versus planned.
 | Energy anomaly detector v2                       | Not implemented   | skills/energy-anomaly-detector/           | Basic triggers only. See P3-R5.                                                                                       |
 | Solar performance monitor skill                  | Not implemented   | skills/solar-performance-monitor/ missing | See P3-R7.                                                                                                            |
 | Energy cost calculator hook                      | Not implemented   | —                                         | See P3-R6.                                                                                                            |
-| Offline Tier C auth tokens                       | Not implemented   | —                                         | See P3-R3c. CLI: ori-cli.                                                                                             |
+| Offline Tier C auth tokens                       | Implemented       | security/offline_tokens.py, action_dispatcher.py, state/store.py | Local-console `TOKEN:<value>` approvals are signature-verified (Ed25519), device/action-bound, expiry-checked, and replay-protected via SQLite token claim table. |
 
 ## Recent updates
 

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -289,6 +289,11 @@ actions:
     poll_interval_ms: 1000
     approval_channel_id: "local_console"
 
+  offline_tokens:
+    enabled: false                   # Tier C offline cryptographic approval tokens
+    public_key_b64: "${ORI_OFFLINE_TOKEN_PUBKEY_B64}"
+    max_clock_skew_s: 300
+
   relay:
     enabled: false                   # CHANGE TO true ONLY WHEN RELAY IS WIRED
     gpio_pin: 26                     # BCM pin number connected to relay IN

--- a/ori/config.py
+++ b/ori/config.py
@@ -86,6 +86,7 @@ class ActionChannelConfig:
     relay: dict = field(default_factory=dict)
     coap: dict = field(default_factory=dict)
     local_console: dict = field(default_factory=dict)
+    offline_tokens: dict = field(default_factory=dict)
 
 
 @dataclass
@@ -622,6 +623,27 @@ def _parse_actions(data: Any) -> ActionChannelConfig:
             "actions.local_console.poll_interval_ms must be >= 100."
         )
 
+    offline_tokens_raw = data.get("offline_tokens") or {}
+    if not isinstance(offline_tokens_raw, dict):
+        raise ConfigValidationError(
+            "'actions.offline_tokens' must be a mapping when provided."
+        )
+    offline_tokens = {
+        "enabled": bool(offline_tokens_raw.get("enabled", False)),
+        "public_key_b64": str(offline_tokens_raw.get("public_key_b64", "")),
+        "max_clock_skew_s": int(offline_tokens_raw.get("max_clock_skew_s", 300)),
+    }
+    if offline_tokens["max_clock_skew_s"] < 0:
+        raise ConfigValidationError(
+            "actions.offline_tokens.max_clock_skew_s must be >= 0."
+        )
+    if offline_tokens["enabled"]:
+        public_key = offline_tokens["public_key_b64"]
+        if not public_key or "${" in public_key:
+            raise ConfigValidationError(
+                "actions.offline_tokens.enabled=true requires actions.offline_tokens.public_key_b64."
+            )
+
     return ActionChannelConfig(
         primary_alert_channel=primary,
         operator_contact=str(data.get("operator_contact") or ""),
@@ -631,6 +653,7 @@ def _parse_actions(data: Any) -> ActionChannelConfig:
         relay=relay,
         coap=coap,
         local_console=local_console,
+        offline_tokens=offline_tokens,
     )
 
 

--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -27,6 +27,7 @@ from ori.network.events import ActionResult, ActionTier, ReasoningResult
 from ori.policy.device_policy import DevicePolicy
 from ori.reasoning.capability_posture import CapabilityPosture
 from ori.reasoning.elevator import SkillContext
+from ori.security.offline_tokens import OfflineTierCTokenVerifier
 from ori.time_utils import now_ms
 
 logger = logging.getLogger(__name__)
@@ -88,12 +89,14 @@ class ActionDispatcher:
         state_store: Any = None,
         alert_sender: Any = None,
         emergency_sms_sender: Any = None,
+        offline_token_verifier: OfflineTierCTokenVerifier | None = None,
         status_indicator: Any = None,
         config: dict | None = None,
     ) -> None:
         self._state_store = state_store
         self._alert_sender = alert_sender
         self._emergency_sms_sender = emergency_sms_sender
+        self._offline_token_verifier = offline_token_verifier
         self._config: dict = config or {}
         self._log_action_decisions = bool(
             self._config.get("log_action_decisions", True)
@@ -645,6 +648,38 @@ class ActionDispatcher:
         try:
             # Parse response
             approved = _parse_approval_response(parsed_operator_response)
+            if (
+                local_console_mode
+                and parsed_operator_response is not None
+                and parsed_operator_response.strip().upper().startswith("TOKEN:")
+            ):
+                token_value = parsed_operator_response.split(":", 1)[1].strip()
+                if self._offline_token_verifier is None:
+                    approved = False
+                    logger.warning(
+                        "ActionDispatcher: offline token provided but verifier is disabled"
+                    )
+                else:
+                    verify_result = await self._offline_token_verifier.verify_token(
+                        token_value,
+                        expected_device_id=device_id,
+                        expected_action=action,
+                        state_store=store,
+                    )
+                    approved = bool(verify_result.approved)
+                    if approved:
+                        operator_response = (
+                            f"LOCAL:TOKEN_APPROVED:{verify_result.token_id}"
+                        )
+                    else:
+                        operator_response = (
+                            f"LOCAL:TOKEN_REJECTED:{verify_result.reason}"
+                        )
+                        logger.warning(
+                            "ActionDispatcher: offline token rejected for action=%r reason=%s",
+                            action,
+                            verify_result.reason,
+                        )
 
             if approved:
                 inner = await self._execute_immediately(action, tier, context)

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -54,6 +54,7 @@ from ori.reasoning.action_dispatcher import ActionDispatcher
 from ori.reasoning.capability_posture import CapabilityPosture, CapabilityPostureTracker
 from ori.reasoning.elevator import IntelligenceElevator, SkillContext
 from ori.reasoning.local_llm import LocalLLM
+from ori.security.offline_tokens import OfflineTierCTokenVerifier
 from ori.skills.loader import SkillLoader
 from ori.skills.signing import verify_signed_payload
 from ori.state.store import StateStore
@@ -304,6 +305,7 @@ class OriRuntime:
             state_store=self._state_store,
             alert_sender=alert_sender,
             emergency_sms_sender=sms_action,
+            offline_token_verifier=_build_offline_token_verifier(config.actions),
             status_indicator=status_indicator,
             config={
                 "operator_contact": _operator_contact,
@@ -1576,6 +1578,20 @@ def _is_truthy(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def _build_offline_token_verifier(actions_cfg: Any) -> OfflineTierCTokenVerifier | None:
+    offline_cfg = {}
+    if actions_cfg is not None and hasattr(actions_cfg, "offline_tokens"):
+        candidate = getattr(actions_cfg, "offline_tokens", {}) or {}
+        if isinstance(candidate, dict):
+            offline_cfg = candidate
+    if not _is_truthy(offline_cfg.get("enabled", False)):
+        return None
+    return OfflineTierCTokenVerifier(
+        public_key_b64=str(offline_cfg.get("public_key_b64", "")),
+        max_clock_skew_s=int(offline_cfg.get("max_clock_skew_s", 300)),
+    )
 
 
 def _is_local_slm_available(local_llm: Any) -> bool:

--- a/ori/security/__init__.py
+++ b/ori/security/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+

--- a/ori/security/__init__.py
+++ b/ori/security/__init__.py
@@ -1,3 +1,2 @@
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0
-

--- a/ori/security/offline_tokens.py
+++ b/ori/security/offline_tokens.py
@@ -1,0 +1,228 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline Tier C token verification with replay protection."""
+
+from __future__ import annotations
+
+import base64
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from ori.skills.sandbox import SkillSecurityError
+from ori.skills.signing import verify_signed_payload
+from ori.time_utils import now_ms
+
+
+@dataclass
+class TokenVerificationResult:
+    approved: bool
+    reason: str
+    token_id: str = ""
+
+
+class OfflineTierCTokenVerifier:
+    """Verify offline token payloads signed with Ed25519.
+
+    Token string format:
+    - base64url encoded JSON payload (preferred), or
+    - raw JSON payload string.
+    """
+
+    def __init__(self, *, public_key_b64: str, max_clock_skew_s: int = 300) -> None:
+        self._public_key_b64 = str(public_key_b64 or "").strip()
+        self._max_clock_skew_s = max(0, int(max_clock_skew_s))
+
+    async def verify_token(
+        self,
+        token: str,
+        *,
+        expected_device_id: str,
+        expected_action: str,
+        state_store: Any,
+    ) -> TokenVerificationResult:
+        payload = self._decode_token_payload(token)
+        if payload is None:
+            return await self._audit(
+                state_store=state_store,
+                token_id="",
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="decode_failed",
+            )
+
+        token_id = str(payload.get("token_id", "")).strip()
+        if not token_id:
+            return await self._audit(
+                state_store=state_store,
+                token_id="",
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="missing_token_id",
+            )
+
+        try:
+            verify_signed_payload(
+                payload,
+                self._public_key_b64,
+                context_label="offline tier c token",
+            )
+        except SkillSecurityError:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="invalid_signature",
+            )
+
+        device_id = str(payload.get("device_id", "")).strip()
+        if device_id != expected_device_id:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="device_mismatch",
+            )
+
+        token_action = str(payload.get("action_scope", "")).strip()
+        if token_action not in {expected_action, "*"}:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="action_scope_mismatch",
+            )
+
+        try:
+            issued_at = int(payload.get("issued_at", 0))
+            expires_at = int(payload.get("expires_at", 0))
+        except (TypeError, ValueError):
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="invalid_timestamp",
+            )
+
+        now_s = now_ms() // 1000
+        if issued_at > now_s + self._max_clock_skew_s:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="issued_in_future",
+            )
+        if expires_at < now_s - self._max_clock_skew_s:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="expired",
+            )
+
+        nonce = str(payload.get("nonce", "")).strip()
+        if not nonce:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="missing_nonce",
+            )
+
+        if state_store is None or not hasattr(state_store, "claim_offline_token"):
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="state_store_unavailable",
+            )
+
+        claimed = await state_store.claim_offline_token(
+            token_id=token_id,
+            device_id=expected_device_id,
+            action=expected_action,
+        )
+        if not claimed:
+            return await self._audit(
+                state_store=state_store,
+                token_id=token_id,
+                device_id=expected_device_id,
+                action=expected_action,
+                approved=False,
+                reason="replay_detected",
+            )
+
+        return await self._audit(
+            state_store=state_store,
+            token_id=token_id,
+            device_id=expected_device_id,
+            action=expected_action,
+            approved=True,
+            reason="approved",
+        )
+
+    def _decode_token_payload(self, token: str) -> dict[str, Any] | None:
+        raw = str(token or "").strip()
+        if not raw:
+            return None
+        # Prefer base64url compact tokens; fallback to direct JSON.
+        payload_txt = ""
+        try:
+            padded = raw + "=" * (-len(raw) % 4)
+            payload_txt = base64.urlsafe_b64decode(padded.encode("ascii")).decode(
+                "utf-8"
+            )
+        except Exception:
+            payload_txt = raw
+        try:
+            decoded = json.loads(payload_txt)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(decoded, dict):
+            return None
+        return decoded
+
+    async def _audit(
+        self,
+        *,
+        state_store: Any,
+        token_id: str,
+        device_id: str,
+        action: str,
+        approved: bool,
+        reason: str,
+    ) -> TokenVerificationResult:
+        if state_store is not None and hasattr(
+            state_store, "log_offline_token_attempt"
+        ):
+            await state_store.log_offline_token_attempt(
+                token_id=token_id,
+                device_id=device_id,
+                action=action,
+                approved=approved,
+                reason=reason,
+            )
+        return TokenVerificationResult(
+            approved=approved,
+            reason=reason,
+            token_id=token_id,
+        )

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -146,6 +146,24 @@ CREATE TABLE IF NOT EXISTS device_policy_cache (
 CREATE INDEX IF NOT EXISTS idx_device_policy_cache_version
     ON device_policy_cache (policy_version DESC, cached_at DESC);
 
+CREATE TABLE IF NOT EXISTS offline_token_consumption (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_id    TEXT    NOT NULL UNIQUE,
+    device_id   TEXT    NOT NULL,
+    action      TEXT    NOT NULL,
+    consumed_at INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS offline_token_audit (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    token_id    TEXT    NOT NULL DEFAULT '',
+    device_id   TEXT    NOT NULL,
+    action      TEXT    NOT NULL,
+    approved    INTEGER NOT NULL,
+    reason      TEXT    NOT NULL,
+    attempted_at INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS sensor_history_5min (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     sensor_id TEXT NOT NULL,
@@ -827,6 +845,83 @@ class StateStore:
             WHERE alert_id = ?
             """,
             (abandoned_ts_ms, alert_id),
+        )
+        self._conn.commit()
+
+    # ─── offline_token_consumption / offline_token_audit ─────────────────────
+
+    async def claim_offline_token(
+        self,
+        *,
+        token_id: str,
+        device_id: str,
+        action: str,
+        consumed_at_ms: int | None = None,
+    ) -> bool:
+        return await self._run_write(
+            self._claim_offline_token_sync,
+            token_id,
+            device_id,
+            action,
+            consumed_at_ms if consumed_at_ms is not None else now_ms(),
+        )
+
+    def _claim_offline_token_sync(
+        self,
+        token_id: str,
+        device_id: str,
+        action: str,
+        consumed_at_ms: int,
+    ) -> bool:
+        assert self._conn is not None
+        cur = self._conn.execute(
+            """
+            INSERT INTO offline_token_consumption (token_id, device_id, action, consumed_at)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(token_id) DO NOTHING
+            """,
+            (token_id, device_id, action, consumed_at_ms),
+        )
+        self._conn.commit()
+        return int(cur.rowcount) > 0
+
+    async def log_offline_token_attempt(
+        self,
+        *,
+        token_id: str,
+        device_id: str,
+        action: str,
+        approved: bool,
+        reason: str,
+        attempted_at_ms: int | None = None,
+    ) -> None:
+        await self._run_write(
+            self._log_offline_token_attempt_sync,
+            token_id,
+            device_id,
+            action,
+            approved,
+            reason,
+            attempted_at_ms if attempted_at_ms is not None else now_ms(),
+        )
+
+    def _log_offline_token_attempt_sync(
+        self,
+        token_id: str,
+        device_id: str,
+        action: str,
+        approved: bool,
+        reason: str,
+        attempted_at_ms: int,
+    ) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            INSERT INTO offline_token_audit
+                (token_id, device_id, action, approved, reason, attempted_at)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (token_id, device_id, action, int(bool(approved)), reason, attempted_at_ms),
         )
         self._conn.commit()
 

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -17,6 +17,7 @@ from ori.policy.device_policy import DevicePolicy
 from ori.reasoning.action_dispatcher import ActionDispatcher, _parse_approval_response
 from ori.reasoning.capability_posture import CapabilityPosture
 from ori.reasoning.elevator import SkillContext
+from ori.security.offline_tokens import TokenVerificationResult
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -1121,3 +1122,72 @@ class TestEmergencySmsSender:
         await d._emergency_sms("trip_relay", "dev-01")
 
         injected_sms.send.assert_awaited_once()
+
+
+class TestOfflineTokenApproval:
+    async def test_local_console_token_approves_tier_c(self):
+        verifier = AsyncMock()
+        verifier.verify_token = AsyncMock(
+            return_value=TokenVerificationResult(
+                approved=True,
+                reason="approved",
+                token_id="tok-1",
+            )
+        )
+        d = ActionDispatcher(
+            offline_token_verifier=verifier,
+            config={
+                "local_console_enabled": True,
+                "operator_contact": "+2348000000000",
+            },
+        )
+        exec_mock = AsyncMock()
+        d.register_executor("trip_main_breaker", exec_mock)
+        with patch.object(
+            d,
+            "_listen_for_local_console_response",
+            new=AsyncMock(return_value="TOKEN:abc"),
+        ):
+            result = await d.dispatch(
+                "trip_main_breaker",
+                ActionTier.HARD_PHYSICAL,
+                _context(),
+                _result(action_tier="C"),
+            )
+        assert result.approved is True
+        assert result.executed is True
+        verifier.verify_token.assert_awaited_once()
+        exec_mock.assert_awaited_once()
+
+    async def test_local_console_token_rejected_runs_safe_default(self):
+        verifier = AsyncMock()
+        verifier.verify_token = AsyncMock(
+            return_value=TokenVerificationResult(
+                approved=False,
+                reason="expired",
+                token_id="tok-2",
+            )
+        )
+        d = ActionDispatcher(
+            offline_token_verifier=verifier,
+            config={
+                "local_console_enabled": True,
+                "operator_contact": "+2348000000000",
+            },
+        )
+        safe_default = AsyncMock()
+        d.register_executor("log_to_dashboard", safe_default)
+        with patch.object(
+            d,
+            "_listen_for_local_console_response",
+            new=AsyncMock(return_value="TOKEN:abc"),
+        ):
+            result = await d.dispatch(
+                "trip_main_breaker",
+                ActionTier.HARD_PHYSICAL,
+                _context(),
+                _result(action_tier="C"),
+            )
+        assert result.approved is False
+        assert result.action_taken == "log_to_dashboard"
+        safe_default.assert_awaited_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1385,6 +1385,8 @@ actions:
         assert cfg.actions.local_console["enabled"] is False
         assert cfg.actions.local_console["poll_interval_ms"] == 1000
         assert cfg.actions.local_console["approval_channel_id"] == "local_console"
+        assert cfg.actions.offline_tokens["enabled"] is False
+        assert cfg.actions.offline_tokens["max_clock_skew_s"] == 300
 
     def test_local_console_poll_interval_minimum(self, tmp_path):
         yaml_path = _write_yaml(
@@ -1401,6 +1403,40 @@ actions:
             match="actions.local_console.poll_interval_ms must be >= 100",
         ):
             Config.load(yaml_path)
+
+    def test_offline_tokens_enabled_requires_public_key(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._yaml(
+                "  primary_alert_channel: sms\n"
+                "  sms:\n"
+                "    enabled: false\n"
+                "  offline_tokens:\n"
+                "    enabled: true\n"
+            ),
+        )
+        with pytest.raises(
+            ConfigValidationError,
+            match="actions.offline_tokens.enabled=true requires",
+        ):
+            Config.load(yaml_path)
+
+    def test_offline_tokens_enabled_with_public_key_is_valid(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            self._yaml(
+                "  primary_alert_channel: sms\n"
+                "  sms:\n"
+                "    enabled: false\n"
+                "  offline_tokens:\n"
+                "    enabled: true\n"
+                "    public_key_b64: 'dGVzdA=='\n"
+                "    max_clock_skew_s: 10\n"
+            ),
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.actions.offline_tokens["enabled"] is True
+        assert cfg.actions.offline_tokens["max_clock_skew_s"] == 10
 
 
 class TestDevicePolicyConfig:

--- a/tests/test_offline_tokens.py
+++ b/tests/test_offline_tokens.py
@@ -1,0 +1,123 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import json
+import time
+
+import pytest
+
+from ori.security.offline_tokens import OfflineTierCTokenVerifier
+from ori.skills.signing import canonical_signed_payload
+from ori.state.store import StateStore
+
+try:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+except ImportError:  # pragma: no cover
+    Ed25519PrivateKey = None
+    serialization = None
+
+
+@pytest.mark.skipif(
+    Ed25519PrivateKey is None or serialization is None,
+    reason="cryptography Ed25519 unavailable",
+)
+class TestOfflineTierCTokenVerifier:
+    @staticmethod
+    def _mint_token(
+        *,
+        private_key,
+        token_id: str,
+        device_id: str,
+        action_scope: str,
+        issued_at: int,
+        expires_at: int,
+        nonce: str = "n1",
+    ) -> str:
+        payload = {
+            "token_id": token_id,
+            "device_id": device_id,
+            "action_scope": action_scope,
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+            "nonce": nonce,
+        }
+        signature = private_key.sign(canonical_signed_payload(payload))
+        payload["signature"] = "ed25519:" + base64.b64encode(signature).decode("ascii")
+        raw = json.dumps(payload, separators=(",", ":"), ensure_ascii=False).encode(
+            "utf-8"
+        )
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    async def test_valid_token_approves_and_claims_single_use(self, tmp_path):
+        private_key = Ed25519PrivateKey.generate()
+        pub = base64.b64encode(
+            private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        ).decode("ascii")
+        now_s = int(time.time())
+        token = self._mint_token(
+            private_key=private_key,
+            token_id="tok-01",
+            device_id="dev-01",
+            action_scope="trip_main_breaker",
+            issued_at=now_s - 5,
+            expires_at=now_s + 120,
+        )
+        verifier = OfflineTierCTokenVerifier(public_key_b64=pub, max_clock_skew_s=300)
+        store = StateStore(str(tmp_path / "offline-token.db"))
+        await store.open()
+        try:
+            first = await verifier.verify_token(
+                token,
+                expected_device_id="dev-01",
+                expected_action="trip_main_breaker",
+                state_store=store,
+            )
+            assert first.approved is True
+
+            second = await verifier.verify_token(
+                token,
+                expected_device_id="dev-01",
+                expected_action="trip_main_breaker",
+                state_store=store,
+            )
+            assert second.approved is False
+            assert second.reason == "replay_detected"
+        finally:
+            await store.close()
+
+    async def test_wrong_device_rejected(self, tmp_path):
+        private_key = Ed25519PrivateKey.generate()
+        pub = base64.b64encode(
+            private_key.public_key().public_bytes(
+                encoding=serialization.Encoding.Raw,
+                format=serialization.PublicFormat.Raw,
+            )
+        ).decode("ascii")
+        now_s = int(time.time())
+        token = self._mint_token(
+            private_key=private_key,
+            token_id="tok-02",
+            device_id="dev-a",
+            action_scope="trip_main_breaker",
+            issued_at=now_s - 5,
+            expires_at=now_s + 120,
+        )
+        verifier = OfflineTierCTokenVerifier(public_key_b64=pub, max_clock_skew_s=300)
+        store = StateStore(str(tmp_path / "offline-token-device.db"))
+        await store.open()
+        try:
+            result = await verifier.verify_token(
+                token,
+                expected_device_id="dev-b",
+                expected_action="trip_main_breaker",
+                state_store=store,
+            )
+            assert result.approved is False
+            assert result.reason == "device_mismatch"
+        finally:
+            await store.close()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -388,6 +388,45 @@ class TestAlertOutbox:
         assert rows == []
 
 
+class TestOfflineTokens:
+    async def test_claim_offline_token_is_single_use(self, store):
+        first = await store.claim_offline_token(
+            token_id="tok-1",
+            device_id="dev-01",
+            action="trip_main_breaker",
+        )
+        second = await store.claim_offline_token(
+            token_id="tok-1",
+            device_id="dev-01",
+            action="trip_main_breaker",
+        )
+        assert first is True
+        assert second is False
+
+    async def test_log_offline_token_attempt_persists(self, store):
+        await store.log_offline_token_attempt(
+            token_id="tok-2",
+            device_id="dev-01",
+            action="trip_main_breaker",
+            approved=False,
+            reason="expired",
+        )
+        row = await store._run_read(
+            lambda conn: conn.execute(
+                """
+                SELECT token_id, approved, reason
+                FROM offline_token_audit
+                ORDER BY id DESC
+                LIMIT 1
+                """
+            ).fetchone()
+        )
+        assert row is not None
+        assert row["token_id"] == "tok-2"
+        assert bool(row["approved"]) is False
+        assert row["reason"] == "expired"
+
+
 class TestDevicePolicyCache:
     async def test_upsert_and_get_latest_device_policy_cache(self, store):
         await store.upsert_device_policy_cache(


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [ ] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
