### PR TITLE
chore: release v0.9.0 beta.1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-1E6B4A?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-1E6B4A?style=flat-square)](https://python.org)
 [![CI](https://github.com/ori-platform/ori-runtime/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ori-platform/ori-runtime/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-alpha-C8A951?style=flat-square)](#release-status)
+[![Release](https://img.shields.io/badge/release-beta-1E6B4A?style=flat-square)](#release-status)
 [![Platform](https://img.shields.io/badge/runs%20on-Raspberry%20Pi%20·%20Linux%20·%20macOS-C8A951?style=flat-square)](#)
 
 </div>
@@ -24,12 +24,13 @@ Built for the world's majority condition — unreliable power, intermittent conn
 
 ## Release Status
 
-**Current channel: Alpha (`0.1.x`)**
+**Current channel: Beta (`0.9.x`)**
 
-- Runtime core is functional and publicly testable.
+- Runtime core is feature-complete for imminent PoC deployment.
 - Safety invariants (tier guards, strict skill validation, sandbox boundaries) are CI-enforced on every PR.
-- APIs/config may still evolve between minor alpha releases.
+- APIs/config are expected to stabilize during beta; minor contract refinements may still occur before `1.0.0`.
 - Recommended use today: pilots, PoCs, and controlled deployments.
+- Release notes: [`docs/releases/v0.9.0-beta.1.md`](docs/releases/v0.9.0-beta.1.md)
 
 Related repos in the org:
 
@@ -392,7 +393,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting, supported versions, 
 
 | Phase  | Status          | Milestone                                                             |
 | ------ | --------------- | --------------------------------------------------------------------- |
-| Core   | ✅ Active Alpha | Core runtime with 6-layer architecture and 4-tier action framework    |
+| Core   | ✅ Active Beta  | Core runtime with 6-layer architecture and 4-tier action framework     |
 | PoC    | 🔨 In Progress  | Energy skill deployed in Lagos. HVAC refrigerant monitor. Demo video. |
 | Launch | 🔨 In Progress  | Skills Hub. CLI tooling. Phone-as-gateway (Termux path live).         |
 | Growth | 🗓️ Planned      | Rust HAL rewrite. 500+ skills. ori-cloud. Enterprise pilots.          |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Ori Runtime controls physical systems. Security issues can have real-world conse
 
 | Version | Supported |
 | ------- | --------- |
-| `0.1.x` (alpha) | Yes |
-| `<0.1.0` | No |
+| `0.9.x` (beta) | Yes |
+| `<0.9.0` | No |
 
 ## Reporting a Vulnerability
 
@@ -75,4 +75,3 @@ If you discover an issue that can cause immediate physical harm, mark the report
 - Trigger conditions
 - Potential hazard
 - Suggested temporary mitigation
-

--- a/docs/beta-release-notes.md
+++ b/docs/beta-release-notes.md
@@ -1,0 +1,7 @@
+# Ori Runtime — Beta Release Notes
+
+Moved to:
+
+- [`docs/releases/beta-release-notes.md`](releases/beta-release-notes.md)
+
+This compatibility file is kept so older links continue to resolve.

--- a/docs/releases/alpha-release-notes.md
+++ b/docs/releases/alpha-release-notes.md
@@ -1,5 +1,9 @@
 # Ori Runtime — Alpha Release Notes
 
+Alpha series archive. Current release channel is beta:
+
+- [`docs/releases/beta-release-notes.md`](beta-release-notes.md)
+
 ## Versioned Notes
 
 - [`v0.1.0-alpha.4`](v0.1.0-alpha.4.md) — latest alpha cut

--- a/docs/releases/beta-release-notes.md
+++ b/docs/releases/beta-release-notes.md
@@ -1,0 +1,22 @@
+# Ori Runtime — Beta Release Notes
+
+## Versioned Notes
+
+- [`v0.9.0-beta.1`](v0.9.0-beta.1.md) — first beta cut
+
+## Version
+
+`v0.9.0-beta.1` (or current `0.9.x` beta tag)
+
+## Beta Scope
+
+Recommended:
+
+- PoCs and controlled field deployments
+- Operator-in-the-loop and autonomous safety validation runs
+- Readiness verification before `v1.0.0`
+
+Not yet guaranteed:
+
+- Frozen external contracts across all companion repos (`ori-cli`, `ori-gateway`, `ori-sdk-python`)
+- Zero behavioral changes between beta minors while PoC learnings are integrated

--- a/docs/releases/v0.9.0-beta.1.md
+++ b/docs/releases/v0.9.0-beta.1.md
@@ -1,0 +1,67 @@
+# Ori Runtime — v0.9.0-beta.1 Release Notes
+
+## Release Type
+
+Beta pre-release (`v0.9.0-beta.1`)
+
+## Compare
+
+`v0.1.0-alpha.4...v0.9.0-beta.1`
+
+https://github.com/ori-platform/ori-runtime/compare/v0.1.0-alpha.4...v0.9.0-beta.1
+
+## Summary
+
+This first beta cut promotes Ori Runtime from alpha hardening to field-ready PoC posture.
+The runtime now includes the full pre-PoC and post-PoC core sequence required for
+imminent deployment validation, including stronger safety paths, policy integrity controls,
+offline resilience improvements, and expanded skill/runtime observability.
+
+## Included Since v0.1.0-alpha.4
+
+- Tiered actuation safety hardening:
+  - Tier D relay bypass invariants enforced against policy/config gating
+  - Tier C approvals and offline fallback path improvements
+- Alerting resilience:
+  - alert outbox + retry delivery path
+  - SMS transport failover improvements (IP/GSM/hybrid)
+  - stronger channel-aware alert composition paths
+- Policy integrity chain:
+  - secure remote policy fetch verification
+  - DevicePolicy enforcement and SQLite cache validation
+  - policy refresh loop with rejection audit behavior
+- Capability and health observability:
+  - structured capability posture signaling
+  - runtime health/status UNIX socket (`/run/ori/health.sock`)
+- Runtime security posture:
+  - Ed25519 community-skill signature verification
+  - OS-level sandbox support for community hooks
+    (seccomp + Landlock on supported kernels, safe fallback path otherwise)
+- Skill quality upgrades:
+  - energy anomaly detector v2
+  - solar performance monitor skill
+  - battery lifecycle observer skill
+- Protocol/perception expansion:
+  - CoAP telemetry adapter integration
+
+## Validation Snapshot
+
+- Full runtime suite passed:
+  - `pytest tests/ -v`
+  - Result: `1040 passed, 8 skipped`
+
+## Known Limitations (Beta)
+
+- Companion repos (`ori-cli`, `ori-gateway`, `ori-sdk-python`) are still converging toward
+  final `1.0.0` contract alignment with runtime.
+- Some operator-facing language/templates are still being tuned from PoC feedback.
+- Kernel-level sandbox behavior depends on host kernel support; fallback remains Python-level
+  sandbox unless strict mode is explicitly required.
+
+## Exit Criteria Toward v1.0.0
+
+- PoC field data confirms:
+  - Tier C/Tier D behavior under real fault conditions
+  - alert channel reliability under intermittent connectivity
+  - policy refresh/cache stability under degraded network states
+  - sustained runtime stability with acceptable resource envelope

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "0.1.0"
+version = "0.9.0b1"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -13,7 +13,7 @@ authors = [
 ]
 keywords = ["iot", "edge-ai", "agentic", "llm", "raspberry-pi", "offline-first"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
