### PR TITLE
fix: implement pre v1 history placeholder hardening

### DIFF
--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -8,6 +8,7 @@ This is the authoritative record of what is real versus planned.
 | Intelligence Elevator Tier 1 (rule engine)       | Implemented       | elevator.py                               | Deterministic. Tier D bypass always.                                                                                  |
 | Intelligence Elevator Tier 2 (local SLM)         | Implemented       | elevator.py                               | Qwen2.5-0.5B via llama-cpp-python                                                                                     |
 | Prompt history placeholder interpolation          | Implemented       | reasoning/elevator.py, tests/test_elevator.py | Supports safe `{history.method(...)}` interpolation in prompts (AST-validated, async-resolved), including compact `history.last_n(...)` output for low-token local SLM reasoning. |
+| Skill prompt history placeholder guard            | Implemented       | skills/loader.py, tests/test_skill_loader.py  | Skill load now fails fast when any prompt template exceeds 16 `{history.*}` placeholders; unresolved/unsupported placeholders are emitted at WARNING level for operator visibility. |
 | Intelligence Elevator Tier 3 (gateway)           | Partial — stubbed | elevator.py:125, :250                     | MQTT request/response not wired. Falls back to local_slm.                                                             |
 | Intelligence Elevator Tier 4 (cloud LLM)         | Partial — stubbed | elevator.py:410, :969                     | Returns stub result. No external API call.                                                                            |
 | CoAP actuation executor                          | Implemented       | actions/coap.py, runtime.py:312           | Host allowlist enforced in config.py:409.                                                                             |
@@ -39,3 +40,4 @@ This is the authoritative record of what is real versus planned.
 
 - 2026-05-07: Runtime async offload refactor changed blocking-call wrappers from `run_in_executor` to `asyncio.to_thread` in actions/HAL/reasoning/store paths. Capability statuses unchanged (implementation detail only).
 - 2026-05-08: Added safe history-placeholder prompt interpolation in the elevator and hardened state compaction with configurable DB-backed clock-skew guard (`state.compaction.max_backward_skew_ms`).
+- 2026-05-09: Added load-time guardrails for history placeholder volume in skill prompts and raised unresolved history placeholder observability to WARNING logs.

--- a/ori/reasoning/elevator.py
+++ b/ori/reasoning/elevator.py
@@ -1040,7 +1040,11 @@ class IntelligenceElevator:
 
         parsed = self._parse_history_expression(expression)
         if parsed is None:
-            logger.debug("Unsupported history placeholder syntax: %s", expression)
+            logger.warning(
+                "Unsupported history placeholder syntax for sensor_id=%s: %s",
+                event.sensor_id,
+                expression,
+            )
             return None
 
         adapter = HookHistoryAdapter(state_store)
@@ -1052,8 +1056,11 @@ class IntelligenceElevator:
                 event,
             )
         except Exception:
-            logger.debug(
-                "Failed to resolve history placeholder %s", expression, exc_info=True
+            logger.warning(
+                "Failed to resolve history placeholder for sensor_id=%s: %s",
+                event.sensor_id,
+                expression,
+                exc_info=True,
             )
             return None
         return self._format_history_placeholder_value(raw)

--- a/ori/skills/loader.py
+++ b/ori/skills/loader.py
@@ -36,6 +36,8 @@ logger = logging.getLogger(__name__)
 
 _VALID_TIERS = frozenset({"A", "B", "C", "D"})
 _TRIGGER_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_HISTORY_PLACEHOLDER_PATTERN = re.compile(r"\{history\.[^{}]+\}")
+_MAX_HISTORY_PLACEHOLDERS = 16
 _HUB_ROOT_PUBLIC_KEY_B64 = "PENDING_REPLACE_AT_HUB_LAUNCH"
 
 
@@ -287,6 +289,12 @@ class SkillLoader:
             raw.get("name", "<unknown>"),
             trigger_names=[t.name for t in triggers],
         )
+        prompts = raw.get("prompts") or {}
+        self._validate_history_placeholder_count(
+            prompts=prompts,
+            skill_name=raw.get("name", "<unknown>"),
+            trigger_names=[t.name for t in triggers],
+        )
         self._verify_community_signature(raw, skill_dir)
         hooks = self._load_hooks(skill_dir)
 
@@ -296,7 +304,7 @@ class SkillLoader:
             author=raw.get("author", ""),
             sensors_required=raw.get("sensors_required") or [],
             triggers=triggers,
-            prompts=raw.get("prompts") or {},
+            prompts=prompts,
             actions=raw.get("actions") or {},
             config=raw.get("config") or {},
             hooks=hooks,
@@ -548,6 +556,33 @@ class SkillLoader:
                 )
             )
         return triggers
+
+    def _validate_history_placeholder_count(
+        self,
+        *,
+        prompts: Any,
+        skill_name: str,
+        trigger_names: list[str],
+    ) -> None:
+        """Fail fast when prompt templates exceed history placeholder cap."""
+        if not isinstance(prompts, dict):
+            return
+        trigger_name_set = set(trigger_names)
+        for prompt_key, template in prompts.items():
+            if not isinstance(template, str):
+                continue
+            count = len(_HISTORY_PLACEHOLDER_PATTERN.findall(template))
+            if count <= _MAX_HISTORY_PLACEHOLDERS:
+                continue
+            scope = (
+                "trigger"
+                if isinstance(prompt_key, str) and prompt_key in trigger_name_set
+                else "prompt key"
+            )
+            raise SkillValidationError(
+                f"Skill {skill_name!r}: {scope} {prompt_key!r} contains {count} "
+                f"history placeholders; maximum allowed is {_MAX_HISTORY_PLACEHOLDERS}."
+            )
 
     def _load_hooks(self, skill_dir: Path) -> Any:
         hooks_path = skill_dir / "hooks.py"

--- a/tests/test_elevator.py
+++ b/tests/test_elevator.py
@@ -439,11 +439,35 @@ class TestReason:
         store = _PromptHistoryStore({"load-current": [1.0, 2.0]})
 
         with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with caplog.at_level(logging.DEBUG):
+            with caplog.at_level(logging.WARNING):
                 result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert "{history.not_a_method('load-current', 2)}" in result.prompt
         assert "Failed to resolve history placeholder" in caplog.text
+
+    async def test_history_placeholder_malformed_expression_logs_warning(self, caplog):
+        mock_llm = AsyncMock()
+        mock_llm.reason.return_value = ReasoningResult(
+            text="ok",
+            tier="local_slm",
+            model="qwen.gguf",
+            tokens_used=12,
+            latency_ms=100,
+        )
+        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
+        skill = _tier_a_skill()
+        skill.prompts = {
+            "anomalous_draw": "Broken: {history.last_n(sensor_id='load-current', n=2)}"
+        }
+        store = _PromptHistoryStore({"load-current": [10.0, 14.0]})
+
+        with patch("ori.reasoning.elevator._is_offline", return_value=True):
+            with caplog.at_level(logging.WARNING):
+                result = await elevator.reason(_event(value=8.2), skill, store)
+
+        assert "{history.last_n(sensor_id='load-current', n=2)}" in result.prompt
+        assert "Unsupported history placeholder syntax" in caplog.text
 
     async def test_history_placeholder_avg_hours_is_substituted(self):
         mock_llm = AsyncMock()

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -390,6 +390,67 @@ class TestLoadOne:
 
 
 class TestValidation:
+    def test_history_placeholders_above_limit_raise(self, tmp_path):
+        placeholders = " ".join(
+            [f"{{history.last_n('load-current', {i})}}" for i in range(1, 18)]
+        )
+        yaml_content = f"""\
+            name: too-many-history-placeholders
+            version: 0.1.0
+            author: test
+            sensors_required:
+              - type: current_clamp
+            triggers:
+              - name: over_threshold
+                condition: "value > 5"
+                action_tier: A
+            prompts:
+              over_threshold: "{placeholders}"
+            actions:
+              available:
+                - name: alert_whatsapp
+                  tier: A
+              defaults:
+                over_threshold: [alert_whatsapp]
+        """
+        skill_dir = tmp_path / "too-many-history-placeholders"
+        _write_skill_yaml(skill_dir, yaml_content)
+        loader = SkillLoader()
+        with pytest.raises(
+            SkillValidationError,
+            match="contains 17 history placeholders; maximum allowed is 16",
+        ):
+            loader.load_one(skill_dir)
+
+    def test_history_placeholders_at_limit_loads(self, tmp_path):
+        placeholders = " ".join(
+            [f"{{history.last_n('load-current', {i})}}" for i in range(1, 17)]
+        )
+        yaml_content = f"""\
+            name: max-history-placeholders
+            version: 0.1.0
+            author: test
+            sensors_required:
+              - type: current_clamp
+            triggers:
+              - name: over_threshold
+                condition: "value > 5"
+                action_tier: A
+            prompts:
+              over_threshold: "{placeholders}"
+            actions:
+              available:
+                - name: alert_whatsapp
+                  tier: A
+              defaults:
+                over_threshold: [alert_whatsapp]
+        """
+        skill_dir = tmp_path / "max-history-placeholders"
+        _write_skill_yaml(skill_dir, yaml_content)
+        loader = SkillLoader()
+        skill = loader.load_one(skill_dir)
+        assert skill.name == "max-history-placeholders"
+
     def test_missing_action_tier_raises(self, tmp_path):
         yaml_content = """\
             name: bad-skill


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
