### PR TITLE
docs(release): add v0.9.0-beta.2 release notes

### DIFF
--- a/docs/releases/beta-release-notes.md
+++ b/docs/releases/beta-release-notes.md
@@ -2,11 +2,12 @@
 
 ## Versioned Notes
 
+- [`v0.9.0-beta.2`](v0.9.0-beta.2.md) — v1-readiness hardening and transport/config safeguards
 - [`v0.9.0-beta.1`](v0.9.0-beta.1.md) — first beta cut
 
 ## Version
 
-`v0.9.0-beta.1` (or current `0.9.x` beta tag)
+`v0.9.0-beta.2` (or current `0.9.x` beta tag)
 
 ## Beta Scope
 

--- a/docs/releases/v0.9.0-beta.2.md
+++ b/docs/releases/v0.9.0-beta.2.md
@@ -1,0 +1,66 @@
+# Ori Runtime — v0.9.0-beta.2 Release Notes
+
+## Release Type
+
+Beta pre-release (`v0.9.0-beta.2`)
+
+## Compare
+
+`v0.9.0-beta.1...v0.9.0-beta.2`
+
+https://github.com/ori-platform/ori-runtime/compare/v0.9.0-beta.1...v0.9.0-beta.2
+
+## Summary
+
+This beta increment focuses on v1-readiness hardening across runtime reasoning paths,
+alert transport reliability, and configuration safety. The goal is to remove ambiguous
+behavior before v1 by making failure modes explicit, deterministic, and test-covered.
+
+## Included Since v0.9.0-beta.1
+
+- Runtime and reasoning hardening:
+  - causal-memory short-circuit path wired into elevator reasoning flow
+  - reduced internal coupling to private store internals in hook/sandbox paths
+  - deterministic safety guard improvements in state/store and runtime loops
+- SMS/WhatsApp resilience and correctness:
+  - shared boolean parsing utility to eliminate channel config drift
+  - channel-aware contact normalization in failover sender
+  - strict Twilio WhatsApp number format validation (`whatsapp:+...`)
+  - Twilio inbound polling safeguards: timeout, minimum poll interval, rate-limit cooldown
+- v1 config and contract safeguards:
+  - `reasoning.default_tier` restricted to supported v1 tiers (`rule`, `local`)
+  - dispatcher fallback approval timeout now deterministic and safety-biased
+    (max declared timeout across loaded skills)
+  - bundled skill signature contract formalized with `signature: bundled` sentinel
+  - explicit rejection message when bundled sentinel is used for community skills
+  - hot-path polling assert replaced with runtime guard + explicit error logging
+- Operator/deployment clarity:
+  - SIGHUP reload semantics documented clearly:
+    - applies to new events only
+    - in-flight actions continue under previous skill/config snapshot
+  - deployment timezone resolution made robust:
+    `device.timezone` -> host timezone -> UTC fallback
+
+## Validation Snapshot
+
+- Full runtime suite passed:
+  - `pytest tests/ -q`
+  - Result: `1087 passed, 8 skipped`
+- Focused regression verification also passed for:
+  - config/timezone/sentinel paths
+  - runtime polling and dispatcher fallback timeout
+  - SMS/WhatsApp failover and Twilio polling safeguards
+
+## Known Limitations (Beta)
+
+- Gateway and cloud reasoning tiers remain intentionally partial/stubbed in this beta line.
+- Community skill distribution workflows still depend on trust-anchor provisioning and
+  kernel/runtime sandbox capabilities of the deployment host.
+
+## Exit Criteria Toward v1.0.0
+
+- Field PoC confirms:
+  - stable Tier C/Tier D behavior under real fault and approval timing conditions
+  - channel reliability under constrained connectivity and Twilio/API throttling conditions
+  - deterministic behavior under skill reload and timezone/config edge cases
+  - sustained runtime stability with acceptable resource envelope on target edge hardware


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
