### PR TITLE
security(runtime): authenticate remote commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -571,6 +571,8 @@ Violating them creates vulnerabilities that affect physical hardware.
     token, or an equivalent replay-resistant check. Tier D evaluation and
     execution paths must not be disableable by any remote command, including SMS,
     WhatsApp, or cloud API.
+    All remote command handlers must call `RemoteCommandVerifier` before executing
+    or queueing any state-changing command.
 
 ---
 

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -38,6 +38,7 @@ This is the authoritative record of what is real versus planned.
 | Solar performance monitor skill                  | Implemented       | skills/solar-performance-monitor/, tests/test_solar_performance_skill.py | Heuristic daytime solar diagnostics with strict config baselines (`installed_pv_capacity_watts`, `battery_capacity_wh`), local-time gating, and plain-language SMS-first alert composition via shared composer helpers. |
 | Energy cost calculator hook                      | Implemented       | skills/energy-anomaly-detector/hooks.py, tests/test_energy_anomaly_skill.py | Deterministic cost math computes both observed window cost and projected `/day` run-rate risk. Currency/voltage inference uses explicit config first, then country-code defaults, with `exact`/`estimated` confidence labeling. |
 | Offline Tier C auth tokens                       | Implemented       | security/offline_tokens.py, action_dispatcher.py, state/store.py | Local-console `TOKEN:<value>` approvals are signature-verified (Ed25519), device/action-bound, expiry-checked, and replay-protected via SQLite token claim table. |
+| Authenticated remote runtime commands            | Implemented       | security/remote_commands.py, actions/sms.py, state/store.py, runtime.py | Structured SMS remote commands are intercepted before approval-message storage, HMAC-SHA256 verified, timestamp checked, replay-protected, audited to SQLite, and fail-closed on Tier D/safety-disabling mutations or direct actuator commands. |
 
 ## Recent updates
 
@@ -49,3 +50,4 @@ This is the authoritative record of what is real versus planned.
 - 2026-05-11: Wired causal-memory into elevator reasoning as an optional pre-LLM cache (`reasoning.causal_memory.enabled`) and aligned keying to event timestamp (UTC) for deterministic pattern reuse across hosts.
 - 2026-05-14: Hardened runtime supply chain: CI now uses explicit least-privilege permissions, SHA-pinned actions and pre-commit hooks, Harden-Runner audit mode, hash-locked installs, `pip-audit`, CycloneDX SBOM artifact generation, Python 3.12 lock generation, and a guard for mutable actions/OIDC/remote script execution.
 - 2026-05-30: Added Tier C decision logging for full proposal, operator decision, safe-default, and outcome context needed for future approval/rejection learning.
+- 2026-05-30: Added authenticated remote command verification with HMAC signatures, timestamp skew checks, replay audit, and Tier D/safety mutation denial.

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -274,6 +274,12 @@ os_sandbox:
   exec_timeout_ms: 2000
   max_output_bytes: 65536
 
+security:
+  remote_commands:
+    enabled: false                               # state-changing SMS/WhatsApp/cloud commands require HMAC
+    hmac_secret_env: ORI_REMOTE_COMMAND_HMAC_SECRET
+    max_skew_seconds: 300
+
 actions:
   # For Nigeria: use sms as primary (Africa's Talking — no approval required)
   # For UK/EU:   use whatsapp as primary

--- a/ori/actions/sms.py
+++ b/ori/actions/sms.py
@@ -29,6 +29,11 @@ import time
 from typing import Any
 
 from ori.bool_utils import is_truthy
+from ori.security.remote_commands import (
+    RemoteCommandVerifier,
+    extract_remote_command_payload,
+    handle_remote_command,
+)
 from ori.time_utils import now_ms
 
 logger = logging.getLogger(__name__)
@@ -74,6 +79,7 @@ class SMSAction:
         state_store: Any = None,
         poll_interval_seconds: int = _POLL_INTERVAL_SECONDS,
         config: dict[str, Any] | None = None,
+        remote_command_verifier: RemoteCommandVerifier | None = None,
     ) -> None:
         sms_cfg = config if isinstance(config, dict) else {}
 
@@ -105,6 +111,7 @@ class SMSAction:
             sms_cfg.get("AT_SENDER_ID") or os.environ.get("AT_SENDER_ID", "ORI")
         )
         self._state_store = state_store
+        self._remote_command_verifier = remote_command_verifier
         self._poll_interval_seconds = max(1, int(poll_interval_seconds))
         self._ip_ready = bool(self._api_key)
 
@@ -420,6 +427,45 @@ class SMSAction:
             return False
 
         try:
+            command_payload = extract_remote_command_payload(
+                payload, channel="sms", from_number=from_number
+            )
+            if command_payload is not None:
+                if self._remote_command_verifier is None:
+                    if hasattr(self._state_store, "log_remote_command_attempt"):
+                        await self._state_store.log_remote_command_attempt(
+                            command_id=str(command_payload.get("command_id", "") or ""),
+                            channel="sms",
+                            command=str(command_payload.get("command", "") or ""),
+                            accepted=False,
+                            reason="remote_command_verifier_disabled",
+                            issued_at_ms=_safe_int_or_none(
+                                command_payload.get("issued_at_ms")
+                            ),
+                        )
+                    logger.warning(
+                        "SMSAction.ingest_incoming_webhook: remote command received but verifier is disabled"
+                    )
+                    return False
+                result = await handle_remote_command(
+                    command_payload,
+                    channel="sms",
+                    state_store=self._state_store,
+                    verifier=self._remote_command_verifier,
+                )
+                if not result.accepted:
+                    logger.warning(
+                        "SMSAction.ingest_incoming_webhook: rejected remote command reason=%s",
+                        result.reason,
+                    )
+                    return False
+                logger.info(
+                    "SMSAction.ingest_incoming_webhook: accepted remote command command_id=%s command=%s",
+                    result.command.command_id if result.command else "",
+                    result.command.command if result.command else "",
+                )
+                return True
+
             await self._state_store.store_incoming_message(
                 channel="sms",
                 from_number=from_number,
@@ -483,3 +529,10 @@ class SMSAction:
 def _normalize_phone(value: str) -> str:
     """Normalize a phone number for stable matching."""
     return "".join(ch for ch in value if ch.isdigit() or ch == "+")
+
+
+def _safe_int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None

--- a/ori/config.py
+++ b/ori/config.py
@@ -174,6 +174,7 @@ class Config:
     hal: HalConfig
     logging: LoggingConfig
     device_policy: dict = field(default_factory=dict)
+    security: dict = field(default_factory=dict)
     health_socket: dict = field(default_factory=dict)
     os_sandbox: dict = field(default_factory=dict)
     state: StateConfig = field(default_factory=StateConfig)
@@ -209,6 +210,7 @@ class Config:
         actions = _parse_actions(data.get("actions", {}))
         hal = _parse_hal(data.get("hal"))
         device_policy = _parse_device_policy(data.get("device_policy"))
+        security = _parse_security(data.get("security"))
         health_socket = _parse_health_socket(data.get("health_socket"))
         os_sandbox = _parse_os_sandbox(data.get("os_sandbox"))
         state_cfg = _parse_state(data.get("state"))
@@ -374,6 +376,7 @@ class Config:
             actions=actions,
             hal=hal,
             device_policy=device_policy,
+            security=security,
             health_socket=health_socket,
             os_sandbox=os_sandbox,
             state=state_cfg,
@@ -1053,6 +1056,50 @@ def _parse_device_policy(data: Any) -> dict:
                 "device_policy.public_key_b64 is missing or not properly interpolated."
             )
 
+    return out
+
+
+def _parse_security(data: Any) -> dict:
+    """Parse security controls that are not tied to one action channel."""
+    if data is None:
+        data = {}
+    if not isinstance(data, dict):
+        raise ConfigValidationError("'security' must be a mapping.")
+
+    out = dict(data)
+    remote = out.get("remote_commands") or {}
+    if not isinstance(remote, dict):
+        raise ConfigValidationError("security.remote_commands must be a mapping.")
+
+    try:
+        max_skew_seconds = int(remote.get("max_skew_seconds", 300))
+    except (TypeError, ValueError) as exc:
+        raise ConfigValidationError(
+            "security.remote_commands.max_skew_seconds must be an integer."
+        ) from exc
+    if max_skew_seconds < 0:
+        raise ConfigValidationError(
+            "security.remote_commands.max_skew_seconds must be >= 0."
+        )
+
+    enabled = (
+        str(remote.get("enabled", "")).strip().lower() == "true"
+        or remote.get("enabled") is True
+    )
+    hmac_secret_env = str(
+        remote.get("hmac_secret_env", "ORI_REMOTE_COMMAND_HMAC_SECRET")
+    ).strip()
+    if enabled and not hmac_secret_env:
+        raise ConfigValidationError(
+            "security.remote_commands.hmac_secret_env is required when enabled."
+        )
+
+    out["remote_commands"] = {
+        **remote,
+        "enabled": enabled,
+        "hmac_secret_env": hmac_secret_env,
+        "max_skew_seconds": max_skew_seconds,
+    }
     return out
 
 

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -57,6 +57,7 @@ from ori.reasoning.elevator import IntelligenceElevator, SkillContext
 from ori.reasoning.local_llm import LocalLLM
 from ori.runtime_health_socket import RuntimeHealthSocketServer
 from ori.security.offline_tokens import OfflineTierCTokenVerifier
+from ori.security.remote_commands import RemoteCommandVerifier
 from ori.skills.loader import SkillLoader
 from ori.skills.signing import verify_signed_payload
 from ori.state.store import StateStore
@@ -283,8 +284,13 @@ class OriRuntime:
         await self._state_store.open()
 
         # ── Step C: Instantiate action executors and ActionDispatcher ─────────
+        remote_command_verifier = _build_remote_command_verifier(config)
         whatsapp_action = WhatsAppAction(provider=TwilioProvider())
-        sms_action = SMSAction(state_store=self._state_store, config=config.actions.sms)
+        sms_action = SMSAction(
+            state_store=self._state_store,
+            config=config.actions.sms,
+            remote_command_verifier=remote_command_verifier,
+        )
         coap_action = CoAPAction(config=config.actions.coap)
         self._sms_action = sms_action
         logger_action = LoggerAction()
@@ -1950,6 +1956,31 @@ def _build_offline_token_verifier(actions_cfg: Any) -> OfflineTierCTokenVerifier
     return OfflineTierCTokenVerifier(
         public_key_b64=str(offline_cfg.get("public_key_b64", "")),
         max_clock_skew_s=int(offline_cfg.get("max_clock_skew_s", 300)),
+    )
+
+
+def _build_remote_command_verifier(config: Config) -> RemoteCommandVerifier | None:
+    security_cfg = config.security if isinstance(config.security, dict) else {}
+    remote_cfg = security_cfg.get("remote_commands") or {}
+    if not isinstance(remote_cfg, dict):
+        return None
+    if not is_truthy(remote_cfg.get("enabled", False)):
+        return None
+
+    secret_env = str(
+        remote_cfg.get("hmac_secret_env", "ORI_REMOTE_COMMAND_HMAC_SECRET")
+    ).strip()
+    shared_secret = os.environ.get(secret_env, "")
+    if not shared_secret:
+        logger.warning(
+            "[runtime] remote commands enabled but %s is not set; commands will fail closed.",
+            secret_env,
+        )
+    max_skew_ms = int(remote_cfg.get("max_skew_seconds", 300)) * 1000
+    return RemoteCommandVerifier(
+        device_id=str(config.device.id),
+        shared_secret=shared_secret,
+        max_skew_ms=max_skew_ms,
     )
 
 

--- a/ori/security/remote_commands.py
+++ b/ori/security/remote_commands.py
@@ -1,0 +1,364 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Authenticated remote runtime command verification.
+
+Remote commands are not Tier C approval replies.  Approval replies answer an
+already-created proposal; remote commands attempt to change runtime state.  This
+module verifies those commands before any channel-specific ingress can dispatch
+or persist them as executable instructions.
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+from dataclasses import dataclass
+from hashlib import sha256
+from typing import Any
+
+from ori.time_utils import now_ms
+
+_ALLOWED_COMMANDS = {
+    "UPDATE_CONFIG",
+    "UPDATE_SKILL",
+    "APPLY_POLICY",
+    "REFRESH_POLICY",
+    "RESTART_RUNTIME",
+    "SET_THRESHOLD",
+    "SET_RELAY_MODE",
+    "TRIGGER_SYNC",
+}
+
+_FORBIDDEN_COMMANDS = {
+    "DISABLE_TIER_D",
+    "DISABLE_SAFETY",
+    "DISABLE_SENSOR_VALIDATION",
+    "BYPASS_DEVICE_POLICY_FOR_TIER_B_OR_C",
+    "EXECUTE_RELAY",
+    "FORCE_ACTUATOR",
+}
+
+_COMMAND_FIELDS = {"command_id", "device_id", "issued_at_ms", "command", "args"}
+
+
+@dataclass(frozen=True)
+class RemoteCommand:
+    command_id: str
+    channel: str
+    device_id: str
+    issued_at_ms: int
+    command: str
+    args: dict[str, Any]
+    signature: str | None = None
+
+
+@dataclass(frozen=True)
+class CommandVerificationResult:
+    accepted: bool
+    reason: str
+    command: RemoteCommand | None = None
+
+
+class RemoteCommandVerifier:
+    """Verify HMAC-authenticated remote commands with replay protection."""
+
+    def __init__(
+        self,
+        *,
+        device_id: str,
+        shared_secret: str | None,
+        max_skew_ms: int = 300_000,
+    ) -> None:
+        self._device_id = str(device_id or "").strip()
+        self._shared_secret = str(shared_secret or "").strip()
+        self._max_skew_ms = max(0, int(max_skew_ms))
+
+    async def verify(
+        self,
+        payload: dict[str, Any],
+        *,
+        state_store: Any,
+    ) -> CommandVerificationResult:
+        parsed, parse_reason = _parse_command(payload)
+        if parsed is None:
+            return await self._audit(
+                state_store=state_store,
+                command_id=str(payload.get("command_id", "") or ""),
+                channel=str(payload.get("channel", "") or ""),
+                command=str(payload.get("command", "") or ""),
+                accepted=False,
+                reason=parse_reason,
+                issued_at_ms=_safe_int_or_none(payload.get("issued_at_ms")),
+            )
+
+        if parsed.device_id != self._device_id:
+            return await self._reject(state_store, parsed, "device_mismatch")
+
+        if not self._shared_secret:
+            return await self._reject(state_store, parsed, "missing_shared_secret")
+
+        now = now_ms()
+        if parsed.issued_at_ms < now - self._max_skew_ms:
+            return await self._reject(state_store, parsed, "stale_timestamp")
+        if parsed.issued_at_ms > now + self._max_skew_ms:
+            return await self._reject(state_store, parsed, "future_timestamp")
+
+        if parsed.command in _FORBIDDEN_COMMANDS:
+            return await self._reject(state_store, parsed, "forbidden_command")
+        if parsed.command not in _ALLOWED_COMMANDS:
+            return await self._reject(state_store, parsed, "unknown_command")
+        if _contains_forbidden_safety_disable(parsed.args):
+            return await self._reject(state_store, parsed, "forbidden_safety_mutation")
+
+        if not parsed.signature:
+            return await self._reject(state_store, parsed, "missing_signature")
+        if not parsed.signature.startswith("hmac-sha256:"):
+            return await self._reject(state_store, parsed, "unsupported_signature")
+
+        expected = sign_remote_command(parsed, self._shared_secret)
+        if not hmac.compare_digest(parsed.signature, expected):
+            return await self._reject(state_store, parsed, "invalid_signature")
+
+        if state_store is None or not hasattr(state_store, "has_remote_command"):
+            return await self._reject(state_store, parsed, "state_store_unavailable")
+        if await state_store.has_remote_command(parsed.command_id):
+            return await self._reject(state_store, parsed, "replay_detected")
+
+        return await self._audit(
+            state_store=state_store,
+            command_id=parsed.command_id,
+            channel=parsed.channel,
+            command=parsed.command,
+            accepted=True,
+            reason="accepted",
+            issued_at_ms=parsed.issued_at_ms,
+            command_obj=parsed,
+        )
+
+    async def _reject(
+        self,
+        state_store: Any,
+        command: RemoteCommand,
+        reason: str,
+    ) -> CommandVerificationResult:
+        return await self._audit(
+            state_store=state_store,
+            command_id=command.command_id,
+            channel=command.channel,
+            command=command.command,
+            accepted=False,
+            reason=reason,
+            issued_at_ms=command.issued_at_ms,
+            command_obj=command,
+        )
+
+    async def _audit(
+        self,
+        *,
+        state_store: Any,
+        command_id: str,
+        channel: str,
+        command: str,
+        accepted: bool,
+        reason: str,
+        issued_at_ms: int | None,
+        command_obj: RemoteCommand | None = None,
+    ) -> CommandVerificationResult:
+        if state_store is not None and hasattr(
+            state_store, "log_remote_command_attempt"
+        ):
+            await state_store.log_remote_command_attempt(
+                command_id=command_id,
+                channel=channel,
+                command=command,
+                accepted=accepted,
+                reason=reason,
+                issued_at_ms=issued_at_ms,
+            )
+        return CommandVerificationResult(
+            accepted=accepted,
+            reason=reason,
+            command=command_obj,
+        )
+
+
+async def handle_remote_command(
+    payload: dict[str, Any],
+    *,
+    channel: str,
+    state_store: Any,
+    verifier: RemoteCommandVerifier,
+) -> CommandVerificationResult:
+    """Verify a remote command before any runtime state mutation is allowed."""
+    candidate = dict(payload)
+    candidate.setdefault("channel", channel)
+    return await verifier.verify(candidate, state_store=state_store)
+
+
+def extract_remote_command_payload(
+    payload: dict[str, Any],
+    *,
+    channel: str,
+    from_number: str = "",
+) -> dict[str, Any] | None:
+    """Extract a structured remote command from webhook payloads.
+
+    Supported SMS text forms:
+    - ``ORI_COMMAND {json}``
+    - raw JSON object containing command fields
+
+    Plain Tier C replies like ``YES`` or ``NO`` return ``None``.
+    """
+    direct = {key: payload.get(key) for key in _COMMAND_FIELDS if key in payload}
+    if _COMMAND_FIELDS <= set(direct):
+        result = dict(payload)
+        result.setdefault("channel", channel)
+        result.setdefault("from_number", from_number)
+        return result
+
+    raw = str(payload.get("text") or payload.get("message") or "").strip()
+    if not raw:
+        return None
+
+    body = raw
+    if raw.upper().startswith("ORI_COMMAND "):
+        body = raw[len("ORI_COMMAND ") :].strip()
+    elif not raw.startswith("{"):
+        return None
+
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(decoded, dict):
+        return None
+    if not _COMMAND_FIELDS <= set(decoded):
+        return None
+
+    decoded.setdefault("channel", channel)
+    decoded.setdefault("from_number", from_number)
+    return decoded
+
+
+def sign_remote_command(
+    command: RemoteCommand | dict[str, Any], shared_secret: str
+) -> str:
+    """Return ``hmac-sha256:<hex>`` for a remote command payload."""
+    if isinstance(command, RemoteCommand):
+        device_id = command.device_id
+        command_id = command.command_id
+        issued_at_ms = command.issued_at_ms
+        command_name = command.command
+        args = command.args
+    else:
+        device_id = str(command.get("device_id", "") or "")
+        command_id = str(command.get("command_id", "") or "")
+        issued_at_ms = int(command.get("issued_at_ms", 0) or 0)
+        command_name = str(command.get("command", "") or "").strip().upper()
+        args = command.get("args") if isinstance(command.get("args"), dict) else {}
+
+    signed = "\n".join(
+        [
+            device_id,
+            command_id,
+            str(issued_at_ms),
+            command_name,
+            _canonical_json(args),
+        ]
+    )
+    digest = hmac.new(
+        str(shared_secret).encode("utf-8"),
+        signed.encode("utf-8"),
+        sha256,
+    ).hexdigest()
+    return f"hmac-sha256:{digest}"
+
+
+def _parse_command(payload: dict[str, Any]) -> tuple[RemoteCommand | None, str]:
+    command_id = str(payload.get("command_id", "") or "").strip()
+    if not command_id:
+        return None, "missing_command_id"
+
+    device_id = str(payload.get("device_id", "") or "").strip()
+    if not device_id:
+        return None, "missing_device_id"
+
+    issued_at_ms = _safe_int_or_none(payload.get("issued_at_ms"))
+    if issued_at_ms is None:
+        return None, "invalid_timestamp"
+
+    command = str(payload.get("command", "") or "").strip().upper()
+    if not command:
+        return None, "missing_command"
+
+    args = payload.get("args")
+    if args is None:
+        args = {}
+    if not isinstance(args, dict):
+        return None, "invalid_args"
+
+    return (
+        RemoteCommand(
+            command_id=command_id,
+            channel=str(payload.get("channel", "") or ""),
+            device_id=device_id,
+            issued_at_ms=issued_at_ms,
+            command=command,
+            args=args,
+            signature=str(payload.get("signature") or "") or None,
+        ),
+        "ok",
+    )
+
+
+def _canonical_json(value: dict[str, Any]) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _safe_int_or_none(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _contains_forbidden_safety_disable(value: Any) -> bool:
+    if isinstance(value, dict):
+        normalized = {_normalize_key(k): v for k, v in value.items()}
+        tier_value = str(
+            normalized.get("actiontier") or normalized.get("tier") or ""
+        ).upper()
+        if tier_value == "D" and (
+            _is_false_like(normalized.get("enabled"))
+            or _is_false_like(normalized.get("bypassllm"))
+        ):
+            return True
+
+        for key, item in normalized.items():
+            if key in {"disabletierd", "disablesafety", "disablesensorvalidation"}:
+                return True
+            if key in {"tierdenabled", "safetyenabled", "sensorvalidationenabled"}:
+                if _is_false_like(item):
+                    return True
+            if _contains_forbidden_safety_disable(item):
+                return True
+        return False
+
+    if isinstance(value, list):
+        return any(_contains_forbidden_safety_disable(item) for item in value)
+    return False
+
+
+def _normalize_key(value: Any) -> str:
+    return str(value).lower().replace("_", "").replace("-", "").replace(".", "")
+
+
+def _is_false_like(value: Any) -> bool:
+    if value is False:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in {"false", "0", "no", "off", "disabled"}
+    if isinstance(value, int | float):
+        return value == 0
+    return False

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -150,6 +150,20 @@ CREATE TABLE IF NOT EXISTS inbound_messages (
 CREATE INDEX IF NOT EXISTS idx_inbound_lookup
     ON inbound_messages (channel, from_number, received_at, consumed_at);
 
+CREATE TABLE IF NOT EXISTS remote_command_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    command_id     TEXT    NOT NULL DEFAULT '',
+    channel        TEXT    NOT NULL DEFAULT '',
+    command        TEXT    NOT NULL DEFAULT '',
+    accepted       INTEGER NOT NULL,
+    reason         TEXT    NOT NULL,
+    issued_at_ms   INTEGER,
+    received_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_command_log_command_id
+    ON remote_command_log (command_id, accepted, received_at_ms DESC);
+
 CREATE TABLE IF NOT EXISTS alert_outbox (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     alert_id        TEXT    NOT NULL UNIQUE,
@@ -873,6 +887,98 @@ class StateStore:
         )
         self._conn.commit()
         return str(row["message"])
+
+    # ─── remote_command_log ───────────────────────────────────────────────────
+
+    async def has_remote_command(self, command_id: str) -> bool:
+        return await self._run_read(self._has_remote_command_sync, command_id)
+
+    def _has_remote_command_sync(
+        self, conn: sqlite3.Connection, command_id: str
+    ) -> bool:
+        row = conn.execute(
+            """
+            SELECT 1
+            FROM remote_command_log
+            WHERE command_id = ? AND accepted = 1
+            LIMIT 1
+            """,
+            (str(command_id or ""),),
+        ).fetchone()
+        return row is not None
+
+    async def log_remote_command_attempt(
+        self,
+        *,
+        command_id: str,
+        channel: str,
+        command: str,
+        accepted: bool,
+        reason: str,
+        issued_at_ms: int | None = None,
+        received_at_ms: int | None = None,
+    ) -> None:
+        await self._run_write(
+            self._log_remote_command_attempt_sync,
+            command_id,
+            channel,
+            command,
+            accepted,
+            reason,
+            issued_at_ms,
+            received_at_ms if received_at_ms is not None else now_ms(),
+        )
+
+    def _log_remote_command_attempt_sync(
+        self,
+        command_id: str,
+        channel: str,
+        command: str,
+        accepted: bool,
+        reason: str,
+        issued_at_ms: int | None,
+        received_at_ms: int,
+    ) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            INSERT INTO remote_command_log
+                (command_id, channel, command, accepted, reason, issued_at_ms, received_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(command_id or ""),
+                str(channel or ""),
+                str(command or ""),
+                1 if accepted else 0,
+                str(reason or ""),
+                issued_at_ms,
+                received_at_ms,
+            ),
+        )
+        self._conn.commit()
+
+    async def get_remote_command_log(self, limit: int = 50) -> list[dict]:
+        return await self._run_read(self._get_remote_command_log_sync, limit)
+
+    def _get_remote_command_log_sync(
+        self, conn: sqlite3.Connection, limit: int
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT command_id, channel, command, accepted, reason, issued_at_ms, received_at_ms
+            FROM remote_command_log
+            ORDER BY received_at_ms DESC, id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        result = []
+        for row in rows:
+            item = dict(row)
+            item["accepted"] = bool(item["accepted"])
+            result.append(item)
+        return result
 
     # ─── alert_outbox ─────────────────────────────────────────────────────────
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -142,6 +142,16 @@ class TestLoadExample:
         assert cfg.health_socket["enabled"] is True
         assert cfg.health_socket["path"] == "/run/ori/health.sock"
         assert cfg.health_socket["mode"] == 0o660
+
+    def test_security_remote_commands_defaults(self):
+        cfg = Config.load(EXAMPLE_YAML)
+        remote = cfg.security["remote_commands"]
+        assert remote["enabled"] is False
+        assert remote["hmac_secret_env"] == "ORI_REMOTE_COMMAND_HMAC_SECRET"
+        assert remote["max_skew_seconds"] == 300
+
+    def test_os_sandbox_defaults(self):
+        cfg = Config.load(EXAMPLE_YAML)
         assert cfg.os_sandbox["enabled"] is True
         assert cfg.os_sandbox["require_for_community"] is False
         assert cfg.os_sandbox["exec_timeout_ms"] == 2000
@@ -417,6 +427,61 @@ class TestDeviceValidation:
             """,
         )
         with pytest.raises(ConfigValidationError, match="country_code"):
+            Config.load(yaml_path)
+
+
+# ─── Security validation ──────────────────────────────────────────────────────
+
+
+class TestSecurityValidation:
+    def test_rejects_non_mapping_security(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            security: []
+            """,
+        )
+
+        with pytest.raises(ConfigValidationError, match="security"):
+            Config.load(yaml_path)
+
+    def test_rejects_invalid_remote_command_skew(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            security:
+              remote_commands:
+                enabled: true
+                hmac_secret_env: ORI_REMOTE_COMMAND_HMAC_SECRET
+                max_skew_seconds: -1
+            """,
+        )
+
+        with pytest.raises(ConfigValidationError, match="max_skew_seconds"):
             Config.load(yaml_path)
 
 

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import pytest
+
+from ori.actions.sms import SMSAction
+from ori.security.remote_commands import (
+    RemoteCommandVerifier,
+    extract_remote_command_payload,
+    sign_remote_command,
+)
+from ori.state.store import StateStore
+
+
+@pytest.fixture
+async def store(tmp_path):
+    s = StateStore(db_path=str(tmp_path / "commands.db"))
+    await s.open()
+    yield s
+    await s.close()
+
+
+@pytest.fixture
+def fixed_now(monkeypatch):
+    now = 1_780_000_000_000
+    monkeypatch.setattr("ori.security.remote_commands.now_ms", lambda: now)
+    return now
+
+
+def _payload(*, now: int, command_id: str = "cmd-1", args: dict | None = None):
+    return {
+        "command_id": command_id,
+        "channel": "sms",
+        "device_id": "dev-01",
+        "issued_at_ms": now,
+        "command": "UPDATE_CONFIG",
+        "args": args if args is not None else {"threshold": 42, "sensor_id": "s1"},
+    }
+
+
+def _signed(payload: dict, secret: str = "shared-secret") -> dict:
+    signed = dict(payload)
+    signed["signature"] = sign_remote_command(payload, secret)
+    return signed
+
+
+def _verifier(secret: str = "shared-secret") -> RemoteCommandVerifier:
+    return RemoteCommandVerifier(
+        device_id="dev-01",
+        shared_secret=secret,
+        max_skew_ms=300_000,
+    )
+
+
+async def test_accepts_valid_hmac_command(store, fixed_now):
+    payload = _signed(_payload(now=fixed_now))
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is True
+    assert result.reason == "accepted"
+    assert await store.has_remote_command("cmd-1") is True
+    rows = await store.get_remote_command_log()
+    assert rows[0]["command_id"] == "cmd-1"
+    assert rows[0]["accepted"] is True
+
+
+async def test_rejects_missing_signature(store, fixed_now):
+    result = await _verifier().verify(_payload(now=fixed_now), state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "missing_signature"
+    rows = await store.get_remote_command_log()
+    assert rows[0]["accepted"] is False
+    assert rows[0]["reason"] == "missing_signature"
+
+
+async def test_rejects_bad_signature(store, fixed_now):
+    payload = _signed(_payload(now=fixed_now), secret="wrong-secret")
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "invalid_signature"
+
+
+async def test_rejects_wrong_device_id(store, fixed_now):
+    payload = _payload(now=fixed_now)
+    payload["device_id"] = "other-device"
+    payload = _signed(payload)
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "device_mismatch"
+
+
+async def test_rejects_stale_timestamp(store, fixed_now):
+    payload = _signed(_payload(now=fixed_now - 300_001))
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "stale_timestamp"
+
+
+async def test_rejects_future_timestamp(store, fixed_now):
+    payload = _signed(_payload(now=fixed_now + 300_001))
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "future_timestamp"
+
+
+async def test_rejects_replayed_command_id(store, fixed_now):
+    payload = _signed(_payload(now=fixed_now))
+
+    first = await _verifier().verify(payload, state_store=store)
+    second = await _verifier().verify(payload, state_store=store)
+
+    assert first.accepted is True
+    assert second.accepted is False
+    assert second.reason == "replay_detected"
+
+
+async def test_logs_rejected_command_attempt(store, fixed_now):
+    payload = _payload(now=fixed_now)
+    payload["args"] = []
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    rows = await store.get_remote_command_log()
+    assert rows[0]["reason"] == "invalid_args"
+
+
+async def test_rejects_disable_tier_d_command(store, fixed_now):
+    payload = _payload(now=fixed_now)
+    payload["command"] = "DISABLE_TIER_D"
+    payload = _signed(payload)
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "forbidden_command"
+
+
+async def test_rejects_nested_tier_d_disable_arg(store, fixed_now):
+    payload = _payload(
+        now=fixed_now,
+        args={"skills": [{"trigger": {"action_tier": "D", "enabled": False}}]},
+    )
+    payload = _signed(payload)
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "forbidden_safety_mutation"
+
+
+async def test_rejects_force_actuator_command(store, fixed_now):
+    payload = _payload(now=fixed_now)
+    payload["command"] = "FORCE_ACTUATOR"
+    payload = _signed(payload)
+
+    result = await _verifier().verify(payload, state_store=store)
+
+    assert result.accepted is False
+    assert result.reason == "forbidden_command"
+
+
+def test_canonical_json_signature_is_order_independent(fixed_now):
+    first = _payload(now=fixed_now, args={"b": 2, "a": 1})
+    second = _payload(now=fixed_now, args={"a": 1, "b": 2})
+
+    assert sign_remote_command(first, "shared-secret") == sign_remote_command(
+        second, "shared-secret"
+    )
+
+
+def test_extract_remote_command_ignores_plain_approval_reply():
+    payload = {"from": "+2348012345678", "text": "YES"}
+
+    result = extract_remote_command_payload(
+        payload, channel="sms", from_number="+2348012345678"
+    )
+
+    assert result is None
+
+
+async def test_sms_command_handler_rejects_unsigned_config_change(store, fixed_now):
+    action = SMSAction(
+        state_store=store,
+        config={},
+        remote_command_verifier=_verifier(),
+    )
+    command = _payload(now=fixed_now)
+    payload = {"from": "+2348012345678", "text": f"ORI_COMMAND {json.dumps(command)}"}
+
+    ok = await action.ingest_incoming_webhook(payload)
+
+    assert ok is False
+    rows = await store.get_remote_command_log()
+    assert rows[0]["reason"] == "missing_signature"
+    assert await store.consume_incoming_message("sms", "+2348012345678", 0) is None
+
+
+async def test_sms_command_handler_audits_when_verifier_disabled(store, fixed_now):
+    action = SMSAction(state_store=store, config={})
+    command = _payload(now=fixed_now)
+    payload = {"from": "+2348012345678", "text": f"ORI_COMMAND {json.dumps(command)}"}
+
+    ok = await action.ingest_incoming_webhook(payload)
+
+    assert ok is False
+    rows = await store.get_remote_command_log()
+    assert rows[0]["command_id"] == "cmd-1"
+    assert rows[0]["reason"] == "remote_command_verifier_disabled"
+
+
+async def test_sms_approval_yes_no_is_not_treated_as_remote_command(store):
+    action = SMSAction(state_store=store, config={})
+
+    ok = await action.ingest_incoming_webhook({"from": "+2348012345678", "text": "YES"})
+
+    assert ok is True
+    assert await store.consume_incoming_message("sms", "+2348012345678", 0) == "YES"
+    assert await store.get_remote_command_log() == []
+
+
+async def test_sms_handler_accepts_signed_command_without_storing_approval(
+    store, fixed_now
+):
+    action = SMSAction(
+        state_store=store,
+        config={},
+        remote_command_verifier=_verifier(),
+    )
+    command = _signed(_payload(now=fixed_now))
+    payload = {"from": "+2348012345678", "text": json.dumps(command)}
+
+    ok = await action.ingest_incoming_webhook(payload)
+
+    assert ok is True
+    rows = await store.get_remote_command_log()
+    assert rows[0]["accepted"] is True
+    assert await store.consume_incoming_message("sms", "+2348012345678", 0) is None

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -90,6 +90,7 @@ class TestLifecycle:
             "tier_c_decision_log",
             "causal_memory",
             "skill_state",
+            "remote_command_log",
             "alert_outbox",
         } <= names
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
