### PR TITLE
security(runtime): add remote command execution policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -573,6 +573,16 @@ Violating them creates vulnerabilities that affect physical hardware.
     WhatsApp, or cloud API.
     All remote command handlers must call `RemoteCommandVerifier` before executing
     or queueing any state-changing command.
+    Verification does not imply execution permission. Authenticated remote commands
+    must pass through `ori.security.remote_command_policy` before any runtime side
+    effect is allowed.
+    `SET_THRESHOLD` must never raise a Tier D trigger threshold above the value
+    configured in `ori.yaml`. After any threshold change, the runtime must
+    immediately re-evaluate active Tier D conditions. A threshold change that
+    would suppress an active Tier D condition must be rejected.
+    Relay fail-safe direction configured in `ori.yaml` is immutable by remote
+    command. `SET_RELAY_MODE` must never change normally-closed to normally-open,
+    or perform any equivalent fail-safe inversion, regardless of authentication.
 
 ---
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,31 @@
+# Ori Runtime Design Decisions
+
+This file records security- and architecture-relevant decisions that future
+contributors must preserve unless a superseding decision is explicitly added.
+
+## 2026-05-31 — Remote APPLY_POLICY Uses Fetch-Then-Verify
+
+**Status:** Accepted
+
+Remote `APPLY_POLICY` must not carry an inline DevicePolicy bundle as the command
+payload. The remote command may carry only a reference to the policy bundle, such
+as a fetch URL and expected content hash. The runtime must fetch the bundle,
+verify that the fetched bytes match the expected hash, and then pass the bundle
+through the existing signed DevicePolicy verification chain before applying it.
+
+Rationale:
+
+- SMS payload size limits make inline policy delivery impractical for real
+  DevicePolicy bundles.
+- Remote command channels should remain authenticated triggers, not privileged
+  data carriers.
+- Fetch-then-verify reuses the existing policy path: HTTPS transport, device
+  authentication, Ed25519 signature verification, timestamp skew checks, and
+  monotonic policy-version protection.
+- Inline policy application would create a second policy injection surface and
+  increase the chance of bypassing existing verification invariants.
+
+Implication:
+
+- `APPLY_POLICY` remains audit-only until the fetch URL, expected hash, and
+  signed bundle verification flow are implemented and tested.

--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -39,6 +39,7 @@ This is the authoritative record of what is real versus planned.
 | Energy cost calculator hook                      | Implemented       | skills/energy-anomaly-detector/hooks.py, tests/test_energy_anomaly_skill.py | Deterministic cost math computes both observed window cost and projected `/day` run-rate risk. Currency/voltage inference uses explicit config first, then country-code defaults, with `exact`/`estimated` confidence labeling. |
 | Offline Tier C auth tokens                       | Implemented       | security/offline_tokens.py, action_dispatcher.py, state/store.py | Local-console `TOKEN:<value>` approvals are signature-verified (Ed25519), device/action-bound, expiry-checked, and replay-protected via SQLite token claim table. |
 | Authenticated remote runtime commands            | Implemented       | security/remote_commands.py, actions/sms.py, actions/whatsapp.py, state/store.py, runtime.py | Structured SMS and WhatsApp remote commands are intercepted before approval-message handling, HMAC-SHA256 verified, timestamp checked, replay-protected, audited to SQLite, and fail-closed on Tier D/safety-disabling mutations or direct actuator commands. |
+| Remote command execution policy                  | Implemented       | security/remote_command_policy.py, runtime.py, state/store.py | Authenticated commands pass through a runtime-owned execution policy. `REFRESH_POLICY` is the only executable command and reuses the signed DevicePolicy refresh path; config, skill, threshold, relay-mode, restart, and sync commands are accepted as audit-only until transactional handlers exist. |
 
 ## Recent updates
 
@@ -52,3 +53,4 @@ This is the authoritative record of what is real versus planned.
 - 2026-05-30: Added Tier C decision logging for full proposal, operator decision, safe-default, and outcome context needed for future approval/rejection learning.
 - 2026-05-30: Added authenticated remote command verification with HMAC signatures, timestamp skew checks, replay audit, and Tier D/safety mutation denial.
 - 2026-05-31: Generalized authenticated remote command ingress across SMS and WhatsApp so structured commands cannot be mistaken for Tier C approval replies.
+- 2026-05-31: Added remote command execution policy and execution audit logging; only `REFRESH_POLICY` executes, while other authenticated commands remain audit-only.

--- a/ori/actions/sms.py
+++ b/ori/actions/sms.py
@@ -26,10 +26,12 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from ori.bool_utils import is_truthy
 from ori.security.remote_commands import (
+    RemoteCommand,
     RemoteCommandVerifier,
     verify_inbound_remote_command,
 )
@@ -79,6 +81,7 @@ class SMSAction:
         poll_interval_seconds: int = _POLL_INTERVAL_SECONDS,
         config: dict[str, Any] | None = None,
         remote_command_verifier: RemoteCommandVerifier | None = None,
+        remote_command_handler: Callable[[RemoteCommand], Awaitable[Any]] | None = None,
     ) -> None:
         sms_cfg = config if isinstance(config, dict) else {}
 
@@ -111,6 +114,7 @@ class SMSAction:
         )
         self._state_store = state_store
         self._remote_command_verifier = remote_command_verifier
+        self._remote_command_handler = remote_command_handler
         self._poll_interval_seconds = max(1, int(poll_interval_seconds))
         self._ip_ready = bool(self._api_key)
 
@@ -445,6 +449,8 @@ class SMSAction:
                     command_result.command.command_id if command_result.command else "",
                     command_result.command.command if command_result.command else "",
                 )
+                if self._remote_command_handler is not None and command_result.command:
+                    await self._remote_command_handler(command_result.command)
                 return True
 
             await self._state_store.store_incoming_message(

--- a/ori/actions/whatsapp.py
+++ b/ori/actions/whatsapp.py
@@ -33,10 +33,12 @@ import asyncio
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from typing import Any, Protocol, runtime_checkable
 
 from ori.network.events import ReasoningResult
 from ori.security.remote_commands import (
+    RemoteCommand,
     RemoteCommandVerifier,
     extract_remote_command_payload,
     verify_extracted_remote_command,
@@ -255,10 +257,12 @@ class WhatsAppAction:
         *,
         state_store: Any = None,
         remote_command_verifier: RemoteCommandVerifier | None = None,
+        remote_command_handler: Callable[[RemoteCommand], Awaitable[Any]] | None = None,
     ) -> None:
         self._provider: WhatsAppProvider = provider or TwilioProvider()
         self._state_store = state_store
         self._remote_command_verifier = remote_command_verifier
+        self._remote_command_handler = remote_command_handler
 
     # ------------------------------------------------------------------
     # Public API
@@ -376,6 +380,11 @@ class WhatsAppAction:
                             if command_result.command
                             else "",
                         )
+                        if (
+                            self._remote_command_handler is not None
+                            and command_result.command
+                        ):
+                            await self._remote_command_handler(command_result.command)
                     else:
                         logger.warning(
                             "WhatsAppAction.listen_for_response: rejected remote command reason=%s",

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -57,7 +57,17 @@ from ori.reasoning.elevator import IntelligenceElevator, SkillContext
 from ori.reasoning.local_llm import LocalLLM
 from ori.runtime_health_socket import RuntimeHealthSocketServer
 from ori.security.offline_tokens import OfflineTierCTokenVerifier
-from ori.security.remote_commands import RemoteCommandVerifier
+from ori.security.remote_command_policy import (
+    STATUS_AUDIT_ONLY,
+    STATUS_EXECUTED,
+    STATUS_FAILED,
+    STATUS_PRECONDITION_FAILED,
+    STATUS_UNSUPPORTED,
+    RemoteCommandExecutionResult,
+    classify_remote_command,
+    command_result,
+)
+from ori.security.remote_commands import RemoteCommand, RemoteCommandVerifier
 from ori.skills.loader import SkillLoader
 from ori.skills.signing import verify_signed_payload
 from ori.state.store import StateStore
@@ -112,6 +122,7 @@ class OriRuntime:
 
     def __init__(self, config_path: str = "ori.yaml") -> None:
         self._config_path = config_path
+        self._config: Config | None = None
         self._shutdown_event: asyncio.Event = asyncio.Event()
         self._adapters: list[BaseAdapter] = []
         self._state_store: StateStore | None = None
@@ -208,6 +219,7 @@ class OriRuntime:
         except ConfigValidationError:
             logger.exception("[runtime] config validation failed — aborting")
             raise
+        self._config = config
 
         from logging.handlers import RotatingFileHandler
 
@@ -289,11 +301,13 @@ class OriRuntime:
             provider=TwilioProvider(),
             state_store=self._state_store,
             remote_command_verifier=remote_command_verifier,
+            remote_command_handler=self._handle_remote_command,
         )
         sms_action = SMSAction(
             state_store=self._state_store,
             config=config.actions.sms,
             remote_command_verifier=remote_command_verifier,
+            remote_command_handler=self._handle_remote_command,
         )
         coap_action = CoAPAction(config=config.actions.coap)
         self._sms_action = sms_action
@@ -879,6 +893,117 @@ class OriRuntime:
             return False
         return await self._sms_action.ingest_incoming_webhook(payload)
 
+    async def _handle_remote_command(
+        self, command: RemoteCommand
+    ) -> RemoteCommandExecutionResult:
+        """Apply runtime-owned execution policy for an authenticated command."""
+        try:
+            result = await self._execute_remote_command(command)
+        except Exception:
+            logger.exception(
+                "[runtime] remote command execution failed unexpectedly command_id=%s command=%s",
+                command.command_id,
+                command.command,
+            )
+            result = command_result(
+                command,
+                status=STATUS_FAILED,
+                detail="unexpected execution error",
+                executed=False,
+            )
+
+        await self._log_remote_command_execution_result(result)
+        return result
+
+    async def _execute_remote_command(
+        self, command: RemoteCommand
+    ) -> RemoteCommandExecutionResult:
+        policy_status = classify_remote_command(command)
+        if policy_status == STATUS_AUDIT_ONLY:
+            return command_result(
+                command,
+                status=STATUS_AUDIT_ONLY,
+                detail="authenticated command accepted but handler is not enabled",
+                executed=False,
+            )
+        if policy_status == STATUS_UNSUPPORTED:
+            return command_result(
+                command,
+                status=STATUS_UNSUPPORTED,
+                detail="authenticated command is not supported by this runtime",
+                executed=False,
+            )
+
+        if command.command == "REFRESH_POLICY":
+            if self._config is None or self._dispatcher is None:
+                return command_result(
+                    command,
+                    status=STATUS_PRECONDITION_FAILED,
+                    detail="runtime config or dispatcher is unavailable",
+                    executed=False,
+                )
+            policy_cfg = (
+                self._config.device_policy
+                if isinstance(self._config.device_policy, dict)
+                else {}
+            )
+            if not bool(policy_cfg.get("enabled", False)):
+                return command_result(
+                    command,
+                    status=STATUS_PRECONDITION_FAILED,
+                    detail="device_policy is not enabled",
+                    executed=False,
+                )
+
+            refreshed = await self._refresh_remote_device_policy_once(
+                config=self._config,
+                dispatcher=self._dispatcher,
+                suppress_transient_audit=False,
+            )
+            if refreshed:
+                return command_result(
+                    command,
+                    status=STATUS_EXECUTED,
+                    detail="remote DevicePolicy refresh completed",
+                    executed=True,
+                )
+            return command_result(
+                command,
+                status=STATUS_FAILED,
+                detail="remote DevicePolicy refresh failed or was rejected",
+                executed=False,
+            )
+
+        logger.error(
+            "[runtime] remote command policy/handler mismatch command_id=%s command=%s policy_status=%s",
+            command.command_id,
+            command.command,
+            policy_status,
+        )
+        return command_result(
+            command,
+            status=STATUS_UNSUPPORTED,
+            detail="execution policy marks command executable but no runtime handler is registered",
+            executed=False,
+        )
+
+    async def _log_remote_command_execution_result(
+        self, result: RemoteCommandExecutionResult
+    ) -> None:
+        if self._state_store is None or not hasattr(
+            self._state_store, "log_remote_command_execution"
+        ):
+            return
+        await self._state_store.log_remote_command_execution(
+            command_id=result.command_id,
+            channel=result.channel,
+            command=result.command,
+            status=result.status,
+            detail=result.detail,
+            executed=result.executed,
+            executed_at_ms=result.executed_at_ms,
+        )
+
     async def _start_sms_webhook_if_enabled(
         self, config: Config
     ) -> asyncio.Task | None:
@@ -1206,7 +1331,7 @@ class OriRuntime:
         config: Config,
         dispatcher: ActionDispatcher,
         suppress_transient_audit: bool,
-    ) -> None:
+    ) -> bool:
         current_version = dispatcher.current_policy_version()
         try:
             fetched = await fetch_remote_device_policy_bundle(
@@ -1244,6 +1369,7 @@ class OriRuntime:
                         policy_version=fetched.policy.policy_version,
                         payload_timestamp=int(fetched.payload.get("timestamp", 0)),
                     )
+            return True
         except RemotePolicyFetchError as exc:
             logger.warning(
                 "[runtime] remote DevicePolicy rejected code=%s detail=%s",
@@ -1257,7 +1383,7 @@ class OriRuntime:
                     detail=str(exc),
                 )
             ):
-                return
+                return False
             await self._audit_policy_rejection(
                 device_id=config.device.id,
                 reason_code=exc.code,
@@ -1265,6 +1391,7 @@ class OriRuntime:
                 policy_version=exc.policy_version,
                 payload_timestamp=exc.payload_timestamp,
             )
+            return False
         except Exception:
             logger.exception("[runtime] unexpected remote DevicePolicy fetch error")
             await self._audit_policy_rejection(
@@ -1274,6 +1401,7 @@ class OriRuntime:
                 policy_version=None,
                 payload_timestamp=None,
             )
+            return False
 
     async def _device_policy_refresh_loop(
         self,

--- a/ori/security/remote_command_policy.py
+++ b/ori/security/remote_command_policy.py
@@ -1,0 +1,76 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execution policy for authenticated remote runtime commands.
+
+Verification only proves that a command came from an authenticated source.
+Execution policy decides whether the runtime is currently allowed to act on
+that command. Keep this boundary explicit: adding a command to the verifier's
+allowlist must not automatically make it executable.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ori.security.remote_commands import RemoteCommand
+from ori.time_utils import now_ms
+
+STATUS_EXECUTED = "executed"
+STATUS_AUDIT_ONLY = "audit_only"
+STATUS_UNSUPPORTED = "unsupported"
+STATUS_FAILED = "failed"
+STATUS_PRECONDITION_FAILED = "precondition_failed"
+
+EXECUTABLE_COMMANDS = frozenset({"REFRESH_POLICY"})
+
+AUDIT_ONLY_COMMANDS = frozenset(
+    {
+        "UPDATE_CONFIG",
+        "UPDATE_SKILL",
+        "APPLY_POLICY",
+        "RESTART_RUNTIME",
+        "SET_THRESHOLD",
+        "SET_RELAY_MODE",
+        "TRIGGER_SYNC",
+    }
+)
+
+
+@dataclass(frozen=True)
+class RemoteCommandExecutionResult:
+    command_id: str
+    channel: str
+    command: str
+    status: str
+    detail: str
+    executed: bool = False
+    executed_at_ms: int = 0
+
+
+def classify_remote_command(command: RemoteCommand) -> str:
+    """Return the default execution status for an authenticated command."""
+    command_name = str(command.command or "").strip().upper()
+    if command_name in EXECUTABLE_COMMANDS:
+        return STATUS_EXECUTED
+    if command_name in AUDIT_ONLY_COMMANDS:
+        return STATUS_AUDIT_ONLY
+    return STATUS_UNSUPPORTED
+
+
+def command_result(
+    command: RemoteCommand,
+    *,
+    status: str,
+    detail: str,
+    executed: bool = False,
+) -> RemoteCommandExecutionResult:
+    return RemoteCommandExecutionResult(
+        command_id=command.command_id,
+        channel=command.channel,
+        command=command.command,
+        status=status,
+        detail=detail,
+        executed=executed,
+        executed_at_ms=now_ms(),
+    )

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -164,6 +164,20 @@ CREATE TABLE IF NOT EXISTS remote_command_log (
 CREATE INDEX IF NOT EXISTS idx_remote_command_log_command_id
     ON remote_command_log (command_id, accepted, received_at_ms DESC);
 
+CREATE TABLE IF NOT EXISTS remote_command_execution_log (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    command_id     TEXT    NOT NULL DEFAULT '',
+    channel        TEXT    NOT NULL DEFAULT '',
+    command        TEXT    NOT NULL DEFAULT '',
+    status         TEXT    NOT NULL,
+    detail         TEXT    NOT NULL DEFAULT '',
+    executed       INTEGER NOT NULL,
+    executed_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_remote_command_execution_log_command_id
+    ON remote_command_execution_log (command_id, executed_at_ms DESC);
+
 CREATE TABLE IF NOT EXISTS alert_outbox (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     alert_id        TEXT    NOT NULL UNIQUE,
@@ -977,6 +991,79 @@ class StateStore:
         for row in rows:
             item = dict(row)
             item["accepted"] = bool(item["accepted"])
+            result.append(item)
+        return result
+
+    async def log_remote_command_execution(
+        self,
+        *,
+        command_id: str,
+        channel: str,
+        command: str,
+        status: str,
+        detail: str,
+        executed: bool,
+        executed_at_ms: int | None = None,
+    ) -> None:
+        await self._run_write(
+            self._log_remote_command_execution_sync,
+            command_id,
+            channel,
+            command,
+            status,
+            detail,
+            executed,
+            executed_at_ms if executed_at_ms is not None else now_ms(),
+        )
+
+    def _log_remote_command_execution_sync(
+        self,
+        command_id: str,
+        channel: str,
+        command: str,
+        status: str,
+        detail: str,
+        executed: bool,
+        executed_at_ms: int,
+    ) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            """
+            INSERT INTO remote_command_execution_log
+                (command_id, channel, command, status, detail, executed, executed_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                str(command_id or ""),
+                str(channel or ""),
+                str(command or ""),
+                str(status or ""),
+                str(detail or ""),
+                1 if executed else 0,
+                executed_at_ms,
+            ),
+        )
+        self._conn.commit()
+
+    async def get_remote_command_execution_log(self, limit: int = 50) -> list[dict]:
+        return await self._run_read(self._get_remote_command_execution_log_sync, limit)
+
+    def _get_remote_command_execution_log_sync(
+        self, conn: sqlite3.Connection, limit: int
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT command_id, channel, command, status, detail, executed, executed_at_ms
+            FROM remote_command_execution_log
+            ORDER BY executed_at_ms DESC, id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        result = []
+        for row in rows:
+            item = dict(row)
+            item["executed"] = bool(item["executed"])
             result.append(item)
         return result
 

--- a/tests/test_remote_command_execution.py
+++ b/tests/test_remote_command_execution.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ori.runtime import OriRuntime
+from ori.security.remote_command_policy import (
+    STATUS_AUDIT_ONLY,
+    STATUS_EXECUTED,
+    STATUS_PRECONDITION_FAILED,
+    STATUS_UNSUPPORTED,
+    classify_remote_command,
+)
+from ori.security.remote_commands import RemoteCommand
+from ori.state.store import StateStore
+
+
+@pytest.fixture
+async def store(tmp_path):
+    s = StateStore(db_path=str(tmp_path / "commands.db"))
+    await s.open()
+    yield s
+    await s.close()
+
+
+def _command(command: str, command_id: str = "cmd-1") -> RemoteCommand:
+    return RemoteCommand(
+        command_id=command_id,
+        channel="sms",
+        device_id="dev-01",
+        issued_at_ms=1_780_000_000_000,
+        command=command,
+        args={},
+        signature="hmac-sha256:test",
+    )
+
+
+def test_policy_executes_only_refresh_policy():
+    assert classify_remote_command(_command("REFRESH_POLICY")) == STATUS_EXECUTED
+    assert classify_remote_command(_command("UPDATE_CONFIG")) == STATUS_AUDIT_ONLY
+    assert classify_remote_command(_command("UPDATE_SKILL")) == STATUS_AUDIT_ONLY
+
+
+async def test_audit_only_command_is_logged_without_execution(store):
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._state_store = store
+    runtime._config = SimpleNamespace(device_policy={"enabled": True})
+    runtime._dispatcher = object()
+    runtime._refresh_remote_device_policy_once = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    result = await runtime._handle_remote_command(_command("UPDATE_CONFIG"))
+
+    assert result.status == STATUS_AUDIT_ONLY
+    assert result.executed is False
+    runtime._refresh_remote_device_policy_once.assert_not_awaited()
+    rows = await store.get_remote_command_execution_log()
+    assert rows[0]["command_id"] == "cmd-1"
+    assert rows[0]["command"] == "UPDATE_CONFIG"
+    assert rows[0]["status"] == STATUS_AUDIT_ONLY
+    assert rows[0]["executed"] is False
+
+
+async def test_refresh_policy_requires_enabled_device_policy(store):
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._state_store = store
+    runtime._config = SimpleNamespace(device_policy={"enabled": False})
+    runtime._dispatcher = object()
+    runtime._refresh_remote_device_policy_once = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    result = await runtime._handle_remote_command(_command("REFRESH_POLICY"))
+
+    assert result.status == STATUS_PRECONDITION_FAILED
+    assert result.executed is False
+    runtime._refresh_remote_device_policy_once.assert_not_awaited()
+    rows = await store.get_remote_command_execution_log()
+    assert rows[0]["status"] == STATUS_PRECONDITION_FAILED
+
+
+async def test_refresh_policy_executes_existing_verified_policy_path(store):
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._state_store = store
+    runtime._config = SimpleNamespace(device_policy={"enabled": True})
+    runtime._dispatcher = object()
+    runtime._refresh_remote_device_policy_once = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    result = await runtime._handle_remote_command(_command("REFRESH_POLICY"))
+
+    assert result.status == STATUS_EXECUTED
+    assert result.executed is True
+    runtime._refresh_remote_device_policy_once.assert_awaited_once()
+    rows = await store.get_remote_command_execution_log()
+    assert rows[0]["command"] == "REFRESH_POLICY"
+    assert rows[0]["status"] == STATUS_EXECUTED
+    assert rows[0]["executed"] is True
+
+
+async def test_unsupported_command_is_logged_without_execution(store):
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._state_store = store
+    runtime._config = SimpleNamespace(device_policy={"enabled": True})
+    runtime._dispatcher = object()
+    runtime._refresh_remote_device_policy_once = AsyncMock(return_value=True)  # type: ignore[method-assign]
+
+    result = await runtime._handle_remote_command(_command("UNKNOWN_COMMAND"))
+
+    assert result.status == STATUS_UNSUPPORTED
+    assert result.executed is False
+    runtime._refresh_remote_device_policy_once.assert_not_awaited()
+    rows = await store.get_remote_command_execution_log()
+    assert rows[0]["command"] == "UNKNOWN_COMMAND"
+    assert rows[0]["status"] == STATUS_UNSUPPORTED
+    assert rows[0]["executed"] is False
+
+
+async def test_executable_policy_without_handler_is_logged_as_mismatch(
+    store, monkeypatch
+):
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._state_store = store
+    runtime._config = SimpleNamespace(device_policy={"enabled": True})
+    runtime._dispatcher = object()
+    runtime._refresh_remote_device_policy_once = AsyncMock(return_value=True)  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        "ori.runtime.classify_remote_command", lambda _: STATUS_EXECUTED
+    )
+
+    result = await runtime._handle_remote_command(_command("NEW_EXECUTABLE"))
+
+    assert result.status == STATUS_UNSUPPORTED
+    assert result.executed is False
+    assert "no runtime handler" in result.detail
+    runtime._refresh_remote_device_policy_once.assert_not_awaited()
+    rows = await store.get_remote_command_execution_log()
+    assert rows[0]["command"] == "NEW_EXECUTABLE"
+    assert rows[0]["status"] == STATUS_UNSUPPORTED

--- a/tests/test_remote_commands.py
+++ b/tests/test_remote_commands.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -295,6 +296,26 @@ async def test_sms_handler_accepts_signed_command_without_storing_approval(
     assert await store.consume_incoming_message("sms", "+2348012345678", 0) is None
 
 
+async def test_sms_handler_invokes_runtime_command_handler(store, fixed_now):
+    handler = AsyncMock()
+    action = SMSAction(
+        state_store=store,
+        config={},
+        remote_command_verifier=_verifier(),
+        remote_command_handler=handler,
+    )
+    command = _signed(_payload(now=fixed_now, command_id="sms-handler"))
+    payload = {"from": "+2348012345678", "text": json.dumps(command)}
+
+    ok = await action.ingest_incoming_webhook(payload)
+
+    assert ok is True
+    handler.assert_awaited_once()
+    handled = handler.await_args.args[0]
+    assert handled.command_id == "sms-handler"
+    assert handled.command == "UPDATE_CONFIG"
+
+
 async def test_whatsapp_approval_yes_no_is_not_treated_as_remote_command(store):
     provider = _InboxWhatsAppProvider(["YES"])
     action = WhatsAppAction(provider=provider, state_store=store)
@@ -353,6 +374,29 @@ async def test_whatsapp_accepts_signed_command_without_returning_it_as_approval(
     assert rows[0]["command_id"] == "wa-signed"
     assert rows[0]["channel"] == "whatsapp"
     assert rows[0]["accepted"] is True
+
+
+async def test_whatsapp_invokes_runtime_command_handler(store, fixed_now):
+    handler = AsyncMock()
+    command = _signed(_payload(now=fixed_now, command_id="wa-handler"))
+    provider = _InboxWhatsAppProvider([json.dumps(command), "NO"])
+    action = WhatsAppAction(
+        provider=provider,
+        state_store=store,
+        remote_command_verifier=_verifier(),
+        remote_command_handler=handler,
+    )
+
+    reply = await action.listen_for_response(
+        from_number="whatsapp:+2348012345678",
+        timeout_seconds=1,
+    )
+
+    assert reply == "NO"
+    handler.assert_awaited_once()
+    handled = handler.await_args.args[0]
+    assert handled.command_id == "wa-handler"
+    assert handled.channel == "whatsapp"
 
 
 async def test_whatsapp_audits_command_when_verifier_disabled(store, fixed_now):

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -91,6 +91,7 @@ class TestLifecycle:
             "causal_memory",
             "skill_state",
             "remote_command_log",
+            "remote_command_execution_log",
             "alert_outbox",
         } <= names
 
@@ -800,3 +801,33 @@ class TestInboundMessages:
         )
         assert first == "NO"
         assert second is None
+
+
+# ─── remote_command_execution_log ─────────────────────────────────────────────
+
+
+class TestRemoteCommandExecutionLog:
+    async def test_log_and_retrieve_execution_result(self, store):
+        await store.log_remote_command_execution(
+            command_id="cmd-1",
+            channel="sms",
+            command="REFRESH_POLICY",
+            status="executed",
+            detail="remote DevicePolicy refresh completed",
+            executed=True,
+            executed_at_ms=1234,
+        )
+
+        rows = await store.get_remote_command_execution_log()
+
+        assert rows == [
+            {
+                "command_id": "cmd-1",
+                "channel": "sms",
+                "command": "REFRESH_POLICY",
+                "status": "executed",
+                "detail": "remote DevicePolicy refresh completed",
+                "executed": True,
+                "executed_at_ms": 1234,
+            }
+        ]


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
