### PR TITLE
docs: update Tier C approval message format to match implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ When Ori proposes a hard physical action, this is what the operator receives:
 ```text
 ORI ALERT — Action Required
 Device: energy-monitor-ikeja-office-01
+Proposal ID: AB12CD34
 Time: Wednesday 14:32
 
 OBSERVATION:
@@ -259,9 +260,14 @@ Open the installer-wired safety circuit to cut power to the protected load.
 
 CONFIDENCE: 94%
 
-Reply YES to approve  |  Reply NO to cancel
+Reply YES-AB12CD34 to approve  |  Reply NO-AB12CD34 to cancel
+Bare YES/NO is accepted only for the active pending proposal.
 Auto-cancel in 5 minutes if no response.
 ```
+
+The message is delivered over SMS (primary for Nigeria deployments) with automatic
+failover to WhatsApp when SMS is unavailable, or WhatsApp-first when configured.
+The same message format is used on both channels.
 
 The agent does the diagnosis. The operator approves or rejects a specific, fully-reasoned proposal.
 


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue


## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
