### PR TITLE
refactor(elevator): remove stale internet gate from tier selection

### DIFF
--- a/ori.linux.yaml.example
+++ b/ori.linux.yaml.example
@@ -49,7 +49,6 @@ reasoning:
   # ─── Local SLM (optional — uncomment after downloading a GGUF model) ─
   # local_model: qwen2.5-0.5b-instruct-q4_k_m
   # model_path: /home/<user>/models/   # directory containing your .gguf file
-  offline_fallback: rule
   escalation_threshold: 0.70
   energy_aware_reasoning:
     enabled: false

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -234,7 +234,6 @@ reasoning:
   default_tier: local                # rule | local (gateway selected by escalation policy)
   local_model: qwen2.5-0.5b-instruct-q4_k_m  # basename or full .gguf filename/path
   model_path: /home/pi/models/       # directory containing local GGUF models
-  offline_fallback: rule             # tier to use when network unavailable
   escalation_threshold: 0.70        # complexity threshold; local SLM confidence is non-authoritative
   capability_posture:
     enabled: true

--- a/ori/config.py
+++ b/ori/config.py
@@ -113,7 +113,6 @@ class ReasoningConfig:
     default_tier: str
     local_model: str
     model_path: str
-    offline_fallback: str
     escalation_threshold: float = 0.70
     energy_aware_reasoning: dict = field(default_factory=dict)
     capability_posture: dict = field(default_factory=dict)
@@ -723,7 +722,6 @@ def _parse_reasoning(data: Any) -> ReasoningConfig:
         default_tier=default_tier,
         local_model=str(data.get("local_model", "")),
         model_path=str(data.get("model_path", "")),
-        offline_fallback=str(data.get("offline_fallback", "rule")),
         escalation_threshold=float(data.get("escalation_threshold", 0.70)),
         energy_aware_reasoning=energy_aware,
         capability_posture=capability_posture_cfg,

--- a/ori/reasoning/elevator.py
+++ b/ori/reasoning/elevator.py
@@ -30,7 +30,6 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from ori.network.events import OriEvent, ReasoningResult
 from ori.reasoning.capability_posture import (
     CapabilityPosture,
-    probe_internet_available,
 )
 from ori.reasoning.causal_memory import CausalMemory
 from ori.reasoning.context_enricher import ContextEnricher
@@ -87,15 +86,6 @@ def _hour_now(event: OriEvent | None = None) -> int:
                 tz_name,
             )
     return datetime.datetime.now(datetime.timezone.utc).hour
-
-
-def _is_offline() -> bool:
-    """Return ``True`` if no internet connectivity is detectable."""
-    return not probe_internet_available(
-        host="one.one.one.one",
-        port=53,
-        timeout_ms=1000,
-    )
 
 
 def _complexity_score(
@@ -414,15 +404,6 @@ class IntelligenceElevator:
             stub.action_tier = "A"
         return stub, rule_result
 
-    async def _is_offline_async(self) -> bool:
-        """Run connectivity probe in a worker thread to avoid blocking the loop."""
-        if (
-            self._capability_posture is not None
-            and not self._capability_posture.is_stale()
-        ):
-            return not self._capability_posture.internet_available
-        return await asyncio.to_thread(_is_offline)
-
     async def _call_gateway_reasoner(
         self,
         *,
@@ -514,7 +495,7 @@ class IntelligenceElevator:
 
         1. Run the rule engine.  If Tier D fires → ``'rule'`` immediately.
         2. Score complexity (0.0–1.0) from deviation, volatility, hour.
-        3. ``complexity < 0.3`` OR offline → ``'local_slm'``
+        3. ``complexity < 0.3`` → ``'local_slm'``
            deterministic gateway signals → ``'gateway'`` when reachable
            fallback → ``'local_slm'``
         """
@@ -623,9 +604,8 @@ class IntelligenceElevator:
             signal.code == "trigger_declares_gateway"
             for signal in gateway_decision.signals
         )
-        offline = await self._is_offline_async()
         if gateway_decision.should_escalate:
-            selected = trigger_floor_gateway or (gateway_available and not offline)
+            selected = trigger_floor_gateway or gateway_available
             attach_gateway_escalation_context(
                 event,
                 gateway_decision,
@@ -639,20 +619,11 @@ class IntelligenceElevator:
             current_value, avg_24h, history, _hour_now(event)
         )
 
-        offline = await self._is_offline_async()
-        fallback = (
-            getattr(self._config, "offline_fallback", "rule")
-            if self._config
-            else "rule"
-        )
         threshold = (
             getattr(self._config, "escalation_threshold", 0.70)
             if self._config
             else 0.70
         )
-
-        if offline:
-            return _apply_floor(fallback)
 
         if complexity < 0.3:
             return _apply_floor("local_slm")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,7 +100,6 @@ class TestLoadExample:
         r = cfg.reasoning
         assert r.default_tier == "local"
         assert r.local_model == "qwen2.5-0.5b-instruct-q4_k_m"
-        assert r.offline_fallback == "rule"
         assert r.escalation_threshold == pytest.approx(0.70)
 
     def test_gateway_disabled(self):
@@ -391,7 +390,6 @@ class TestLoadExample:
               default_tier: local
               local_model: ""
               model_path: ""
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: ""
@@ -442,7 +440,6 @@ class TestLoadExample:
               default_tier: local
               local_model: ""
               model_path: ""
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: ""
@@ -628,7 +625,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -652,7 +648,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -677,7 +672,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -703,7 +697,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -735,7 +728,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -763,7 +755,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -792,7 +783,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -818,7 +808,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -844,7 +833,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -870,7 +858,6 @@ class TestDeviceValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1033,7 +1020,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1225,7 +1211,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1259,7 +1244,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1294,7 +1278,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1322,7 +1305,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1356,7 +1338,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1391,7 +1372,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1471,7 +1451,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1496,7 +1475,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
               escalation_threshold: 0.85
             gateway:
               enabled: false
@@ -1522,7 +1500,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
               energy_aware_reasoning:
                 enabled: true
                 throttle_threshold_percent: 20
@@ -1555,7 +1532,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
               causal_memory:
                 rejection_expiry_days: 30
             gateway:
@@ -1583,7 +1559,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1611,7 +1586,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
               capability_posture:
                 enabled: true
                 probe_interval_seconds: 20
@@ -1648,7 +1622,6 @@ class TestReasoningConfig:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
               capability_posture:
                 probe_interval_seconds: 31
             gateway:
@@ -1683,7 +1656,6 @@ class TestActionsValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1708,7 +1680,6 @@ class TestActionsValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1738,7 +1709,6 @@ class TestActionsValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1766,7 +1736,6 @@ class TestActionsValidation:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -1809,7 +1778,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -1986,7 +1954,6 @@ class TestEnvExpansion:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -2017,7 +1984,6 @@ class TestEnvExpansion:
               default_tier: local
               local_model: x
               model_path: /tmp
-              offline_fallback: rule
             gateway:
               enabled: false
               broker_url: mqtt://localhost
@@ -2062,7 +2028,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -2320,7 +2285,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -2436,7 +2400,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -2495,7 +2458,6 @@ reasoning:
   default_tier: local
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost
@@ -2541,7 +2503,6 @@ reasoning:
   default_tier: {tier}
   local_model: x
   model_path: /tmp
-  offline_fallback: rule
 gateway:
   enabled: false
   broker_url: mqtt://localhost

--- a/tests/test_elevator.py
+++ b/tests/test_elevator.py
@@ -243,27 +243,24 @@ class TestSelectTier:
         assert tier == "rule"
 
     async def test_offline_returns_local_slm(self):
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(config=conf)
         skill = FakeSkill()
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            tier = await elevator.select_tier(_event(), skill, None)
+        tier = await elevator.select_tier(_event(), skill, None)
         assert tier == "local_slm"
 
     async def test_low_complexity_returns_local_slm(self):
         elevator = IntelligenceElevator()
         skill = FakeSkill()
         store = _mock_state_store(avg=5.0, history=[5.0, 5.0, 5.0])
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            with patch("ori.reasoning.elevator._hour_now", return_value=12):
-                tier = await elevator.select_tier(_event(value=5.1), skill, store)
+        with patch("ori.reasoning.elevator._hour_now", return_value=12):
+            tier = await elevator.select_tier(_event(value=5.1), skill, store)
         assert tier == "local_slm"
 
     async def test_no_state_store_returns_local_slm(self):
         elevator = IntelligenceElevator()
         skill = FakeSkill()
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            tier = await elevator.select_tier(_event(), skill, None)
+        tier = await elevator.select_tier(_event(), skill, None)
         assert tier == "local_slm"
 
     async def test_tier_d_does_not_reach_state_store(self):
@@ -274,10 +271,10 @@ class TestSelectTier:
         # History not fetched for Tier D — returns immediately
         store.avg_last_hours.assert_not_called()
 
-    async def test_escalate_to_local_slm_floors_tier_when_offline_fallback_is_rule(
+    async def test_escalate_to_local_slm_trigger_returns_local_slm(
         self,
     ):
-        conf = type("obj", (object,), {"offline_fallback": "rule"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(config=conf)
         skill = FakeSkill(
             triggers=[
@@ -291,12 +288,14 @@ class TestSelectTier:
                 }
             ]
         )
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            tier = await elevator.select_tier(_event(value=5.0), skill, None)
+        tier = await elevator.select_tier(_event(value=5.0), skill, None)
         assert tier == "local_slm"
 
     async def test_fresh_capability_posture_is_used_without_probe(self):
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        # Verify gateway_reachable=False + local_slm_loaded=True → local_slm
+        # with no internet probe. The internet gate was removed in issue #145:
+        # an air-gapped site with a reachable gateway must still escalate.
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(config=conf)
         posture = CapabilityPosture(
             sms_available=True,
@@ -310,12 +309,42 @@ class TestSelectTier:
             gateway_last_heartbeat_ms=None,
         )
         elevator.update_capability_posture(posture)
-        with patch(
-            "ori.reasoning.elevator._is_offline",
-            side_effect=AssertionError("offline probe should not run"),
-        ):
-            tier = await elevator.select_tier(_event(value=5.0), FakeSkill(), None)
+        tier = await elevator.select_tier(_event(value=5.0), FakeSkill(), None)
         assert tier == "local_slm"
+
+    async def test_gateway_selected_on_airgapped_site(self):
+        # Air-gapped site: gateway is on LAN but there is no internet.
+        # Before issue #145 the internet gate (_is_offline_async) would block
+        # gateway escalation here, falling back to local_slm incorrectly.
+        # The correct behaviour: gateway_available=True → "gateway", regardless
+        # of internet_available.
+        elevator = IntelligenceElevator()
+        skill = FakeSkill(
+            triggers=[
+                {
+                    "name": "airgap_trigger",
+                    "condition": "value > 1.0",
+                    "action_tier": "A",
+                    "escalate_to": "gateway",
+                    "bypass_llm": False,
+                    "cooldown_seconds": 0,
+                }
+            ]
+        )
+        posture = CapabilityPosture(
+            sms_available=True,
+            whatsapp_available=True,
+            gateway_reachable=True,
+            local_slm_loaded=True,
+            relay_connected=False,
+            internet_available=False,
+            checked_at_ms=_ms(),
+            expires_at_ms=_ms() + 60_000,
+            gateway_last_heartbeat_ms=_ms() - 5_000,
+        )
+        elevator.update_capability_posture(posture)
+        tier = await elevator.select_tier(_event(value=5.0), skill, None)
+        assert tier == "gateway"
 
     async def test_trigger_declares_gateway_is_authoritative_floor(self):
         elevator = IntelligenceElevator()
@@ -334,8 +363,7 @@ class TestSelectTier:
         event = _event(value=5.0)
         store = _mock_state_store(avg=5.0, history=[5.0, 5.0])
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            tier = await elevator.select_tier(event, skill, store)
+        tier = await elevator.select_tier(event, skill, store)
 
         assert tier == "gateway"
         ctx = event.context[GATEWAY_ESCALATION_CONTEXT_KEY]
@@ -448,12 +476,11 @@ class TestReason:
             tokens_used=20,
             latency_ms=500,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = FakeSkill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(), skill, None)
+        result = await elevator.reason(_event(), skill, None)
 
         mock_llm.reason.assert_called_once()
         assert result.tier == "local_slm"
@@ -473,7 +500,7 @@ class TestReason:
         elevator = IntelligenceElevator(
             local_llm=local_llm,
             gateway_reasoner=gateway,
-            config=type("obj", (object,), {"offline_fallback": "local_slm"})(),
+            config=type("obj", (object,), {})(),
         )
         elevator.update_capability_posture(_fresh_gateway_posture())
         event = _event(value=5.0)
@@ -491,7 +518,7 @@ class TestReason:
         local_llm = AsyncMock()
         elevator = IntelligenceElevator(
             local_llm=local_llm,
-            config=type("obj", (object,), {"offline_fallback": "local_slm"})(),
+            config=type("obj", (object,), {})(),
         )
         skill = FakeSkill(
             triggers=[
@@ -512,8 +539,7 @@ class TestReason:
         event = _event(value=5.0)
         store = _mock_state_store(avg=5.0, history=[5.0, 5.0])
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            result = await elevator.reason(event, skill, store)
+        result = await elevator.reason(event, skill, store)
 
         local_llm.reason.assert_not_called()
         assert result.tier == "gateway"
@@ -531,7 +557,7 @@ class TestReason:
         elevator = IntelligenceElevator(
             local_llm=local_llm,
             gateway_reasoner=gateway,
-            config=type("obj", (object,), {"offline_fallback": "local_slm"})(),
+            config=type("obj", (object,), {})(),
         )
         elevator.update_capability_posture(_fresh_gateway_posture())
         skill = FakeSkill(
@@ -553,8 +579,7 @@ class TestReason:
         event = _event(value=5.0)
         store = _mock_state_store(avg=5.0, history=[5.0, 5.0])
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            result = await elevator.reason(event, skill, store)
+        result = await elevator.reason(event, skill, store)
 
         gateway.reason.assert_awaited_once()
         local_llm.reason.assert_not_called()
@@ -576,7 +601,6 @@ class TestReason:
             "obj",
             (object,),
             {
-                "offline_fallback": "local_slm",
                 "causal_memory": {"enabled": True},
             },
         )()
@@ -585,8 +609,7 @@ class TestReason:
         store = _mock_state_store()
         store.lookup_causal_memory.return_value = "Cached known-good resolution."
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=5.0), skill, store)
+        result = await elevator.reason(_event(value=5.0), skill, store)
 
         assert result.model == "causal_memory"
         assert result.text == "Cached known-good resolution."
@@ -607,7 +630,6 @@ class TestReason:
             "obj",
             (object,),
             {
-                "offline_fallback": "local_slm",
                 "causal_memory": {
                     "enabled": True,
                     "min_confidence_to_store": 0.5,
@@ -619,8 +641,7 @@ class TestReason:
         store = _mock_state_store()
         store.lookup_causal_memory.return_value = None
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=5.0), skill, store)
+        result = await elevator.reason(_event(value=5.0), skill, store)
 
         assert result.text == "Fresh LLM resolution."
         store.store_causal_memory.assert_awaited_once()
@@ -638,12 +659,11 @@ class TestReason:
             tokens_used=20,
             latency_ms=500,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = FakeSkill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(), skill, None)
+        result = await elevator.reason(_event(), skill, None)
 
         assert result.prompt != ""
         assert "load-current" in result.prompt  # sensor_id appears in prompt
@@ -657,7 +677,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -665,8 +685,7 @@ class TestReason:
             "current_clamp": "SENSOR_PROMPT",
         }
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=5.0), skill, None)
+        result = await elevator.reason(_event(value=5.0), skill, None)
 
         assert "TRIGGER_PROMPT" in result.prompt
         assert "SENSOR_PROMPT" not in result.prompt
@@ -680,13 +699,12 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {"current_clamp": "SENSOR_PROMPT"}
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=5.0), skill, None)
+        result = await elevator.reason(_event(value=5.0), skill, None)
 
         assert "SENSOR_PROMPT" in result.prompt
 
@@ -699,7 +717,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {"anomalous_draw": "Value is {value}{unit} on {device_id}"}
@@ -715,8 +733,7 @@ class TestReason:
             "ikeja-01",
         )
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(event, skill, None)
+        result = await elevator.reason(event, skill, None)
 
         assert "Value is 8.2A on ikeja-01" in result.prompt
 
@@ -729,7 +746,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -737,8 +754,7 @@ class TestReason:
         }
         store = _PromptHistoryStore({"load-current": [12.4, 12.5, 12.6]})
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=8.2), skill, store)
+        result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert "{history.last_n('load-current', 6)}" not in result.prompt
         assert "[12.4,12.5,12.6]" in result.prompt
@@ -752,7 +768,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -760,9 +776,8 @@ class TestReason:
         }
         store = _PromptHistoryStore({"load-current": [1.0, 2.0]})
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with caplog.at_level(logging.WARNING):
-                result = await elevator.reason(_event(value=8.2), skill, store)
+        with caplog.at_level(logging.WARNING):
+            result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert "{history.not_a_method('load-current', 2)}" not in result.prompt
         assert "Check: null" in result.prompt
@@ -777,7 +792,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -785,9 +800,8 @@ class TestReason:
         }
         store = _PromptHistoryStore({"load-current": [10.0, 14.0]})
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with caplog.at_level(logging.WARNING):
-                result = await elevator.reason(_event(value=8.2), skill, store)
+        with caplog.at_level(logging.WARNING):
+            result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert "{history.last_n(sensor_id='load-current', n=2)}" not in result.prompt
         assert "Broken: null" in result.prompt
@@ -802,7 +816,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -810,8 +824,7 @@ class TestReason:
         }
         store = _PromptHistoryStore({"load-current": [10.0, 14.0]})
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=8.2), skill, store)
+        result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert '{history.avg_hours("load-current", 24)}' not in result.prompt
         assert "24h avg: 12.0" in result.prompt
@@ -825,7 +838,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
@@ -833,8 +846,7 @@ class TestReason:
         }
         store = _PromptHistoryStore({"load-current": [10.0, 14.0]})
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(value=8.2), skill, store)
+        result = await elevator.reason(_event(value=8.2), skill, store)
 
         assert "{history.last_n(sensor_id='load-current', n=2)}" not in result.prompt
         assert "Broken: null" in result.prompt
@@ -848,16 +860,15 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {
             "anomalous_draw": "No store: {history.last_n('load-current', 3)}"
         }
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with caplog.at_level(logging.WARNING):
-                result = await elevator.reason(_event(value=8.2), skill, None)
+        with caplog.at_level(logging.WARNING):
+            result = await elevator.reason(_event(value=8.2), skill, None)
 
         assert "{history.last_n('load-current', 3)}" not in result.prompt
         assert "No store: null" in result.prompt
@@ -872,7 +883,7 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
         skill.prompts = {"anomalous_draw": "Sensor reference: {sensor_id}"}
@@ -888,8 +899,7 @@ class TestReason:
             "ikeja-01",
         )
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(event, skill, None)
+        result = await elevator.reason(event, skill, None)
 
         assert "{malicious: inject}" not in result.prompt
         assert "malicious inject" in result.prompt
@@ -903,17 +913,16 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with patch.object(
-                elevator,
-                "_lookup_rejection_record",
-                new=AsyncMock(return_value={"operator_response": "<override safety>"}),
-            ):
-                result = await elevator.reason(_event(value=5.0), skill, None)
+        with patch.object(
+            elevator,
+            "_lookup_rejection_record",
+            new=AsyncMock(return_value={"operator_response": "<override safety>"}),
+        ):
+            result = await elevator.reason(_event(value=5.0), skill, None)
 
         assert "<override safety>" not in result.prompt
         assert "override safety" in result.prompt
@@ -927,19 +936,18 @@ class TestReason:
             tokens_used=12,
             latency_ms=100,
         )
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = _tier_a_skill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            with patch.object(
-                elevator,
-                "_lookup_rejection_record",
-                new=AsyncMock(
-                    return_value={"operator_response": "yes, proceed with caution"}
-                ),
-            ):
-                result = await elevator.reason(_event(value=5.0), skill, None)
+        with patch.object(
+            elevator,
+            "_lookup_rejection_record",
+            new=AsyncMock(
+                return_value={"operator_response": "yes, proceed with caution"}
+            ),
+        ):
+            result = await elevator.reason(_event(value=5.0), skill, None)
 
         assert "yes, proceed with caution" in result.prompt
 
@@ -961,24 +969,22 @@ class TestReason:
     async def test_local_slm_failure_falls_back_to_stub(self):
         mock_llm = AsyncMock()
         mock_llm.reason.side_effect = RuntimeError("model crashed")
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=mock_llm, config=conf)
         skill = FakeSkill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(), skill, None)
+        result = await elevator.reason(_event(), skill, None)
 
         # Must not raise — returns a stub result
         assert result.model == "stub"
         assert result.action_tier == "A"
 
     async def test_no_llm_returns_stub(self):
-        conf = type("obj", (object,), {"offline_fallback": "local_slm"})()
+        conf = type("obj", (object,), {})()
         elevator = IntelligenceElevator(local_llm=None, config=conf)
         skill = FakeSkill()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            result = await elevator.reason(_event(), skill, None)
+        result = await elevator.reason(_event(), skill, None)
 
         assert result.model == "stub"
 
@@ -997,10 +1003,9 @@ class TestReasonAndDispatch:
         skill = _tier_a_skill()
         elevator = IntelligenceElevator()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), skill, None, mock_dispatcher
-            )
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), skill, None, mock_dispatcher
+        )
 
         mock_dispatcher.dispatch.assert_called_once()
         call = mock_dispatcher.dispatch.call_args
@@ -1047,8 +1052,7 @@ class TestReasonAndDispatch:
         event = _event(value=5.0)
         event.context = {"__handler_trigger_name": "sleep_blocked_terminate_candidate"}
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
+        await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
 
         call = mock_dispatcher.dispatch.call_args
         assert call[1]["approval_timeout"] == 60
@@ -1099,8 +1103,7 @@ class TestReasonAndDispatch:
             )
             elevator = IntelligenceElevator()
 
-            with patch("ori.reasoning.elevator._is_offline", return_value=True):
-                await elevator.reason_and_dispatch(event, skill, store, dispatcher)
+            await elevator.reason_and_dispatch(event, skill, store, dispatcher)
 
             rows = await store.get_tier_c_decision_log()
             assert len(rows) == 1
@@ -1172,11 +1175,10 @@ class TestReasonAndDispatch:
         skill = _tier_a_skill()
         elevator = IntelligenceElevator()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            # Must not raise
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), skill, None, mock_dispatcher
-            )
+        # Must not raise
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), skill, None, mock_dispatcher
+        )
 
     async def test_reasoning_logged_when_store_has_log_reasoning(self):
         store = _mock_state_store()
@@ -1184,10 +1186,9 @@ class TestReasonAndDispatch:
         elevator = IntelligenceElevator()
         mock_dispatcher = AsyncMock()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), skill, store, mock_dispatcher
-            )
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), skill, store, mock_dispatcher
+        )
 
         store.log_reasoning.assert_called_once()
 
@@ -1211,10 +1212,9 @@ class TestReasonAndDispatch:
             )
             elevator = IntelligenceElevator(local_llm=local_llm)
 
-            with patch("ori.reasoning.elevator._is_offline", return_value=True):
-                await elevator.reason_and_dispatch(
-                    _event(value=5.0), _tier_a_skill(), store, dispatcher
-                )
+            await elevator.reason_and_dispatch(
+                _event(value=5.0), _tier_a_skill(), store, dispatcher
+            )
 
             actions = await store.get_action_log()
             row = await store._run(
@@ -1251,10 +1251,9 @@ class TestReasonAndDispatch:
         store = _mock_state_store(avg=4.0, history=[4.0, 4.1])
         elevator = IntelligenceElevator(local_llm=local_llm)
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
-            )
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
+        )
 
         assert calls == [
             ("switch_power_source", "B"),
@@ -1278,10 +1277,9 @@ class TestReasonAndDispatch:
             dispatcher.register_executor("alert_whatsapp", successful_executor)
             elevator = IntelligenceElevator(local_llm=local_llm)
 
-            with patch("ori.reasoning.elevator._is_offline", return_value=True):
-                await elevator.reason_and_dispatch(
-                    _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
-                )
+            await elevator.reason_and_dispatch(
+                _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
+            )
 
             actions = await store.get_action_log()
             correlations = {row["correlation_id"] for row in actions}
@@ -1302,10 +1300,9 @@ class TestReasonAndDispatch:
         store = _mock_state_store(avg=4.0, history=[4.0, 4.1])
         elevator = IntelligenceElevator(local_llm=None)
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
-            )
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), _tier_b_post_action_skill(), store, dispatcher
+        )
 
         logged = store.log_reasoning.call_args.kwargs["result"]
         assert logged.reasoning_status == "incomplete"
@@ -1333,13 +1330,12 @@ class TestReasonAndDispatch:
             )
             elevator = IntelligenceElevator(local_llm=local_llm)
 
-            with patch("ori.reasoning.elevator._is_offline", return_value=True):
-                await elevator.reason_and_dispatch(
-                    _event(value=5.0),
-                    _tier_b_post_action_skill(),
-                    store,
-                    dispatcher,
-                )
+            await elevator.reason_and_dispatch(
+                _event(value=5.0),
+                _tier_b_post_action_skill(),
+                store,
+                dispatcher,
+            )
 
             local_llm.reason.assert_not_called()
             actions = await store.get_action_log()
@@ -1392,13 +1388,12 @@ class TestReasonAndDispatch:
             )
             elevator = IntelligenceElevator(local_llm=local_llm)
 
-            with patch("ori.reasoning.elevator._is_offline", return_value=True):
-                await elevator.reason_and_dispatch(
-                    _event(value=5.0),
-                    _tier_b_post_action_skill(),
-                    store,
-                    dispatcher,
-                )
+            await elevator.reason_and_dispatch(
+                _event(value=5.0),
+                _tier_b_post_action_skill(),
+                store,
+                dispatcher,
+            )
 
             actions = await store.get_action_log()
             by_action = {row["action_name"]: row for row in actions}
@@ -1427,8 +1422,7 @@ class TestReasonAndDispatch:
         skill = FakeSkill()  # no _actions configured
         elevator = IntelligenceElevator()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(_event(), skill, None, mock_dispatcher)
+        await elevator.reason_and_dispatch(_event(), skill, None, mock_dispatcher)
 
         mock_dispatcher.dispatch.assert_not_called()
 
@@ -1467,8 +1461,7 @@ class TestReasonAndDispatch:
         # Ensure "major" is the matched rule for this event.
         event.context = {"__handler_trigger_name": "major"}
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
+        await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
 
         call = mock_dispatcher.dispatch.call_args
         assert call[1]["action"] == "log_to_dashboard"
@@ -1494,8 +1487,7 @@ class TestReasonAndDispatch:
         event = _event(value=5.0)
         event.context = {"__handler_trigger_name": "never"}
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
+        await elevator.reason_and_dispatch(event, skill, None, mock_dispatcher)
 
         mock_dispatcher.dispatch.assert_not_called()
 
@@ -1505,10 +1497,9 @@ class TestReasonAndDispatch:
         elevator = IntelligenceElevator()
         store = _mock_state_store()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            await elevator.reason_and_dispatch(
-                _event(value=5.0), skill, store, mock_dispatcher
-            )
+        await elevator.reason_and_dispatch(
+            _event(value=5.0), skill, store, mock_dispatcher
+        )
 
         call = mock_dispatcher.dispatch.call_args
         ctx = call[1]["context"]
@@ -1521,11 +1512,10 @@ class TestReasonAndDispatch:
         skill = FakeSkill()
         elevator = IntelligenceElevator()
 
-        with patch("ori.reasoning.elevator._is_offline", return_value=True):
-            task = asyncio.create_task(
-                elevator.reason_and_dispatch(_event(), skill, None, mock_dispatcher)
-            )
-            await task  # must complete without raising
+        task = asyncio.create_task(
+            elevator.reason_and_dispatch(_event(), skill, None, mock_dispatcher)
+        )
+        await task  # must complete without raising
 
     async def test_reason_and_dispatch_catches_safety_error_and_dispatches_tier_a(self):
         """A RuleEngineSafetyError must be caught and routed as a Tier A synthetic event."""

--- a/tests/test_energy_throttle.py
+++ b/tests/test_energy_throttle.py
@@ -105,7 +105,6 @@ def _cfg(enabled: bool = True) -> object:
         "C",
         (object,),
         {
-            "offline_fallback": "local_slm",
             "escalation_threshold": 0.70,
             "energy_aware_reasoning": (
                 {
@@ -155,20 +154,18 @@ class TestEnergyAwareThrottle:
         conf = type(
             "C",
             (object,),
-            {"offline_fallback": "local_slm", "escalation_threshold": 0.70},
+            {"escalation_threshold": 0.70},
         )()
         elevator = IntelligenceElevator(config=conf)
         store = _state_store(battery_pct=5.0)
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
+        tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
         assert tier == "local_slm"
 
     @pytest.mark.asyncio
     async def test_battery_above_threshold_normal(self):
         elevator = IntelligenceElevator(config=_cfg(enabled=True))
         store = _state_store(battery_pct=50.0)
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
+        tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
         assert tier == "local_slm"
 
     @pytest.mark.asyncio
@@ -234,6 +231,5 @@ class TestEnergyAwareThrottle:
         cfg.energy_aware_reasoning["battery_sensor_id"] = "inverter-battery"
         elevator = IntelligenceElevator(config=cfg)
         store = _state_store(battery_pct=None)
-        with patch("ori.reasoning.elevator._is_offline", return_value=False):
-            tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
+        tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
         assert tier == "local_slm"

--- a/tests/test_external_watchdog.py
+++ b/tests/test_external_watchdog.py
@@ -71,7 +71,6 @@ def _write_runtime_config(tmp_path: Path, hal_block: str = "") -> Path:
               default_tier: local
               local_model: ""
               model_path: ""
-              offline_fallback: rule
 
             gateway:
               enabled: false

--- a/tests/test_rejection_memory.py
+++ b/tests/test_rejection_memory.py
@@ -95,7 +95,6 @@ def _elevator_config() -> object:
         "Cfg",
         (object,),
         {
-            "offline_fallback": "local_slm",
             "escalation_threshold": 0.7,
             "causal_memory": {"rejection_expiry_days": 30},
         },
@@ -210,8 +209,6 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
         )
         elevator = IntelligenceElevator(local_llm=llm, config=_elevator_config())
-
-        monkeypatch.setattr("ori.reasoning.elevator._is_offline", lambda: True)
         result = await elevator.reason(event, skill, store)
         assert result.action_tier == "A"
 
@@ -253,7 +250,6 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
         )
         elevator = IntelligenceElevator(local_llm=llm, config=_elevator_config())
-        monkeypatch.setattr("ori.reasoning.elevator._is_offline", lambda: True)
         result = await elevator.reason(event, skill, store)
         assert result.action_tier == "C"
 
@@ -292,8 +288,6 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
         )
         elevator = IntelligenceElevator(local_llm=llm, config=_elevator_config())
-        monkeypatch.setattr("ori.reasoning.elevator._is_offline", lambda: True)
-
         result = await elevator.reason(event, _FakeSkill(), store)
         assert "previously rejected by the operator" in result.prompt
         assert "scheduled run" in result.prompt

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -198,7 +198,6 @@ def minimal_config(tmp_path: Path) -> Path:
               default_tier: local
               local_model: ""
               model_path: ""
-              offline_fallback: rule
 
             gateway:
               enabled: false
@@ -457,7 +456,6 @@ class TestAdapterProtocol:
                   default_tier: local
                   local_model: ""
                   model_path: ""
-                  offline_fallback: rule
                 gateway:
                   enabled: false
                   broker_url: ""
@@ -599,7 +597,6 @@ class TestLifecycle:
                   default_tier: local
                   local_model: ""
                   model_path: ""
-                  offline_fallback: rule
                 gateway:
                   enabled: false
                   broker_url: ""
@@ -1525,7 +1522,6 @@ class TestWebhookServerStartup:
                   default_tier: local
                   local_model: ""
                   model_path: ""
-                  offline_fallback: rule
 
                 gateway:
                   enabled: false
@@ -1629,7 +1625,6 @@ class TestWebhookServerStartup:
                   default_tier: local
                   local_model: ""
                   model_path: ""
-                  offline_fallback: rule
 
                 gateway:
                   enabled: false
@@ -1727,7 +1722,6 @@ class TestWebhookServerStartup:
                   default_tier: local
                   local_model: ""
                   model_path: ""
-                  offline_fallback: rule
                 gateway:
                   enabled: false
                   broker_url: ""


### PR DESCRIPTION


## What does this PR do?

Cloud reasoning moved behind the gateway in commit 4fad25d. The gateway is a LAN process — internet reachability is irrelevant to whether it can be reached. The two `_is_offline_async` gates in `select_tier` were blocking gateway escalation on any site without internet (factories, off-grid installs, air-gapped deployments), silently degrading reasoning quality to rule-only on exactly the sites where the gateway matters most.

Gateway escalation is now gated solely on `gateway_reachable` from `CapabilityPosture`, which is populated by the MQTT heartbeat `subscriber. internet_available` remains in `CapabilityPosture` for gateway-layer decisions but no longer affects runtime tier selection.

Removes: `_is_offline()`, `_is_offline_async()`, `offline_fallback` config key.
Adds: `test_gateway_selected_on_airgapped_site` to cover the fixed case.


## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

Closes #145 

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
