### PR TITLE
feat(integration): add typed rule evaluation boundary

### DIFF
--- a/ori/integration/__init__.py
+++ b/ori/integration/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable integration boundaries for product and demo consumers."""
+
+from ori.integration.rule_evaluation import (
+    ActionTier,
+    RuleEvaluationRequest,
+    RuleEvaluationResult,
+    RuleEvaluationSession,
+    bundled_skill_path,
+    evaluate_sensor_reading,
+)
+
+__all__ = [
+    "ActionTier",
+    "RuleEvaluationRequest",
+    "RuleEvaluationResult",
+    "RuleEvaluationSession",
+    "bundled_skill_path",
+    "evaluate_sensor_reading",
+]

--- a/ori/integration/rule_evaluation.py
+++ b/ori/integration/rule_evaluation.py
@@ -1,0 +1,359 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stable in-process rule-evaluation boundary for demos and product tests.
+
+This module lets product/demo consumers prove Ori runtime rule decisions without
+starting the full runtime loop. It uses the real SkillLoader and RuleEngine, but
+it deliberately does not touch hardware, MQTT, LLMs, actions, or SQLite unless a
+caller explicitly supplies a compatible state-store object for history lookups.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import sysconfig
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal, cast
+
+from ori.network.events import OriEvent, SensorReading
+from ori.reasoning.rule_engine import RuleEngine, RuleResult
+from ori.skills.hooks_api import HookContext
+from ori.skills.loader import Skill, SkillLoader, Trigger
+
+ActionTier = Literal["A", "B", "C", "D"]
+
+_THRESHOLD_VAR_RE = re.compile(r"\bvalue\s*(?:>=|>|<=|<)\s*([A-Za-z_][A-Za-z0-9_]*)")
+_THRESHOLD_LITERAL_RE = re.compile(
+    r"\bvalue\s*(?:>=|>|<=|<)\s*(-?(?:\d+(?:\.\d*)?|\.\d+))\b"
+)
+_DEFAULT_SKILLS_DATA_DIR = Path("share") / "ori-runtime" / "skills"
+_DEFAULT_SESSIONS: dict[tuple[str, str | None], "RuleEvaluationSession"] = {}
+
+
+@dataclass(frozen=True)
+class RuleEvaluationRequest:
+    """Typed input for deterministic runtime rule evaluation.
+
+    ``skill_config_overrides`` exists for demos and product tests that need to
+    model a site-specific configuration, such as a different overcurrent
+    threshold, without modifying the bundled skill file.
+    """
+
+    sensor_id: str
+    sensor_type: str
+    value: float
+    unit: str
+    timestamp_ms: int
+    quality: float = 1.0
+    device_id: str = "demo-device-01"
+    skill_name: str = "energy-anomaly-detector"
+    skills_root: str | None = None
+    metadata: dict[str, object] = field(default_factory=dict)
+    event_context: dict[str, object] = field(default_factory=dict)
+    skill_config_overrides: dict[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        _validate_request(self)
+
+
+@dataclass(frozen=True)
+class RuleEvaluationResult:
+    """Typed output with proof fields suitable for demo Proof Mode."""
+
+    matched: bool
+    action_tier: ActionTier
+    trigger_name: str | None
+    proposed_action: str | None
+    default_actions: tuple[str, ...]
+    latency_ms: int
+    proof_rule_condition: str
+    proof_threshold: float | None
+    proof_threshold_name: str | None
+    proof_sensor_value: float
+    proof_tier_selected: ActionTier
+    skill_name: str
+    skill_version: str
+    escalation_target: str | None
+    bypass_llm: bool
+    reasoning_policy: str | None
+    requires_approval: bool
+
+
+class RuleEvaluationSession:
+    """Reusable rule-evaluation session with stable skill and cooldown state."""
+
+    def __init__(
+        self,
+        *,
+        skill_name: str = "energy-anomaly-detector",
+        skills_root: str | None = None,
+        rule_engine: RuleEngine | None = None,
+    ) -> None:
+        self._key = _session_key(skill_name, skills_root)
+        self._skill = SkillLoader().load_one(_skill_dir(skill_name, skills_root))
+        self._rule_engine = rule_engine or RuleEngine()
+
+    async def evaluate(
+        self,
+        request: RuleEvaluationRequest,
+        *,
+        state_store: object | None = None,
+    ) -> RuleEvaluationResult:
+        if _session_key(request.skill_name, request.skills_root) != self._key:
+            raise ValueError(
+                "RuleEvaluationSession can only evaluate requests for its skill"
+            )
+        return await _evaluate_with_skill(
+            request,
+            skill=self._skill,
+            rule_engine=self._rule_engine,
+            state_store=state_store,
+        )
+
+
+def _session_key(skill_name: str, skills_root: str | None) -> tuple[str, str | None]:
+    root = str(Path(skills_root).resolve(strict=False)) if skills_root else None
+    return _validate_skill_name(skill_name), root
+
+
+def bundled_skill_path(skill_name: str) -> Path:
+    """Return the path for a bundled skill in source checkouts or installed wheels."""
+    clean_name = _validate_skill_name(skill_name)
+
+    source_candidate = Path(__file__).resolve().parents[2] / "skills" / clean_name
+    if (source_candidate / "skill.yaml").is_file():
+        return source_candidate
+
+    installed_candidate = (
+        Path(sysconfig.get_path("data")) / _DEFAULT_SKILLS_DATA_DIR / clean_name
+    )
+    if (installed_candidate / "skill.yaml").is_file():
+        return installed_candidate
+
+    raise FileNotFoundError(f"bundled skill {clean_name!r} was not found")
+
+
+async def evaluate_sensor_reading(
+    request: RuleEvaluationRequest,
+    *,
+    state_store: object | None = None,
+) -> RuleEvaluationResult:
+    """Evaluate one reading through the real runtime rule engine.
+
+    This is intentionally in-process and deterministic. It is for product demos,
+    tests, and SDK runtime extras; production product surfaces should use the
+    gateway/runtime transport contracts instead.
+
+    Repeated calls for the same skill reuse a session so trigger cooldown state
+    and skill loading semantics match the long-lived runtime more closely.
+    """
+    session = _default_session(request)
+    return await session.evaluate(request, state_store=state_store)
+
+
+async def _evaluate_with_skill(
+    request: RuleEvaluationRequest,
+    *,
+    skill: Skill,
+    rule_engine: RuleEngine,
+    state_store: object | None,
+) -> RuleEvaluationResult:
+    start = time.perf_counter()
+
+    skill_config = _merged_skill_config(skill, request.skill_config_overrides)
+    event = _event_from_request(request)
+    context = await _rule_context(event, skill, skill_config, state_store)
+    rule_result = await rule_engine.evaluate(
+        event,
+        skill.triggers,
+        context=context,
+        state_store=state_store,
+    )
+    latency_ms = max(0, int((time.perf_counter() - start) * 1000))
+
+    return _result_from_rule(
+        request=request,
+        skill=skill,
+        context=context,
+        rule_result=rule_result,
+        latency_ms=latency_ms,
+    )
+
+
+def _default_session(request: RuleEvaluationRequest) -> RuleEvaluationSession:
+    key = _session_key(request.skill_name, request.skills_root)
+    session = _DEFAULT_SESSIONS.get(key)
+    if session is None:
+        session = RuleEvaluationSession(
+            skill_name=request.skill_name,
+            skills_root=request.skills_root,
+        )
+        _DEFAULT_SESSIONS[key] = session
+    return session
+
+
+def _validate_request(request: RuleEvaluationRequest) -> None:
+    if not request.sensor_id.strip():
+        raise ValueError("sensor_id must not be empty")
+    if not request.sensor_type.strip():
+        raise ValueError("sensor_type must not be empty")
+    if not request.unit.strip():
+        raise ValueError("unit must not be empty")
+    if not (0.0 <= request.quality <= 1.0):
+        raise ValueError("quality must be between 0.0 and 1.0")
+    if request.timestamp_ms < 0:
+        raise ValueError("timestamp_ms must be non-negative")
+    _validate_skill_name(request.skill_name)
+
+
+def _validate_skill_name(skill_name: str) -> str:
+    clean_name = skill_name.strip()
+    if not clean_name:
+        raise ValueError("skill_name must not be empty")
+    if any(part in clean_name for part in ("/", "\\", "..")):
+        raise ValueError("skill_name must be a bundled skill directory name")
+    if len(Path(clean_name).parts) != 1:
+        raise ValueError("skill_name must be a single directory name")
+    return clean_name
+
+
+def _skill_dir(skill_name: str, skills_root: str | None) -> Path:
+    clean_name = _validate_skill_name(skill_name)
+    if skills_root is None:
+        return bundled_skill_path(clean_name)
+
+    root = Path(skills_root).resolve(strict=False)
+    skill_dir = (root / clean_name).resolve(strict=False)
+    try:
+        skill_dir.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("skill_name resolves outside skills_root") from exc
+    if not (skill_dir / "skill.yaml").is_file():
+        raise FileNotFoundError(f"skill {clean_name!r} was not found under {root}")
+    return skill_dir
+
+
+def _merged_skill_config(
+    skill: Skill,
+    overrides: dict[str, object],
+) -> dict[str, object]:
+    config: dict[str, object] = dict(skill.config)
+    config.update(overrides)
+    return config
+
+
+def _event_from_request(request: RuleEvaluationRequest) -> OriEvent:
+    reading = SensorReading(
+        sensor_id=request.sensor_id,
+        sensor_type=request.sensor_type,
+        value=request.value,
+        unit=request.unit,
+        timestamp=request.timestamp_ms,
+        quality=request.quality,
+        metadata=dict(request.metadata),
+    )
+    event = OriEvent.from_reading(reading, request.device_id)
+    event.context.update(request.event_context)
+    return event
+
+
+async def _rule_context(
+    event: OriEvent,
+    skill: Skill,
+    skill_config: dict[str, object],
+    state_store: object | None,
+) -> dict[str, object]:
+    context: dict[str, object] = dict(skill_config)
+    hooks = skill.hooks
+    pre_trigger_eval = getattr(hooks, "pre_trigger_eval", None)
+    if not callable(pre_trigger_eval):
+        return context
+
+    hook_ctx = HookContext.build(
+        event,
+        state_store,
+        skill.name,
+        skill_config=skill_config,
+    )
+    maybe = pre_trigger_eval(hook_ctx)
+    if asyncio.iscoroutine(maybe):
+        await maybe
+    context.update(hook_ctx.derived)
+    return context
+
+
+def _result_from_rule(
+    *,
+    request: RuleEvaluationRequest,
+    skill: Skill,
+    context: dict[str, object],
+    rule_result: RuleResult,
+    latency_ms: int,
+) -> RuleEvaluationResult:
+    action_tier = _as_action_tier(rule_result.action_tier)
+    trigger = _trigger_by_name(skill, rule_result.rule_name)
+    condition = trigger.condition if trigger is not None else ""
+    threshold_name, threshold = _proof_threshold(condition, context)
+    default_actions = tuple(
+        skill.get_default_actions_for_trigger(rule_result.rule_name or "")
+    )
+    proposed_action = rule_result.action or (
+        default_actions[0] if default_actions else None
+    )
+
+    return RuleEvaluationResult(
+        matched=rule_result.matched,
+        action_tier=action_tier,
+        trigger_name=rule_result.rule_name,
+        proposed_action=proposed_action,
+        default_actions=default_actions,
+        latency_ms=latency_ms,
+        proof_rule_condition=condition,
+        proof_threshold=threshold,
+        proof_threshold_name=threshold_name,
+        proof_sensor_value=request.value,
+        proof_tier_selected=action_tier,
+        skill_name=skill.name,
+        skill_version=skill.version,
+        escalation_target=rule_result.escalate_to,
+        bypass_llm=rule_result.bypass_llm,
+        reasoning_policy=rule_result.reasoning_policy,
+        requires_approval=rule_result.requires_approval,
+    )
+
+
+def _trigger_by_name(skill: Skill, trigger_name: str | None) -> Trigger | None:
+    if trigger_name is None:
+        return None
+    for trigger in skill.triggers:
+        if trigger.name == trigger_name:
+            return trigger
+    return None
+
+
+def _proof_threshold(
+    condition: str,
+    context: dict[str, object],
+) -> tuple[str | None, float | None]:
+    match = _THRESHOLD_VAR_RE.search(condition)
+    if match is not None:
+        name = match.group(1)
+        raw = context.get(name)
+        if isinstance(raw, bool) or not isinstance(raw, (int, float)):
+            return name, None
+        return name, float(raw)
+
+    literal_match = _THRESHOLD_LITERAL_RE.search(condition)
+    if literal_match is None:
+        return None, None
+    return None, float(literal_match.group(1))
+
+
+def _as_action_tier(value: str) -> ActionTier:
+    if value not in {"A", "B", "C", "D"}:
+        return "A"
+    return cast(ActionTier, value)

--- a/ori/reasoning/rule_engine.py
+++ b/ori/reasoning/rule_engine.py
@@ -107,11 +107,21 @@ class EvalContext:
 
     def avg_24h(self, sensor_id: str) -> float:
         """Return 24-hour rolling average for *sensor_id* (0.0 if unavailable)."""
-        return self._cache.get(("avg_24h", sensor_id), 0.0)
+        value = self._cache.get(("avg_24h", sensor_id), 0.0)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return 0.0
+        return float(value)
 
     def last_n(self, sensor_id: str, n: int) -> list[float]:
         """Return the last *n* values for *sensor_id* (empty list if unavailable)."""
-        return self._cache.get(("last_n", sensor_id, n), [])
+        values = self._cache.get(("last_n", sensor_id, n), [])
+        if not isinstance(values, list):
+            return []
+        return [
+            float(value)
+            for value in values
+            if not isinstance(value, bool) and isinstance(value, (int, float))
+        ]
 
     def as_dict(self) -> dict[str, Any]:
         """Return the namespace dict used for ``eval``."""
@@ -233,7 +243,7 @@ def _check_safety_ast(condition: str) -> None:
             continue
 
         # ast.Call — only permit history.method(...) calls.
-        if node_type is ast.Call:
+        if isinstance(node, ast.Call):
             func = node.func
             if (
                 isinstance(func, ast.Attribute)
@@ -248,11 +258,9 @@ def _check_safety_ast(condition: str) -> None:
             )
 
         # ast.Attribute — only permit access on the history object.
-        if node_type is ast.Attribute:
-            if (
-                isinstance(node.value, ast.Name)
-                and node.value.id in _ALLOWED_ATTRIBUTE_ROOTS
-            ):
+        if isinstance(node, ast.Attribute):
+            value = node.value
+            if isinstance(value, ast.Name) and value.id in _ALLOWED_ATTRIBUTE_ROOTS:
                 continue
             raise RuleEngineSafetyError(
                 f"Rule condition contains forbidden attribute access: {condition!r}"
@@ -365,16 +373,16 @@ class RuleEngine:
         # Pre-fetch history if needed to safely inject into synchronous eval.
         history_cache: dict[tuple, Any] = {}
         for rule in rules:
-            condition = _rule_get(rule, "condition", "")
-            if not condition:
+            prefetch_condition = _rule_get(rule, "condition", "")
+            if not prefetch_condition:
                 continue
-            _check_safety_ast(condition)
-            history_calls = _extract_history_calls(condition)
+            _check_safety_ast(prefetch_condition)
+            history_calls = _extract_history_calls(prefetch_condition)
             if state_store is None:
                 continue
             for method, args in history_calls:
                 if method == "avg_24h":
-                    key = ("avg_24h", args[0])
+                    key: tuple[Any, ...] = ("avg_24h", args[0])
                     if key in history_cache:
                         continue
                     try:

--- a/ori/skills/hooks_api.py
+++ b/ori/skills/hooks_api.py
@@ -31,22 +31,36 @@ class HookHistoryAdapter:
             return method(*args)
         return None
 
+    @staticmethod
+    def _optional_float(value: Any) -> Optional[float]:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return float(value)
+
+    @staticmethod
+    def _optional_int(value: Any) -> Optional[int]:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return None
+        return int(value)
+
     def avg_hours(self, sensor_id: str, hours: int) -> Optional[float]:
         if not self._store:
             return None
-        return self._read("hooks_avg_last_hours", sensor_id, hours)
+        return self._optional_float(
+            self._read("hooks_avg_last_hours", sensor_id, hours)
+        )
 
     def avg_last_n(self, sensor_id: str, n: int) -> Optional[float]:
         if not self._store:
             return None
-        return self._read("hooks_avg_last_n", sensor_id, n)
+        return self._optional_float(self._read("hooks_avg_last_n", sensor_id, n))
 
     def last_value(self, sensor_id: str) -> Optional[float]:
         if not self._store:
             return None
         history = self._read("hooks_get_history", sensor_id, 1) or []
         if history:
-            return history[0].value
+            return self._optional_float(getattr(history[0], "value", None))
         return None
 
     def last_timestamp(self, sensor_id: str) -> Optional[int]:
@@ -54,7 +68,7 @@ class HookHistoryAdapter:
             return None
         history = self._read("hooks_get_history", sensor_id, 1) or []
         if history:
-            return history[0].timestamp
+            return self._optional_int(getattr(history[0], "timestamp", None))
         return None
 
     def fetch_history(self, sensor_id: str, limit: int = 1) -> list[dict[str, Any]]:
@@ -120,7 +134,8 @@ class HookStateAdapter:
     def get(self, key: str) -> Optional[str]:
         if not self._store or not self._skill_name:
             return None
-        return self._read("hooks_get_skill_state", self._skill_name, key)
+        value = self._read("hooks_get_skill_state", self._skill_name, key)
+        return value if isinstance(value, str) else None
 
     def set(self, key: str, value: str) -> None:
         if not self._store or not self._skill_name:

--- a/ori/skills/loader.py
+++ b/ori/skills/loader.py
@@ -22,6 +22,7 @@ import logging
 import os
 import re
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -107,11 +108,11 @@ class Skill:
     name: str
     version: str
     author: str
-    sensors_required: list[dict] = field(default_factory=list)
+    sensors_required: list[dict[str, Any]] = field(default_factory=list)
     triggers: list[Trigger] = field(default_factory=list)
     prompts: dict[str, str] = field(default_factory=dict)
-    actions: dict = field(default_factory=dict)
-    config: dict = field(default_factory=dict)
+    actions: dict[str, Any] = field(default_factory=dict)
+    config: dict[str, Any] = field(default_factory=dict)
     hooks: Any = None  # loaded module or None
 
     def get_default_actions_for_trigger(self, trigger_name: str) -> list[str]:
@@ -138,7 +139,11 @@ class Skill:
         """
         defaults: dict[str, list[str]] = self.actions.get("defaults") or {}
         # Find triggers that match sensor_type via sensors_required
-        matching_sensor_types = {s.get("type") for s in self.sensors_required}
+        matching_sensor_types: set[str] = set()
+        for sensor in self.sensors_required:
+            declared_sensor_type = sensor.get("type")
+            if isinstance(declared_sensor_type, str):
+                matching_sensor_types.add(declared_sensor_type)
         for trigger in self.triggers:
             if sensor_type in matching_sensor_types:
                 actions = defaults.get(trigger.name, [])
@@ -428,12 +433,14 @@ class SkillLoader:
             Callers can reuse this list to unsubscribe the exact handlers later.
         """
         tracker = _CooldownTracker()
-        subscriptions: list[tuple[str, Any]] = []
+        subscriptions: list[tuple[str, Callable[[OriEvent], Awaitable[None]]]] = []
 
         for trigger in skill.triggers:
-            sensor_types = [
-                s.get("type") for s in skill.sensors_required if s.get("type")
-            ]
+            sensor_types: list[str] = []
+            for sensor in skill.sensors_required:
+                sensor_type = sensor.get("type")
+                if isinstance(sensor_type, str) and sensor_type:
+                    sensor_types.append(sensor_type)
             if not sensor_types:
                 # Subscribe to wildcard if no sensor types declared
                 sensor_types = ["*"]
@@ -781,7 +788,7 @@ class SkillLoader:
         skill: Skill,
         trigger: Trigger,
         tracker: _CooldownTracker,
-    ):
+    ) -> Callable[[OriEvent], Awaitable[None]]:
         """Return a coroutine function suitable for EventBus subscription.
 
         The returned handler:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,41 @@ Repository = "https://github.com/ori-platform/ori-runtime"
 Documentation = "https://github.com/ori-platform/ori-runtime#readme"
 Issues = "https://github.com/ori-platform/ori-runtime/issues"
 
+
+[tool.setuptools.data-files]
+"share/ori-runtime/skills/battery-lifecycle-observer" = [
+    "skills/battery-lifecycle-observer/skill.yaml",
+    "skills/battery-lifecycle-observer/hooks.py",
+]
+"share/ori-runtime/skills/energy-anomaly-detector" = [
+    "skills/energy-anomaly-detector/skill.yaml",
+    "skills/energy-anomaly-detector/hooks.py",
+]
+"share/ori-runtime/skills/hvac-refrigerant-monitor" = [
+    "skills/hvac-refrigerant-monitor/skill.yaml",
+    "skills/hvac-refrigerant-monitor/hooks.py",
+]
+"share/ori-runtime/skills/pc-network-threat-monitor" = [
+    "skills/pc-network-threat-monitor/skill.yaml",
+    "skills/pc-network-threat-monitor/hooks.py",
+]
+"share/ori-runtime/skills/pc-system-health" = [
+    "skills/pc-system-health/skill.yaml",
+    "skills/pc-system-health/hooks.py",
+]
+"share/ori-runtime/skills/retail-occupancy-optimizer" = [
+    "skills/retail-occupancy-optimizer/skill.yaml",
+    "skills/retail-occupancy-optimizer/hooks.py",
+]
+"share/ori-runtime/skills/site-safety-ppe" = [
+    "skills/site-safety-ppe/skill.yaml",
+    "skills/site-safety-ppe/hooks.py",
+]
+"share/ori-runtime/skills/solar-performance-monitor" = [
+    "skills/solar-performance-monitor/skill.yaml",
+    "skills/solar-performance-monitor/hooks.py",
+]
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["ori*"]
@@ -101,7 +136,11 @@ warn_unused_ignores = true
 [[tool.mypy.overrides]]
 module = [
     "ori.gateway.*",
+    "ori.integration.*",
     "ori.network.events",
+    "ori.reasoning.rule_engine",
+    "ori.skills.hooks_api",
+    "ori.skills.loader",
     "ori.policy.*",
     "ori.reasoning.capability_posture",
     "ori.reasoning.escalation_policy",
@@ -115,6 +154,11 @@ module = [
     "ori.hal.*",
     "ori.hardware.*",
     "ori.skills.sandbox",
+    "ori.skills.os_sandbox",
     "tests.*",
 ]
 ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = ["yaml"]
+ignore_missing_imports = true

--- a/scripts/typecheck-boundaries.sh
+++ b/scripts/typecheck-boundaries.sh
@@ -14,6 +14,10 @@ fi
 
 "${MYPY[@]}" \
   ori/network/events.py \
+  ori/reasoning/rule_engine.py \
+  ori/skills/hooks_api.py \
+  ori/skills/loader.py \
+  ori/integration/rule_evaluation.py \
   ori/security/gateway_messages.py \
   ori/security/remote_commands.py \
   ori/policy/device_policy.py \

--- a/tests/test_integration_rule_evaluation.py
+++ b/tests/test_integration_rule_evaluation.py
@@ -1,0 +1,234 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ori.integration.rule_evaluation import (
+    RuleEvaluationRequest,
+    RuleEvaluationSession,
+    bundled_skill_path,
+    evaluate_sensor_reading,
+)
+
+
+def _request(value: float, **kwargs: object) -> RuleEvaluationRequest:
+    return RuleEvaluationRequest(
+        sensor_id="main-circuit-current",
+        sensor_type="current_clamp",
+        value=value,
+        unit="ampere",
+        timestamp_ms=1_710_000_000_123,
+        quality=1.0,
+        device_id="demo-site-a",
+        metadata={"source": "demo-api"},
+        **kwargs,
+    )
+
+
+def _write_skill(
+    root: Path,
+    *,
+    name: str,
+    condition: str,
+    cooldown_seconds: int = 0,
+    config: str = "",
+    hooks: str | None = None,
+) -> None:
+    skill_dir = root / name
+    skill_dir.mkdir()
+    skill_dir.joinpath("skill.yaml").write_text(
+        f"""
+name: {name}
+version: 0.1.0
+author: test
+signature: bundled
+sensors_required:
+  - type: current_clamp
+triggers:
+  - name: demo_trigger
+    condition: "{condition}"
+    action_tier: A
+    cooldown_seconds: {cooldown_seconds}
+prompts:
+  demo_trigger: Demo.
+actions:
+  available:
+    - name: alert_whatsapp
+      tier: A
+  defaults:
+    demo_trigger: [alert_whatsapp]
+config:
+{config or "  threshold: 10.0"}
+""",
+        encoding="utf-8",
+    )
+    if hooks is not None:
+        skill_dir.joinpath("hooks.py").write_text(hooks, encoding="utf-8")
+
+
+@pytest.mark.asyncio
+async def test_dangerous_overcurrent_returns_tier_d_with_proof_fields() -> None:
+    result = await evaluate_sensor_reading(_request(52.0))
+
+    assert result.matched is True
+    assert result.action_tier == "D"
+    assert result.trigger_name == "dangerous_overcurrent"
+    assert result.bypass_llm is True
+    assert result.proof_rule_condition == "value > dangerous_overcurrent_threshold"
+    assert result.proof_threshold_name == "dangerous_overcurrent_threshold"
+    assert result.proof_threshold == pytest.approx(20.0)
+    assert result.proof_sensor_value == pytest.approx(52.0)
+    assert result.proof_tier_selected == "D"
+    assert result.proposed_action == "alert_whatsapp"
+    assert result.default_actions == ("alert_whatsapp", "log_to_dashboard")
+    assert result.latency_ms >= 0
+
+
+@pytest.mark.asyncio
+async def test_below_dangerous_overcurrent_threshold_does_not_match_tier_d() -> None:
+    result = await evaluate_sensor_reading(_request(12.0))
+
+    assert result.matched is False
+    assert result.action_tier == "A"
+    assert result.trigger_name is None
+    assert result.proof_rule_condition == ""
+    assert result.proof_threshold is None
+    assert result.proposed_action is None
+    assert result.default_actions == ()
+
+
+@pytest.mark.asyncio
+async def test_skill_config_override_changes_threshold_without_editing_skill() -> None:
+    result = await evaluate_sensor_reading(
+        _request(52.0, skill_config_overrides={"dangerous_overcurrent_threshold": 50.0})
+    )
+
+    assert result.matched is True
+    assert result.action_tier == "D"
+    assert result.proof_threshold == pytest.approx(50.0)
+
+
+@pytest.mark.asyncio
+async def test_higher_override_can_prevent_dangerous_overcurrent_match() -> None:
+    result = await evaluate_sensor_reading(
+        _request(52.0, skill_config_overrides={"dangerous_overcurrent_threshold": 60.0})
+    )
+
+    assert result.matched is False
+    assert result.action_tier == "A"
+
+
+def test_bundled_skill_path_resolves_energy_anomaly_detector() -> None:
+    path = bundled_skill_path("energy-anomaly-detector")
+
+    assert path.name == "energy-anomaly-detector"
+    assert (path / "skill.yaml").is_file()
+    assert (path / "hooks.py").is_file()
+
+
+@pytest.mark.parametrize("bad_name", ["", "../energy-anomaly-detector", "a/b", "a\\b"])
+def test_bundled_skill_path_rejects_invalid_names(bad_name: str) -> None:
+    with pytest.raises(ValueError):
+        bundled_skill_path(bad_name)
+
+
+@pytest.mark.parametrize("bad_name", ["../evil", "safe/evil", "safe\\evil", ".."])
+def test_skills_root_rejects_traversal_skill_names(
+    tmp_path: Path,
+    bad_name: str,
+) -> None:
+    _write_skill(tmp_path, name="safe", condition="value > threshold")
+
+    with pytest.raises(ValueError):
+        RuleEvaluationRequest(
+            sensor_id="main-circuit-current",
+            sensor_type="current_clamp",
+            value=12.0,
+            unit="ampere",
+            timestamp_ms=1,
+            skill_name=bad_name,
+            skills_root=str(tmp_path),
+        )
+
+
+def test_rule_evaluation_request_rejects_invalid_state_at_construction() -> None:
+    with pytest.raises(ValueError, match="sensor_id"):
+        RuleEvaluationRequest(
+            sensor_id=" ",
+            sensor_type="current_clamp",
+            value=12.0,
+            unit="ampere",
+            timestamp_ms=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_session_preserves_trigger_cooldown_state(tmp_path: Path) -> None:
+    _write_skill(
+        tmp_path,
+        name="cooldown-skill",
+        condition="value > threshold",
+        cooldown_seconds=600,
+    )
+    session = RuleEvaluationSession(
+        skill_name="cooldown-skill",
+        skills_root=str(tmp_path),
+    )
+    request = _request(
+        12.0,
+        skill_name="cooldown-skill",
+        skills_root=str(tmp_path),
+    )
+
+    first = await session.evaluate(request)
+    second = await session.evaluate(request)
+
+    assert first.matched is True
+    assert second.matched is False
+
+
+@pytest.mark.asyncio
+async def test_non_callable_pre_trigger_eval_is_ignored(tmp_path: Path) -> None:
+    _write_skill(
+        tmp_path,
+        name="non-callable-hook-skill",
+        condition="value > threshold",
+        hooks="pre_trigger_eval = True\n",
+    )
+
+    result = await evaluate_sensor_reading(
+        _request(
+            12.0,
+            skill_name="non-callable-hook-skill",
+            skills_root=str(tmp_path),
+        )
+    )
+
+    assert result.matched is True
+
+
+@pytest.mark.asyncio
+async def test_inline_numeric_threshold_is_exposed_in_proof_fields(
+    tmp_path: Path,
+) -> None:
+    _write_skill(
+        tmp_path,
+        name="literal-threshold-skill",
+        condition="value > 50.0",
+    )
+
+    result = await evaluate_sensor_reading(
+        _request(
+            52.0,
+            skill_name="literal-threshold-skill",
+            skills_root=str(tmp_path),
+        )
+    )
+
+    assert result.matched is True
+    assert result.proof_threshold_name is None
+    assert result.proof_threshold == pytest.approx(50.0)


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->
