### PR TITLE
feat: add Termux phone smoke validation

### DIFF
--- a/docs/android-phone-install.md
+++ b/docs/android-phone-install.md
@@ -105,6 +105,12 @@ Run the doctor before starting the runtime:
 ori-phone-doctor --config ori.yaml
 ```
 
+For a fuller phone diagnostic on the Android device:
+
+```sh
+bash scripts/termux-phone-smoke.sh --config ori.yaml
+```
+
 Start the runtime:
 
 ```sh
@@ -153,9 +159,23 @@ cp ori.yaml.phone.example ori.yaml
 Edit the same site/device fields as the development install, then start:
 
 ```sh
-ori-phone-doctor --config ori.yaml
+bash scripts/termux-phone-smoke.sh --config ori.yaml
 termux-wake-lock
 ori-runtime --config ori.yaml
+```
+
+To validate the offline wheelhouse installation itself on a test phone, run:
+
+```sh
+export ORI_WHEELHOUSE_DIR="$HOME/ori-wheelhouse"
+bash scripts/termux-phone-smoke.sh --install-wheelhouse --config ori.yaml
+```
+
+To prove the runtime can stay alive briefly without taking over the terminal
+forever:
+
+```sh
+bash scripts/termux-phone-smoke.sh --config ori.yaml --runtime-startup-seconds 10
 ```
 
 ## Termux:Boot Startup
@@ -184,6 +204,7 @@ Run these checks before calling a phone deployment usable:
 ```sh
 python -c "import ori; print('imports ok')"
 ori-phone-doctor --config ori.yaml
+bash scripts/termux-phone-smoke.sh --config ori.yaml
 ori-runtime --config ori.yaml
 ```
 

--- a/docs/phone-termux-path.md
+++ b/docs/phone-termux-path.md
@@ -91,6 +91,18 @@ The doctor validates Termux command availability, USB readiness, phone-mode
 config, relay disablement, telemetry API-key presence when enabled, and operator
 contact setup without starting the runtime loop.
 
+Run this on the actual Android phone for end-to-end install readiness:
+
+```sh
+bash scripts/termux-phone-smoke.sh --config ori.yaml
+```
+
+Use `--install-wheelhouse` to validate the offline signed wheelhouse install
+path, and `--runtime-startup-seconds 10` to confirm the runtime stays alive
+briefly without leaving it running forever. The smoke script wraps the doctor
+and adds Termux package, wheelhouse, import, USB snapshot, and optional runtime
+startup checks.
+
 ## PWA Role
 
 The PWA is an operator and commercial surface, not the sensing runtime. It can

--- a/scripts/phone-doctor.sh
+++ b/scripts/phone-doctor.sh
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Phone Starter readiness check wrapper for Android/Termux installs.
+#
+# For full phone validation, including wheelhouse install checks and optional
+# runtime startup smoke, use scripts/termux-phone-smoke.sh.
 set -euo pipefail
 
 CONFIG_PATH="${1:-ori.yaml}"

--- a/scripts/termux-phone-smoke.sh
+++ b/scripts/termux-phone-smoke.sh
@@ -1,0 +1,354 @@
+#!/data/data/com.termux/files/usr/bin/bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+# Validate the Android/Termux Phone Starter path on a real phone.
+#
+# By default this script is non-destructive: it checks the Termux environment,
+# current Ori install, config, phone doctor, and USB readiness. Pass
+# --install-wheelhouse to validate the signed offline wheelhouse install path.
+set -u
+
+CONFIG_PATH="${ORI_CONFIG:-ori.yaml}"
+WHEELHOUSE_DIR="${ORI_WHEELHOUSE_DIR:-${HOME}/ori-wheelhouse}"
+PYTHON_BIN="${ORI_PYTHON:-python}"
+INSTALL_WHEELHOUSE=false
+NO_FAIL=false
+RUNTIME_STARTUP_SECONDS=0
+
+PASS_COUNT=0
+WARN_COUNT=0
+FAIL_COUNT=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/termux-phone-smoke.sh [options]
+
+Options:
+  --config PATH                 Path to ori.yaml. Defaults to ORI_CONFIG or ./ori.yaml.
+  --wheelhouse DIR              Offline phone wheelhouse. Defaults to ORI_WHEELHOUSE_DIR or ~/ori-wheelhouse.
+  --install-wheelhouse          Install dependencies and ori-runtime from the offline wheelhouse before checks.
+  --runtime-startup-seconds N   Start ori-runtime and require it to stay alive for N seconds. Default: 0, disabled.
+  --no-fail                     Always exit 0; useful when collecting diagnostics.
+  -h, --help                    Show this help.
+
+Examples:
+  scripts/termux-phone-smoke.sh --config ori.yaml
+  ORI_WHEELHOUSE_DIR=~/ori-wheelhouse scripts/termux-phone-smoke.sh --install-wheelhouse --config ori.yaml
+  ORI_PYTHON=.venv/bin/python scripts/termux-phone-smoke.sh --config ori.yaml.phone.example --no-fail
+  scripts/termux-phone-smoke.sh --config ori.yaml --runtime-startup-seconds 10
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --config)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --config requires a path" >&2
+        exit 2
+      fi
+      CONFIG_PATH="$2"
+      shift 2
+      ;;
+    --wheelhouse)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --wheelhouse requires a directory" >&2
+        exit 2
+      fi
+      WHEELHOUSE_DIR="$2"
+      shift 2
+      ;;
+    --install-wheelhouse)
+      INSTALL_WHEELHOUSE=true
+      shift
+      ;;
+    --runtime-startup-seconds)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --runtime-startup-seconds requires a number" >&2
+        exit 2
+      fi
+      RUNTIME_STARTUP_SECONDS="$2"
+      shift 2
+      ;;
+    --no-fail)
+      NO_FAIL=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "ERROR: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+record_pass() {
+  PASS_COUNT=$((PASS_COUNT + 1))
+  echo "PASS  $1"
+}
+
+record_warn() {
+  WARN_COUNT=$((WARN_COUNT + 1))
+  echo "WARN  $1"
+}
+
+record_fail() {
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+  echo "FAIL  $1"
+}
+
+have_command() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+run_step() {
+  local label="$1"
+  shift
+  echo ""
+  echo "==> ${label}"
+  if "$@"; then
+    record_pass "${label}"
+    return 0
+  fi
+  record_fail "${label}"
+  return 1
+}
+
+require_command() {
+  local command_name="$1"
+  local package_hint="${2:-}"
+  if have_command "${command_name}"; then
+    record_pass "command ${command_name} is available"
+    return 0
+  fi
+  if [ -n "${package_hint}" ]; then
+    record_fail "command ${command_name} is missing; ${package_hint}"
+  else
+    record_fail "command ${command_name} is missing"
+  fi
+  return 1
+}
+
+warn_command() {
+  local command_name="$1"
+  local package_hint="${2:-}"
+  if have_command "${command_name}"; then
+    record_pass "command ${command_name} is available"
+    return 0
+  fi
+  if [ -n "${package_hint}" ]; then
+    record_warn "command ${command_name} is missing; ${package_hint}"
+  else
+    record_warn "command ${command_name} is missing"
+  fi
+  return 0
+}
+
+check_termux_environment() {
+  echo ""
+  echo "==> Termux environment"
+  if [ "${PREFIX:-}" = "/data/data/com.termux/files/usr" ] || echo "${HOME:-}" | grep -q "com.termux"; then
+    record_pass "Termux app sandbox detected"
+  else
+    record_warn "Termux app sandbox not detected; run this script on the Android phone for final validation"
+  fi
+
+  require_command "${PYTHON_BIN}" "install Python with pkg install python, or set ORI_PYTHON"
+  require_command pkg "run inside Termux; pkg is part of the Termux base environment"
+  warn_command git "install git with pkg install git"
+  warn_command sshd "install OpenSSH with pkg install openssh"
+  warn_command termux-usb "install termux-api and the Termux:API app from the same source as Termux"
+  warn_command termux-wake-lock "install termux-api and the Termux:API app from the same source as Termux"
+}
+
+check_config_file() {
+  echo ""
+  echo "==> Config file"
+  if [ -f "${CONFIG_PATH}" ]; then
+    record_pass "config exists: ${CONFIG_PATH}"
+    return 0
+  fi
+  record_fail "config missing: ${CONFIG_PATH}"
+  return 1
+}
+
+check_usb_snapshot() {
+  echo ""
+  echo "==> USB snapshot"
+  local tty_devices
+  tty_devices=$(ls /dev/ttyUSB* /dev/ttyACM* 2>/dev/null || true)
+  if [ -n "${tty_devices}" ]; then
+    echo "${tty_devices}"
+    record_pass "direct USB serial path detected"
+  elif have_command termux-usb; then
+    local usb_devices
+    usb_devices=$(termux-usb -l 2>/dev/null || true)
+    if [ -n "${usb_devices}" ] && [ "${usb_devices}" != "[]" ]; then
+      echo "${usb_devices}"
+      record_warn "termux-usb sees USB device(s), but no direct serial tty is exposed"
+    else
+      record_warn "no USB meter detected by termux-usb yet"
+    fi
+  else
+    record_warn "termux-usb unavailable; cannot inspect Android USB host state"
+  fi
+}
+
+check_wheelhouse() {
+  echo ""
+  echo "==> Phone wheelhouse"
+  if [ ! -d "${WHEELHOUSE_DIR}" ]; then
+    if [ "${INSTALL_WHEELHOUSE}" = "true" ]; then
+      record_fail "wheelhouse directory missing: ${WHEELHOUSE_DIR}"
+      return 1
+    fi
+    record_warn "wheelhouse directory missing: ${WHEELHOUSE_DIR}; skipping install validation"
+    return 0
+  fi
+
+  record_pass "wheelhouse directory exists: ${WHEELHOUSE_DIR}"
+
+  if [ -f "${WHEELHOUSE_DIR}/requirements.txt" ]; then
+    record_pass "wheelhouse install requirements.txt exists"
+  else
+    record_fail "wheelhouse requirements.txt missing"
+    return 1
+  fi
+
+  if ls "${WHEELHOUSE_DIR}"/ori_runtime-*.whl >/dev/null 2>&1; then
+    record_pass "ori-runtime wheel exists in wheelhouse"
+  else
+    record_fail "ori-runtime wheel missing from wheelhouse"
+    return 1
+  fi
+
+  if [ -f "${WHEELHOUSE_DIR}/requirements-phone.txt" ]; then
+    record_pass "phone source/build lockfile is present"
+  else
+    record_warn "requirements-phone.txt missing; install can proceed, but build provenance is incomplete"
+  fi
+}
+
+install_from_wheelhouse() {
+  if [ "${INSTALL_WHEELHOUSE}" != "true" ]; then
+    return 0
+  fi
+  check_wheelhouse || return 1
+  run_step "install phone wheelhouse dependencies" \
+    "${PYTHON_BIN}" -m pip install --break-system-packages --no-index --find-links "${WHEELHOUSE_DIR}" --require-hashes -r "${WHEELHOUSE_DIR}/requirements.txt" || return 1
+  run_step "install ori-runtime wheel" \
+    "${PYTHON_BIN}" -m pip install --break-system-packages --no-index --find-links "${WHEELHOUSE_DIR}" --no-deps ori-runtime || return 1
+}
+
+check_python_imports() {
+  run_step "import ori.runtime" "${PYTHON_BIN}" -c "import ori.runtime; print('ori.runtime import ok')"
+  run_step "import ori.phone_doctor" "${PYTHON_BIN}" -c "import ori.phone_doctor; print('ori.phone_doctor import ok')"
+}
+
+run_doctor() {
+  echo ""
+  echo "==> ori-phone-doctor"
+  "${PYTHON_BIN}" -m ori.phone_doctor --config "${CONFIG_PATH}"
+  local status=$?
+  if [ "${status}" -eq 0 ]; then
+    record_pass "ori-phone-doctor passed"
+    return 0
+  fi
+  record_fail "ori-phone-doctor reported blocking checks"
+  return "${status}"
+}
+
+check_runtime_startup() {
+  if [ "${RUNTIME_STARTUP_SECONDS}" = "0" ]; then
+    record_warn "runtime startup smoke skipped; pass --runtime-startup-seconds N to enable"
+    return 0
+  fi
+
+  case "${RUNTIME_STARTUP_SECONDS}" in
+    ''|*[!0-9]*)
+      record_fail "--runtime-startup-seconds must be a non-negative integer"
+      return 1
+      ;;
+  esac
+
+  echo ""
+  echo "==> ori-runtime startup smoke (${RUNTIME_STARTUP_SECONDS}s)"
+  "${PYTHON_BIN}" - "${CONFIG_PATH}" "${RUNTIME_STARTUP_SECONDS}" <<'PY'
+import subprocess
+import sys
+
+config_path = sys.argv[1]
+timeout_s = int(sys.argv[2])
+
+command = [sys.executable, "-m", "ori.runtime", "--config", config_path, "--log-level", "INFO"]
+try:
+    result = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        timeout=timeout_s,
+    )
+except FileNotFoundError:
+    print("ori-runtime command is not available on PATH")
+    raise SystemExit(1)
+except subprocess.TimeoutExpired as exc:
+    output = exc.stdout or ""
+    if isinstance(output, bytes):
+        output = output.decode(errors="replace")
+    print(output[-4000:])
+    print(f"ori-runtime stayed alive for {timeout_s}s")
+    raise SystemExit(0)
+
+print(result.stdout[-4000:])
+print(f"ori-runtime exited early with code {result.returncode}")
+raise SystemExit(1)
+PY
+  local status=$?
+  if [ "${status}" -eq 0 ]; then
+    record_pass "ori-runtime stayed alive for ${RUNTIME_STARTUP_SECONDS}s"
+    return 0
+  fi
+  record_fail "ori-runtime exited before ${RUNTIME_STARTUP_SECONDS}s"
+  return "${status}"
+}
+
+main() {
+  echo "Ori Termux Phone Smoke"
+  echo "Config: ${CONFIG_PATH}"
+  echo "Wheelhouse: ${WHEELHOUSE_DIR}"
+  echo "Python: ${PYTHON_BIN}"
+  echo "Install wheelhouse: ${INSTALL_WHEELHOUSE}"
+  echo "Runtime startup seconds: ${RUNTIME_STARTUP_SECONDS}"
+
+  check_termux_environment
+  check_config_file || true
+  check_usb_snapshot
+  if [ "${INSTALL_WHEELHOUSE}" = "true" ]; then
+    install_from_wheelhouse || true
+  else
+    check_wheelhouse || true
+  fi
+  check_python_imports || true
+  run_doctor || true
+  check_runtime_startup || true
+
+  echo ""
+  echo "Summary: ${PASS_COUNT} pass, ${WARN_COUNT} warn, ${FAIL_COUNT} fail"
+  if [ "${FAIL_COUNT}" -gt 0 ]; then
+    echo "Result: FAIL"
+    if [ "${NO_FAIL}" = "true" ]; then
+      exit 0
+    fi
+    exit 1
+  fi
+  echo "Result: PASS"
+}
+
+main

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -102,6 +102,18 @@ def test_phone_wheelhouse_build_allows_platform_local_wheels() -> None:
     assert "--only-binary=:all:" in script
 
 
+def test_termux_phone_smoke_script_keeps_install_and_runtime_startup_opt_in() -> None:
+    script = Path("scripts/termux-phone-smoke.sh").read_text(encoding="utf-8")
+
+    assert "INSTALL_WHEELHOUSE=false" in script
+    assert "--install-wheelhouse" in script
+    assert "RUNTIME_STARTUP_SECONDS=0" in script
+    assert "--runtime-startup-seconds" in script
+    assert 'PYTHON_BIN="${ORI_PYTHON:-python}"' in script
+    assert "python -m pip install --break-system-packages --no-index" not in script
+    assert '"${PYTHON_BIN}" -m pip install --break-system-packages --no-index' in script
+
+
 def test_eval_extra_is_intentionally_empty() -> None:
     pyproject = tomllib.loads(Path("pyproject.toml").read_text(encoding="utf-8"))
 


### PR DESCRIPTION
## What does this PR do?

Adds a real Android/Termux phone validation harness for the Phone Starter path.

The new `scripts/termux-phone-smoke.sh` script is non-destructive by default and validates the parts desktop CI cannot prove: Termux command availability, config presence, USB snapshot, optional offline wheelhouse install, runtime imports, phone doctor output, and optional timeout-bounded runtime startup.

This gives a concrete command to run on the actual Android phone before phone activation instead of relying on macOS/Linux smoke tests for Android-specific behavior.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

None.

## Testing notes

Validated with:

- `bash -n scripts/termux-phone-smoke.sh scripts/phone-doctor.sh scripts/install-phone.sh`
- `.venv/bin/python -m ruff format --check tests/test_packaging_metadata.py ori/phone_doctor.py`
- `.venv/bin/python -m ruff check tests/test_packaging_metadata.py ori/phone_doctor.py`
- `.venv/bin/python -m pytest tests/test_packaging_metadata.py tests/test_phone_doctor.py -q`
- `.venv/bin/python scripts/check_workflows.py`
- `ORI_PYTHON=.venv/bin/python bash scripts/termux-phone-smoke.sh --config ori.yaml.phone.example --no-fail`

The dry-run smoke was run on macOS, where it correctly reports missing Termux-only commands such as `pkg`, `termux-usb`, and `termux-wake-lock`. The useful final validation must be run on an actual Android phone.

[skip-cap-matrix] This adds validation tooling and install documentation for the existing phone deployment path. It does not add, remove, or alter runtime capability tiers, action authority, or safety semantics.
