### PR TITLE
feat: add edge node deployment type

### DIFF
--- a/docs/CAPABILITY_MATRIX.md
+++ b/docs/CAPABILITY_MATRIX.md
@@ -71,6 +71,7 @@ This is the authoritative record of what is real versus planned.
 
 ## Recent updates
 
+- 2026-06-30: Added `edge_node` as a first-class runtime deployment type. Product-generated Ori Edge Node configs can now preserve `device.deployment_type: edge_node` instead of collapsing to the Pi profile, while the runtime continues to use the Linux/Pi hardware path unless a module explicitly handles Edge Node-specific hardware.
 - 2026-05-07: Runtime async offload refactor changed blocking-call wrappers from `run_in_executor` to `asyncio.to_thread` in actions/HAL/reasoning/store paths. Capability statuses unchanged (implementation detail only).
 - 2026-05-08: Added safe history-placeholder prompt interpolation in the elevator and hardened state compaction with configurable DB-backed clock-skew guard (`state.compaction.max_backward_skew_ms`).
 - 2026-05-09: Added load-time guardrails for history placeholder volume in skill prompts and raised unresolved history placeholder observability to WARNING logs.

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -16,7 +16,7 @@ device:
   location: Lagos, Nigeria
   site_type: office                 # business context for Tier C logs: office | pharmacy | factory | warehouse
   country_code: NG                  # ISO 3166-1 alpha-2 (e.g. NG, KE, US)
-  deployment_type: pi                # pi | phone | server
+  deployment_type: pi                # pi | phone | edge_node | server
   deployment_profile: development    # development | staging | production
                                      # staging/production enforce hardened posture
   rated_capacity_amps: 10.0          # used for Tier D threshold calculations

--- a/ori/config.py
+++ b/ori/config.py
@@ -99,7 +99,7 @@ class DeviceConfig:
     rated_capacity_amps: float = 10.0
     timezone: str = "Africa/Lagos"
     country_code: str = ""
-    deployment_type: str = "pi"  # 'pi' | 'phone' | 'server'
+    deployment_type: str = "pi"  # 'pi' | 'phone' | 'edge_node' | 'server'
     deployment_profile: str = "development"  # 'development' | 'staging' | 'production'
     site_type: str = ""  # business/site context, e.g. pharmacy | office | factory
 
@@ -566,9 +566,10 @@ def _parse_device(data: Any) -> DeviceConfig:
         )
 
     deployment_type = str(data.get("deployment_type", "pi")).strip().lower()
-    if deployment_type not in {"pi", "phone", "server"}:
+    if deployment_type not in {"pi", "phone", "edge_node", "server"}:
         raise ConfigValidationError(
-            "device.deployment_type must be one of ['phone', 'pi', 'server']."
+            "device.deployment_type must be one of "
+            "['phone', 'pi', 'edge_node', 'server']."
         )
     deployment_profile = (
         str(data.get("deployment_profile", "development")).strip().lower()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1953,6 +1953,34 @@ class TestDeviceValidation:
         cfg = Config.load(yaml_path)
         assert cfg.device.deployment_type == "phone"
 
+    def test_edge_node_deployment_type(self, tmp_path):
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+            device:
+              id: edge-node-01
+              name: Ori Edge Node
+              location: Lagos
+              deployment_type: edge_node
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: local
+              local_model: x
+              model_path: /tmp
+            gateway:
+              enabled: false
+              broker_url: mqtt://localhost
+            actions:
+              primary_alert_channel: sms
+              relay:
+                enabled: true
+                gpio_pin: 26
+            """,
+        )
+        cfg = Config.load(yaml_path)
+        assert cfg.device.deployment_type == "edge_node"
+
     def test_invalid_device_timezone_falls_back_to_host_tz_env(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary
- Adds edge_node as a first-class ori-runtime deployment_type.
- Updates the example config and config parser coverage.

## Validation
- .venv/bin/python -m pytest tests/test_config.py::TestDeviceValidation
- .venv/bin/python -m ruff check ori/config.py tests/test_config.py
- .venv/bin/python -m ruff format --check ori/config.py tests/test_config.py
- .venv/bin/python - <<'PY'
from pathlib import Path
import yaml
yaml.safe_load(Path('ori.yaml.example').read_text(encoding='utf-8'))
print('ori.yaml.example parses')
PY