### PR TITLE
feat(runtime): enforce device policy alert caps

### DIFF
--- a/ori/policy/device_policy.py
+++ b/ori/policy/device_policy.py
@@ -3,6 +3,7 @@
 
 import time
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
@@ -15,6 +16,8 @@ class DevicePolicy:
     policy_version: int  # monotonically increasing
     issued_at: int
     signature: str  # ed25519:<base64> — verified at load time
+    alert_sms_monthly_cap: Optional[int] = None
+    alert_whatsapp_monthly_cap: Optional[int] = None
 
     def permits_action(self, action_tier: str) -> bool:
         if action_tier in ("D", "A"):  # Tier D: Invariant 10. Tier A: always.
@@ -26,6 +29,35 @@ class DevicePolicy:
         if action_tier == "C":
             return self.relay_c_enabled
         return False
+
+    def permits_external_alert(
+        self,
+        *,
+        channel: str,
+        action_tier: str,
+        current_month_count: int,
+    ) -> bool:
+        """Apply commercial alert caps without blocking safety.
+
+        Tier D emergency notification is always allowed. Tier A remains a valid
+        action, but paid SMS/WhatsApp transport can be capped by policy so free
+        deployments keep basic awareness without unbounded messaging cost.
+        """
+
+        if action_tier == "D":
+            return True
+        cap = self.alert_monthly_cap(channel)
+        if cap is None or cap < 0:
+            return True
+        return int(current_month_count) < cap
+
+    def alert_monthly_cap(self, channel: str) -> Optional[int]:
+        normalized = str(channel or "").strip().lower()
+        if normalized == "sms":
+            return self.alert_sms_monthly_cap
+        if normalized == "whatsapp":
+            return self.alert_whatsapp_monthly_cap
+        return None
 
     @property
     def is_expired(self) -> bool:
@@ -47,4 +79,6 @@ class DevicePolicy:
             policy_version=0,
             issued_at=0,
             signature="self_hosted",
+            alert_sms_monthly_cap=None,
+            alert_whatsapp_monthly_cap=None,
         )

--- a/ori/policy/remote_fetch.py
+++ b/ori/policy/remote_fetch.py
@@ -68,6 +68,12 @@ def _to_int(value: Any, field: str) -> int:
         ) from exc
 
 
+def _optional_int(value: Any, field: str) -> int | None:
+    if value is None:
+        return None
+    return _to_int(value, field)
+
+
 def device_policy_from_payload(
     payload: dict[str, Any],
     *,
@@ -99,6 +105,13 @@ def device_policy_from_payload(
         policy_version=_to_int(payload.get("policy_version"), "policy_version"),
         issued_at=_to_int(payload.get("issued_at"), "issued_at"),
         signature=str(payload.get("signature", "")),
+        alert_sms_monthly_cap=_optional_int(
+            payload.get("alert_sms_monthly_cap"), "alert_sms_monthly_cap"
+        ),
+        alert_whatsapp_monthly_cap=_optional_int(
+            payload.get("alert_whatsapp_monthly_cap"),
+            "alert_whatsapp_monthly_cap",
+        ),
     )
 
 

--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -233,6 +233,8 @@ class ActionDispatcher:
                 "relay_b_enabled": None,
                 "relay_c_enabled": None,
                 "cloud_llm_enabled": None,
+                "alert_sms_monthly_cap": None,
+                "alert_whatsapp_monthly_cap": None,
                 "valid_until": None,
                 "issued_at": None,
                 "is_expired": None,
@@ -244,6 +246,8 @@ class ActionDispatcher:
             "relay_b_enabled": bool(self._policy.relay_b_enabled),
             "relay_c_enabled": bool(self._policy.relay_c_enabled),
             "cloud_llm_enabled": bool(self._policy.cloud_llm_enabled),
+            "alert_sms_monthly_cap": self._policy.alert_sms_monthly_cap,
+            "alert_whatsapp_monthly_cap": self._policy.alert_whatsapp_monthly_cap,
             "valid_until": int(self._policy.valid_until),
             "issued_at": int(self._policy.issued_at),
             "is_expired": bool(self._policy.is_expired),
@@ -259,6 +263,22 @@ class ActionDispatcher:
             self._policy if self._policy is not None else DevicePolicy.unrestricted()
         )
         return self._relay_b_c_enabled and active_policy.permits_action(action_tier)
+
+    def permits_external_alert(
+        self,
+        *,
+        channel: str,
+        action_tier: str,
+        current_month_count: int,
+    ) -> bool:
+        active_policy = (
+            self._policy if self._policy is not None else DevicePolicy.unrestricted()
+        )
+        return active_policy.permits_external_alert(
+            channel=channel,
+            action_tier=str(action_tier).upper(),
+            current_month_count=current_month_count,
+        )
 
     def get_inflight_tier_d_tasks(self) -> set[asyncio.Task[Any]]:
         """Return currently running Tier D execution tasks."""

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -14,6 +14,7 @@ Or via the CLI entry point::
 """
 
 import asyncio
+import datetime as dt
 import hashlib
 import json
 import logging
@@ -2582,6 +2583,18 @@ class OriRuntime:
             )
             return False
 
+        if not await self._policy_permits_external_alert(
+            channel=channel,
+            action_tier=action_tier,
+        ):
+            logger.info(
+                "[runtime] %s alert suppressed by DevicePolicy monthly cap tier=%s trigger=%s",
+                channel,
+                action_tier,
+                trigger_name,
+            )
+            return False
+
         delivered = False
         try:
             if allow_failover:
@@ -2612,6 +2625,7 @@ class OriRuntime:
             delivered = False
 
         if delivered:
+            await self._record_policy_counted_alert(channel, action_tier=action_tier)
             return True
 
         if self._state_store is None:
@@ -2638,6 +2652,7 @@ class OriRuntime:
             original_ts=original_ts,
         )
         if inserted:
+            await self._record_policy_counted_alert(channel, action_tier=action_tier)
             logger.info(
                 "[runtime] queued failed %s alert id=%s tier=%s trigger=%s original_ts=%d",
                 channel,
@@ -2651,6 +2666,60 @@ class OriRuntime:
                 "[runtime] alert already queued id=%s channel=%s", alert_id, channel
             )
         return True
+
+    async def _policy_permits_external_alert(
+        self,
+        *,
+        channel: str,
+        action_tier: str,
+    ) -> bool:
+        if str(action_tier).upper() == "D":
+            return True
+        if self._dispatcher is None or self._state_store is None:
+            return True
+        count = await self._current_policy_counted_alerts(channel)
+        return self._dispatcher.permits_external_alert(
+            channel=channel,
+            action_tier=action_tier,
+            current_month_count=count,
+        )
+
+    async def _current_policy_counted_alerts(self, channel: str) -> int:
+        if self._state_store is None:
+            return 0
+        raw = await self._state_store.get_skill_state(
+            "__runtime_alert_policy__",
+            _alert_policy_count_key(channel, now_ms()),
+        )
+        try:
+            return max(0, int(raw or "0"))
+        except (TypeError, ValueError):
+            return 0
+
+    async def _record_policy_counted_alert(
+        self,
+        channel: str,
+        *,
+        action_tier: str,
+    ) -> None:
+        if str(action_tier).upper() == "D":
+            return
+        if self._state_store is None:
+            return
+        try:
+            key = _alert_policy_count_key(channel, now_ms())
+            current = await self._current_policy_counted_alerts(channel)
+            await self._state_store.set_skill_state(
+                "__runtime_alert_policy__",
+                key,
+                str(current + 1),
+            )
+        except Exception:
+            logger.warning(
+                "[runtime] failed to persist %s alert policy count; delivered alert remains valid",
+                channel,
+                exc_info=True,
+            )
 
     async def _send_setup_success_notifications(
         self,
@@ -2974,6 +3043,15 @@ def _build_alert_id(
 ) -> str:
     raw = f"{channel}|{recipient}|{action_tier}|{trigger_name}|{original_ts}|{message}"
     return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _alert_policy_count_key(channel: str, timestamp_ms: int) -> str:
+    month = dt.datetime.fromtimestamp(
+        max(0, int(timestamp_ms)) / 1000,
+        tz=dt.UTC,
+    ).strftime("%Y-%m")
+    normalized = str(channel or "").strip().lower() or "unknown"
+    return f"external_alert_count:{normalized}:{month}"
 
 
 def _validate_remote_policy_reference_args(

--- a/tests/test_remote_policy_fetch.py
+++ b/tests/test_remote_policy_fetch.py
@@ -83,6 +83,50 @@ async def test_fetch_remote_policy_accepts_valid_signed_payload(monkeypatch):
     reason="cryptography ed25519 is unavailable",
 )
 @pytest.mark.asyncio
+async def test_fetch_remote_policy_accepts_alert_caps(monkeypatch):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_b64 = base64.b64encode(
+        private_key.public_key().public_bytes(
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
+        )
+    ).decode("ascii")
+    payload = _signed_payload(
+        private_key,
+        alert_sms_monthly_cap=3,
+        alert_whatsapp_monthly_cap=5,
+    )
+
+    monkeypatch.setattr(
+        "ori.policy.remote_fetch._http_get_json",
+        lambda _cfg: (json.dumps(payload), payload),
+    )
+    fetched = await fetch_remote_device_policy_bundle(_base_config(public_key_b64))
+
+    assert fetched.policy.alert_sms_monthly_cap == 3
+    assert fetched.policy.alert_whatsapp_monthly_cap == 5
+    assert fetched.policy.permits_external_alert(
+        channel="sms",
+        action_tier="A",
+        current_month_count=2,
+    )
+    assert not fetched.policy.permits_external_alert(
+        channel="sms",
+        action_tier="A",
+        current_month_count=3,
+    )
+    assert fetched.policy.permits_external_alert(
+        channel="sms",
+        action_tier="D",
+        current_month_count=999,
+    )
+
+
+@pytest.mark.skipif(
+    Ed25519PrivateKey is None,
+    reason="cryptography ed25519 is unavailable",
+)
+@pytest.mark.asyncio
 async def test_fetch_remote_policy_bundle_returns_exact_raw_payload(monkeypatch):
     private_key = Ed25519PrivateKey.generate()
     public_key_b64 = base64.b64encode(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -2165,6 +2165,137 @@ class TestAlertOutbox:
         finally:
             await runtime._state_store.close()
 
+    async def test_send_or_queue_alert_respects_device_policy_monthly_cap(
+        self, tmp_path
+    ):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "alert-cap.db"))
+        await runtime._state_store.open()
+        dispatcher = ActionDispatcher()
+        dispatcher.update_policy(
+            DevicePolicy(
+                tier="restricted",
+                relay_b_enabled=False,
+                relay_c_enabled=False,
+                cloud_llm_enabled=False,
+                valid_until=int(time.time()) + 3600,
+                policy_version=3,
+                issued_at=int(time.time()),
+                signature="test",
+                alert_sms_monthly_cap=1,
+                alert_whatsapp_monthly_cap=1,
+            )
+        )
+        runtime._dispatcher = dispatcher
+        alert_sender = AsyncMock()
+        alert_sender.send = AsyncMock(return_value=True)
+
+        try:
+            first = await runtime._send_or_queue_alert(
+                channel="sms",
+                message="first alert",
+                recipient="+2340000000000",
+                action_tier="A",
+                trigger_name="high_draw",
+                original_ts=1234567890,
+                alert_sender=alert_sender,
+            )
+            second = await runtime._send_or_queue_alert(
+                channel="sms",
+                message="second alert",
+                recipient="+2340000000000",
+                action_tier="A",
+                trigger_name="high_draw",
+                original_ts=1234567891,
+                alert_sender=alert_sender,
+            )
+            assert first is True
+            assert second is False
+            alert_sender.send.assert_awaited_once()
+        finally:
+            await runtime._state_store.close()
+
+    async def test_send_or_queue_alert_never_caps_tier_d(self, tmp_path):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "alert-cap-tier-d.db"))
+        await runtime._state_store.open()
+        dispatcher = ActionDispatcher()
+        dispatcher.update_policy(
+            DevicePolicy(
+                tier="restricted",
+                relay_b_enabled=False,
+                relay_c_enabled=False,
+                cloud_llm_enabled=False,
+                valid_until=int(time.time()) + 3600,
+                policy_version=3,
+                issued_at=int(time.time()),
+                signature="test",
+                alert_sms_monthly_cap=0,
+                alert_whatsapp_monthly_cap=0,
+            )
+        )
+        runtime._dispatcher = dispatcher
+        alert_sender = AsyncMock()
+        alert_sender.send = AsyncMock(return_value=True)
+
+        try:
+            delivered = await runtime._send_or_queue_alert(
+                channel="sms",
+                message="tier d alert",
+                recipient="+2340000000000",
+                action_tier="D",
+                trigger_name="dangerous_overcurrent",
+                original_ts=1234567890,
+                alert_sender=alert_sender,
+            )
+            assert delivered is True
+            alert_sender.send.assert_awaited_once()
+        finally:
+            await runtime._state_store.close()
+
+    async def test_send_or_queue_alert_ignores_alert_count_persistence_failure(
+        self, tmp_path
+    ):
+        runtime = OriRuntime(config_path="ori.yaml")
+        runtime._state_store = StateStore(str(tmp_path / "alert-count-failure.db"))
+        await runtime._state_store.open()
+        dispatcher = ActionDispatcher()
+        dispatcher.update_policy(
+            DevicePolicy(
+                tier="restricted",
+                relay_b_enabled=False,
+                relay_c_enabled=False,
+                cloud_llm_enabled=False,
+                valid_until=int(time.time()) + 3600,
+                policy_version=3,
+                issued_at=int(time.time()),
+                signature="test",
+                alert_sms_monthly_cap=1,
+                alert_whatsapp_monthly_cap=1,
+            )
+        )
+        runtime._dispatcher = dispatcher
+        alert_sender = AsyncMock()
+        alert_sender.send = AsyncMock(return_value=True)
+        runtime._state_store.set_skill_state = AsyncMock(  # type: ignore[method-assign]
+            side_effect=RuntimeError("sqlite unavailable")
+        )
+
+        try:
+            delivered = await runtime._send_or_queue_alert(
+                channel="sms",
+                message="delivered alert",
+                recipient="+2340000000000",
+                action_tier="A",
+                trigger_name="high_draw",
+                original_ts=1234567890,
+                alert_sender=alert_sender,
+            )
+            assert delivered is True
+            alert_sender.send.assert_awaited_once()
+        finally:
+            await runtime._state_store.close()
+
     async def test_remote_command_incident_emits_tier_a_alert(self, tmp_path):
         runtime = OriRuntime(config_path="ori.yaml")
         runtime._state_store = StateStore(str(tmp_path / "remote-lockout.db"))


### PR DESCRIPTION
## What does this PR do?

Adds runtime support for signed DevicePolicy SMS/WhatsApp monthly alert caps. The runtime parses the optional cap fields, exposes them through the dispatcher policy snapshot, checks caps before sending or queueing non-emergency external alerts, and records monthly per-channel usage in local state.

Tier D emergency alerts bypass caps unconditionally. Count persistence failures are logged but do not retroactively fail an already delivered alert.

## Type of change

- [x] `feat` — new feature
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue


## Testing notes

- `python -m ruff check ori tests/test_remote_policy_fetch.py tests/test_runtime.py`
- `python -m pytest tests/test_remote_policy_fetch.py tests/test_runtime.py::TestAlertOutbox -q` (`21 passed`)
- `python -m pytest tests -q` (`1683 passed, 8 skipped`)

[skip-cap-matrix] This change enforces commercial alert transport caps for existing alert actions. It does not add a new runtime capability row or change the declared support status of an existing capability.
