### PR TITLE
fix(runtime): fail loudly on missing Tier D executors

### DIFF
--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -567,9 +567,10 @@ class ActionDispatcher:
     ) -> ActionResult:
         """Execute *action* without any approval step.
 
-        If an executor is registered for *action*, it is called.  If no
-        executor exists, the action is logged as executed (the intent is
-        recorded even if no physical action fired).
+        If an executor is registered for *action*, it is called. If no
+        executor exists, non-safety actions are logged as intent-only
+        compatibility behaviour. Tier D actions fail loudly instead: a missing
+        safety executor means the physical safety action did not happen.
 
         Args:
             action: Action name to execute.
@@ -592,13 +593,12 @@ class ActionDispatcher:
                 if maybe_ok is False:
                     executed = False
             else:
-                if (
-                    action in ("trip_relay", "release_relay")
-                    and tier == ActionTier.SAFETY_CRITICAL
-                ):
+                if tier == ActionTier.SAFETY_CRITICAL:
                     executed = False
                     logger.critical(
-                        "ActionDispatcher: Tier D relay executor is not registered (hardware initialization failed)."
+                        "ActionDispatcher: Tier D executor is not registered for action=%r. "
+                        "No physical safety action was taken.",
+                        action,
                     )
                 elif self._log_action_decisions:
                     logger.debug(

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -575,7 +575,11 @@ class OriRuntime:
 
         dispatcher.register_executor("log_to_dashboard", _exec_log_to_dashboard)
 
-        # Relay executors — only if relay successfully connected
+        # Relay-backed safety executors — only if relay successfully connected.
+        # Semantic safety actions such as close_gas_valve still resolve through
+        # the physical relay path; commissioning must wire the relay output to
+        # the named fail-safe valve/contactor before that semantic action is
+        # safety-creditable.
         if relay_action is not None:
 
             async def _exec_trip_relay(*_: Any) -> None:
@@ -590,6 +594,7 @@ class OriRuntime:
 
             dispatcher.register_executor("trip_relay", _exec_trip_relay)
             dispatcher.register_executor("release_relay", _exec_release_relay)
+            dispatcher.register_executor("close_gas_valve", _exec_trip_relay)
 
         # ── Step D: Capability posture tracker + IntelligenceElevator ─────────
         posture_cfg = (

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -251,21 +251,28 @@ class TestTierA:
 
 class TestTierD:
     async def test_executes_immediately(self):
+        mock_exec = AsyncMock(return_value=True)
         d = ActionDispatcher()
+        d.register_executor("emergency_cutoff", mock_exec)
         result = await d.dispatch(
             "emergency_cutoff", ActionTier.SAFETY_CRITICAL, _context(), _result()
         )
         assert result.executed is True
+        mock_exec.assert_awaited_once()
 
     async def test_approved_is_none(self):
+        mock_exec = AsyncMock(return_value=True)
         d = ActionDispatcher()
+        d.register_executor("emergency_cutoff", mock_exec)
         result = await d.dispatch(
             "emergency_cutoff", ActionTier.SAFETY_CRITICAL, _context(), _result()
         )
         assert result.approved is None
 
     async def test_tier_d_in_result(self):
+        mock_exec = AsyncMock(return_value=True)
         d = ActionDispatcher()
+        d.register_executor("emergency_cutoff", mock_exec)
         result = await d.dispatch(
             "emergency_cutoff", ActionTier.SAFETY_CRITICAL, _context(), _result()
         )
@@ -280,12 +287,36 @@ class TestTierD:
         mock_exec.assert_awaited_once()
 
     async def test_bypasses_approval_workflow(self):
+        mock_exec = AsyncMock(return_value=True)
         d = ActionDispatcher()
+        d.register_executor("emergency_cutoff", mock_exec)
         with patch.object(d, "_approval_workflow", new=AsyncMock()) as mock_wf:
             await d.dispatch(
                 "emergency_cutoff", ActionTier.SAFETY_CRITICAL, _context(), _result()
             )
         mock_wf.assert_not_awaited()
+
+    async def test_missing_non_relay_executor_fails_loudly_and_alerts(self):
+        d = ActionDispatcher(config={"operator_contact": "+234000000000"})
+
+        with (
+            patch.object(d, "_emergency_sms", new=AsyncMock()) as mock_sms,
+            patch("ori.reasoning.action_dispatcher.logger") as mock_logger,
+        ):
+            result = await d.dispatch(
+                "close_gas_valve", ActionTier.SAFETY_CRITICAL, _context(), _result()
+            )
+
+        assert result.executed is False
+        assert result.action_taken == ""
+        critical_messages = [
+            str(call.args) for call in mock_logger.critical.call_args_list
+        ]
+        assert any(
+            "Tier D executor is not registered" in msg for msg in critical_messages
+        )
+        assert any("TIER D ACTION FAILED" in msg for msg in critical_messages)
+        mock_sms.assert_awaited_once_with("close_gas_valve", "dev-01")
 
     async def test_tier_d_tasks_are_tracked_without_task_attribute_hacks(self):
         running_flags: list[bool] = []

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1013,6 +1013,44 @@ class TestLifecycle:
             for r in caplog.records
         )
 
+    async def test_runtime_registers_close_gas_valve_as_relay_backed_tier_d_action(
+        self, minimal_config, monkeypatch
+    ):
+        _patch_external(monkeypatch)
+        cfg_path = Path(minimal_config)
+        config_text = cfg_path.read_text(encoding="utf-8")
+        relay_disabled = "  relay:\n    enabled: false\n"
+        assert relay_disabled in config_text
+        cfg_path.write_text(
+            config_text.replace(
+                relay_disabled,
+                "  relay:\n    enabled: true\n    gpio_pin: 26\n",
+            ),
+            encoding="utf-8",
+        )
+        connect = AsyncMock(return_value=None)
+        trigger = AsyncMock(return_value=True)
+        monkeypatch.setattr("ori.actions.relay.RelayAction.connect", connect)
+        monkeypatch.setattr("ori.actions.relay.RelayAction.trigger", trigger)
+
+        runtime = OriRuntime(config_path=str(cfg_path))
+
+        async def _stop():
+            await asyncio.sleep(0.1)
+            await runtime.stop()
+
+        await asyncio.gather(runtime.start(), _stop())
+
+        assert runtime._dispatcher is not None
+        close_gas_valve = runtime._dispatcher._executors["close_gas_valve"]
+        trip_relay = runtime._dispatcher._executors["trip_relay"]
+        assert close_gas_valve is trip_relay
+
+        await close_gas_valve("close_gas_valve", SimpleNamespace())
+
+        connect.assert_awaited_once_with(gpio_pin=26)
+        trigger.assert_awaited_once_with(duration_seconds=None)
+
 
 class TestStartupLogs:
     async def test_startup_logs_skill_tiers(self, minimal_config, monkeypatch, caplog):


### PR DESCRIPTION
## What does this PR do?

Fixes a Tier D safety execution bug where a safety-critical action with no registered executor could be logged as an intent-only success. Missing Tier D executors now fail loudly, return `executed=false`, emit the existing critical failure path, and trigger emergency SMS fallback where configured.

The PR also wires the bundled HVAC `close_gas_valve` Tier D default to the relay-backed safety executor when relay hardware is successfully initialized. This preserves the semantic action name while keeping safety credit dependent on commissioning wiring the relay output to the actual fail-safe valve or contactor.

## Type of change

- [x] `fix` — bug fix
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [x] Relevant pytest subset passes with 0 failures
- [x] `ruff check` is clean for touched runtime/test files
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

[skip-cap-matrix] This fixes Tier D executor failure semantics and runtime registration for an existing bundled action. It does not add a new capability, sensor family, deployment mode, or product-facing capability matrix row.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Follow-up from the safety-case review of Tier D executor behavior.

## Testing notes

- `.venv/bin/python -m pytest tests/test_action_dispatcher.py::TestTierD tests/test_tier_d_relay_bypass.py tests/test_runtime.py::TestLifecycle::test_runtime_registers_close_gas_valve_as_relay_backed_tier_d_action tests/test_runtime.py::TestLifecycle::test_phone_deployment_skips_relay_init tests/test_hvac_skill.py -q` -> 21 passed
- `.venv/bin/python -m pytest tests/test_action_dispatcher.py tests/test_runtime.py tests/test_tier_d_relay_bypass.py tests/test_hvac_skill.py -q` -> 185 passed
- `.venv/bin/python -m ruff check ori/reasoning/action_dispatcher.py ori/runtime.py tests/test_action_dispatcher.py tests/test_runtime.py` -> clean
- `git diff --check` -> clean