### PR TITLE
docs: record Rust kernel boundary and evidence-chain decisions

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1258,3 +1258,125 @@ Non-goals:
 - The runtime does not maintain provider IP range lists automatically.
 - The runtime does not prove carrier-origin sender identity.
 - The runtime does not replace firewall or reverse-proxy controls.
+
+---
+
+## 2026-07-10 — Rust Is For Stable Kernels, Not A Runtime Rewrite
+
+**Status:** Accepted
+
+**Supersedes:** the early Phase 2 migration sketch that listed the HAL as the
+first Rust migration target ("high I/O frequency... benefits most from
+zero-overhead threading") and the EventBus as second.
+
+The runtime stays a Python modular monolith. Rust is reserved for small,
+semantically frozen kernels where Python's failure modes have physical or
+evidentiary consequences.
+
+Decisions:
+
+- **The general adapter HAL stays Python — permanently, not "for now".** The
+  adapter surface is the highest-churn code in the repo (every new inverter,
+  meter, and protocol lands here) and the primary community-contribution
+  surface. Freezing it in Rust would raise contribution friction exactly
+  where the open-core strategy needs it lowest. This reverses the earlier
+  migration plan; the community argument outranks the I/O-throughput argument
+  at real sensor rates (~1 Hz). Rust may own narrow safety-kernel I/O paths
+  that are not part of the community adapter surface; those are kernel
+  internals, not HAL adapters.
+- **EventBus stays Python.** It is async orchestration glue coupled to skills
+  and hooks, which are Python-facing by design. A Rust EventBus buys
+  microseconds at IoT event rates and costs a hostile FFI boundary.
+- **Rust targets, in order:** (1) the verifiable evidence chain (already built
+  as a separate crate), (2) a deterministic Tier D safety kernel, (3) selected
+  low-level safety I/O paths only as the kernel needs them. The deduplicator
+  joins the kernel only as part of its deterministic input path, not as a
+  standalone rewrite.
+
+Rationale for the safety kernel: on intermittent power, devices restart
+constantly and the Python runtime takes seconds to tens of seconds to boot
+(config, DB, local model load). During that window Tier D evaluation is
+absent; a commissioned fail-safe relay/contactor installation can cover the
+de-energised default, but active hazard evaluation is absent until the
+runtime is up — and NC wiring alone does not prove fail-safe behaviour for
+energise-to-trip or incorrectly wired downstream installations. A Rust kernel
+boots in milliseconds and holds the safety line through brownout cycles and
+Python crashes.
+
+Phasing and versioning:
+
+- v2.x: hardened Python runtime; evidence-chain signing lands as additive
+  minor releases. Release notes must distinguish v2 hardening from future
+  Rust authority.
+- v3.0.0: the Rust safety kernel becomes authoritative for Tier D. Before the
+  authority flip, the kernel runs in shadow mode with Python authoritative,
+  and the flip requires ALL of:
+  - zero unexplained divergences between the Rust kernel and the Python rule
+    engine across a full replay of the recorded event corpus from all live
+    sites;
+  - 30 consecutive live deployment days in shadow mode;
+  - a minimum of 250,000 rule evaluations observed in shadow mode;
+  - a minimum of 50 Tier D boundary evaluations, from replay or labelled
+    synthetic injection (injection must be logged as such);
+  - every divergence classified and signed off — "zero divergences" may not
+    be satisfied by zero evaluations.
+
+Non-goals:
+
+- No broad rewrite of runtime.py, skills, actions, or reasoning orchestration.
+- No Rust in the skills SDK or hooks surface.
+
+---
+
+## 2026-07-10 — The Evidence Chain Is Core Infrastructure, Consumed As A Pinned Dependency
+
+**Status:** Accepted
+
+The Verity evidence chain (device-side Ed25519 signing + hash-chain ledger,
+built in its own repository) is core runtime infrastructure, not an optional
+feature, because **signed evidence cannot be backfilled**: an event not signed
+at emission time is permanently unverifiable to any third-party verifier
+(insurers, auditors, financiers). The start date of on-device signing is the
+one irreversible clock in the roadmap; export, ingestion, and receipt
+verification can all arrive later and retroactively consume the chain, but
+signing cannot be retrofitted onto history.
+
+Decisions:
+
+- **Separate repository + exact pin is the default boundary.** The runtime
+  consumes the evidence crate as an exactly pinned, prebuilt artifact (wheel
+  or static binary in the offline wheelhouse), never a floating version. An
+  evidence protocol is more credible to auditors as an independently
+  specified, independently CI'd artifact than as a subdirectory of the thing
+  it attests — and the separation keeps its cross-compilation CI out of the
+  runtime's pipeline entirely. Vendoring into this repo is reconsidered only
+  if the boundary churns under packaging pressure, and would be a packaging
+  decision, not an architectural one.
+- **The irreducible first production slice** is: device key generated at
+  provisioning/install time; public verification anchor registered outside
+  the device; Tier C/D decision/action events signed at emission on the real
+  dispatch path; chain head persisted locally; runtime health and node
+  heartbeat expose evidence status. Heartbeat visibility is a truncation
+  *signal*, not the archive — the locally persisted, exportable chain is the
+  evidence object.
+- **Atomicity choice (documented fork):** first implementation uses
+  **append-after-log with reconciliation** (Option B), explicitly and
+  testedly weaker than single-transaction atomicity. Every action_log row
+  carries an `attestation_status` (`pending | signed | failed | reconciled`);
+  startup reconciliation detects, logs, and repairs missing attestations
+  where possible; health exposes `attestation_status` counts,
+  `chain_head_hash`, `last_attested_action_id`, and `attestation_gap_count`.
+  Single-transaction append (Option A — evidence append and action log in one
+  SQLite transaction or a formally equivalent commit protocol) is the target
+  for third-party-verifier-grade claims and requires extending the FFI
+  boundary to share the state store's connection.
+- Signing on Android/Termux may use the existing subprocess/JSON CLI bridge
+  pattern with a static binary if the Python-ABI wheel path proves costly;
+  the chain format is identical either way.
+
+Non-goals:
+
+- The runtime never fabricates or backfills evidence for events that predate
+  signing; gaps are recorded as gaps.
+- Chain export receipts and ingestion-side verification are contract work in
+  the platform specs, not runtime scope.


### PR DESCRIPTION
## What does this PR do?

Records two accepted architecture decisions in `DECISIONS.md` so they survive outside chat transcripts, per the certification-prep documentation discipline.

**Why:** the Rust migration direction genuinely reversed (HAL/EventBus were previously the *first* Rust candidates; they are now Python-permanent for community-contribution velocity), and a future contributor or assessor finding the old plan and the new behavior disagreeing — with no dated record of why — is exactly the documentation inconsistency that erodes trust. The evidence-chain decision records the one irreversible clock in the roadmap (signed evidence cannot be backfilled) and the deliberately chosen weaker-first atomicity model, so neither can later be mistaken for an accident.

**Decision 1 — Rust is for stable kernels, not a runtime rewrite:**
- General adapter HAL: Python permanently (community surface; explicitly supersedes the earlier migration sketch). Rust may own narrow safety-kernel I/O paths that are not part of the community adapter surface.
- EventBus: Python (orchestration glue; hostile FFI boundary for microseconds).
- Rust targets in order: evidence chain (separate crate), deterministic Tier D safety kernel, kernel-owned safety I/O.
- v3.0.0 Tier D authority flip is gated on numeric shadow-mode exit criteria (replay corpus, 30 live days, ≥250k evaluations, ≥50 Tier D boundary evaluations, all divergences classified and signed off) — evaluation counts, not calendar time.
- Safety rationale is worded to the safety-case standard: a commissioned fail-safe installation covers the de-energised default, but NC wiring alone does not prove fail-safe behaviour for energise-to-trip or mis-wired installations.

**Decision 2 — the evidence chain is core infrastructure, consumed as a pinned dependency:**
- Separate repo + exact-pin artifact boundary (auditor credibility; CI isolation falls out for free).
- The irreducible first production slice: install-time key provisioning, off-device verification anchor, Tier C/D signing on the real dispatch path, chain head persisted, health/heartbeat evidence visibility (signal, not archive).
- Documented atomicity fork: Option B append-after-log with `attestation_status`/`chain_head_hash`/`last_attested_action_id`/`attestation_gap_count` and tested startup reconciliation now; Option A single-transaction append as the verifier-grade target.
- Non-goal: the runtime never fabricates or backfills evidence; gaps are recorded as gaps.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures (docs-only change; suite unaffected)
- [x] `ruff check --fix ori/ tests/ skills/` is clean (no Python touched)
- [x] Every new `.py` file has the Apache-2.0 license header (no new files)
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR — `[skip-cap-matrix]`: no capability behavior changed; this records decisions only
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Follow-up to #206/#207 (security-soundness thread); records the decisions agreed in architecture review.

## Testing notes

Docs-only. Pre-commit hooks pass on the changed file.