### PR TITLE
chore(release): prepare v2.0.0 — hardened runtime, fail-closed production posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/license-Apache%202.0-1E6B4A?style=flat-square)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-1E6B4A?style=flat-square)](https://python.org)
 [![CI](https://github.com/ori-platform/ori-runtime/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ori-platform/ori-runtime/actions/workflows/ci.yml)
-[![Release](https://img.shields.io/badge/release-v1.0.0-1E6B4A?style=flat-square)](#release-status)
+[![Release](https://img.shields.io/badge/release-v2.0.0-1E6B4A?style=flat-square)](#release-status)
 [![Platform](https://img.shields.io/badge/runs%20on-Raspberry%20Pi%20·%20Linux%20·%20macOS-C8A951?style=flat-square)](#)
 
 </div>
@@ -24,13 +24,17 @@ Built for the world's majority condition — unreliable power, intermittent conn
 
 ## Release Status
 
-**Current channel: Stable (`1.0.x`)**
+**Current channel: Stable (`2.0.x`)**
 
-- Runtime core is v1-stable for PoC, demo API, and controlled field deployment.
+- Runtime core is stable for PoC, demo API, and controlled field deployment,
+  with a fail-closed production security posture: staging/production configs
+  must meet the hardened gateway, remote-command, webhook, skill-signing,
+  state-encryption, and signed-config requirements or the runtime refuses to
+  start. Development-profile deployments remain warning-only.
 - Safety invariants (tier guards, strict skill validation, sandbox boundaries) are CI-enforced on every PR.
-- Public runtime contracts used by companion repos are the MQTT gateway/export contracts and the typed `ori.integration` rule-evaluation boundary.
+- Public runtime contracts used by companion repos are the MQTT gateway/export contracts and the typed `ori.integration` rule-evaluation boundary — unchanged from v1.0.0.
 - Recommended use today: pilots, PoCs, controlled deployments, product provisioning, and downstream demo/API integration.
-- Release notes: [`docs/releases/v1.0.0.md`](docs/releases/v1.0.0.md)
+- Release notes: [`docs/releases/v2.0.0.md`](docs/releases/v2.0.0.md)
 
 Related repos in the org:
 

--- a/docs/releases/stable-release-notes.md
+++ b/docs/releases/stable-release-notes.md
@@ -2,15 +2,16 @@
 
 ## Versioned Notes
 
+- [`v2.0.0`](v2.0.0.md) — hardened runtime: fail-closed production security posture
 - [`v1.0.0`](v1.0.0.md) — first stable runtime release
 
 ## Version
 
-`v1.0.0`
+`v2.0.0`
 
 ## Stable Scope
 
-Guaranteed by the runtime v1 line:
+Guaranteed by the runtime v1/v2 line:
 
 - Tier A/B/C/D action authority invariants
 - deterministic Tier D rule-only safety behavior

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,0 +1,155 @@
+# Ori Runtime — v2.0.0 Release Notes
+
+## Release Type
+
+Stable runtime release (`v2.0.0`) — major version.
+
+## Compare
+
+`v1.0.0...v2.0.0`
+
+https://github.com/ori-platform/ori-runtime/compare/v1.0.0...v2.0.0
+
+## Summary
+
+Ori Runtime v2.0.0 is the **hardened Python runtime**: it takes the v1.0.0
+stable contract and makes the production security posture fail-closed. The
+major version exists because staging/production configurations that loaded
+under v1.0.0 with weaker settings now refuse to start until they meet the
+posture requirements listed under Breaking Changes.
+
+This release is hardening and posture work on the existing runtime framework.
+It does **not** change where authority lives: Tier D safety remains
+deterministic, local, and Python-owned. The future migration of Tier D
+authority to a Rust safety kernel is a separate, explicitly gated milestone
+reserved for v3.0.0 (see `DECISIONS.md`, 2026-07-10 — the authority flip
+requires numeric shadow-mode exit criteria, not calendar time). Downstream
+consumers should continue to pin exact commit SHAs or tags, never floating
+ranges.
+
+The core posture is unchanged from v1.0.0: Tier D safety is deterministic and
+local, Tier C requires approval, Tier B physical autonomy requires explicit
+policy, local SLM confidence is non-authoritative, and cloud reasoning is a
+gateway backend rather than a runtime dependency.
+
+## Breaking Changes — Migration Required for Staging/Production Configs
+
+Configs with `device.deployment_profile: staging|production` (or
+`security.enforce_production_posture: true`) now **fail config load** unless
+all of the following hold. Development-profile deployments are unaffected
+(warnings only).
+
+- **Gateway broker posture.** In staging/production posture, every enabled
+  gateway broker requires gateway HMAC auth and payload encryption,
+  **including loopback brokers**. Non-loopback brokers additionally require
+  TLS (`mqtts://` or `gateway.tls.enabled`), MQTT credentials in the broker
+  URL, declared anonymous-access disablement, deployment check `required`,
+  and per-device ACL posture. Development loopback remains available for
+  local testing.
+- **Remote command lockout.** When remote commands are enabled, production
+  posture requires `security.remote_commands.lockout.enforcement_enabled:
+  true`. Lockout enforcement is no longer advisory-only: critical-risk
+  senders are blocked before an authenticated command can mutate runtime
+  state, and lockout evaluation failure fails closed under enforcement.
+- **Remote command senders.** `allow_unlisted_senders: true` is forbidden and
+  `allowed_senders` is required when remote commands are enabled.
+- **SMS webhook ingress.** Public (non-loopback) webhook hosts require HMAC
+  signature mode plus `allowed_source_cidrs`; token-only mode is rejected.
+- **Skill signing.** Local/non-core skills require Ed25519 signatures
+  (`security.skills.require_signed: true`).
+- **State encryption posture.** `state.encryption.mode: filesystem_required`
+  with a valid marker file or an encrypted path prefix covering
+  `database.path`.
+- **Config signature.** Production posture requires a verified
+  `config_signature` envelope once all other hardening checks pass.
+
+## Security Hardening Since v1.0.0
+
+- Production security posture enforcement (fail-closed, profile-driven,
+  cannot be opted out by staging/production configs)
+- Remote-command sender lockout enforcement with risk classification,
+  persisted security incidents, and health visibility
+- Gateway envelope replay protection now persists seen keys to the state
+  database (`gateway.auth.persistent_replay_cache`, default on) so a runtime
+  restart or power cycle cannot reopen the replay window
+- Runtime config signature verification (Ed25519 envelope, trust anchor
+  supplied via environment, fail-closed installer path via
+  `ori-config-install`)
+- HMAC secret rotation via verify-only previous secrets for gateway,
+  remote-command, and webhook verifiers
+- SMS webhook source CIDR allowlisting, raw-body HMAC mode, and documented
+  carrier-identity deployment boundary (`docs/SMS_WEBHOOK_SECURITY.md`)
+- Gateway broker posture declaration (`gateway.broker_posture`) surfaced in
+  runtime health
+- State-store encryption-at-rest posture with health exposure
+- Tier C SMS ingress hardening and scoped approval replies
+- Missing Tier D executors now fail loudly at startup
+- Runtime setup protection alerts and device-policy alert caps
+
+## Features Since v1.0.0
+
+- Phone deployment path: install doctor, offline wheelhouse targets, USB
+  serial and USB power support, telemetry export, Termux smoke validation,
+  APK readiness hardening, and phone inverter profiles
+- Edge node deployment type
+- Prosumer energy suite: energy advisor skill, optimization engine, energy
+  ledger, export-cap policy, versioned tariff policy profiles
+- Inverter integration groundwork: telemetry target catalog, profile
+  registry, profile doctor, evidence review and templates
+- NERC compliance tracker
+- CLI bridge JSON commands
+- Android Rust payload for the mobile runtime path
+- Guarded Tier B grid source transfers in the bundled energy anomaly
+  detector (fail-closed unless deployment context confirms the destination
+  source)
+- Demo simulation triggers in four bundled skills
+
+## Architecture Decisions Recorded
+
+`DECISIONS.md` (2026-07-10) records the boundaries this release ships under:
+
+- Rust targets stable safety/evidence kernels, not a runtime rewrite; the
+  general adapter HAL and EventBus stay Python for contribution velocity.
+- The evidence chain is core infrastructure consumed as an exactly pinned
+  separate-repo artifact; signed evidence cannot be backfilled.
+- v2.x releases are the hardened Python runtime; v3.0.0 is reserved for the
+  Rust Tier D authority flip behind numeric shadow-mode exit criteria.
+
+## Validation Snapshot
+
+Maintainer local validation at release prep:
+
+- Full runtime suite:
+  - `pytest tests/ -q`
+  - Result: `1714 passed, 5 skipped` (skips require Pi hardware)
+- Runtime contract-boundary typecheck:
+  - `bash scripts/typecheck-boundaries.sh`
+  - Result: clean across 19 boundary modules
+- Release wheel smoke:
+  - `bash scripts/smoke-release-wheel.sh`
+  - Result: built the wheel, installed into a clean venv, resolved bundled
+    `energy-anomaly-detector` from installed `share/ori-runtime/skills`, and
+    executed real Tier D rule evaluation through `ori.integration`
+- Supply-chain guard:
+  - `python scripts/check_workflows.py`
+  - Result: passed
+
+## Stable Runtime Contract
+
+Unchanged from v1.0.0 and stabilized further by the posture work:
+
+- Skill YAML action-tier contract and loader validation rules
+- `SensorReading` and `OriEvent` event data model
+- Tier A/B/C/D action authority invariants
+- Runtime-owned MQTT gateway reasoning/export/heartbeat contracts
+- Runtime bounded export surfaces for gateway/cloud consumers
+- `ori.integration` in-process rule-evaluation boundary for demos and
+  product tests
+
+## Explicit Non-Goals
+
+- v2.0.0 does not move Tier D authority to Rust. That is v3.0.0, gated on
+  the shadow-mode exit criteria in `DECISIONS.md`.
+- v2.0.0 does not include on-device evidence-chain signing; that lands as an
+  additive v2.x minor release consuming the pinned evidence crate.
+- Repo-wide mypy remains scoped to contract-boundary modules, as in v1.0.0.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "1.0.0"
+version = "2.0.0"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Release preparation for **v2.0.0**: version bump, release notes, release index, and README release surface — updated together so the public-facing posture is consistent. **No tag is applied by this PR**;

**Why a major version:** staging/production configurations that loaded under v1.0.0 with weaker settings now fail config load (lockout enforcement, gateway posture including loopback HMAC auth + payload encryption, webhook HMAC + source CIDRs, signed skills, state-encryption posture, verified config signatures). Under semver, refusing previously-valid production configs is breaking — the migration list is the centerpiece of the notes.

**Framing requirements carried into the notes:**
- v2 = hardened **Python** runtime. The notes explicitly state Tier D authority does not move to Rust in this release; that is reserved for v3.0.0 behind the numeric shadow-mode exit criteria in `DECISIONS.md`.
- Gateway loopback posture is worded exactly as implemented: staging/production requires HMAC auth + payload encryption for every enabled broker including loopback; non-loopback brokers additionally require TLS, credentials, anonymous-access disablement, and per-device ACL posture; development loopback remains available for local testing.
- Downstream consumers are advised to pin exact SHAs/tags; no product-specific framing appears in the notes.

## Type of change

- [x] `docs` — documentation only (plus the `pyproject.toml` version bump)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures (1714 passed, 5 hardware skips — re-run after the version bump)
- [x] `ruff check --fix ori/ tests/ skills/` is clean (no Python behavior touched)
- [x] Every new `.py` file has the Apache-2.0 license header (no new files)
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR — `[skip-cap-matrix]`: release notes/version metadata only, no capability behavior changed
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue


## Testing notes

Validation snapshot in the notes was confirmed against the **2.0.0** wheel after the bump: full suite 1714 passed / 5 skipped, `typecheck-boundaries.sh` clean across 19 modules, `smoke-release-wheel.sh` built and exercised `ori_runtime-2.0.0-py3-none-any.whl` end-to-end (Tier D rule evaluation through `ori.integration`), supply-chain guard passed.