### PR TITLE
feat(ci): prove runtime and real ori_verity artifact agree

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,3 +167,83 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  evidence-artifact:
+    name: Evidence FFI smoke (real ori_verity)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Read verity artifact pin
+        id: pin
+        run: |
+          repo="$(grep '^repo=' verity-artifact.pin | cut -d= -f2)"
+          ref="$(grep '^ref=' verity-artifact.pin | cut -d= -f2)"
+          version="$(grep '^expected_artifact_version=' verity-artifact.pin | cut -d= -f2)"
+          if [ -z "$repo" ] || [ -z "$ref" ] || [ -z "$version" ]; then
+            echo "verity-artifact.pin is missing repo/ref/expected_artifact_version" >&2
+            exit 1
+          fi
+          if ! echo "$ref" | grep -Eq '^[0-9a-f]{40}$'; then
+            echo "verity-artifact.pin ref must be a full commit SHA, got: $ref" >&2
+            exit 1
+          fi
+          echo "repo=$repo" >> "$GITHUB_OUTPUT"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout pinned ori-verity source
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          repository: ${{ steps.pin.outputs.repo }}
+          ref: ${{ steps.pin.outputs.ref }}
+          token: ${{ secrets.ORI_VERITY_CI_TOKEN }}
+          path: .verity-src
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+
+      - name: Install pinned Rust toolchain (from verity rust-toolchain.toml)
+        working-directory: .verity-src
+        run: rustup toolchain install
+
+      - name: Install hash-locked dependencies
+        run: |
+          python -m pip install --require-hashes -r requirements-dev.txt
+          python -m pip install --require-hashes --no-deps -r requirements-verity-ci.txt
+          python -m pip install --no-deps -e .
+
+      - name: Build ori_verity wheel from the pinned ref
+        working-directory: .verity-src
+        run: |
+          maturin build --release --features python \
+            --manifest-path ori-verity/Cargo.toml \
+            --out ../verity-wheel
+
+      - name: Install built wheel and verify artifact identity
+        run: |
+          python -m pip install --no-deps verity-wheel/*.whl
+          python - <<'EOF'
+          import ori_verity
+          expected = "${{ steps.pin.outputs.version }}"
+          assert ori_verity.ARTIFACT_VERSION == expected, (
+              f"built artifact {ori_verity.ARTIFACT_VERSION!r} != pinned {expected!r}"
+          )
+          print(
+              f"ori_verity {ori_verity.ARTIFACT_VERSION} "
+              f"(protocol {ori_verity.PROTOCOL_VERSION}) OK"
+          )
+          EOF
+
+      - name: Run real-artifact FFI smoke tests
+        run: pytest tests/test_evidence_artifact.py -v

--- a/ori/security/evidence.py
+++ b/ori/security/evidence.py
@@ -154,6 +154,7 @@ class EvidenceAttestor:
         logged so the provisioning flow can register it off-device.
         """
         loop = asyncio.get_running_loop()
+        chain: Any = None
         try:
             chain = await loop.run_in_executor(self._executor, self._open_sync)
             self._public_key_hex = await loop.run_in_executor(
@@ -166,6 +167,9 @@ class EvidenceAttestor:
                 "recorded as attestation gaps until signing is restored.",
                 exc_info=True,
             )
+            holder = [chain]
+            chain = None
+            self._release_chain(holder)
             return False
         if self._protocol_version != EXPECTED_PROTOCOL_VERSION or not hasattr(
             chain, "seq_for_event_id"
@@ -178,6 +182,9 @@ class EvidenceAttestor:
                 self._protocol_version,
                 EXPECTED_PROTOCOL_VERSION,
             )
+            holder = [chain]
+            chain = None
+            self._release_chain(holder)
             return False
         self._action_event_type = (
             SAFETY_ACTION_EVENT_TYPE
@@ -299,5 +306,29 @@ class EvidenceAttestor:
             logger.warning("[evidence] pending count read failed", exc_info=True)
             return None
 
+    def _release_chain(self, holder: list) -> None:
+        """Drop the chain held in *holder* on the evidence thread.
+
+        The pyo3 VerityChain is unsendable: its LAST reference must be
+        released on the thread that created it, or the extension raises
+        at GC time. This must run on EVERY path where a chain object
+        exists but is not (or no longer) retained — rejected starts
+        included. Callers must MOVE their only reference into *holder*
+        (and clear their local) before calling, so the reference cleared
+        here on the evidence thread is the final one.
+        """
+        if not holder or holder[0] is None:
+            return
+        try:
+            self._executor.submit(holder.clear).result(timeout=5)
+        except Exception:
+            logger.warning(
+                "[evidence] chain release on evidence thread failed",
+                exc_info=True,
+            )
+
     def close(self) -> None:
+        holder = [self._chain]
+        self._chain = None
+        self._release_chain(holder)
         self._executor.shutdown(wait=False)

--- a/ori/security/evidence.py
+++ b/ori/security/evidence.py
@@ -154,11 +154,15 @@ class EvidenceAttestor:
         logged so the provisioning flow can register it off-device.
         """
         loop = asyncio.get_running_loop()
-        chain: Any = None
+        # The chain lives in this single-slot holder, never in a bare
+        # local: on any rejection path the holder is handed whole to
+        # _release_chain(), so no frame keeps a reference that would make
+        # the unsendable pyo3 object drop on the wrong thread.
+        holder: list[Any] = [None]
         try:
-            chain = await loop.run_in_executor(self._executor, self._open_sync)
+            holder[0] = await loop.run_in_executor(self._executor, self._open_sync)
             self._public_key_hex = await loop.run_in_executor(
-                self._executor, chain.public_key_hex
+                self._executor, holder[0].public_key_hex
             )
         except Exception:
             self._chain = None
@@ -167,12 +171,10 @@ class EvidenceAttestor:
                 "recorded as attestation gaps until signing is restored.",
                 exc_info=True,
             )
-            holder = [chain]
-            chain = None
             self._release_chain(holder)
             return False
         if self._protocol_version != EXPECTED_PROTOCOL_VERSION or not hasattr(
-            chain, "seq_for_event_id"
+            holder[0], "seq_for_event_id"
         ):
             logger.warning(
                 "[evidence] loaded ori_verity artifact (version=%r, protocol=%r) "
@@ -182,8 +184,6 @@ class EvidenceAttestor:
                 self._protocol_version,
                 EXPECTED_PROTOCOL_VERSION,
             )
-            holder = [chain]
-            chain = None
             self._release_chain(holder)
             return False
         self._action_event_type = (
@@ -191,7 +191,7 @@ class EvidenceAttestor:
             if _artifact_supports_safety_event(self._artifact_version)
             else LEGACY_ACTION_EVENT_TYPE
         )
-        self._chain = chain
+        self._chain = holder.pop()
         logger.warning(
             "[evidence] chain open db=%s artifact=%s — REGISTER this device "
             "verification anchor off-device at provisioning: %s",

--- a/requirements-verity-ci.txt
+++ b/requirements-verity-ci.txt
@@ -1,0 +1,5 @@
+# Build tool for the ori_verity FFI smoke job (CI, linux x86_64 only).
+# Hash-locked like every other CI dependency; maturin has no runtime
+# dependencies on Python >= 3.11 so it installs with --no-deps.
+maturin==1.14.1 \
+    --hash=sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -11,6 +11,7 @@ graceful degradation when the artifact or chain is unavailable.
 """
 
 import sys
+import threading
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -279,6 +280,55 @@ class TestActionEventVocabulary:
             device_id="dev-01",
         )
         assert attestor.action_event_type == "MAINTENANCE_PERFORMED"
+        attestor.close()
+
+
+@pytest.mark.asyncio
+class TestChainReleaseThread:
+    """The pyo3 chain is unsendable: every path that lets go of a chain
+    object — close() and rejected starts alike — must drop it on the
+    evidence thread, or the real extension raises at GC time."""
+
+    @staticmethod
+    def _tracking_chain_cls():
+        class _TrackingChain(_FakeVerityChain):
+            deleted_on: list[str] = []
+
+            def __del__(self) -> None:
+                _TrackingChain.deleted_on.append(threading.current_thread().name)
+
+        return _TrackingChain
+
+    async def test_close_drops_chain_on_evidence_thread(self, monkeypatch, tmp_path):
+        cls = self._tracking_chain_cls()
+        _install_fake_verity(monkeypatch)
+        sys.modules["ori_verity"].VerityChain = cls
+        attestor = EvidenceAttestor(
+            db_path=str(tmp_path / "verity.db"),
+            key_path=str(tmp_path / "verity.key"),
+            device_secret="install-secret",
+            device_id="dev-01",
+        )
+        assert await attestor.start() is True
+        attestor.close()
+        assert len(cls.deleted_on) == 1
+        assert cls.deleted_on[0].startswith("ori-evidence")
+
+    async def test_rejected_start_drops_chain_on_evidence_thread(
+        self, monkeypatch, tmp_path
+    ):
+        cls = self._tracking_chain_cls()
+        _install_fake_verity(monkeypatch, protocol_version="verity.v0")
+        sys.modules["ori_verity"].VerityChain = cls
+        attestor = EvidenceAttestor(
+            db_path=str(tmp_path / "verity.db"),
+            key_path=str(tmp_path / "verity.key"),
+            device_secret="install-secret",
+            device_id="dev-01",
+        )
+        assert await attestor.start() is False
+        assert len(cls.deleted_on) == 1
+        assert cls.deleted_on[0].startswith("ori-evidence")
         attestor.close()
 
 

--- a/tests/test_evidence_artifact.py
+++ b/tests/test_evidence_artifact.py
@@ -1,0 +1,173 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""FFI compatibility smoke tests against the REAL ori_verity artifact.
+
+The unit suite in test_evidence.py deliberately runs against a fake
+``ori_verity`` module: absence behaviour and fault injection can only be
+tested without the real artifact. What the fake cannot prove is that the
+runtime and the real artifact speak the same protocol — a drifted FFI
+signature would leave the fake suite green while every deployment fell
+back to "evidence unavailable".
+
+This module closes that gap. It auto-skips when ``ori_verity`` is not
+importable (dev machines and the main CI matrix), and runs in the
+dedicated ``evidence-artifact`` CI job, which builds the wheel from the
+exact ref recorded in ``verity-artifact.pin`` and installs it first.
+Everything here drives the real EvidenceAttestor against the real chain:
+key provisioning, signing, idempotent re-append, late-marking, chain
+verification against the provisioned anchor, and restart persistence.
+"""
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+ori_verity = pytest.importorskip(
+    "ori_verity", reason="real ori_verity artifact not installed"
+)
+
+from ori.security.evidence import (  # noqa: E402
+    EXPECTED_PROTOCOL_VERSION,
+    EvidenceAttestor,
+    _artifact_supports_safety_event,
+)
+
+_PIN_FILE = Path(__file__).resolve().parents[1] / "verity-artifact.pin"
+
+
+def _pinned_artifact_version() -> str | None:
+    if not _PIN_FILE.exists():
+        return None
+    for line in _PIN_FILE.read_text().splitlines():
+        line = line.strip()
+        if line.startswith("expected_artifact_version="):
+            return line.split("=", 1)[1].strip()
+    return None
+
+
+def _attestor(tmp_path, *, device_secret: str = "install-secret") -> EvidenceAttestor:
+    return EvidenceAttestor(
+        db_path=str(tmp_path / "verity.db"),
+        key_path=str(tmp_path / "verity.key"),
+        device_secret=device_secret,
+        device_id="artifact-smoke-01",
+    )
+
+
+def _tier_d_row(row_id: int) -> dict:
+    return {
+        "id": row_id,
+        "action_name": "emergency_cutoff",
+        "tier": "D",
+        "executed": True,
+        "approved": None,
+        "action_taken": "emergency_cutoff",
+        "trigger_name": "dangerous_overcurrent",
+        "timestamp": 1_760_000_000_000 + row_id,
+    }
+
+
+def _chain_row(db_path: str, seq: int) -> dict:
+    # Test-only forensic read; the runtime itself never reads chain SQLite.
+    with sqlite3.connect(db_path) as conn:
+        conn.row_factory = sqlite3.Row
+        row = conn.execute(
+            "SELECT event_type, device_id, emitted_at_ms, payload_json "
+            "FROM verity_chain WHERE seq = ?",
+            (seq,),
+        ).fetchone()
+    assert row is not None, f"chain row seq={seq} missing"
+    return dict(row)
+
+
+def test_artifact_identity_matches_pin():
+    assert ori_verity.PROTOCOL_VERSION == EXPECTED_PROTOCOL_VERSION
+    pinned = _pinned_artifact_version()
+    assert pinned, "verity-artifact.pin missing expected_artifact_version"
+    assert ori_verity.ARTIFACT_VERSION == pinned, (
+        f"installed artifact {ori_verity.ARTIFACT_VERSION!r} does not match "
+        f"verity-artifact.pin {pinned!r} — bump ref and "
+        f"expected_artifact_version together"
+    )
+    # The pinned artifact must be vocabulary-capable; the runtime selects
+    # SAFETY_ACTION_EXECUTED from it.
+    assert _artifact_supports_safety_event(ori_verity.ARTIFACT_VERSION)
+
+
+@pytest.mark.asyncio
+async def test_provisioning_signing_idempotency_and_verification(tmp_path):
+    attestor = _attestor(tmp_path)
+    try:
+        assert await attestor.start() is True
+        assert attestor.available is True
+        anchor = attestor.public_key_hex
+        assert len(anchor) == 64 and int(anchor, 16) >= 0
+        assert attestor.action_event_type == "SAFETY_ACTION_EXECUTED"
+
+        seq = await attestor.attest_action(_tier_d_row(1))
+        assert seq == 1
+        # Idempotent against the real UNIQUE event_id + seq lookup.
+        assert await attestor.attest_action(_tier_d_row(1)) == 1
+
+        head = await attestor.chain_head_hash()
+        assert head and len(head) == 64
+        assert await attestor.pending_export_count() == 1
+
+        row = _chain_row(attestor._db_path, 1)
+        assert row["event_type"] == "SAFETY_ACTION_EXECUTED"
+        assert row["device_id"] == "artifact-smoke-01"
+        assert row["emitted_at_ms"] == 1_760_000_000_001
+        payload = json.loads(row["payload_json"])
+        assert payload["kind"] == "runtime_action"
+        assert payload["attestation"] == "at_emission"
+        assert payload["action_tier"] == "D"
+
+        # Late signing is explicit in the real signed payload too.
+        assert await attestor.attest_action(_tier_d_row(2), reconciled=True) == 2
+        late = json.loads(_chain_row(attestor._db_path, 2)["payload_json"])
+        assert late["attestation"] == "reconciled_late"
+
+        # The whole chain verifies against the provisioned anchor. The pyo3
+        # chain is unsendable, so the call must run on the attestor's
+        # dedicated evidence thread; it raises on any integrity failure.
+        attestor._executor.submit(attestor._chain.verify_chain, anchor).result()
+    finally:
+        attestor.close()
+
+
+@pytest.mark.asyncio
+async def test_chain_survives_restart_with_same_secret(tmp_path):
+    first = _attestor(tmp_path)
+    assert await first.start() is True
+    anchor = first.public_key_hex
+    assert await first.attest_action(_tier_d_row(1)) == 1
+    head = await first.chain_head_hash()
+    first.close()
+
+    second = _attestor(tmp_path)
+    try:
+        assert await second.start() is True
+        assert second.public_key_hex == anchor
+        assert await second.chain_head_hash() == head
+        # The idempotency lookup works across restarts.
+        assert await second.attest_action(_tier_d_row(1)) == 1
+    finally:
+        second.close()
+
+
+@pytest.mark.asyncio
+async def test_wrong_device_secret_fails_closed(tmp_path):
+    first = _attestor(tmp_path)
+    assert await first.start() is True
+    first.close()
+
+    imposter = _attestor(tmp_path, device_secret="wrong-secret")
+    try:
+        assert await imposter.start() is False
+        assert imposter.available is False
+        assert await imposter.attest_action(_tier_d_row(9)) is None
+    finally:
+        imposter.close()

--- a/verity-artifact.pin
+++ b/verity-artifact.pin
@@ -1,0 +1,14 @@
+# Exact pin of the ori_verity evidence-chain artifact this runtime consumes.
+#
+# The runtime never vendors the chain implementation; deployments install a
+# prebuilt wheel from an offline wheelhouse and this file is the single
+# auditable record of which source ref that wheel must be built from. CI
+# builds the wheel from `ref` and runs tests/test_evidence_artifact.py
+# against it, so the runtime and the real artifact are proven to speak the
+# same protocol before merge — not just against the fake used by unit tests.
+#
+# Bump deliberately: update ref + expected_artifact_version together, in the
+# same PR as any runtime change that depends on the new artifact behaviour.
+repo=ori-platform/ori-verity
+ref=af258f0ddd18d4873d426065db4b5c6cd23afe7c
+expected_artifact_version=0.2.0

--- a/verity-artifact.pin
+++ b/verity-artifact.pin
@@ -10,5 +10,5 @@
 # Bump deliberately: update ref + expected_artifact_version together, in the
 # same PR as any runtime change that depends on the new artifact behaviour.
 repo=ori-platform/ori-verity
-ref=af258f0ddd18d4873d426065db4b5c6cd23afe7c
+ref=29913e28e54fa277ef785ffabba24cd328800522
 expected_artifact_version=0.2.0


### PR DESCRIPTION
## What does this PR do?

Closes the last asserted-but-not-demonstrated gap in the evidence slice: the unit suite runs against a fake `ori_verity` (deliberately — absence behaviour and fault injection need one), but nothing proved the runtime and the **real** artifact speak the same protocol. A drifted FFI signature would leave unit tests green while every deployment silently fell back to "evidence unavailable". For a system whose entire value is adversarial verifiability, "the two sides were never tested against each other" is itself an audit finding.

Three pieces:

- **`verity-artifact.pin`** — the auditable record of exactly which ori-verity ref + artifact version this runtime consumes (full commit SHA enforced by CI). Bumped deliberately, in the same PR as any runtime change depending on new artifact behaviour.
- **`tests/test_evidence_artifact.py`** — smoke tests that auto-skip when `ori_verity` isn't importable (dev machines, main CI matrix) and drive the real `EvidenceAttestor` against the real chain: artifact identity vs the pin, key provisioning, Tier D signing, idempotent re-append via the real UNIQUE `event_id`, `SAFETY_ACTION_EXECUTED` and `reconciled_late` verified by reading the real chain rows back, full `verify_chain` against the provisioned anchor, restart persistence with the same secret, wrong-secret fail-closed.
- **`evidence-artifact` CI job** — parses the pin, checks out ori-verity at that exact ref (`ORI_VERITY_CI_TOKEN` secret; the repo is private), installs the verity-pinned Rust toolchain, builds the wheel with hash-locked maturin 1.14.1, asserts the built `ARTIFACT_VERSION` matches the pin, and runs the smoke tests. All actions SHA-pinned; `persist-credentials: false` on the cross-repo checkout.

**The approach justified itself before merging.** Exercising the real artifact caught two defects the fake could never see:

1. The pinned artifact was **unbuildable as a wheel** — maturin derives the module name from the hyphenated crate name. Fixed in ori-verity PR #6; the pin points at that merge SHA.
2. A real runtime bug: the attestor dropped the unsendable pyo3 `VerityChain` on the wrong thread (GC-time error in the real extension). `close()` and every `start()` rejection path (open failure, protocol mismatch) now move the **final** chain reference onto the evidence thread via `_release_chain()`; two new fake-based regression tests pin the actual drop thread and would have caught both the original bug and an early flawed version of the fix.

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures (1752 passed, 6 skipped: 5 hardware + the artifact module skipped without the wheel)
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR — no capability change; CI/test infrastructure plus a shutdown-path fix. `[skip-cap-matrix]`: no capability files changed (guard list untouched), evidence capability semantics unchanged.
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code (sequenced in-review from Codex's residual note on runtime PR #210 and maintainer direction in this work stream)
- [x] Every new Tier D code path has test coverage (no new Tier D paths; the release-helper paths are covered by the two thread-release regression tests)
- [x] No new dependencies added without prior issue discussion (maturin is CI-only, hash-locked in `requirements-verity-ci.txt`, never a runtime dependency)

## Related issue

Implements the wheel-level FFI compatibility smoke test flagged as a residual note in the runtime PR #210 review. Companion fix: ori-verity PR #6 (merged; pinned here).

## Testing notes

Verified locally against a real wheel built from the pinned ref (macOS arm64): 4 artifact tests + 38 fake tests pass with `-W error`, zero unsendable-drop warnings; full suite 1752 passed. The `evidence-artifact` CI job repeats the same build+test on linux from the exact pin. `scripts/check_workflows.py` and pre-commit pass on all changed files.