### PR TITLE
feat(cli): accept noun verb bridge commands

### DIFF
--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -27,12 +27,19 @@ from ori.skills.sandbox import SkillSecurityError
 _SCHEMA_VERSION = 1
 _DEFAULT_HEALTH_TIMEOUT_MS = 3000
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
-_KNOWN_COMMANDS = {
-    "config-validate",
-    "config-show",
-    "skills-list",
-    "skills-validate",
-    "health-snapshot",
+_LEGACY_COMMANDS = {
+    "config-validate": "config validate",
+    "config-show": "config show",
+    "skills-list": "skills list",
+    "skills-validate": "skills validate",
+    "health-snapshot": "health snapshot",
+}
+_PUBLIC_COMMANDS = {
+    ("config", "validate"): "config-validate",
+    ("config", "show"): "config-show",
+    ("skills", "list"): "skills-list",
+    ("skills", "validate"): "skills-validate",
+    ("health", "snapshot"): "health-snapshot",
 }
 _SENSITIVE_KEY_FRAGMENTS = (
     "authorization",
@@ -64,12 +71,11 @@ def main(argv: list[str] | None = None) -> int:
 def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
     """Execute a bridge command and return ``(exit_code, response_payload)``."""
 
-    command = argv[0] if argv else ""
+    command = ""
+    public_command = ""
     try:
-        if not command:
-            raise BridgeError("missing_command", "bridge command is required")
+        command, public_command, args = _parse_command(argv)
 
-        args = argv[1:]
         if command in {"config-validate", "config-show"}:
             path = _required_option(args, "--path", command)
             result = _config_result(path)
@@ -102,25 +108,25 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
             )
     except BridgeError as exc:
         return 2, _error(
-            command=_public_command(command),
+            command=public_command,
             code=exc.code,
             detail=exc.detail,
         )
     except ConfigValidationError as exc:
         return 2, _error(
-            command=_public_command(command),
+            command=public_command,
             code="config_validation_error",
             detail=str(exc),
         )
     except (OSError, ValueError, yaml.YAMLError) as exc:
         return 2, _error(
-            command=_public_command(command),
+            command=public_command,
             code="runtime_error",
             detail=str(exc),
         )
     except Exception as exc:
         return 1, _error(
-            command=_public_command(command),
+            command=public_command,
             code="internal_error",
             detail=str(exc),
         )
@@ -128,9 +134,49 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
     return 0, {
         "schema_version": _SCHEMA_VERSION,
         "ok": True,
-        "command": command,
+        "command": public_command,
         "result": result,
     }
+
+
+def _parse_command(argv: list[str]) -> tuple[str, str, list[str]]:
+    """Parse public noun/verb bridge commands with legacy aliases.
+
+    The public bridge shape mirrors operator-facing CLI grouping:
+    ``config validate --path ori.yaml``. The legacy single-token verbs are
+    accepted as compatibility aliases until all sibling CLIs migrate.
+    """
+
+    if not argv:
+        raise BridgeError("missing_command", "bridge command is required")
+
+    first = argv[0]
+    if first in _LEGACY_COMMANDS:
+        return first, _LEGACY_COMMANDS[first], argv[1:]
+
+    if first in {group for group, _ in _PUBLIC_COMMANDS}:
+        if len(argv) < 2:
+            raise BridgeError(
+                "invalid_arguments",
+                f"{first} requires a subcommand",
+            )
+        pair = (first, argv[1])
+        command = _PUBLIC_COMMANDS.get(pair)
+        if command is None:
+            allowed = sorted(
+                subcommand for group, subcommand in _PUBLIC_COMMANDS if group == first
+            )
+            raise BridgeError(
+                "unknown_command",
+                f"unsupported {first} subcommand {argv[1]!r}; expected one of: "
+                + ", ".join(allowed),
+            )
+        return command, " ".join(pair), argv[2:]
+
+    raise BridgeError(
+        "unknown_command",
+        "unsupported bridge command",
+    )
 
 
 def _required_option(args: list[str], name: str, command: str) -> str:
@@ -184,11 +230,6 @@ def _optional_int_option(
 
 def _flag_present(args: list[str], name: str) -> bool:
     return name in set(args)
-
-
-def _public_command(command: str) -> str:
-    """Return command only when it is one of the bridge's public verbs."""
-    return command if command in _KNOWN_COMMANDS else ""
 
 
 def _config_result(path: str) -> dict[str, Any]:

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -134,10 +134,22 @@ def test_cli_bridge_config_validate_reports_signed_phone_posture(
     assert public_key_b64 not in json.dumps(payload)
 
 
+def test_cli_bridge_config_validate_accepts_public_noun_verb_command(tmp_path, capsys):
+    config_path = _write_config(tmp_path, _base_config())
+
+    rc = cli_bridge.main(["config", "validate", "--path", str(config_path)])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "config validate"
+    assert payload["result"]["valid"] is True
+
+
 def test_cli_bridge_config_show_preserves_edge_node_deployment_type(tmp_path, capsys):
     config_path = _write_config(tmp_path, _base_config(deployment_type="edge_node"))
 
-    rc = cli_bridge.main(["config-show", "--path", str(config_path)])
+    rc = cli_bridge.main(["config", "show", "--path", str(config_path)])
 
     payload = _read_stdout_json(capsys)
     assert rc == 0
@@ -145,6 +157,19 @@ def test_cli_bridge_config_show_preserves_edge_node_deployment_type(tmp_path, ca
     assert result["device"]["deployment_type"] == "edge_node"
     assert result["phone_runtime_mobile"]["applies"] is False
     assert result["phone_runtime_mobile"]["tier_c_physical_authority"] is None
+
+
+def test_cli_bridge_config_show_accepts_legacy_alias_during_cli_migration(
+    tmp_path, capsys
+):
+    config_path = _write_config(tmp_path, _base_config(deployment_type="edge_node"))
+
+    rc = cli_bridge.main(["config-show", "--path", str(config_path)])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "config show"
 
 
 def test_cli_bridge_invalid_config_returns_structured_json(tmp_path, capsys):
@@ -183,7 +208,8 @@ def test_cli_bridge_health_snapshot_preserves_device_policy_caps(monkeypatch, ca
 
     rc = cli_bridge.main(
         [
-            "health-snapshot",
+            "health",
+            "snapshot",
             "--socket",
             "/tmp/ori-health.sock",
             "--timeout-ms",
@@ -225,7 +251,9 @@ def test_cli_bridge_skills_validate_reports_invalid_skill(tmp_path, capsys):
         encoding="utf-8",
     )
 
-    rc = cli_bridge.main(["skills-validate", "--skills-dir", str(tmp_path / "skills")])
+    rc = cli_bridge.main(
+        ["skills", "validate", "--skills-dir", str(tmp_path / "skills")]
+    )
 
     payload = _read_stdout_json(capsys)
     assert rc == 0
@@ -242,3 +270,13 @@ def test_cli_bridge_unknown_command_returns_json_error(capsys):
     assert rc == 2
     assert payload["ok"] is False
     assert payload["error"]["code"] == "unknown_command"
+
+
+def test_cli_bridge_public_group_requires_supported_subcommand(capsys):
+    rc = cli_bridge.main(["config", "reload"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "unknown_command"
+    assert "expected one of: show, validate" in payload["error"]["detail"]


### PR DESCRIPTION
## Summary
- Accept public noun/verb bridge commands such as `config validate`, `skills validate`, and `health snapshot`.
- Keep existing hyphenated bridge commands as compatibility aliases for current sibling CLI callers.
- Return the public command name in bridge JSON responses and cover both command shapes in tests.

## Verification
- `.venv/bin/pytest tests/test_cli_bridge.py -q`
- `.venv/bin/python -m ruff check ori/cli_bridge.py tests/test_cli_bridge.py`
- `.venv/bin/python -m ruff format --check ori/cli_bridge.py tests/test_cli_bridge.py`
