### PR TITLE
feat(cli): expose state bridge reads

### DIFF
--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -21,11 +21,15 @@ from urllib.parse import urlparse
 import yaml
 
 from ori.config import Config, ConfigValidationError, SensorConfig
+from ori.network.events import SensorReading
 from ori.skills.loader import Skill, SkillLoader, SkillValidationError
 from ori.skills.sandbox import SkillSecurityError
+from ori.state.store import StateStore
 
 _SCHEMA_VERSION = 1
 _DEFAULT_HEALTH_TIMEOUT_MS = 3000
+_DEFAULT_STATE_DB_PATH = "ori_state.db"
+_MAX_STATE_LIMIT = 1000
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _LEGACY_COMMANDS = {
     "config-validate": "config validate",
@@ -40,6 +44,8 @@ _PUBLIC_COMMANDS = {
     ("skills", "list"): "skills-list",
     ("skills", "validate"): "skills-validate",
     ("health", "snapshot"): "health-snapshot",
+    ("state", "action-log"): "state-action-log",
+    ("state", "history"): "state-history",
 }
 _SENSITIVE_KEY_FRAGMENTS = (
     "authorization",
@@ -101,6 +107,10 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
                 command=command,
             )
             result = asyncio.run(_read_health_snapshot(socket_path, timeout_ms))
+        elif command == "state-action-log":
+            result = asyncio.run(_read_state_action_log(args))
+        elif command == "state-history":
+            result = asyncio.run(_read_state_history(args))
         else:
             raise BridgeError(
                 "unknown_command",
@@ -491,6 +501,123 @@ async def _read_health_snapshot(socket_path: str, timeout_ms: int) -> dict[str, 
             "health socket response must be a JSON object",
         )
     return response
+
+
+async def _read_state_action_log(args: list[str]) -> list[dict[str, Any]]:
+    filters = _parse_state_filters(
+        args,
+        command="state action-log",
+        allowed={"limit"},
+    )
+    limit = _state_limit(filters.get("limit"), default=50)
+    store = _state_store_from_default_path()
+    await store.open()
+    try:
+        return await store.get_action_log(limit=limit)
+    finally:
+        await store.close()
+
+
+async def _read_state_history(args: list[str]) -> list[dict[str, Any]]:
+    filters = _parse_state_filters(
+        args,
+        command="state history",
+        allowed={"sensor_id", "limit"},
+    )
+    sensor_id = str(filters.get("sensor_id", "") or "").strip()
+    if not sensor_id:
+        raise BridgeError(
+            "invalid_arguments",
+            "state history requires sensor_id",
+        )
+    limit = _state_limit(filters.get("limit"), default=100)
+    store = _state_store_from_default_path()
+    await store.open()
+    try:
+        readings = await store.get_history(sensor_id=sensor_id, limit=limit)
+    finally:
+        await store.close()
+    return [_sensor_reading_to_dict(reading) for reading in readings]
+
+
+def _parse_state_filters(
+    args: list[str],
+    *,
+    command: str,
+    allowed: set[str],
+) -> dict[str, str]:
+    filters: dict[str, str] = {}
+    for raw in args:
+        if "=" not in raw:
+            raise BridgeError(
+                "invalid_arguments",
+                f"{command} filter {raw!r} must use key=value syntax",
+            )
+        key, value = raw.split("=", 1)
+        key = key.strip()
+        if not key or key not in allowed:
+            expected = ", ".join(sorted(allowed))
+            raise BridgeError(
+                "invalid_arguments",
+                f"{command} unsupported filter {key!r}; expected one of: {expected}",
+            )
+        if key in filters:
+            raise BridgeError(
+                "invalid_arguments",
+                f"{command} received duplicate filter {key!r}",
+            )
+        if value == "":
+            raise BridgeError(
+                "invalid_arguments",
+                f"{command} filter {key!r} requires a non-empty value",
+            )
+        filters[key] = value
+    return filters
+
+
+def _state_limit(raw: str | None, *, default: int) -> int:
+    if raw is None:
+        return default
+    try:
+        limit = int(raw)
+    except ValueError as exc:
+        raise BridgeError(
+            "invalid_arguments",
+            "limit must be an integer",
+        ) from exc
+    if limit < 1 or limit > _MAX_STATE_LIMIT:
+        raise BridgeError(
+            "invalid_arguments",
+            f"limit must be between 1 and {_MAX_STATE_LIMIT}",
+        )
+    return limit
+
+
+def _state_store_from_default_path() -> StateStore:
+    path = Path(_DEFAULT_STATE_DB_PATH)
+    if not path.exists():
+        raise BridgeError(
+            "state_store_unavailable",
+            f"state database does not exist: {_DEFAULT_STATE_DB_PATH}",
+        )
+    if not path.is_file():
+        raise BridgeError(
+            "state_store_unavailable",
+            f"state database path is not a file: {_DEFAULT_STATE_DB_PATH}",
+        )
+    return StateStore(str(path))
+
+
+def _sensor_reading_to_dict(reading: SensorReading) -> dict[str, Any]:
+    return {
+        "sensor_id": reading.sensor_id,
+        "sensor_type": reading.sensor_type,
+        "value": reading.value,
+        "unit": reading.unit,
+        "timestamp": reading.timestamp,
+        "quality": reading.quality,
+        "metadata": reading.metadata,
+    }
 
 
 def _optional_str(value: Any) -> str | None:

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import base64
 import json
 import textwrap
@@ -9,10 +10,12 @@ from pathlib import Path
 import yaml
 
 from ori import cli_bridge
+from ori.network.events import ActionResult, OriEvent, SensorReading
 from ori.security.config_signatures import (
     CONFIG_SIGNATURE_SCHEMA,
     canonical_config_signature_payload,
 )
+from ori.state.store import StateStore
 
 
 def _ed25519_keypair():
@@ -97,6 +100,42 @@ def _read_stdout_json(capsys) -> dict:
     captured = capsys.readouterr()
     assert captured.err == ""
     return json.loads(captured.out)
+
+
+async def _seed_state_store(path: Path) -> None:
+    store = StateStore(str(path))
+    await store.open()
+    try:
+        await store.append_history(
+            OriEvent.from_reading(
+                SensorReading(
+                    sensor_id="pir_01",
+                    sensor_type="motion",
+                    value=1.0,
+                    unit="binary",
+                    timestamp=1_800_000_000_000,
+                    quality=0.95,
+                    metadata={"source": "test"},
+                ),
+                device_id="dev-01",
+            )
+        )
+        await store.log_action_for_event(
+            ActionResult(
+                action_name="trip_relay",
+                tier="D",
+                executed=True,
+                approved=None,
+                action_taken="open_relay",
+                timestamp=1_800_000_000_100,
+            ),
+            trigger_name="dangerous_overcurrent",
+            device_id="dev-01",
+            sensor_id="pir_01",
+            sensor_type="motion",
+        )
+    finally:
+        await store.close()
 
 
 def test_cli_bridge_config_validate_reports_signed_phone_posture(
@@ -223,6 +262,86 @@ def test_cli_bridge_health_snapshot_preserves_device_policy_caps(monkeypatch, ca
     assert (
         payload["result"]["health"]["device_policy"]["alert_whatsapp_monthly_cap"] == 20
     )
+
+
+def test_cli_bridge_state_action_log_reads_runtime_store(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
+
+    rc = cli_bridge.main(["state", "action-log", "limit=5"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "state action-log"
+    assert payload["result"][0]["action_name"] == "trip_relay"
+    assert payload["result"][0]["tier"] == "D"
+    assert payload["result"][0]["executed"] is True
+    assert payload["result"][0]["sensor_id"] == "pir_01"
+
+
+def test_cli_bridge_state_history_requires_sensor_id(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
+
+    rc = cli_bridge.main(["state", "history", "limit=5"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["command"] == "state history"
+    assert payload["error"]["code"] == "invalid_arguments"
+    assert "sensor_id" in payload["error"]["detail"]
+
+
+def test_cli_bridge_state_history_reads_bounded_sensor_history(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.chdir(tmp_path)
+    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
+
+    rc = cli_bridge.main(["state", "history", "sensor_id=pir_01", "limit=5"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    assert payload["ok"] is True
+    assert payload["command"] == "state history"
+    assert payload["result"] == [
+        {
+            "sensor_id": "pir_01",
+            "sensor_type": "motion",
+            "value": 1.0,
+            "unit": "binary",
+            "timestamp": 1_800_000_000_000,
+            "quality": 0.95,
+            "metadata": {"source": "test"},
+        }
+    ]
+
+
+def test_cli_bridge_state_rejects_unknown_filter(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
+
+    rc = cli_bridge.main(["state", "action-log", "table=sensor_history"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "invalid_arguments"
+    assert "unsupported filter" in payload["error"]["detail"]
+
+
+def test_cli_bridge_state_rejects_missing_database(tmp_path, monkeypatch, capsys):
+    monkeypatch.chdir(tmp_path)
+
+    rc = cli_bridge.main(["state", "action-log"])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "state_store_unavailable"
+    assert not (tmp_path / "ori_state.db").exists()
 
 
 def test_cli_bridge_skills_validate_reports_invalid_skill(tmp_path, capsys):


### PR DESCRIPTION
## What does this PR do?

Adds the runtime side of the CLI state-read surface that `ori-cli` now delegates to:

- `state action-log` returns bounded rows from the runtime-owned `StateStore.get_action_log()` path.
- `state history` requires `sensor_id` and returns bounded rows from `StateStore.get_history()`.
- State filters are intentionally narrow: `limit` for action log, `sensor_id` and `limit` for history.
- Missing state DBs fail with `state_store_unavailable` instead of silently creating an empty SQLite file.

This keeps the CLI from opening SQLite directly while also avoiding a broad ad hoc query language in the bridge.

[skip-cap-matrix] This only exposes already-existing runtime state reads through the CLI bridge; it does not add or change a runtime capability.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

Complements `ori-platform/ori-cli#19` and the CLI-005 state-read surface.

## Testing notes

- `.venv/bin/python -m pytest tests/test_cli_bridge.py -q` — 14 passed
- `.venv/bin/python -m pytest tests/test_cli_bridge.py tests/test_gateway_export.py -q` — 35 passed
- `.venv/bin/python -m ruff check ori/cli_bridge.py tests/test_cli_bridge.py` — passed
- `.venv/bin/python -m ruff format --check ori/cli_bridge.py tests/test_cli_bridge.py` — passed
