### PR TITLE
Accept ingress_degraded firmware fault events

### DIFF
--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -100,6 +100,7 @@ FIRMWARE_FAULT_CODES = frozenset(
         "interlock_tripped",
         "sensor_fault",
         "brownout_relay_fault",
+        "ingress_degraded",
     }
 )
 

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -379,6 +379,30 @@ class TestFailClosed:
         assert result.subject == "relay0"
         assert result.detail == "replayed"
 
+    def test_ingress_degraded_fault_verifies_with_each_detail(self) -> None:
+        # firmware-telemetry/v1: ingress loss is never silent. Each
+        # machine-readable detail token rides the same signed fault path.
+        for i, detail in enumerate(
+            ["inbound_overflow", "subscribe_failed", "anchor_persist_failed"]
+        ):
+            result = verify_fault_message(
+                signed_fault_message(
+                    seq=130_500 + i,
+                    code="ingress_degraded",
+                    subject="inbound",
+                    detail=detail,
+                ),
+                anchor_device_id=SEALED_DEVICE,
+                anchor_public_key_b64=PUBLIC_KEY_B64,
+                anchor_posture="sealed_flash",
+                accepted_manifest_hash=SEALED_HASH,
+                last_boot_id=0,
+                last_seq=0,
+            )
+            assert result.accepted
+            assert result.code == "ingress_degraded"
+            assert result.detail == detail
+
     def test_fault_event_rejects_unknown_code(self) -> None:
         result = verify_fault_message(
             signed_fault_message(code="made_up_fault"),


### PR DESCRIPTION
## Summary

Adds `ingress_degraded` to the closed firmware fault vocabulary in `ori/security/firmware_telemetry.py`, per the firmware-telemetry/v1 addition in ori-platform/ori-specs#25. Device-side inbound loss — ingress queue exhaustion (`inbound_overflow`), unacknowledged subscriptions (`subscribe_failed`), and approval-anchor persistence failure (`anchor_persist_failed`) — now verifies as signed fault evidence instead of being rejected as an unknown code.

Purely additive acceptance: no verifier ordering, grading, or store ingestion changes. A test verifies a signed `ingress_degraded` fault is accepted with each detail token.

## Release sequence
Contract: ori-platform/ori-specs#25. Device implementation: ori-platform/ori-edge-firmware#37. This sync must merge before bench E2E exercises that firmware against the runtime.

## Evidence
- `tests/test_firmware_telemetry.py`: 50 passed
- Full suite: 1832 passed, 6 skipped
- ruff format and check clean