### PR TITLE
fix: align runtime telemetry canonicalization

### DIFF
--- a/mobile/ori-runtime-mobile/src/main.rs
+++ b/mobile/ori-runtime-mobile/src/main.rs
@@ -22,6 +22,7 @@ const CONFIG_SIGNATURE_SCHEMA: &str = "ori.config_signature.v1";
 const CONFIG_REQUIRE_SIGNED_ENV: &str = "ORI_CONFIG_REQUIRE_SIGNED";
 const DEFAULT_CONFIG_TRUST_ANCHOR_ENV: &str = "ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64";
 const TELEMETRY_SCHEMA_VERSION: &str = "runtime.telemetry.v1";
+const JSON_SAFE_INT_MAX: u64 = 9_007_199_254_740_991;
 const USER_AGENT: &str = "ori-runtime-mobile/0.1";
 
 type HmacSha256 = Hmac<Sha256>;
@@ -419,8 +420,7 @@ fn post_telemetry_batch(
         "sent_at_ms": now_ms(),
         "events": events,
     });
-    let body = serde_json::to_vec(&payload)
-        .map_err(|error| format!("failed to serialize telemetry payload: {error}"))?;
+    let body = canonical_telemetry_json(&payload)?;
     let timestamp_ms = now_ms().to_string();
     let signature = telemetry_signature(api_key.as_bytes(), timestamp_ms.as_bytes(), &body)?;
     let response = ureq::post(&config.telemetry_export.endpoint)
@@ -448,6 +448,49 @@ fn telemetry_signature(key: &[u8], timestamp_ms: &[u8], body: &[u8]) -> Result<S
     mac.update(b".");
     mac.update(body);
     Ok(hex::encode(mac.finalize().into_bytes()))
+}
+
+fn canonical_telemetry_json(value: &JsonValue) -> Result<Vec<u8>, String> {
+    validate_canonical_numbers(value, "$")?;
+    serde_json::to_vec(value)
+        .map_err(|error| format!("failed to serialize telemetry payload: {error}"))
+}
+
+fn validate_canonical_numbers(value: &JsonValue, path: &str) -> Result<(), String> {
+    match value {
+        JsonValue::Number(number) => {
+            if let Some(integer) = number.as_i64() {
+                if integer.unsigned_abs() > JSON_SAFE_INT_MAX {
+                    return Err(format!("integer outside JSON-safe range at {path}"));
+                }
+            } else if let Some(integer) = number.as_u64() {
+                if integer > JSON_SAFE_INT_MAX {
+                    return Err(format!("integer outside JSON-safe range at {path}"));
+                }
+            } else if let Some(number) = number.as_f64() {
+                let magnitude = number.abs();
+                if !number.is_finite() || (magnitude != 0.0 && !(1e-4..1e16).contains(&magnitude)) {
+                    return Err(format!(
+                        "float outside cross-language canonical zone at {path}"
+                    ));
+                }
+            } else {
+                return Err(format!("unsupported JSON number at {path}"));
+            }
+        }
+        JsonValue::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                validate_canonical_numbers(item, &format!("{path}[{index}]"))?;
+            }
+        }
+        JsonValue::Object(items) => {
+            for (key, item) in items {
+                validate_canonical_numbers(item, &format!("{path}.{key}"))?;
+            }
+        }
+        JsonValue::Null | JsonValue::Bool(_) | JsonValue::String(_) => {}
+    }
+    Ok(())
 }
 
 fn compute_fingerprint(device_id: &str, reading: &SensorReading) -> String {
@@ -641,4 +684,41 @@ fn now_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or(Duration::from_secs(0))
         .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const GOLDEN_BODY: &str = concat!(
+        "{\"device_id\":\"phone-gateway-ikeja-01\",\"events\":[{\"context\":{\"location\":\"Ìkẹjà\"},",
+        "\"device_id\":\"phone-gateway-ikeja-01\",\"event_id\":\"00000000-0000-4000-8000-000000000001\",",
+        "\"event_type\":\"sensor.reading\",\"fingerprint\":\"\",\"reading\":{\"metadata\":{\"label\":\"Mains – east\"},",
+        "\"quality\":1.0,\"sensor_id\":\"phone-main-power\",\"sensor_type\":\"usb_power\",",
+        "\"timestamp\":1719000000000,\"unit\":\"watt\",\"value\":1240.5},\"sensor_id\":\"phone-main-power\",",
+        "\"source\":\"usb_serial\",\"timestamp\":1719000000000}],\"schema_version\":\"runtime.telemetry.v1\",",
+        "\"sent_at_ms\":1719000000000,\"sequence\":1}"
+    );
+
+    #[test]
+    fn runtime_telemetry_matches_specs_golden_fixture() {
+        let payload: JsonValue = serde_json::from_str(GOLDEN_BODY).expect("valid fixture");
+        let body = canonical_telemetry_json(&payload).expect("canonical fixture");
+        assert_eq!(body, GOLDEN_BODY.as_bytes());
+        assert_eq!(
+            hex::encode(Sha256::digest(&body)),
+            "51e7a268d28c96f7ba516593b7d4ca160848ff641888ce1b3b513f2bbf2370ea"
+        );
+        assert_eq!(
+            telemetry_signature(b"test-runtime-telemetry-key", b"1719000000123", &body)
+                .expect("HMAC"),
+            "5ed66b6fc38a5d68e8c0c16bf18ade62968549432fb52baeb8b56625927dba79"
+        );
+    }
+
+    #[test]
+    fn runtime_telemetry_rejects_numbers_outside_agreement_zone() {
+        assert!(canonical_telemetry_json(&json!({"value": 1e-5})).is_err());
+        assert!(canonical_telemetry_json(&json!({"value": 9_007_199_254_740_992_u64})).is_err());
+    }
 }

--- a/ori/policy/device_policy.py
+++ b/ori/policy/device_policy.py
@@ -19,6 +19,14 @@ class DevicePolicy:
     alert_sms_monthly_cap: Optional[int] = None
     alert_whatsapp_monthly_cap: Optional[int] = None
 
+    def __post_init__(self) -> None:
+        for field_name, cap in (
+            ("alert_sms_monthly_cap", self.alert_sms_monthly_cap),
+            ("alert_whatsapp_monthly_cap", self.alert_whatsapp_monthly_cap),
+        ):
+            if cap is not None and cap < -1:
+                raise ValueError(f"{field_name} must be null, -1, or non-negative")
+
     def permits_action(self, action_tier: str) -> bool:
         if action_tier in ("D", "A"):  # Tier D: Invariant 10. Tier A: always.
             return True
@@ -47,7 +55,7 @@ class DevicePolicy:
         if action_tier == "D":
             return True
         cap = self.alert_monthly_cap(channel)
-        if cap is None or cap < 0:
+        if cap is None or cap == -1:
             return True
         return int(current_month_count) < cap
 

--- a/ori/policy/remote_fetch.py
+++ b/ori/policy/remote_fetch.py
@@ -74,6 +74,15 @@ def _optional_int(value: Any, field: str) -> int | None:
     return _to_int(value, field)
 
 
+def _optional_alert_cap(value: Any, field: str) -> int | None:
+    cap = _optional_int(value, field)
+    if cap is not None and cap < -1:
+        raise RemotePolicyFetchError(
+            "invalid_payload", f"{field} must be null, -1, or non-negative"
+        )
+    return cap
+
+
 def device_policy_from_payload(
     payload: dict[str, Any],
     *,
@@ -105,10 +114,10 @@ def device_policy_from_payload(
         policy_version=_to_int(payload.get("policy_version"), "policy_version"),
         issued_at=_to_int(payload.get("issued_at"), "issued_at"),
         signature=str(payload.get("signature", "")),
-        alert_sms_monthly_cap=_optional_int(
+        alert_sms_monthly_cap=_optional_alert_cap(
             payload.get("alert_sms_monthly_cap"), "alert_sms_monthly_cap"
         ),
-        alert_whatsapp_monthly_cap=_optional_int(
+        alert_whatsapp_monthly_cap=_optional_alert_cap(
             payload.get("alert_whatsapp_monthly_cap"),
             "alert_whatsapp_monthly_cap",
         ),

--- a/ori/telemetry/canonical.py
+++ b/ori/telemetry/canonical.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical bytes and HMAC signing for ``runtime.telemetry.v1``."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+from typing import Any
+
+JSON_SAFE_INT_MAX = 9_007_199_254_740_991
+
+
+class TelemetryCanonicalizationError(ValueError):
+    """Raised when telemetry cannot be represented byte-identically."""
+
+
+def _check_numbers(value: Any, path: str = "$") -> None:
+    if isinstance(value, bool) or value is None or isinstance(value, str):
+        return
+    if isinstance(value, int):
+        if abs(value) > JSON_SAFE_INT_MAX:
+            raise TelemetryCanonicalizationError(
+                f"integer outside JSON-safe range at {path}"
+            )
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise TelemetryCanonicalizationError(f"non-finite number at {path}")
+        magnitude = abs(value)
+        if magnitude != 0.0 and not (1e-4 <= magnitude < 1e16):
+            raise TelemetryCanonicalizationError(
+                f"float outside cross-language canonical zone at {path}"
+            )
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TelemetryCanonicalizationError(f"non-string object key at {path}")
+            _check_numbers(item, f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, item in enumerate(value):
+            _check_numbers(item, f"{path}[{index}]")
+
+
+def canonical_telemetry_bytes(payload: object) -> bytes:
+    """Return the canonical UTF-8 bytes defined by runtime-telemetry/v1."""
+
+    _check_numbers(payload)
+    try:
+        return json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise TelemetryCanonicalizationError(str(exc)) from exc
+
+
+def telemetry_hmac_sha256(
+    api_key: str | bytes, timestamp_ms: int | str | bytes, body: bytes
+) -> str:
+    """Return the lowercase hex HMAC for an already-canonical body."""
+
+    key = api_key.encode("utf-8") if isinstance(api_key, str) else api_key
+    if isinstance(timestamp_ms, int):
+        timestamp = str(timestamp_ms).encode("ascii")
+    elif isinstance(timestamp_ms, str):
+        timestamp = timestamp_ms.encode("ascii")
+    else:
+        timestamp = timestamp_ms
+    return hmac.new(key, timestamp + b"." + body, hashlib.sha256).hexdigest()

--- a/ori/telemetry/http_export.py
+++ b/ori/telemetry/http_export.py
@@ -4,8 +4,6 @@
 """HTTP telemetry export for phone and lightweight provisioned deployments."""
 
 import asyncio
-import hashlib
-import hmac
 import json
 import logging
 import os
@@ -14,6 +12,7 @@ from typing import Any
 
 from ori.config import TelemetryExportConfig
 from ori.network.events import OriEvent, SensorReading
+from ori.telemetry.canonical import canonical_telemetry_bytes, telemetry_hmac_sha256
 from ori.utils.time_utils import now_ms
 
 logger = logging.getLogger(__name__)
@@ -158,17 +157,9 @@ class HttpTelemetryExporter:
             "sent_at_ms": now_ms(),
             "events": batch,
         }
-        body = json.dumps(
-            payload,
-            sort_keys=True,
-            separators=(",", ":"),
-        ).encode("utf-8")
+        body = canonical_telemetry_bytes(payload)
         timestamp_ms = str(now_ms())
-        signature = hmac.new(
-            api_key.encode("utf-8"),
-            timestamp_ms.encode("utf-8") + b"." + body,
-            hashlib.sha256,
-        ).hexdigest()
+        signature = telemetry_hmac_sha256(api_key, timestamp_ms, body)
         headers = {
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",

--- a/tests/test_remote_policy_fetch.py
+++ b/tests/test_remote_policy_fetch.py
@@ -8,6 +8,7 @@ import time
 
 import pytest
 
+from ori.policy.device_policy import DevicePolicy
 from ori.policy.remote_fetch import (
     RemotePolicyFetchError,
     fetch_remote_device_policy_bundle,
@@ -120,6 +121,46 @@ async def test_fetch_remote_policy_accepts_alert_caps(monkeypatch):
         action_tier="D",
         current_month_count=999,
     )
+
+
+@pytest.mark.skipif(
+    Ed25519PrivateKey is None,
+    reason="cryptography ed25519 is unavailable",
+)
+@pytest.mark.asyncio
+async def test_fetch_remote_policy_rejects_alert_cap_below_minus_one(monkeypatch):
+    private_key = Ed25519PrivateKey.generate()
+    public_key_b64 = base64.b64encode(
+        private_key.public_key().public_bytes(
+            encoding=Encoding.Raw,
+            format=PublicFormat.Raw,
+        )
+    ).decode("ascii")
+    payload = _signed_payload(private_key, alert_sms_monthly_cap=-2)
+    monkeypatch.setattr(
+        "ori.policy.remote_fetch._http_get_json",
+        lambda _cfg: (json.dumps(payload), payload),
+    )
+
+    with pytest.raises(
+        RemotePolicyFetchError, match="must be null, -1, or non-negative"
+    ):
+        await fetch_remote_device_policy_bundle(_base_config(public_key_b64))
+
+
+def test_device_policy_constructor_rejects_alert_cap_below_minus_one() -> None:
+    with pytest.raises(ValueError, match="must be null, -1, or non-negative"):
+        DevicePolicy(
+            tier="cloud",
+            relay_b_enabled=True,
+            relay_c_enabled=True,
+            cloud_llm_enabled=True,
+            valid_until=1,
+            policy_version=1,
+            issued_at=1,
+            signature="test",
+            alert_sms_monthly_cap=-2,
+        )
 
 
 @pytest.mark.skipif(

--- a/tests/test_telemetry_http_export.py
+++ b/tests/test_telemetry_http_export.py
@@ -12,7 +12,22 @@ import pytest
 from ori.config import TelemetryExportConfig
 from ori.network.events import OriEvent, SensorReading
 from ori.telemetry import http_export
+from ori.telemetry.canonical import (
+    TelemetryCanonicalizationError,
+    canonical_telemetry_bytes,
+    telemetry_hmac_sha256,
+)
 from ori.telemetry.http_export import HttpTelemetryExporter
+
+GOLDEN_BODY = (
+    '{"device_id":"phone-gateway-ikeja-01","events":[{"context":{"location":"Ìkẹjà"},'
+    '"device_id":"phone-gateway-ikeja-01","event_id":"00000000-0000-4000-8000-000000000001",'
+    '"event_type":"sensor.reading","fingerprint":"","reading":{"metadata":{"label":"Mains – east"},'
+    '"quality":1.0,"sensor_id":"phone-main-power","sensor_type":"usb_power",'
+    '"timestamp":1719000000000,"unit":"watt","value":1240.5},"sensor_id":"phone-main-power",'
+    '"source":"usb_serial","timestamp":1719000000000}],"schema_version":"runtime.telemetry.v1",'
+    '"sent_at_ms":1719000000000,"sequence":1}'
+).encode("utf-8")
 
 
 def _event(value: float = 1250.0) -> OriEvent:
@@ -139,6 +154,29 @@ async def test_flush_once_posts_hmac_signed_batch(monkeypatch):
         hashlib.sha256,
     ).hexdigest()
     assert headers["X-Ori-Signature"] == f"v1={expected}"
+
+
+def test_runtime_telemetry_golden_body_and_hmac() -> None:
+    payload = json.loads(GOLDEN_BODY)
+
+    assert canonical_telemetry_bytes(payload) == GOLDEN_BODY
+    assert hashlib.sha256(GOLDEN_BODY).hexdigest() == (
+        "51e7a268d28c96f7ba516593b7d4ca160848ff641888ce1b3b513f2bbf2370ea"
+    )
+    assert (
+        telemetry_hmac_sha256(
+            "test-runtime-telemetry-key", 1_719_000_000_123, GOLDEN_BODY
+        )
+        == "5ed66b6fc38a5d68e8c0c16bf18ade62968549432fb52baeb8b56625927dba79"
+    )
+    assert "Ìkẹjà".encode("utf-8") in GOLDEN_BODY
+    assert b"\\u" not in GOLDEN_BODY
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf"), float("-inf"), 1e-5])
+def test_runtime_telemetry_rejects_noncanonical_numbers(value: float) -> None:
+    with pytest.raises(TelemetryCanonicalizationError):
+        canonical_telemetry_bytes({"value": value})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What changed

- Add canonical `runtime.telemetry.v1` JSON and HMAC helpers for the Python exporter.
- Emit direct UTF-8 Unicode, reject non-finite and cross-language-unsafe numbers, and reproduce the specs-owned golden fixture.
- Align the Rust Android runtime-mobile producer with the same byte and HMAC fixture.
- Reject DevicePolicy alert caps below `-1` in both payload parsing and direct construction.

## Why

Python and Rust used different Unicode serialization defaults before signing telemetry. That made signatures implementation-dependent for non-ASCII payloads. Runtime policy also treated values below `-1` as unlimited, drifting from the DevicePolicy contract.

## Impact

Python runtime and Android runtime-mobile now produce byte-identical canonical telemetry for the shared contract zone. The telemetry path remains observational and outside gateway authority. Tier D emergency alert bypass is unchanged.

## Contract dependency

This implementation follows the coordinated contract in ori-platform/ori-specs#29.

## Validation

- `pytest -q`: 1,853 passed, 6 skipped
- Rust mobile golden tests: 2 passed
- Ruff lint and format checks
- Workflow and Rust supply-chain guards
- `git diff --check`
