### PR TITLE
feat(firmware): add the operator CLI for the provisioning transaction

### DIFF
--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -1,0 +1,455 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Operator CLI for the firmware provisioning transaction.
+
+Supports the bench proof in ori-edge-firmware#14. It **orchestrates the
+runtime's existing provisioning path** — it is not a second authority.
+Approvals are signed by :class:`FirmwareCommandService` from the stored
+registry row, so registration, explicit operator approval, and
+revocation are all honoured. A tool that signed approvals from a
+presented manifest would let firmware accept a device the runtime still
+regards as unknown, unapproved, or revoked; that split-brain is the
+thing this command exists to prevent.
+
+The transaction, in the order the subcommands run:
+
+``keygen``
+    Create the provisioning-authority and runtime-command keys. Emits
+    the authority public key as the C array the firmware compiles in as
+    ``BENCH_PROVISIONER_PUBKEY`` (its all-zero default refuses every
+    approval), and both seeds in the canonical base64 the runtime's
+    ``load_raw_ed25519_seed_from_env`` expects.
+
+``register``
+    Verify the manifest the device published on ``ori/fw/<id>/manifest``
+    and store its anchor **unapproved** via
+    ``FirmwareTelemetryGate.register_device``. Prints the device public
+    key for the operator to confirm out of band.
+
+``approve``
+    Record explicit operator approval, but only after the operator
+    supplies the device public key they observed independently — read
+    from the device's serial console, which prints
+    ``ori: device public key (b64) <KEY>`` at boot, not from the
+    manifest. Verifying a manifest against the key inside that same
+    manifest proves internal consistency, never that the bytes came
+    from the board in front of you.
+
+``publish``
+    Sign from the stored, approved, unrevoked row and publish retained
+    on ``ori/fw/<id>/provision``.
+
+``selfcheck``
+    Contract diagnostic: reproduce the shared golden vectors, which is
+    what ties these bytes to the firmware's C verifier. No hardware, no
+    network, no store.
+
+The authority private key grants command authority over a fleet. It is
+written owner-only, never printed, and never overwritten.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+from ori.security.firmware_commands import build_provisioning_approval_bytes
+from ori.security.firmware_telemetry import FirmwareVerificationError
+
+# The shared corpus that ties these bytes to the C verifier in
+# ori-edge-firmware; the same bytes its test_provisioning.c accepts.
+_VECTORS = (
+    Path(__file__).resolve().parent.parent
+    / "tests"
+    / "fixtures"
+    / "firmware_provisioning_approval_vectors.json"
+)
+
+
+class ProvisionerError(Exception):
+    """An operator-facing failure with a message worth reading."""
+
+
+# ── key material ─────────────────────────────────────────────────────
+
+
+def _public_key_b64(seed: bytes) -> str:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    pub = Ed25519PrivateKey.from_private_bytes(seed).public_key()
+    return base64.b64encode(pub.public_bytes(Encoding.Raw, PublicFormat.Raw)).decode(
+        "ascii"
+    )
+
+
+def _c_array(seed: bytes, name: str) -> str:
+    """The authority public key in the form app_main.c declares it."""
+    raw = base64.b64decode(_public_key_b64(seed))
+    rows = [
+        "    " + " ".join(f"0x{b:02X}," for b in raw[i : i + 8])
+        for i in range(0, len(raw), 8)
+    ]
+    body = "\n".join(rows)
+    return f"static const uint8_t {name}[ORI_ED25519_PUBLIC_KEY_LEN] = {{\n{body}\n}};"
+
+
+def _write_secret(path: Path, seed: bytes) -> None:
+    # Owner-only and created exclusively: a second keygen must not
+    # silently invalidate a fleet's authority.
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError as exc:
+        raise ProvisionerError(
+            f"{path} already exists; refusing to overwrite an authority key"
+        ) from exc
+    except OSError as exc:
+        raise ProvisionerError(f"cannot write {path}: {exc}") from exc
+    with os.fdopen(fd, "w", encoding="ascii") as fh:
+        # Canonical base64: the form load_raw_ed25519_seed_from_env
+        # reads. Writing hex here would generate keys the runtime cannot
+        # load, so the approval would install a key it never uses.
+        fh.write(base64.b64encode(seed).decode("ascii") + "\n")
+
+
+def read_seed(path: Path, label: str) -> bytes:
+    try:
+        raw = path.read_text(encoding="ascii").strip()
+    except OSError as exc:
+        raise ProvisionerError(f"cannot read {label} at {path}: {exc}") from exc
+    try:
+        seed = base64.b64decode(raw.encode("ascii"), validate=True)
+    except Exception as exc:
+        raise ProvisionerError(
+            f"{label} at {path} must be canonical base64 (the form the runtime loads)"
+        ) from exc
+    if len(seed) != 32:
+        raise ProvisionerError(f"{label} must be 32 bytes ({len(seed)} found)")
+    return seed
+
+
+def cmd_keygen(args: argparse.Namespace) -> int:
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    seed_auth = os.urandom(32)
+    seed_rt = os.urandom(32)
+    _write_secret(out / "provisioner_seed.b64", seed_auth)
+    _write_secret(out / "runtime_command_seed.b64", seed_rt)
+
+    print(f"authority seed      : {out / 'provisioner_seed.b64'}  (0600, keep offline)")
+    print(f"runtime command seed: {out / 'runtime_command_seed.b64'}  (0600)")
+    print()
+    print("Load into the runtime environment (canonical base64):")
+    print(
+        f"  export ORI_FIRMWARE_PROVISIONER_SEED=$(cat {out / 'provisioner_seed.b64'})"
+    )
+    print(
+        f"  export ORI_FIRMWARE_COMMAND_SEED=$(cat {out / 'runtime_command_seed.b64'})"
+    )
+    print()
+    print("Compile into device/main/app_main.c, replacing the all-zero")
+    print("BENCH_PROVISIONER_PUBKEY — until you do, the device refuses every")
+    print("approval and stays telemetry-only:")
+    print()
+    print(_c_array(seed_auth, "BENCH_PROVISIONER_PUBKEY"))
+    return 0
+
+
+# ── store-backed transaction ─────────────────────────────────────────
+
+
+async def _open_store(db_path: str) -> Any:
+    """Open the runtime's own state store. `open()` applies the DDL
+    migrations, so the registry this CLI reads is the same table the
+    runtime uses — not a private copy."""
+    from ori.state.store import StateStore
+
+    store = StateStore(db_path=db_path)
+    await store.open()
+    return store
+
+
+def _load_manifest_message(path: str) -> dict[str, Any]:
+    try:
+        message = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ProvisionerError(f"cannot read manifest message {path}: {exc}") from exc
+    if not isinstance(message, dict) or not isinstance(message.get("manifest"), dict):
+        raise ProvisionerError("message has no manifest object")
+    return message
+
+
+async def _register(
+    db_path: str, manifest_path: str, allow_revoked: bool = False
+) -> tuple[str, str]:
+    from ori.security.firmware_ingest import FirmwareTelemetryGate
+
+    message = _load_manifest_message(manifest_path)
+    manifest = message["manifest"]
+    device_id = manifest.get("device_id")
+    device_pub = manifest.get("public_key_b64")
+    posture = manifest.get("posture")
+    if not all(isinstance(v, str) for v in (device_id, device_pub, posture)):
+        raise ProvisionerError(
+            "manifest is missing device_id, public_key_b64, or posture"
+        )
+
+    store = await _open_store(db_path)
+    try:
+        # Re-registering silently clears `revoked` in the store's upsert,
+        # so a revoked device could be quietly re-armed by running this
+        # command again. Refuse unless the operator says so explicitly —
+        # un-revoking is a deliberate act, not a side effect of
+        # re-registration. (Tracked upstream; see the CLI docstring.)
+        existing = await store.get_firmware_device(device_id)
+        if existing is not None and existing.get("revoked") and not allow_revoked:
+            raise ProvisionerError(
+                f"device {device_id!r} is REVOKED. Re-registering would clear that "
+                "revocation. If you genuinely intend to re-provision this device, "
+                "pass --allow-revoked and record why."
+            )
+        gate = FirmwareTelemetryGate(store)
+        capability_hash = await gate.register_device(
+            device_id=device_id,
+            public_key_b64=device_pub,
+            posture=posture,
+            manifest_message=message,
+            board_profile=str(manifest.get("board_profile", "")),
+        )
+    except FirmwareVerificationError as exc:
+        raise ProvisionerError(f"manifest rejected: {exc}") from exc
+    finally:
+        await store.close()
+    return str(device_pub), capability_hash
+
+
+def cmd_register(args: argparse.Namespace) -> int:
+    device_pub, capability_hash = asyncio.run(
+        _register(args.db, args.manifest, allow_revoked=args.allow_revoked)
+    )
+    print("registered UNAPPROVED — telemetry is not accepted until approval")
+    print(f"  capability hash : {capability_hash}")
+    print(f"  device key (b64): {device_pub}")
+    print()
+    print("Before approving, read the key off the device itself. Its serial")
+    print("console prints, at boot:")
+    print()
+    print("    ori: device public key (b64) <KEY>")
+    print()
+    print("Confirm that string matches the one above, then pass it to")
+    print("`approve --confirm-device-key`. A manifest verified against the key")
+    print("carried inside it proves the message is self-consistent, not that it")
+    print("came from the board in front of you.")
+    return 0
+
+
+async def _approve(db_path: str, device_id: str, confirmed_key: str) -> None:
+    from ori.security.firmware_ingest import FirmwareTelemetryGate
+
+    store = await _open_store(db_path)
+    try:
+        row = await store.get_firmware_device(device_id)
+        if row is None:
+            raise ProvisionerError(
+                f"unknown device {device_id!r}; run `register` first"
+            )
+        if row.get("revoked"):
+            raise ProvisionerError(
+                f"device {device_id!r} is revoked; approving it here would contradict "
+                "the registry — re-provision deliberately instead"
+            )
+        stored_key = str(row.get("public_key_b64", ""))
+        if confirmed_key != stored_key:
+            raise ProvisionerError(
+                "the confirmed device key does not match the registered anchor.\n"
+                f"  registered: {stored_key}\n"
+                f"  confirmed : {confirmed_key}\n"
+                "Approving would bind authority to a device you did not verify."
+            )
+        gate = FirmwareTelemetryGate(store)
+        if not await gate.approve_device(device_id):
+            raise ProvisionerError(f"registry refused to approve {device_id!r}")
+    finally:
+        await store.close()
+
+
+def cmd_approve(args: argparse.Namespace) -> int:
+    asyncio.run(_approve(args.db, args.device_id, args.confirm_device_key))
+    print(f"{args.device_id} approved in the runtime registry")
+    print("Run `publish` to sign and publish the retained approval.")
+    return 0
+
+
+async def _publish(
+    db_path: str,
+    device_id: str,
+    provisioner_seed: bytes,
+    runtime_seed: bytes,
+    dry_run: bool,
+) -> bytes:
+    from ori.gateway.firmware_commands import (
+        FirmwareCommandError,
+        FirmwareCommandService,
+    )
+
+    store = await _open_store(db_path)
+
+    class _CapturingPublisher:
+        """Dry-run publisher: exercises every store-backed control and
+        returns the bytes without touching a broker."""
+
+        def __init__(self) -> None:
+            self.published: bytes | None = None
+
+        async def publish_provisioning_approval(
+            self, device_id: str, message: bytes
+        ) -> None:
+            del device_id
+            self.published = message
+
+    if dry_run:
+        publisher: Any = _CapturingPublisher()
+    else:
+        raise ProvisionerError(
+            "live publishing runs inside the runtime's gateway; use --dry-run here "
+            "and publish through the runtime, or hand the emitted bytes to your "
+            "bench MQTT client"
+        )
+
+    try:
+        service = FirmwareCommandService(
+            store=store,
+            publisher=publisher,
+            runtime_command_key_bytes=runtime_seed,
+            provisioner_key_bytes=provisioner_seed,
+        )
+        return await service.publish_provisioning_approval(device_id)
+    except FirmwareCommandError as exc:
+        # Unknown / unapproved / revoked all land here — the controls a
+        # parallel signer would have skipped.
+        raise ProvisionerError(f"registry refused: {exc}") from exc
+    finally:
+        await store.close()
+
+
+def cmd_publish(args: argparse.Namespace) -> int:
+    message = asyncio.run(
+        _publish(
+            args.db,
+            args.device_id,
+            read_seed(Path(args.provisioner_seed), "provisioner seed"),
+            read_seed(Path(args.runtime_command_seed), "runtime command seed"),
+            dry_run=True,
+        )
+    )
+    if args.out:
+        Path(args.out).write_bytes(message)
+        print(f"approval written to {args.out}")
+    else:
+        sys.stdout.write(message.decode("utf-8") + "\n")
+    print(
+        f"publish RETAINED on ori/fw/{args.device_id}/provision (QoS 1)",
+        file=sys.stderr,
+    )
+    return 0
+
+
+# ── contract diagnostic ──────────────────────────────────────────────
+
+
+def golden_selfcheck() -> list[str]:
+    """Reproduce the shared vectors. A mismatch means this runtime and
+    the firmware's C verifier no longer agree on the wire bytes."""
+    problems: list[str] = []
+    vectors = json.loads(_VECTORS.read_text(encoding="utf-8"))
+    seed = bytes.fromhex(vectors["provisioner_test_seed_hex"])
+    for case in vectors["cases"]:
+        i = case["input"]
+        produced = build_provisioning_approval_bytes(
+            capability_hash=i["capability_hash"],
+            device_id=i["device_id"],
+            posture=i["posture"],
+            public_key_b64=i["public_key_b64"],
+            runtime_public_key_b64=i["runtime_public_key_b64"],
+            provisioner_private_key_bytes=seed,
+        )
+        if produced.hex() != case["message_hex"]:
+            problems.append(f"{case['name']}: wire message does not match the vector")
+    return problems
+
+
+def cmd_selfcheck(args: argparse.Namespace) -> int:
+    del args
+    problems = golden_selfcheck()
+    for p in problems:
+        print(f"FAIL: {p}", file=sys.stderr)
+    if problems:
+        return 1
+    count = len(json.loads(_VECTORS.read_text(encoding="utf-8"))["cases"])
+    print(f"golden vectors reproduced byte-for-byte ({count} cases)")
+    print("runtime and firmware agree on the approval wire format")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ori-firmware-provisioner",
+        description="Operator CLI for the firmware provisioning transaction.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p = sub.add_parser("keygen", help="create authority + runtime keys")
+    p.add_argument("--out-dir", required=True)
+    p.set_defaults(func=cmd_keygen)
+
+    p = sub.add_parser("register", help="store a device anchor, unapproved")
+    p.add_argument("--db", required=True)
+    p.add_argument("--manifest", required=True)
+    p.add_argument(
+        "--allow-revoked",
+        action="store_true",
+        help="re-register a REVOKED device, clearing its revocation (deliberate act)",
+    )
+    p.set_defaults(func=cmd_register)
+
+    p = sub.add_parser("approve", help="record explicit operator approval")
+    p.add_argument("--db", required=True)
+    p.add_argument("--device-id", required=True)
+    p.add_argument(
+        "--confirm-device-key",
+        required=True,
+        metavar="B64",
+        help="device public key as observed on the device itself, not from the manifest",
+    )
+    p.set_defaults(func=cmd_approve)
+
+    p = sub.add_parser(
+        "publish", help="sign from the approved row and emit the approval"
+    )
+    p.add_argument("--db", required=True)
+    p.add_argument("--device-id", required=True)
+    p.add_argument("--provisioner-seed", required=True)
+    p.add_argument("--runtime-command-seed", required=True)
+    p.add_argument("--out")
+    p.set_defaults(func=cmd_publish)
+
+    p = sub.add_parser("selfcheck", help="reproduce the shared golden vectors")
+    p.set_defaults(func=cmd_selfcheck)
+
+    args = parser.parse_args(argv)
+    try:
+        return int(args.func(args))
+    except ProvisionerError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ ori-runtime = "ori.runtime:main"
 ori-config-install = "ori.config_installer:main"
 ori-phone-doctor = "ori.phone_doctor:main"
 ori-inverter-profile-doctor = "ori.inverter_profile_doctor:main"
+ori-firmware-provisioner = "ori.firmware_provisioner:main"
 
 [project.urls]
 Homepage = "https://github.com/ori-platform/ori-runtime"

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -21,6 +21,7 @@ import hashlib
 import json
 import os
 import stat
+from pathlib import Path
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -161,7 +162,7 @@ class TestTransactionControls:
         assert _register(bench) == 0
         assert _approve(bench) == 0
         assert _publish(bench) == 0
-        approval = json.loads(open(bench["out"]).read())["approval"]
+        approval = json.loads(Path(bench["out"]).read_text())["approval"]
         assert approval["device_id"] == "ori-fw-bench0001"
         assert approval["public_key_b64"] == bench["device_key"]
 
@@ -190,11 +191,11 @@ class TestTransactionControls:
         # Corrupt the on-disk manifest after registration. The approval
         # must still reflect the stored row, because the registry is the
         # source of truth once the anchor exists.
-        bad = json.loads(open(bench["manifest"]).read())
+        bad = json.loads(Path(bench["manifest"]).read_text())
         bad["manifest"]["device_id"] = "ori-fw-someone-else"
-        open(bench["manifest"], "w").write(json.dumps(bad))
+        Path(bench["manifest"]).write_text(json.dumps(bad))
         assert _publish(bench) == 0
-        approval = json.loads(open(bench["out"]).read())["approval"]
+        approval = json.loads(Path(bench["out"]).read_text())["approval"]
         assert approval["device_id"] == "ori-fw-bench0001"
 
 
@@ -212,9 +213,9 @@ class TestIdentityConfirmation:
 
 class TestRegistration:
     def test_tampered_manifest_is_not_registered(self, bench) -> None:
-        message = json.loads(open(bench["manifest"]).read())
+        message = json.loads(Path(bench["manifest"]).read_text())
         message["manifest"]["firmware_version"] = "9.9.9"
-        open(bench["manifest"], "w").write(json.dumps(message))
+        Path(bench["manifest"]).write_text(json.dumps(message))
         assert _register(bench) == 2
 
     def test_inconsistent_posture_is_not_registered(self, bench, tmp_path) -> None:

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -1,0 +1,322 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Provisioning CLI tests.
+
+The CLI orchestrates the runtime's existing provisioning path rather
+than signing approvals itself, so the properties worth testing are the
+ones a parallel authority would have skipped: an unregistered,
+unapproved, or revoked device must not receive an approval, and the
+operator must confirm the device identity independently of the manifest
+that asserts it.
+
+Approval *bytes* are already covered by the shared golden vectors and by
+the firmware's own C tests; ``selfcheck`` guards that agreement here.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import stat
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from ori.firmware_provisioner import golden_selfcheck, main
+from ori.security.firmware_telemetry import canonical_json_bytes
+
+
+def _pub_b64(seed: bytes) -> str:
+    raw = (
+        Ed25519PrivateKey.from_private_bytes(seed)
+        .public_key()
+        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+    return base64.b64encode(raw).decode("ascii")
+
+
+def signed_manifest(device_seed: bytes, **overrides) -> dict:
+    """A manifest message shaped exactly as the device publishes one."""
+    manifest = {
+        "v": 1,
+        "alg": "ed25519",
+        "device_id": "ori-fw-bench0001",
+        "firmware_version": "0.1.0",
+        "board_profile": "esp32s3-devkit",
+        "device_mode": "mixed",
+        "public_key_b64": _pub_b64(device_seed),
+        "posture": "development",
+        "secure_boot_enabled": False,
+        "flash_encryption_enabled": False,
+        "key_storage": "dev_flash",
+        "transports": ["mqtt"],
+        "channels": [
+            {
+                "channel": "ch0",
+                "sensor_type": "current",
+                "unit": "ampere",
+                "protocol": "uart",
+                "source": "pzem",
+                "quality_floor": 0.8,
+            }
+        ],
+        "actions": [
+            {
+                "action": "relay_open",
+                "channel": "relay0",
+                "authority": "runtime_commanded",
+            }
+        ],
+        "interlocks": [
+            {
+                "name": "local_overcurrent_interlock",
+                "channel": "ch0",
+                "action": "relay_open",
+            }
+        ],
+    }
+    manifest.update(overrides)
+    canonical = canonical_json_bytes(manifest)
+    signature = Ed25519PrivateKey.from_private_bytes(device_seed).sign(canonical)
+    return {
+        "manifest": manifest,
+        "manifest_hash": "sha256:" + hashlib.sha256(canonical).hexdigest(),
+        "signature": "ed25519:" + base64.b64encode(signature).decode("ascii"),
+    }
+
+
+@pytest.fixture
+def bench(tmp_path):
+    """A keyed bench: authority + runtime seeds on disk, a device
+    manifest ready to register, and paths for the CLI."""
+    device_seed = os.urandom(32)
+    main(["keygen", "--out-dir", str(tmp_path)])
+    message = signed_manifest(device_seed)
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(message))
+    return {
+        "db": str(tmp_path / "o.db"),
+        "manifest": str(manifest_path),
+        "message": message,
+        "device_key": message["manifest"]["public_key_b64"],
+        "auth_seed": str(tmp_path / "provisioner_seed.b64"),
+        "rt_seed": str(tmp_path / "runtime_command_seed.b64"),
+        "out": str(tmp_path / "approval.json"),
+        "tmp": tmp_path,
+    }
+
+
+def _publish(bench, device_id="ori-fw-bench0001"):
+    return main(
+        [
+            "publish",
+            "--db",
+            bench["db"],
+            "--device-id",
+            device_id,
+            "--provisioner-seed",
+            bench["auth_seed"],
+            "--runtime-command-seed",
+            bench["rt_seed"],
+            "--out",
+            bench["out"],
+        ]
+    )
+
+
+def _register(bench):
+    return main(["register", "--db", bench["db"], "--manifest", bench["manifest"]])
+
+
+def _approve(bench, key=None):
+    return main(
+        [
+            "approve",
+            "--db",
+            bench["db"],
+            "--device-id",
+            "ori-fw-bench0001",
+            "--confirm-device-key",
+            key if key is not None else bench["device_key"],
+        ]
+    )
+
+
+class TestTransactionControls:
+    """Each of these is a control a parallel signing path would skip."""
+
+    def test_unregistered_device_gets_no_approval(self, bench) -> None:
+        assert _publish(bench) == 2
+
+    def test_registered_but_unapproved_gets_no_approval(self, bench) -> None:
+        assert _register(bench) == 0
+        # register stores the anchor UNAPPROVED on purpose.
+        assert _publish(bench) == 2
+
+    def test_approved_device_gets_an_approval(self, bench) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        assert _publish(bench) == 0
+        approval = json.loads(open(bench["out"]).read())["approval"]
+        assert approval["device_id"] == "ori-fw-bench0001"
+        assert approval["public_key_b64"] == bench["device_key"]
+
+    def test_revoked_device_gets_no_approval(self, bench) -> None:
+        import asyncio
+
+        from ori.security.firmware_ingest import FirmwareTelemetryGate
+        from ori.state.store import StateStore
+
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+
+        async def revoke():
+            store = StateStore(db_path=bench["db"])
+            await store.open()
+            await FirmwareTelemetryGate(store).revoke_device("ori-fw-bench0001")
+            await store.close()
+
+        asyncio.run(revoke())
+        # A revoked device must not be re-armed by publishing again.
+        assert _publish(bench) == 2
+
+    def test_approval_is_signed_from_the_registry_not_the_manifest(self, bench) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        # Corrupt the on-disk manifest after registration. The approval
+        # must still reflect the stored row, because the registry is the
+        # source of truth once the anchor exists.
+        bad = json.loads(open(bench["manifest"]).read())
+        bad["manifest"]["device_id"] = "ori-fw-someone-else"
+        open(bench["manifest"], "w").write(json.dumps(bad))
+        assert _publish(bench) == 0
+        approval = json.loads(open(bench["out"]).read())["approval"]
+        assert approval["device_id"] == "ori-fw-bench0001"
+
+
+class TestIdentityConfirmation:
+    def test_wrong_confirmed_key_blocks_approval(self, bench) -> None:
+        assert _register(bench) == 0
+        # Verifying a manifest against the key inside it proves internal
+        # consistency, not that it came from the board on the bench.
+        assert _approve(bench, key=_pub_b64(os.urandom(32))) == 2
+        assert _publish(bench) == 2
+
+    def test_approving_an_unregistered_device_fails(self, bench) -> None:
+        assert _approve(bench) == 2
+
+
+class TestRegistration:
+    def test_tampered_manifest_is_not_registered(self, bench) -> None:
+        message = json.loads(open(bench["manifest"]).read())
+        message["manifest"]["firmware_version"] = "9.9.9"
+        open(bench["manifest"], "w").write(json.dumps(message))
+        assert _register(bench) == 2
+
+    def test_inconsistent_posture_is_not_registered(self, bench, tmp_path) -> None:
+        # A development board must not register as sealed_flash: the
+        # posture's boolean fields disagree with the claim.
+        seed = os.urandom(32)
+        message = signed_manifest(seed, posture="sealed_flash")
+        path = tmp_path / "sealed.json"
+        path.write_text(json.dumps(message))
+        assert main(["register", "--db", bench["db"], "--manifest", str(path)]) == 2
+
+
+class TestKeygen:
+    def test_seeds_are_owner_only_and_never_overwritten(self, tmp_path) -> None:
+        assert main(["keygen", "--out-dir", str(tmp_path)]) == 0
+        seed = tmp_path / "provisioner_seed.b64"
+        # This key grants command authority over a fleet.
+        assert stat.S_IMODE(seed.stat().st_mode) == 0o600
+        # A second keygen must not silently invalidate a fleet's anchor.
+        assert main(["keygen", "--out-dir", str(tmp_path)]) == 2
+
+    def test_seeds_are_canonical_base64_the_runtime_can_load(self, tmp_path) -> None:
+        # The runtime loads seeds from env as base64. Emitting hex would
+        # generate keys it cannot use, so the approval would install a
+        # runtime key that never signs anything.
+        from ori.gateway.firmware_commands import load_raw_ed25519_seed_from_env
+
+        main(["keygen", "--out-dir", str(tmp_path)])
+        for name in ("provisioner_seed.b64", "runtime_command_seed.b64"):
+            value = (tmp_path / name).read_text().strip()
+            os.environ["ORI_TEST_SEED"] = value
+            try:
+                loaded = load_raw_ed25519_seed_from_env(
+                    "ORI_TEST_SEED", label="test seed"
+                )
+            finally:
+                del os.environ["ORI_TEST_SEED"]
+            assert len(loaded) == 32
+
+    def test_emits_the_firmware_c_array(self, tmp_path, capsys) -> None:
+        main(["keygen", "--out-dir", str(tmp_path)])
+        out = capsys.readouterr().out
+        # Must match the declaration in device/main/app_main.c.
+        assert (
+            "static const uint8_t BENCH_PROVISIONER_PUBKEY"
+            "[ORI_ED25519_PUBLIC_KEY_LEN] = {" in out
+        )
+        assert out.count("0x") == 32
+
+
+class TestContractDiagnostic:
+    def test_selfcheck_reproduces_the_shared_vectors(self) -> None:
+        # The tie to the firmware's C verifier: these are the same bytes
+        # ori-edge-firmware's test_provisioning.c accepts.
+        assert golden_selfcheck() == []
+
+    def test_selfcheck_cli(self, capsys) -> None:
+        assert main(["selfcheck"]) == 0
+        assert "reproduced byte-for-byte" in capsys.readouterr().out
+
+
+class TestRevocationIsNotSilentlyCleared:
+    """The store's anchor upsert resets `revoked` to 0. Re-registering a
+    revoked device would therefore re-arm it silently, so the CLI
+    requires the operator to say so explicitly."""
+
+    def _revoke(self, bench) -> None:
+        import asyncio
+
+        from ori.security.firmware_ingest import FirmwareTelemetryGate
+        from ori.state.store import StateStore
+
+        async def go():
+            store = StateStore(db_path=bench["db"])
+            await store.open()
+            await FirmwareTelemetryGate(store).revoke_device("ori-fw-bench0001")
+            await store.close()
+
+        asyncio.run(go())
+
+    def test_reregistering_a_revoked_device_is_refused(self, bench) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        self._revoke(bench)
+        # Without this guard the upsert would clear the revocation and a
+        # subsequent approve+publish would re-arm a revoked device.
+        assert _register(bench) == 2
+        assert _publish(bench) == 2
+
+    def test_reregistration_is_possible_when_explicit(self, bench) -> None:
+        assert _register(bench) == 0
+        self._revoke(bench)
+        rc = main(
+            [
+                "register",
+                "--db",
+                bench["db"],
+                "--manifest",
+                bench["manifest"],
+                "--allow-revoked",
+            ]
+        )
+        assert rc == 0
+        # Still unapproved: clearing revocation does not grant authority.
+        assert _publish(bench) == 2


### PR DESCRIPTION
## What does this PR do?

Adds `ori-firmware-provisioner`, the operator CLI for the firmware provisioning transaction, so the bench proof in [ori-edge-firmware#14](https://github.com/ori-platform/ori-edge-firmware/issues/14) does not begin by hand-assembling JSON with a board on the desk.

The signing primitive and the store-backed `FirmwareCommandService` already existed. What was missing was the operator path: creating the authority key, getting its public key into the firmware, and driving registration through to a published approval.

## It orchestrates the existing path — it is not a second authority

This is the important design point, and an earlier draft of this PR got it wrong.

That draft signed approvals **directly from a presented manifest**. It never touched the device registry, so it skipped registration, explicit operator approval, and revocation entirely. Firmware would have accepted a device that the runtime still regarded as unknown, unapproved, or revoked — a cross-repo split-brain, and precisely the failure this contract exists to prevent.

Approvals are now signed by `FirmwareCommandService.publish_provisioning_approval()` from the **stored registry row**. Every control in `_require_approved_device` applies, and the registry stays the source of truth. One test corrupts the on-disk manifest after registration and asserts the emitted approval still reflects the stored row.

The transaction, in operator order:

| Subcommand | What it does |
| --- | --- |
| `keygen` | Authority + runtime-command keys; emits the firmware C array |
| `register` | `FirmwareTelemetryGate.register_device` — stores the anchor **unapproved** |
| `approve` | Explicit operator approval, gated on independent identity confirmation |
| `publish` | Signs from the approved row and emits the retained approval |
| `selfcheck` | Contract diagnostic against the shared golden vectors |

## Identity confirmation is independent, not self-asserted

Verifying a manifest against the public key carried **inside that same manifest** proves the message is self-consistent — never that it came from the board in front of you.

So `approve` requires `--confirm-device-key`, the key the operator reads from the device's serial console, and refuses if it disagrees with the registered anchor. The companion firmware PR ([ori-edge-firmware#52](https://github.com/ori-platform/ori-edge-firmware/pull/52)) prints that line; without it the confirmation step could not be performed at all.

## Keys are emitted in the forms their consumers take

Seeds are written as **canonical base64**, the form `load_raw_ed25519_seed_from_env` reads. An earlier draft wrote hex, which the runtime cannot load — the approval would have installed a runtime command key the runtime never uses. A test loads both generated seeds through the real env loader.

The authority public key is emitted as the C array `app_main.c` declares, since the firmware's all-zero default refuses every approval and a board without it is telemetry-only by construction.

Authority seeds are written `0600`, never printed, and `keygen` refuses to overwrite an existing key rather than silently invalidating a fleet's anchor.

## One guard that is explicitly a mitigation, not a fix

`register` refuses to re-register a **revoked** device without `--allow-revoked`, because the store's anchor upsert clears `revoked` and would otherwise re-arm it silently.

That is a guard in one caller. The store-level behaviour — and the fact that ori-verity's `register_device` is a plain `INSERT` that *errors* on a duplicate device id, the opposite policy — is tracked separately in #239. The docstring says so, so nobody mistakes the flag for the fix.

## Type of change

- [x] `feat` — new feature (operator CLI)
- [x] `security` — touches provisioning authority and key handling

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures — **1921 passed, 6 skipped**
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR — see below
- [x] PR description explains **why**, not just what

No matrix update needed: the capability guard covers `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py`, and `ori/config.py`. This adds an operator CLI and touches none of them. No new capability surface, tier, or action authority — it drives the existing provisioning path.

### If you used AI assistance

- [x] I can explain every line in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in review

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — tracked by ori-edge-firmware#14, whose bench proof this supports
- [x] Every new Tier D code path has test coverage — none added; this is provisioning tooling
- [x] No new dependencies added

## Related issue

Refs [ori-edge-firmware#14](https://github.com/ori-platform/ori-edge-firmware/issues/14). Companion: [ori-edge-firmware#52](https://github.com/ori-platform/ori-edge-firmware/pull/52). Follow-up: #239.

## Testing notes

16 new tests, focused on the controls a parallel signer would have skipped:

```
unregistered device            -> no approval
registered but unapproved      -> no approval
revoked device                 -> no approval
re-register a revoked device   -> refused without --allow-revoked
wrong --confirm-device-key     -> approval blocked
manifest corrupted post-register -> approval still reflects the registry
tampered / inconsistent-posture manifest -> not registered
generated seeds                -> load through the real env loader
selfcheck                      -> shared golden vectors reproduced byte-for-byte

pytest tests/            1921 passed, 6 skipped
pre-commit run --all-files   all hooks pass
```

Beyond the suite, the emitted approval was fed to the **firmware's actual C verifier** through a throwaway harness with freshly generated keys: accepted, with the correct runtime command key installed, while a different authority key and a tampered approval body were both rejected.
