### PR TITLE
fix(security): registration preserves revocation and refuses changed anchors

### DIFF
--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -186,9 +186,7 @@ def _load_manifest_message(path: str) -> dict[str, Any]:
     return message
 
 
-async def _register(
-    db_path: str, manifest_path: str, allow_revoked: bool = False
-) -> tuple[str, str]:
+async def _register(db_path: str, manifest_path: str) -> tuple[str, str]:
     from ori.security.firmware_ingest import FirmwareTelemetryGate
 
     message = _load_manifest_message(manifest_path)
@@ -203,18 +201,10 @@ async def _register(
 
     store = await _open_store(db_path)
     try:
-        # Re-registering silently clears `revoked` in the store's upsert,
-        # so a revoked device could be quietly re-armed by running this
-        # command again. Refuse unless the operator says so explicitly —
-        # un-revoking is a deliberate act, not a side effect of
-        # re-registration. (Tracked upstream; see the CLI docstring.)
-        existing = await store.get_firmware_device(device_id)
-        if existing is not None and existing.get("revoked") and not allow_revoked:
-            raise ProvisionerError(
-                f"device {device_id!r} is REVOKED. Re-registering would clear that "
-                "revocation. If you genuinely intend to re-provision this device, "
-                "pass --allow-revoked and record why."
-            )
+        # The store refuses a revoked identity and a changed key outright
+        # (ori-specs/device-provisioning/v1.md), so no flag here could
+        # override it. Returning a revoked identity to service is
+        # reinstatement: an explicit, audited operation.
         gate = FirmwareTelemetryGate(store)
         capability_hash = await gate.register_device(
             device_id=device_id,
@@ -231,9 +221,7 @@ async def _register(
 
 
 def cmd_register(args: argparse.Namespace) -> int:
-    device_pub, capability_hash = asyncio.run(
-        _register(args.db, args.manifest, allow_revoked=args.allow_revoked)
-    )
+    device_pub, capability_hash = asyncio.run(_register(args.db, args.manifest))
     print("registered UNAPPROVED — telemetry is not accepted until approval")
     print(f"  capability hash : {capability_hash}")
     print(f"  device key (b64): {device_pub}")
@@ -412,11 +400,6 @@ def main(argv: list[str] | None = None) -> int:
     p = sub.add_parser("register", help="store a device anchor, unapproved")
     p.add_argument("--db", required=True)
     p.add_argument("--manifest", required=True)
-    p.add_argument(
-        "--allow-revoked",
-        action="store_true",
-        help="re-register a REVOKED device, clearing its revocation (deliberate act)",
-    )
     p.set_defaults(func=cmd_register)
 
     p = sub.add_parser("approve", help="record explicit operator approval")

--- a/ori/security/firmware_ingest.py
+++ b/ori/security/firmware_ingest.py
@@ -30,6 +30,9 @@ from typing import Any
 
 from ori.network.events import SensorReading
 from ori.security.firmware_telemetry import (
+    ERR_DEVICE_REVOKED,
+    ERR_KEY_CHANGE_REQUIRES_REPROVISIONING,
+    ERR_MANIFEST_EPOCH_UNSUPPORTED,
     ERR_SEQUENCE_REPLAY,
     GRADE_REJECTED,
     FirmwareFaultVerification,
@@ -88,7 +91,7 @@ class FirmwareTelemetryGate:
                 "manifest posture does not match provisioning posture",
             )
         channel_map = manifest_channel_map(manifest)
-        await self._store.upsert_firmware_device_anchor(
+        outcome = await self._store.upsert_firmware_device_anchor(
             device_id=device_id,
             public_key_b64=public_key_b64,
             posture=posture,
@@ -103,11 +106,43 @@ class FirmwareTelemetryGate:
                 allow_nan=False,
             ),
         )
-        logger.info(
-            "firmware device %s provisioned (posture=%s, awaiting approval)",
-            device_id,
-            posture,
-        )
+
+        # ori-specs/device-provisioning/v1.md. Registration may refuse; it
+        # never silently overwrites an anchor or clears a revocation.
+        if outcome == "refused_revoked":
+            raise FirmwareVerificationError(
+                ERR_DEVICE_REVOKED,
+                f"device {device_id!r} is revoked; reinstatement is an explicit "
+                "operation, never a side effect of registration",
+            )
+        if outcome == "refused_manifest_epoch_unsupported":
+            raise FirmwareVerificationError(
+                ERR_MANIFEST_EPOCH_UNSUPPORTED,
+                f"device {device_id!r} published a new capability hash under its "
+                "existing key. The lifecycle requires this to become a pending "
+                "candidate beside the active anchor; that state model is not "
+                "implemented yet, so it is refused rather than overwriting the "
+                "active anchor.",
+            )
+        if outcome == "refused_key_change":
+            raise FirmwareVerificationError(
+                ERR_KEY_CHANGE_REQUIRES_REPROVISIONING,
+                f"device {device_id!r} presented a different public key; a key "
+                "change requires an explicit re-provisioning transaction with "
+                "independent identity confirmation",
+            )
+
+        if outcome == "unchanged":
+            logger.debug(
+                "firmware device %s re-published an identical anchor (no-op)",
+                device_id,
+            )
+        else:
+            logger.info(
+                "firmware device %s provisioned (posture=%s, awaiting approval)",
+                device_id,
+                posture,
+            )
         return manifest_hash
 
     async def approve_device(self, device_id: str) -> bool:

--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -91,6 +91,13 @@ ERR_INVALID_ENVELOPE = "invalid_envelope"
 ERR_UNSUPPORTED_ALG = "unsupported_alg"
 ERR_DEVICE_REVOKED = "device_revoked"
 ERR_DEVICE_NOT_APPROVED = "device_not_approved"
+# ori-specs/device-provisioning/v1.md: a changed key may never arrive
+# through ordinary registration.
+ERR_KEY_CHANGE_REQUIRES_REPROVISIONING = "key_change_requires_reprovisioning"
+# Interim: the pending-anchor state model is not implemented yet, so a
+# same-key manifest change fails closed instead of overwriting the active
+# anchor. Removed when anchor epochs and pending state land.
+ERR_MANIFEST_EPOCH_UNSUPPORTED = "manifest_epoch_unsupported"
 
 FIRMWARE_FAULT_CODES = frozenset(
     {

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -2375,11 +2375,34 @@ class StateStore:
         channel_map_json: str,
         board_profile: str = "",
         provisioned_at_ms: int | None = None,
-    ) -> None:
-        """Store (or replace) a provisioning anchor. Re-provisioning a
-        device resets approval and freshness state: a new anchor is a
-        new key epoch."""
-        await self._run_write(
+    ) -> str:
+        """Register a provisioning anchor, per the lifecycle in
+        ori-specs/device-provisioning/v1.md.
+
+        Returns an outcome code rather than silently overwriting:
+
+        ``registered``
+            No prior anchor; stored unapproved.
+        ``unchanged``
+            The anchor already matches exactly. Idempotent no-op — nothing
+            is touched, including approval and freshness.
+        ``refused_manifest_epoch_unsupported``
+            Same key, new capability hash. The contract requires this to
+            be stored as a PENDING candidate beside the still-active
+            anchor; that state model does not exist yet, so this fails
+            closed rather than overwriting the active anchor.
+        ``refused_revoked``
+            The identity is revoked. Revocation belongs to the identity
+            and is never cleared by registration.
+        ``refused_key_change``
+            The device key differs. A changed key through ordinary
+            registration is indistinguishable from a takeover attempt and
+            requires an explicit re-provisioning transaction.
+
+        The decision is made inside the write transaction so a concurrent
+        revocation cannot be raced.
+        """
+        return await self._run_write(
             self._upsert_firmware_device_anchor_sync,
             device_id,
             public_key_b64,
@@ -2391,7 +2414,7 @@ class StateStore:
             provisioned_at_ms if provisioned_at_ms is not None else now_ms(),
         )
 
-    def _upsert_firmware_device_anchor_sync(
+    def _upsert_firmware_device_anchor_sync(  # noqa: PLR0913
         self,
         device_id: str,
         public_key_b64: str,
@@ -2401,41 +2424,75 @@ class StateStore:
         channel_map_json: str,
         board_profile: str,
         provisioned_at_ms: int,
-    ) -> None:
+    ) -> str:
         assert self._conn is not None
-        self._conn.execute(
+        # Decide inside the transaction: a read-then-write in the caller
+        # could be raced by a concurrent revocation.
+        row = self._conn.execute(
             """
-            INSERT INTO firmware_device_registry
-                (device_id, public_key_b64, posture, capability_hash, manifest_json,
-                 channel_map_json, board_profile,
-                 approved, provisioned_at_ms, last_boot_id, last_seq, revoked, revoked_at_ms)
-            VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 0, 0, NULL)
-            ON CONFLICT(device_id) DO UPDATE SET
-                public_key_b64 = excluded.public_key_b64,
-                posture = excluded.posture,
-                capability_hash = excluded.capability_hash,
-                manifest_json = excluded.manifest_json,
-                channel_map_json = excluded.channel_map_json,
-                board_profile = excluded.board_profile,
-                approved = 0,
-                provisioned_at_ms = excluded.provisioned_at_ms,
-                last_boot_id = 0,
-                last_seq = 0,
-                revoked = 0,
-                revoked_at_ms = NULL
+            SELECT public_key_b64, posture, capability_hash, revoked
+              FROM firmware_device_registry
+             WHERE device_id = ?
             """,
-            (
-                device_id,
-                public_key_b64,
-                posture,
-                capability_hash,
-                manifest_json,
-                channel_map_json,
-                board_profile,
-                provisioned_at_ms,
-            ),
-        )
-        self._conn.commit()
+            (device_id,),
+        ).fetchone()
+
+        if row is None:
+            self._conn.execute(
+                """
+                INSERT INTO firmware_device_registry
+                    (device_id, public_key_b64, posture, capability_hash,
+                     manifest_json, channel_map_json, board_profile,
+                     approved, provisioned_at_ms, last_boot_id, last_seq,
+                     revoked, revoked_at_ms)
+                VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 0, 0, NULL)
+                """,
+                (
+                    device_id,
+                    public_key_b64,
+                    posture,
+                    capability_hash,
+                    manifest_json,
+                    channel_map_json,
+                    board_profile,
+                    provisioned_at_ms,
+                ),
+            )
+            self._conn.commit()
+            return "registered"
+
+        # Revocation belongs to the identity. It is never cleared as a
+        # side effect of a device re-publishing its manifest.
+        if row["revoked"]:
+            return "refused_revoked"
+
+        # A changed key through ordinary registration is indistinguishable
+        # from an attacker presenting a key they control for an identity
+        # they do not own: the manifest is self-signed, so verifying it
+        # against the key inside it proves consistency, never provenance.
+        if row["public_key_b64"] != public_key_b64:
+            return "refused_key_change"
+
+        if row["posture"] == posture and row["capability_hash"] == capability_hash:
+            # Exact match: idempotent. Touch nothing — not approval, not
+            # freshness, not provisioned_at_ms. Re-publishing a manifest
+            # is not an event.
+            return "unchanged"
+
+        # Same key, new manifest (or posture).
+        #
+        # The contract (ori-specs/device-provisioning/v1.md) requires this
+        # to become a PENDING candidate while the active anchor keeps
+        # operating — which needs the anchor state model and append-only
+        # history that this store does not have yet.
+        #
+        # Until it does, this FAILS CLOSED. Overwriting the active anchor
+        # and clearing approval, as this method used to, is the behaviour
+        # the contract forbids: it lets a device replace its own accepted
+        # capability surface by publishing. Refusing is the honest
+        # interim: an operator can still revoke and re-provision
+        # deliberately, and nothing is silently accepted.
+        return "refused_manifest_epoch_unsupported"
 
     async def get_firmware_device(self, device_id: str) -> dict | None:
         return await self._run_read(self._get_firmware_device_sync, device_id)

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -104,6 +104,7 @@ def bench(tmp_path):
         "manifest": str(manifest_path),
         "message": message,
         "device_key": message["manifest"]["public_key_b64"],
+        "device_seed": device_seed,
         "auth_seed": str(tmp_path / "provisioner_seed.b64"),
         "rt_seed": str(tmp_path / "runtime_command_seed.b64"),
         "out": str(tmp_path / "approval.json"),
@@ -277,10 +278,11 @@ class TestContractDiagnostic:
         assert "reproduced byte-for-byte" in capsys.readouterr().out
 
 
-class TestRevocationIsNotSilentlyCleared:
-    """The store's anchor upsert resets `revoked` to 0. Re-registering a
-    revoked device would therefore re-arm it silently, so the CLI
-    requires the operator to say so explicitly."""
+class TestRevocationSurvivesRegistration:
+    """ori-specs/device-provisioning/v1.md: revocation belongs to the
+    identity. The store refuses registration of a revoked identity, so no
+    CLI flag can clear it — returning a device to service is reinstatement,
+    an explicit operation."""
 
     def _revoke(self, bench) -> None:
         import asyncio
@@ -300,24 +302,22 @@ class TestRevocationIsNotSilentlyCleared:
         assert _register(bench) == 0
         assert _approve(bench) == 0
         self._revoke(bench)
-        # Without this guard the upsert would clear the revocation and a
-        # subsequent approve+publish would re-arm a revoked device.
+        # Registration must not re-arm a revoked identity, and there is no
+        # flag that would let it.
         assert _register(bench) == 2
         assert _publish(bench) == 2
 
-    def test_reregistration_is_possible_when_explicit(self, bench) -> None:
+    def test_revocation_survives_a_manifest_change(self, bench) -> None:
         assert _register(bench) == 0
+        assert _approve(bench) == 0
         self._revoke(bench)
-        rc = main(
-            [
-                "register",
-                "--db",
-                bench["db"],
-                "--manifest",
-                bench["manifest"],
-                "--allow-revoked",
-            ]
-        )
-        assert rc == 0
-        # Still unapproved: clearing revocation does not grant authority.
+
+        # RE-SIGNED with the device's own key, so the manifest is valid and
+        # the refusal comes from the anchor lifecycle rather than from
+        # signature verification. An unsigned edit would be rejected before
+        # revocation was ever consulted, and would prove nothing.
+        changed = signed_manifest(bench["device_seed"], firmware_version="0.2.0")
+        Path(bench["manifest"]).write_text(json.dumps(changed))
+
+        assert _register(bench) == 2
         assert _publish(bench) == 2

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -16,10 +16,12 @@ import base64
 import copy
 import hashlib
 import json
+import os
 from pathlib import Path
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from ori.security.firmware_ingest import FirmwareTelemetryGate
 from ori.security.firmware_telemetry import (
@@ -136,6 +138,57 @@ def golden_fault_message(case_name: str) -> dict:
     """The exact signed wire message the firmware publishes."""
     case = FAULT_CASES[case_name]
     return {"fault": copy.deepcopy(case["input"]), "signature": wire_signature(case)}
+
+
+def signed_manifest_for_key(seed: bytes, *, device_id: str, **overrides) -> dict:
+    """Build a manifest message genuinely signed by `seed`.
+
+    Needed so a changed-key test presents a SELF-CONSISTENT manifest —
+    exactly the attacker shape: someone signs a manifest with a key they
+    control, claiming a device_id they do not own. A manifest signed by
+    one key but presented with another is rejected at verification and
+    never reaches the anchor lifecycle.
+    """
+    pub = base64.b64encode(
+        Ed25519PrivateKey.from_private_bytes(seed)
+        .public_key()
+        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+    ).decode("ascii")
+    manifest = {
+        "v": 1,
+        "alg": "ed25519",
+        "device_id": device_id,
+        "firmware_version": "0.1.0",
+        "board_profile": "esp32s3-devkit",
+        "device_mode": "sensor_node",
+        "public_key_b64": pub,
+        "posture": "development",
+        "secure_boot_enabled": False,
+        "flash_encryption_enabled": False,
+        "key_storage": "dev_flash",
+        "transports": ["mqtt"],
+        "channels": [
+            {
+                "channel": "ch0",
+                "sensor_type": "current",
+                "unit": "ampere",
+                "protocol": "adc",
+                "source": "ads1115",
+                "quality_floor": 0.8,
+            }
+        ],
+        "actions": [],
+        "interlocks": [],
+    }
+    manifest.update(overrides)
+    canonical = canonical_json_bytes(manifest)
+    sig = Ed25519PrivateKey.from_private_bytes(seed).sign(canonical)
+    return {
+        "manifest": manifest,
+        "manifest_hash": "sha256:" + hashlib.sha256(canonical).hexdigest(),
+        "signature": "ed25519:" + base64.b64encode(sig).decode("ascii"),
+        "public_key_b64": pub,
+    }
 
 
 class TestGoldenVectors:
@@ -778,3 +831,112 @@ class TestFirmwareTelemetryGate:
         )
         assert replayed.error_code == "sequence_replay"
         assert readings == []
+
+
+class TestRegistrationLifecycle:
+    """ori-specs/device-provisioning/v1.md.
+
+    Registration decides what a receiver will trust for everything
+    afterwards, so it must never silently overwrite an anchor, clear a
+    revocation, or re-open a replay window.
+    """
+
+    async def _register(self, gate, case="manifest_minimal_dev"):
+        case_data = CASES[case]
+        return await gate.register_device(
+            device_id=case_data["input"]["device_id"],
+            public_key_b64=PUBLIC_KEY_B64,
+            posture=case_data["input"]["posture"],
+            manifest_message=manifest_message(case),
+        )
+
+    @pytest.mark.asyncio
+    async def test_exact_reregistration_is_idempotent(self, gate) -> None:
+        await self._register(gate)
+        await gate.approve_device(DEV_DEVICE)
+        # Actually advance it, so a reset would be visible.
+        await gate._store.advance_firmware_freshness(DEV_DEVICE, boot_id=3, seq=99)
+        row_before = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row_before["last_seq"] == 99
+
+        await self._register(gate)  # identical anchor, again
+
+        row_after = await gate._store.get_firmware_device(DEV_DEVICE)
+        # Approval must survive: re-publishing a manifest is not an event.
+        assert row_after["approved"] == row_before["approved"] == 1
+        assert row_after["last_boot_id"] == row_before["last_boot_id"]
+        assert row_after["last_seq"] == row_before["last_seq"]
+
+    @pytest.mark.asyncio
+    async def test_revocation_survives_registration(self, gate) -> None:
+        await self._register(gate)
+        await gate.approve_device(DEV_DEVICE)
+        await gate.revoke_device(DEV_DEVICE)
+
+        # The whole point: a device re-publishing its manifest is not a
+        # decision to trust it again.
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            await self._register(gate)
+        assert excinfo.value.code == "device_revoked"
+
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["revoked"] == 1
+        assert row["approved"] == 0
+
+    @pytest.mark.asyncio
+    async def test_changed_key_is_refused(self, gate) -> None:
+        await self._register(gate)
+        await gate.approve_device(DEV_DEVICE)
+
+        # The attacker shape: a manifest SIGNED BY A KEY THEY CONTROL,
+        # claiming a device_id they do not own. It is internally
+        # consistent, so it passes verification — which is precisely why
+        # the anchor lifecycle, not the signature check, must refuse it.
+        attacker = signed_manifest_for_key(os.urandom(32), device_id=DEV_DEVICE)
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            await gate.register_device(
+                device_id=DEV_DEVICE,
+                public_key_b64=attacker["public_key_b64"],
+                posture="development",
+                manifest_message=attacker,
+            )
+        assert excinfo.value.code == "key_change_requires_reprovisioning"
+
+        # The stored anchor is untouched.
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["public_key_b64"] == PUBLIC_KEY_B64
+        assert row["approved"] == 1
+
+    @pytest.mark.asyncio
+    async def test_manifest_change_fails_closed_for_now(self, gate) -> None:
+        # The contract requires a same-key manifest change to become a
+        # PENDING candidate beside the still-active anchor. That state
+        # model is not implemented yet, so this refuses rather than
+        # overwriting the active anchor — the behaviour the contract
+        # forbids, and what this method used to do.
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=manifest_message("manifest_full_sealed"),
+        )
+        await gate.approve_device(SEALED_DEVICE)
+        await gate._store.advance_firmware_freshness(SEALED_DEVICE, boot_id=7, seq=1234)
+        before = await gate._store.get_firmware_device(SEALED_DEVICE)
+
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            await gate.register_device(
+                device_id=SEALED_DEVICE,
+                public_key_b64=PUBLIC_KEY_B64,
+                posture="sealed_flash",
+                manifest_message=manifest_message("manifest_command_bench"),
+            )
+        assert excinfo.value.code == "manifest_epoch_unsupported"
+
+        # Nothing moved: the active anchor, its approval, and the replay
+        # window are all exactly as they were.
+        after = await gate._store.get_firmware_device(SEALED_DEVICE)
+        assert after["capability_hash"] == before["capability_hash"]
+        assert after["approved"] == 1
+        assert after["last_boot_id"] == 7
+        assert after["last_seq"] == 1234


### PR DESCRIPTION
## What does this PR do?

Step 2 of the plan in #239. The firmware anchor upsert violated **four** rules of the lifecycle now normative in [ori-specs/device-provisioning/v1.md](https://github.com/ori-platform/ori-specs/blob/main/device-provisioning/v1.md), in a single SQL statement:

| Clause | Violation |
|---|---|
| `revoked = 0, revoked_at_ms = NULL` | cleared revocation |
| `public_key_b64 = excluded....` | silently accepted a changed key |
| `last_boot_id = 0, last_seq = 0` | reset freshness |
| `approved = 0` | un-approved an identical anchor |

**The first is the serious one.** Revocation belongs to the identity, so a device re-publishing its manifest is not a decision to trust it again — yet any device able to publish could undo its own revocation. The runtime effectively offered no revocation at all.

**The second is next.** A changed key under an existing `device_id` is indistinguishable on the wire from an attacker presenting a key they control for an identity they do not own. The manifest is self-signed, so verifying it against the key inside it proves consistency, never provenance.

Registration is now a **decision, not an overwrite**, made inside the write transaction so a concurrent revocation cannot be raced. It returns an outcome the gate maps to `device_revoked` or the new `key_change_requires_reprovisioning`.

## This is deliberately narrow — it does NOT implement the lifecycle

No anchor epochs, no pending/active/superseded states, no append-only history, no promotion/re-provisioning/reinstatement operations, no transition audit, no Verity epoch gating. All are required by the contract and all follow in later steps.

Because of that, **a same-key manifest change now fails closed** with `manifest_epoch_unsupported` rather than overwriting the active anchor. The contract requires it to become a *pending candidate beside the still-active anchor*; without that state model, the old behaviour let a device replace its own accepted capability surface simply by publishing. Refusing is the honest interim — an operator can still revoke and re-provision deliberately, and nothing is silently accepted.

`--allow-revoked` is removed from the CLI. It only ever guarded against the store's behaviour; the store now refuses outright, so no flag could override it, and a flag that silently does nothing is worse than none.

## Three tests were passing for the wrong reasons

Worth calling out, because green tests concealing incomplete behaviour is the failure mode this PR had:

- **Changed-key test** presented a manifest signed by *one* key while claiming *another*, so it died at signature verification and never reached the anchor refusal — and it accepted **either** error code, which hid that. It now builds a manifest genuinely signed by the attacker's key (the real attack shape: internally consistent, wrong provenance) and asserts the exact lifecycle code.
- **Revocation test** edited a signed manifest without re-signing it, so signature verification rejected it before revocation was consulted. It now re-signs with the device key.
- **Idempotence test** said it advanced freshness and never did.

I verified the first directly: before the fix it raised `public_key_mismatch`, not the store's refusal.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (revocation durability, anchor identity)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures — **1925 passed, 6 skipped**
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header *(no new files)*
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated — see below
- [x] PR description explains **why**, not just what

No matrix update: the guard covers `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py`, `ori/config.py`. This touches the store, the ingest gate, and the provisioning CLI. No new capability surface or tier.

### If you used AI assistance

- [x] I can explain every line in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in review

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #239
- [x] Every new Tier D code path has test coverage — none added
- [x] No new dependencies added

## Behaviour changes worth flagging

1. Registering a **revoked** identity now raises `device_revoked` instead of silently re-arming it.
2. Registering with a **changed key** now raises `key_change_requires_reprovisioning` instead of overwriting the anchor.
3. A **same-key manifest change** now raises `manifest_epoch_unsupported` instead of overwriting the active anchor. This is the interim fail-closed posture; step 4 replaces it with pending candidates.

## Related

Refs #239 — **not closed.** Steps 3–6 (reprovision/reinstate operations, epochs and history, Verity API, shared lifecycle vectors) remain.