### PR TITLE
feat(security): anchor epochs, states, and append-only history

### DIFF
--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -28,7 +28,12 @@ The transaction, in the order the subcommands run:
     key for the operator to confirm out of band.
 
 ``approve``
-    Record explicit operator approval, but only after the operator
+    Promote the pending anchor to active. Requires ``--reason``:
+    promotion is a trust transition and every one is audited. The actor
+    is the authenticated OS principal, derived from the real UID rather
+    than supplied on the command line, because a typed name is an
+    assertion rather than attribution. Records explicit operator approval, but only after the
+    operator
     supplies the device public key they observed independently — read
     from the device's serial console, which prints
     ``ori: device public key (b64) <KEY>`` at boot, not from the
@@ -135,6 +140,42 @@ def read_seed(path: Path, label: str) -> bytes:
     return seed
 
 
+def authenticated_actor(label: str = "") -> str:
+    """The OS principal running this command, for the audit log.
+
+    The contract requires the *authenticated* operator. A caller-supplied
+    name is an assertion, not attribution: anyone can type any name. So
+    the recorded actor is derived from the real UID via the passwd
+    database — deliberately not ``getpass.getuser()``, which trusts the
+    LOGNAME/USER environment variables and is therefore caller-controlled.
+
+    An optional display label is appended for human context but never
+    replaces the principal. Raises :class:`ProvisionerError` where no real
+    UID is available, rather than recording a placeholder that would look
+    like attribution.
+    """
+    getuid = getattr(os, "getuid", None)
+    if getuid is None:
+        # No real UID to authenticate against. Recording a placeholder
+        # would put an unattributable row in the audit log while looking
+        # like attribution, so fail closed instead.
+        raise ProvisionerError(
+            "cannot determine an authenticated OS principal on this platform; "
+            "trust transitions must be attributable, so this operation is "
+            "refused rather than audited to a placeholder"
+        )
+    uid = getuid()
+    try:
+        import pwd
+
+        principal = f"uid={uid}:{pwd.getpwuid(uid).pw_name}"
+    except (ImportError, KeyError):
+        # The UID itself is still authenticated even without a name.
+        principal = f"uid={uid}"
+    clean = str(label).strip()
+    return f"{principal} ({clean})" if clean else principal
+
+
 def cmd_keygen(args: argparse.Namespace) -> int:
     out = Path(args.out_dir)
     out.mkdir(parents=True, exist_ok=True)
@@ -238,7 +279,9 @@ def cmd_register(args: argparse.Namespace) -> int:
     return 0
 
 
-async def _approve(db_path: str, device_id: str, confirmed_key: str) -> None:
+async def _approve(
+    db_path: str, device_id: str, confirmed_key: str, actor: str, reason: str
+) -> None:
     from ori.security.firmware_ingest import FirmwareTelemetryGate
 
     store = await _open_store(db_path)
@@ -262,14 +305,25 @@ async def _approve(db_path: str, device_id: str, confirmed_key: str) -> None:
                 "Approving would bind authority to a device you did not verify."
             )
         gate = FirmwareTelemetryGate(store)
-        if not await gate.approve_device(device_id):
-            raise ProvisionerError(f"registry refused to approve {device_id!r}")
+        if not await gate.approve_device(device_id, actor=actor, reason=reason):
+            raise ProvisionerError(
+                f"registry refused to promote {device_id!r}: there is no pending "
+                "anchor to promote, or the identity is revoked"
+            )
     finally:
         await store.close()
 
 
 def cmd_approve(args: argparse.Namespace) -> int:
-    asyncio.run(_approve(args.db, args.device_id, args.confirm_device_key))
+    asyncio.run(
+        _approve(
+            args.db,
+            args.device_id,
+            args.confirm_device_key,
+            authenticated_actor(args.actor_label),
+            args.reason,
+        )
+    )
     print(f"{args.device_id} approved in the runtime registry")
     print("Run `publish` to sign and publish the retained approval.")
     return 0
@@ -410,6 +464,17 @@ def main(argv: list[str] | None = None) -> int:
         required=True,
         metavar="B64",
         help="device public key as observed on the device itself, not from the manifest",
+    )
+    p.add_argument(
+        "--actor-label",
+        default="",
+        help="optional display name; the audit log always records the "
+        "authenticated OS principal regardless",
+    )
+    p.add_argument(
+        "--reason",
+        required=True,
+        help="why this device is being approved; recorded in the audit log",
     )
     p.set_defaults(func=cmd_approve)
 

--- a/ori/security/firmware_ingest.py
+++ b/ori/security/firmware_ingest.py
@@ -32,7 +32,6 @@ from ori.network.events import SensorReading
 from ori.security.firmware_telemetry import (
     ERR_DEVICE_REVOKED,
     ERR_KEY_CHANGE_REQUIRES_REPROVISIONING,
-    ERR_MANIFEST_EPOCH_UNSUPPORTED,
     ERR_SEQUENCE_REPLAY,
     GRADE_REJECTED,
     FirmwareFaultVerification,
@@ -115,15 +114,6 @@ class FirmwareTelemetryGate:
                 f"device {device_id!r} is revoked; reinstatement is an explicit "
                 "operation, never a side effect of registration",
             )
-        if outcome == "refused_manifest_epoch_unsupported":
-            raise FirmwareVerificationError(
-                ERR_MANIFEST_EPOCH_UNSUPPORTED,
-                f"device {device_id!r} published a new capability hash under its "
-                "existing key. The lifecycle requires this to become a pending "
-                "candidate beside the active anchor; that state model is not "
-                "implemented yet, so it is refused rather than overwriting the "
-                "active anchor.",
-            )
         if outcome == "refused_key_change":
             raise FirmwareVerificationError(
                 ERR_KEY_CHANGE_REQUIRES_REPROVISIONING,
@@ -132,7 +122,14 @@ class FirmwareTelemetryGate:
                 "independent identity confirmation",
             )
 
-        if outcome == "unchanged":
+        if outcome == "pending_manifest_epoch":
+            logger.info(
+                "firmware device %s published a new manifest epoch; stored as a "
+                "PENDING candidate awaiting promotion (the active anchor is "
+                "unchanged)",
+                device_id,
+            )
+        elif outcome == "unchanged":
             logger.debug(
                 "firmware device %s re-published an identical anchor (no-op)",
                 device_id,
@@ -145,12 +142,26 @@ class FirmwareTelemetryGate:
             )
         return manifest_hash
 
-    async def approve_device(self, device_id: str) -> bool:
-        """Operator approval for the currently stored verified anchor."""
-        return bool(await self._store.approve_firmware_device(device_id))
+    async def approve_device(self, device_id: str, *, actor: str, reason: str) -> bool:
+        """Promote the pending anchor to active.
 
-    async def revoke_device(self, device_id: str) -> bool:
-        return bool(await self._store.revoke_firmware_device(device_id))
+        `actor` and `reason` are mandatory: promotion is a trust
+        transition, and ori-specs/device-provisioning/v1.md requires every
+        one to be attributed.
+        """
+        return bool(
+            await self._store.approve_firmware_device(
+                device_id, actor=actor, reason=reason
+            )
+        )
+
+    async def revoke_device(self, device_id: str, *, actor: str, reason: str) -> bool:
+        """Take an identity out of service. Attribution is mandatory."""
+        return bool(
+            await self._store.revoke_firmware_device(
+                device_id, actor=actor, reason=reason
+            )
+        )
 
     async def ingest(
         self,

--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -94,10 +94,58 @@ ERR_DEVICE_NOT_APPROVED = "device_not_approved"
 # ori-specs/device-provisioning/v1.md: a changed key may never arrive
 # through ordinary registration.
 ERR_KEY_CHANGE_REQUIRES_REPROVISIONING = "key_change_requires_reprovisioning"
-# Interim: the pending-anchor state model is not implemented yet, so a
-# same-key manifest change fails closed instead of overwriting the active
-# anchor. Removed when anchor epochs and pending state land.
-ERR_MANIFEST_EPOCH_UNSUPPORTED = "manifest_epoch_unsupported"
+
+
+def key_epoch_id(*, device_id: str, public_key_b64: str) -> str:
+    """The epoch identifier for a device identity and its key.
+
+    ori-specs/device-provisioning/v1.md. Deterministically derived so two
+    independent stores compute the same value without coordinating —
+    that is what makes "both accepted the same epoch" checkable rather
+    than asserted. Changes ONLY when the device key changes, which is why
+    it is the epoch telemetry replay state is scoped to.
+    """
+    return (
+        "sha256:"
+        + hashlib.sha256(
+            canonical_json_bytes(
+                {"device_id": device_id, "public_key_b64": public_key_b64, "v": 1}
+            )
+        ).hexdigest()
+    )
+
+
+def anchor_epoch_id(
+    *,
+    device_id: str,
+    public_key_b64: str,
+    posture: str,
+    capability_hash: str,
+) -> str:
+    """The epoch identifier for a whole anchor.
+
+    Changes when the key, posture, or capability hash changes. Posture is
+    included because a device that becomes ``sealed_flash`` is materially
+    a different trust proposition from the same device in
+    ``development``, even with an unchanged key and manifest.
+
+    This is the value cross-store agreement is expressed in.
+    """
+    return (
+        "sha256:"
+        + hashlib.sha256(
+            canonical_json_bytes(
+                {
+                    "capability_hash": capability_hash,
+                    "device_id": device_id,
+                    "posture": posture,
+                    "public_key_b64": public_key_b64,
+                    "v": 1,
+                }
+            )
+        ).hexdigest()
+    )
+
 
 FIRMWARE_FAULT_CODES = frozenset(
     {

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -357,6 +357,80 @@ CREATE TABLE IF NOT EXISTS firmware_device_registry (
     revoked_at_ms     INTEGER
 );
 
+-- Append-only anchor history for the device provisioning lifecycle
+-- (ori-specs/device-provisioning/v1.md).
+--
+-- firmware_device_registry holds the ACTIVE anchor and identity-level
+-- state (revocation, freshness). This table holds every anchor an
+-- identity has ever had, including pending candidates that were never
+-- promoted. Rows are never updated in place except to move `state`,
+-- because evidence outlives the anchor that authorised it: an
+-- overwritten anchor makes old evidence unattributable.
+CREATE TABLE IF NOT EXISTS firmware_device_anchors (
+    anchor_epoch_id     TEXT    PRIMARY KEY,
+    device_id           TEXT    NOT NULL,
+    key_epoch_id        TEXT    NOT NULL,
+    public_key_b64      TEXT    NOT NULL,
+    alg                 TEXT    NOT NULL DEFAULT 'ed25519',
+    posture             TEXT    NOT NULL,
+    capability_hash     TEXT    NOT NULL,
+    manifest_json       TEXT    NOT NULL DEFAULT '{}',
+    channel_map_json    TEXT    NOT NULL DEFAULT '{}',
+    board_profile       TEXT    NOT NULL DEFAULT '',
+    -- The normative anchor states. `revoked` is the anchor retained when
+    -- the identity was revoked, so reinstatement has something to return
+    -- to. Constrained by the database: an unrecognised state would make
+    -- every acceptance decision below unsound.
+    state               TEXT    NOT NULL
+        CHECK (state IN ('pending', 'active', 'superseded', 'discarded',
+                         'revoked')),
+    created_at_ms       INTEGER NOT NULL,
+    state_changed_at_ms INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_firmware_anchors_device
+    ON firmware_device_anchors (device_id, state);
+
+-- At most one active and one pending anchor per identity. Enforced by
+-- the database rather than by convention, because "two active anchors"
+-- is a state no amount of careful calling code should be trusted to
+-- prevent.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_firmware_anchors_one_active
+    ON firmware_device_anchors (device_id) WHERE state = 'active';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_firmware_anchors_one_pending
+    ON firmware_device_anchors (device_id) WHERE state = 'pending';
+
+-- Append-only audit of every trust transition. An unattributed anchor
+-- change is indistinguishable from a compromise after the fact.
+CREATE TABLE IF NOT EXISTS firmware_anchor_transitions (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    device_id      TEXT    NOT NULL,
+    -- registered | promoted | superseded | discarded | revoked
+    -- | reinstated | reprovisioned
+    transition     TEXT    NOT NULL,
+    from_epoch_id  TEXT,
+    to_epoch_id    TEXT,
+    key_epoch_id   TEXT    NOT NULL DEFAULT '',
+    actor          TEXT    NOT NULL DEFAULT '',
+    reason         TEXT    NOT NULL DEFAULT '',
+    occurred_at_ms INTEGER NOT NULL,
+    -- Promotion, revocation, reinstatement and re-provisioning are
+    -- operator decisions that change what a receiver will accept, so they
+    -- MUST be attributed. Only device-initiated registration and the
+    -- replacement of a pending candidate may be unattributed — they grant
+    -- nothing. Enforced here so an unattributed trust transition cannot be
+    -- written by any code path, however careful.
+    -- trim(): `actor <> ''` would accept "   ", which is attribution in
+    -- form only.
+    CHECK (
+        transition IN ('registered', 'discarded')
+        OR (length(trim(actor)) > 0 AND length(trim(reason)) > 0)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS idx_firmware_anchor_transitions_device
+    ON firmware_anchor_transitions (device_id, occurred_at_ms DESC);
+
 CREATE TABLE IF NOT EXISTS firmware_fault_events (
     id                INTEGER PRIMARY KEY AUTOINCREMENT,
     device_id         TEXT    NOT NULL,
@@ -374,6 +448,24 @@ CREATE TABLE IF NOT EXISTS firmware_fault_events (
     UNIQUE(device_id, boot_id, seq)
 );
 """
+
+
+def _require_attribution(operation: str, actor: str, reason: str) -> None:
+    """Mandatory audit fields for a trust transition.
+
+    ori-specs/device-provisioning/v1.md requires actor and reason on every
+    operator decision that changes acceptance. An unattributed anchor
+    change is indistinguishable from a compromise after the fact, so this
+    refuses before any state moves rather than writing a blank row.
+    """
+    if not str(actor).strip():
+        raise ValueError(
+            f"{operation} requires an actor: trust transitions are audited"
+        )
+    if not str(reason).strip():
+        raise ValueError(
+            f"{operation} requires a reason: trust transitions are audited"
+        )
 
 
 class StateStore:
@@ -489,10 +581,14 @@ class StateStore:
         for col, typedef in (
             ("manifest_json", "TEXT    NOT NULL DEFAULT '{}'"),
             ("channel_map_json", "TEXT    NOT NULL DEFAULT '{}'"),
+            # Device provisioning lifecycle: the active anchor's epochs.
+            ("anchor_epoch_id", "TEXT    NOT NULL DEFAULT ''"),
+            ("key_epoch_id", "TEXT    NOT NULL DEFAULT ''"),
         ):
             self._add_column_if_missing_on_conn(
                 conn, "firmware_device_registry", col, typedef
             )
+        self._backfill_firmware_anchor_epochs_on_conn(conn)
         conn.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_remote_command_log_sender_rejections
@@ -505,6 +601,100 @@ class StateStore:
         """Backward-compatible helper used by tests and migrations."""
         assert self._conn is not None
         self._add_column_if_missing_on_conn(self._conn, table, column, typedef)
+
+    def _backfill_firmware_anchor_epochs_on_conn(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        """Give pre-lifecycle rows their epoch identifiers and an anchor
+        history entry.
+
+        Databases created before the provisioning lifecycle hold an
+        active anchor in firmware_device_registry with no epoch ids and
+        no row in firmware_device_anchors. Derive the ids from what is
+        already stored and record the anchor, so existing devices are not
+        invisible to the lifecycle.
+
+        An approved, unrevoked row becomes `active`. A revoked row becomes
+        `revoked` — never `pending`, which would hand a revoked identity a
+        promotable anchor. Anything else becomes `pending`, because it was
+        never trusted for acceptance.
+        """
+        from ori.security.firmware_telemetry import (
+            anchor_epoch_id as _anchor_epoch_id,
+        )
+        from ori.security.firmware_telemetry import (
+            key_epoch_id as _key_epoch_id,
+        )
+
+        rows = conn.execute(
+            """
+            SELECT device_id, public_key_b64, posture, capability_hash,
+                   manifest_json, channel_map_json, board_profile,
+                   approved, revoked, provisioned_at_ms
+              FROM firmware_device_registry
+             WHERE anchor_epoch_id = '' OR key_epoch_id = ''
+            """
+        ).fetchall()
+        for row in rows:
+            kid = _key_epoch_id(
+                device_id=row["device_id"], public_key_b64=row["public_key_b64"]
+            )
+            aid = _anchor_epoch_id(
+                device_id=row["device_id"],
+                public_key_b64=row["public_key_b64"],
+                posture=row["posture"],
+                capability_hash=row["capability_hash"],
+            )
+            conn.execute(
+                """
+                UPDATE firmware_device_registry
+                   SET anchor_epoch_id = ?, key_epoch_id = ?
+                 WHERE device_id = ?
+                """,
+                (aid, kid, row["device_id"]),
+            )
+            if row["revoked"]:
+                # A revoked identity must NOT acquire a promotable pending
+                # anchor. The anchor is retained in `revoked` so a later
+                # reinstatement has something to return to.
+                state = "revoked"
+            elif row["approved"]:
+                state = "active"
+            else:
+                state = "pending"
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO firmware_device_anchors
+                    (anchor_epoch_id, device_id, key_epoch_id, public_key_b64,
+                     posture, capability_hash, manifest_json, channel_map_json,
+                     board_profile, state, created_at_ms, state_changed_at_ms)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    aid,
+                    row["device_id"],
+                    kid,
+                    row["public_key_b64"],
+                    row["posture"],
+                    row["capability_hash"],
+                    row["manifest_json"],
+                    row["channel_map_json"],
+                    row["board_profile"],
+                    state,
+                    row["provisioned_at_ms"],
+                    row["provisioned_at_ms"],
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO firmware_anchor_transitions
+                    (device_id, transition, from_epoch_id, to_epoch_id,
+                     key_epoch_id, actor, reason, occurred_at_ms)
+                VALUES (?, 'registered', NULL, ?, ?, 'migration',
+                        'backfilled from a pre-lifecycle registry row', ?)
+                """,
+                (row["device_id"], aid, kid, row["provisioned_at_ms"]),
+            )
 
     def _add_column_if_missing_on_conn(
         self,
@@ -2386,11 +2576,10 @@ class StateStore:
         ``unchanged``
             The anchor already matches exactly. Idempotent no-op — nothing
             is touched, including approval and freshness.
-        ``refused_manifest_epoch_unsupported``
-            Same key, new capability hash. The contract requires this to
-            be stored as a PENDING candidate beside the still-active
-            anchor; that state model does not exist yet, so this fails
-            closed rather than overwriting the active anchor.
+        ``pending_manifest_epoch``
+            Same key, new capability hash. Stored as a PENDING candidate
+            beside the still-active anchor, which is untouched. Nothing is
+            accepted against it until it is promoted.
         ``refused_revoked``
             The identity is revoked. Revocation belongs to the identity
             and is never cleared by registration.
@@ -2426,16 +2615,70 @@ class StateStore:
         provisioned_at_ms: int,
     ) -> str:
         assert self._conn is not None
+        from ori.security.firmware_telemetry import (
+            anchor_epoch_id as _anchor_epoch_id,
+        )
+        from ori.security.firmware_telemetry import (
+            key_epoch_id as _key_epoch_id,
+        )
+
+        kid = _key_epoch_id(device_id=device_id, public_key_b64=public_key_b64)
+        aid = _anchor_epoch_id(
+            device_id=device_id,
+            public_key_b64=public_key_b64,
+            posture=posture,
+            capability_hash=capability_hash,
+        )
+
         # Decide inside the transaction: a read-then-write in the caller
         # could be raced by a concurrent revocation.
         row = self._conn.execute(
             """
-            SELECT public_key_b64, posture, capability_hash, revoked
+            SELECT public_key_b64, posture, capability_hash, revoked,
+                   anchor_epoch_id, key_epoch_id
               FROM firmware_device_registry
              WHERE device_id = ?
             """,
             (device_id,),
         ).fetchone()
+
+        def _record_anchor(state: str) -> None:
+            self._conn.execute(  # type: ignore[union-attr]
+                """
+                INSERT OR REPLACE INTO firmware_device_anchors
+                    (anchor_epoch_id, device_id, key_epoch_id, public_key_b64,
+                     posture, capability_hash, manifest_json, channel_map_json,
+                     board_profile, state, created_at_ms, state_changed_at_ms)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    aid,
+                    device_id,
+                    kid,
+                    public_key_b64,
+                    posture,
+                    capability_hash,
+                    manifest_json,
+                    channel_map_json,
+                    board_profile,
+                    state,
+                    provisioned_at_ms,
+                    provisioned_at_ms,
+                ),
+            )
+
+        def _record_transition(
+            transition: str, from_epoch: str | None, to_epoch: str | None
+        ) -> None:
+            self._conn.execute(  # type: ignore[union-attr]
+                """
+                INSERT INTO firmware_anchor_transitions
+                    (device_id, transition, from_epoch_id, to_epoch_id,
+                     key_epoch_id, actor, reason, occurred_at_ms)
+                VALUES (?, ?, ?, ?, ?, '', '', ?)
+                """,
+                (device_id, transition, from_epoch, to_epoch, kid, provisioned_at_ms),
+            )
 
         if row is None:
             self._conn.execute(
@@ -2444,8 +2687,10 @@ class StateStore:
                     (device_id, public_key_b64, posture, capability_hash,
                      manifest_json, channel_map_json, board_profile,
                      approved, provisioned_at_ms, last_boot_id, last_seq,
-                     revoked, revoked_at_ms)
-                VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 0, 0, NULL)
+                     revoked, revoked_at_ms, anchor_epoch_id, key_epoch_id)
+                -- anchor_epoch_id stays empty until promotion: it names the
+                -- ACTIVE anchor, and nothing is active yet.
+                VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 0, 0, NULL, '', ?)
                 """,
                 (
                     device_id,
@@ -2456,8 +2701,11 @@ class StateStore:
                     channel_map_json,
                     board_profile,
                     provisioned_at_ms,
+                    kid,
                 ),
             )
+            _record_anchor("pending")
+            _record_transition("registered", None, aid)
             self._conn.commit()
             return "registered"
 
@@ -2473,26 +2721,142 @@ class StateStore:
         if row["public_key_b64"] != public_key_b64:
             return "refused_key_change"
 
-        if row["posture"] == posture and row["capability_hash"] == capability_hash:
-            # Exact match: idempotent. Touch nothing — not approval, not
-            # freshness, not provisioned_at_ms. Re-publishing a manifest
-            # is not an event.
+        # Authoritative: the anchors table, not the registry pointer. For
+        # an identity with no active anchor the registry tracks the pending
+        # candidate, so consulting it alone would call a superseded or
+        # discarded anchor "unchanged".
+        existing_anchor = self._conn.execute(
+            "SELECT state FROM firmware_device_anchors WHERE anchor_epoch_id = ?",
+            (aid,),
+        ).fetchone()
+        if existing_anchor is not None and existing_anchor["state"] in (
+            "active",
+            "pending",
+        ):
+            # Exact match against the live anchor: idempotent. Touch
+            # nothing — not approval, not freshness, not
+            # provisioned_at_ms. Re-publishing a manifest is not an event.
             return "unchanged"
 
-        # Same key, new manifest (or posture).
-        #
-        # The contract (ori-specs/device-provisioning/v1.md) requires this
-        # to become a PENDING candidate while the active anchor keeps
-        # operating — which needs the anchor state model and append-only
-        # history that this store does not have yet.
-        #
-        # Until it does, this FAILS CLOSED. Overwriting the active anchor
-        # and clearing approval, as this method used to, is the behaviour
-        # the contract forbids: it lets a device replace its own accepted
-        # capability surface by publishing. Refusing is the honest
-        # interim: an operator can still revoke and re-provision
-        # deliberately, and nothing is silently accepted.
-        return "refused_manifest_epoch_unsupported"
+        # Same key, new manifest or posture: a PENDING candidate beside
+        # the still-active anchor. The active anchor is deliberately
+        # untouched — overwriting it would let a device replace its own
+        # accepted capability surface by publishing, and would reset a
+        # replay window that never left its key epoch.
+        existing_pending = self._conn.execute(
+            """
+            SELECT anchor_epoch_id FROM firmware_device_anchors
+             WHERE device_id = ? AND state = 'pending'
+            """,
+            (device_id,),
+        ).fetchone()
+        if existing_pending is not None:
+            if existing_pending["anchor_epoch_id"] == aid:
+                return "unchanged"
+            # A pending anchor grants nothing, so replacing one loses no
+            # authority; refusing would strand a device whose earlier
+            # manifest nobody promoted.
+            self._conn.execute(
+                """
+                UPDATE firmware_device_anchors
+                   SET state = 'discarded', state_changed_at_ms = ?
+                 WHERE anchor_epoch_id = ?
+                """,
+                (provisioned_at_ms, existing_pending["anchor_epoch_id"]),
+            )
+            _record_transition("discarded", existing_pending["anchor_epoch_id"], aid)
+
+        _record_anchor("pending")
+        _record_transition("registered", row["anchor_epoch_id"] or None, aid)
+
+        has_active = self._conn.execute(
+            "SELECT 1 FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'active'",
+            (device_id,),
+        ).fetchone()
+        if has_active is None:
+            # Nothing is active, so the registry row is the identity's
+            # description of its only candidate. Point it at the new one —
+            # otherwise it would still describe the anchor just discarded,
+            # and promotion would activate the wrong manifest.
+            self._conn.execute(
+                """
+                UPDATE firmware_device_registry
+                   SET posture = ?, capability_hash = ?, manifest_json = ?,
+                       channel_map_json = ?, board_profile = ?,
+                       provisioned_at_ms = ?
+                 WHERE device_id = ?
+                """,
+                (
+                    posture,
+                    capability_hash,
+                    manifest_json,
+                    channel_map_json,
+                    board_profile,
+                    provisioned_at_ms,
+                    device_id,
+                ),
+            )
+        self._conn.commit()
+        return "pending_manifest_epoch"
+
+    async def get_pending_firmware_anchor(self, device_id: str) -> dict | None:
+        """The pending candidate for a device, if one is awaiting
+        promotion. A pending anchor grants nothing."""
+        return await self._run_read(self._get_pending_firmware_anchor_sync, device_id)
+
+    def _get_pending_firmware_anchor_sync(
+        self, conn: sqlite3.Connection, device_id: str
+    ) -> dict | None:
+        row = conn.execute(
+            """
+            SELECT * FROM firmware_device_anchors
+             WHERE device_id = ? AND state = 'pending'
+            """,
+            (device_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
+
+    async def list_firmware_anchor_history(self, device_id: str) -> list[dict]:
+        """Every anchor this identity has held, newest first.
+
+        Append-only: evidence outlives the anchor that authorised it, so
+        superseded and discarded anchors are retained rather than
+        overwritten.
+        """
+        return await self._run_read(self._list_firmware_anchor_history_sync, device_id)
+
+    def _list_firmware_anchor_history_sync(
+        self, conn: sqlite3.Connection, device_id: str
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT * FROM firmware_device_anchors
+             WHERE device_id = ?
+             ORDER BY state_changed_at_ms DESC, rowid DESC
+            """,
+            (device_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    async def list_firmware_anchor_transitions(self, device_id: str) -> list[dict]:
+        """The audited trust transitions for an identity, oldest first."""
+        return await self._run_read(
+            self._list_firmware_anchor_transitions_sync, device_id
+        )
+
+    def _list_firmware_anchor_transitions_sync(
+        self, conn: sqlite3.Connection, device_id: str
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT * FROM firmware_anchor_transitions
+             WHERE device_id = ?
+             ORDER BY occurred_at_ms ASC, id ASC
+            """,
+            (device_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
 
     async def get_firmware_device(self, device_id: str) -> dict | None:
         return await self._run_read(self._get_firmware_device_sync, device_id)
@@ -2504,7 +2868,8 @@ class StateStore:
             """
             SELECT device_id, public_key_b64, alg, posture, capability_hash,
                    manifest_json, channel_map_json, board_profile, approved,
-                   provisioned_at_ms, last_boot_id, last_seq, revoked, revoked_at_ms
+                   provisioned_at_ms, last_boot_id, last_seq, revoked,
+                   revoked_at_ms, anchor_epoch_id, key_epoch_id
             FROM firmware_device_registry WHERE device_id = ?
             """,
             (device_id,),
@@ -2526,36 +2891,163 @@ class StateStore:
             "last_seq": int(row[11]),
             "revoked": bool(row[12]),
             "revoked_at_ms": int(row[13]) if row[13] is not None else None,
+            "anchor_epoch_id": row[14],
+            "key_epoch_id": row[15],
         }
 
-    async def approve_firmware_device(self, device_id: str) -> bool:
-        """Operator approval for the currently verified provisioning anchor."""
-        return await self._run_write(self._approve_firmware_device_sync, device_id)
+    async def approve_firmware_device(
+        self,
+        device_id: str,
+        *,
+        actor: str,
+        reason: str,
+        occurred_at_ms: int | None = None,
+    ) -> bool:
+        """Promote the pending anchor to active (ori-specs
+        device-provisioning/v1.md). Promotion is the only path to active.
 
-    def _approve_firmware_device_sync(self, device_id: str) -> bool:
+        `actor` and `reason` are REQUIRED and recorded in the transition
+        log. Promotion is a trust transition; an unattributed one is
+        indistinguishable from a compromise after the fact.
+        """
+        return await self._run_write(
+            self._approve_firmware_device_sync,
+            device_id,
+            actor,
+            reason,
+            occurred_at_ms if occurred_at_ms is not None else now_ms(),
+        )
+
+    def _approve_firmware_device_sync(
+        self, device_id: str, actor: str, reason: str, occurred_at_ms: int
+    ) -> bool:
+        """Promotion: the ONLY path an anchor becomes active.
+
+        Moves the pending candidate to `active`, the previously active
+        anchor to `superseded`, and points the registry at the promoted
+        anchor — all in one transaction, so the registry and the anchor
+        history cannot disagree about which anchor is trusted.
+        """
         assert self._conn is not None
-        cur = self._conn.execute(
+        _require_attribution("promotion", actor, reason)
+        registry = self._conn.execute(
+            "SELECT revoked, anchor_epoch_id FROM firmware_device_registry "
+            "WHERE device_id = ?",
+            (device_id,),
+        ).fetchone()
+        if registry is None or registry["revoked"]:
+            return False
+
+        pending = self._conn.execute(
+            "SELECT * FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'pending'",
+            (device_id,),
+        ).fetchone()
+        if pending is None:
+            # Nothing to promote. An already-active anchor is not
+            # re-promoted, and inventing one here would be the implicit
+            # transition this model exists to remove.
+            return False
+
+        previous = self._conn.execute(
+            "SELECT anchor_epoch_id FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'active'",
+            (device_id,),
+        ).fetchone()
+        if previous is not None:
+            self._conn.execute(
+                "UPDATE firmware_device_anchors SET state = 'superseded', "
+                "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+                (occurred_at_ms, previous["anchor_epoch_id"]),
+            )
+
+        self._conn.execute(
+            "UPDATE firmware_device_anchors SET state = 'active', "
+            "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+            (occurred_at_ms, pending["anchor_epoch_id"]),
+        )
+
+        # The registry now reflects the promoted anchor. Freshness is left
+        # alone: promotion within one key epoch must not re-open a replay
+        # window, and a key change cannot reach here (ordinary
+        # registration refuses it).
+        self._conn.execute(
             """
             UPDATE firmware_device_registry
-            SET approved = 1
-            WHERE device_id = ? AND revoked = 0
+               SET approved = 1,
+                   public_key_b64 = ?,
+                   posture = ?,
+                   capability_hash = ?,
+                   manifest_json = ?,
+                   channel_map_json = ?,
+                   board_profile = ?,
+                   anchor_epoch_id = ?,
+                   key_epoch_id = ?
+             WHERE device_id = ? AND revoked = 0
             """,
-            (device_id,),
+            (
+                pending["public_key_b64"],
+                pending["posture"],
+                pending["capability_hash"],
+                pending["manifest_json"],
+                pending["channel_map_json"],
+                pending["board_profile"],
+                pending["anchor_epoch_id"],
+                pending["key_epoch_id"],
+                device_id,
+            ),
+        )
+        self._conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'promoted', ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                device_id,
+                previous["anchor_epoch_id"] if previous is not None else None,
+                pending["anchor_epoch_id"],
+                pending["key_epoch_id"],
+                actor,
+                reason,
+                occurred_at_ms,
+            ),
         )
         self._conn.commit()
-        return cur.rowcount > 0
+        return True
 
     async def revoke_firmware_device(
-        self, device_id: str, *, revoked_at_ms: int | None = None
+        self,
+        device_id: str,
+        *,
+        revoked_at_ms: int | None = None,
+        actor: str,
+        reason: str,
     ) -> bool:
+        """Take an identity out of service: the active anchor is retained
+        as `revoked`, any pending candidate is discarded, and the
+        transition is recorded."""
         return await self._run_write(
             self._revoke_firmware_device_sync,
             device_id,
             revoked_at_ms if revoked_at_ms is not None else now_ms(),
+            actor,
+            reason,
         )
 
-    def _revoke_firmware_device_sync(self, device_id: str, revoked_at_ms: int) -> bool:
+    def _revoke_firmware_device_sync(
+        self, device_id: str, revoked_at_ms: int, actor: str, reason: str
+    ) -> bool:
+        """Takes an identity out of service, in one transaction.
+
+        The active anchor is retained as `revoked` so reinstatement has
+        something to return to, and any pending candidate is discarded —
+        an unpromoted candidate must not survive a revocation and become
+        promotable later.
+        """
         assert self._conn is not None
+        _require_attribution("revocation", actor, reason)
         cur = self._conn.execute(
             """
             UPDATE firmware_device_registry
@@ -2564,8 +3056,49 @@ class StateStore:
             """,
             (revoked_at_ms, device_id),
         )
+        if cur.rowcount == 0:
+            return False
+
+        active = self._conn.execute(
+            "SELECT anchor_epoch_id, key_epoch_id FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'active'",
+            (device_id,),
+        ).fetchone()
+        if active is not None:
+            self._conn.execute(
+                "UPDATE firmware_device_anchors SET state = 'revoked', "
+                "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+                (revoked_at_ms, active["anchor_epoch_id"]),
+            )
+        pending = self._conn.execute(
+            "SELECT anchor_epoch_id FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'pending'",
+            (device_id,),
+        ).fetchone()
+        if pending is not None:
+            self._conn.execute(
+                "UPDATE firmware_device_anchors SET state = 'discarded', "
+                "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+                (revoked_at_ms, pending["anchor_epoch_id"]),
+            )
+        self._conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'revoked', ?, NULL, ?, ?, ?, ?)
+            """,
+            (
+                device_id,
+                active["anchor_epoch_id"] if active is not None else None,
+                active["key_epoch_id"] if active is not None else "",
+                actor,
+                reason,
+                revoked_at_ms,
+            ),
+        )
         self._conn.commit()
-        return cur.rowcount > 0
+        return True
 
     async def allocate_firmware_command_seq(self, device_id: str) -> int:
         """Allocate the next strictly increasing command sequence for a

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -595,7 +595,9 @@ class TestDispatcherAttestation:
                 board_profile="esp32-s3-pzem-v1",
                 provisioned_at_ms=1_760_000_000_000,
             )
-            assert await store.approve_firmware_device("ori-fw-7c9f2b3a")
+            assert await store.approve_firmware_device(
+                "ori-fw-7c9f2b3a", actor="test-operator", reason="test"
+            )
             dispatcher = self._dispatcher(store, attestor)
             reading = SensorReading(
                 sensor_id="ori-fw-7c9f2b3a:ch0",

--- a/tests/test_firmware_command_egress.py
+++ b/tests/test_firmware_command_egress.py
@@ -75,7 +75,9 @@ async def _register_device(store: StateStore, *, approve: bool = True) -> str:
         manifest_message=_manifest_message("manifest_full_sealed"),
     )
     if approve:
-        assert await gate.approve_device(manifest["device_id"])
+        assert await gate.approve_device(
+            manifest["device_id"], actor="test-operator", reason="test"
+        )
     return manifest["device_id"]
 
 
@@ -313,8 +315,12 @@ async def test_service_refuses_approval_for_unapproved_or_revoked_device(store) 
     with pytest.raises(FirmwareCommandError, match="not approved"):
         await service.publish_provisioning_approval(device_id)
 
-    assert await store.approve_firmware_device(device_id)
-    assert await store.revoke_firmware_device(device_id)
+    assert await store.approve_firmware_device(
+        device_id, actor="test-operator", reason="test"
+    )
+    assert await store.revoke_firmware_device(
+        device_id, actor="test-operator", reason="test"
+    )
     with pytest.raises(FirmwareCommandError, match="revoked"):
         await service.publish_provisioning_approval(device_id)
 

--- a/tests/test_firmware_commands.py
+++ b/tests/test_firmware_commands.py
@@ -116,7 +116,9 @@ async def provision(store) -> str:
         posture=manifest["posture"],
         manifest_message=manifest_message("manifest_full_sealed"),
     )
-    assert await gate.approve_device(manifest["device_id"])
+    assert await gate.approve_device(
+        manifest["device_id"], actor="test-operator", reason="test"
+    )
     return manifest["device_id"]
 
 
@@ -186,15 +188,20 @@ class TestSequenceAllocation:
                 "authority": "runtime_commanded",
             }
         ]
+        # A different manifest is a different capability hash, so this is
+        # a new anchor epoch: it arrives as a pending candidate and must be
+        # promoted before it grants anything.
         await store.upsert_firmware_device_anchor(
             device_id=device_id,
             public_key_b64=row["public_key_b64"],
             posture=row["posture"],
-            capability_hash=row["capability_hash"],
+            capability_hash="sha256:" + "ee" * 32,
             manifest_json=json.dumps(doctored),
             channel_map_json="{}",
         )
-        assert await store.approve_firmware_device(device_id)
+        assert await store.approve_firmware_device(
+            device_id, actor="test-operator", reason="test"
+        )
         with pytest.raises(FirmwareCommandError, match="vocabulary"):
             await signer.sign_command(
                 device_id=device_id, action="ota_begin", channel="relay0"
@@ -217,11 +224,15 @@ class TestSequenceAllocation:
             await signer.sign_command(
                 device_id=manifest["device_id"], action="relay_open", channel="relay0"
             )
-        assert await gate.approve_device(manifest["device_id"])
+        assert await gate.approve_device(
+            manifest["device_id"], actor="test-operator", reason="test"
+        )
         await signer.sign_command(
             device_id=manifest["device_id"], action="relay_open", channel="relay0"
         )
-        assert await gate.revoke_device(manifest["device_id"])
+        assert await gate.revoke_device(
+            manifest["device_id"], actor="test-operator", reason="test"
+        )
         with pytest.raises(FirmwareCommandError):
             await signer.sign_command(
                 device_id=manifest["device_id"], action="relay_open", channel="relay0"

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -144,6 +144,8 @@ def _approve(bench, key=None):
             "ori-fw-bench0001",
             "--confirm-device-key",
             key if key is not None else bench["device_key"],
+            "--reason",
+            "bench provisioning",
         ]
     )
 
@@ -179,7 +181,9 @@ class TestTransactionControls:
         async def revoke():
             store = StateStore(db_path=bench["db"])
             await store.open()
-            await FirmwareTelemetryGate(store).revoke_device("ori-fw-bench0001")
+            await FirmwareTelemetryGate(store).revoke_device(
+                "ori-fw-bench0001", actor="test-operator", reason="test"
+            )
             await store.close()
 
         asyncio.run(revoke())
@@ -293,7 +297,9 @@ class TestRevocationSurvivesRegistration:
         async def go():
             store = StateStore(db_path=bench["db"])
             await store.open()
-            await FirmwareTelemetryGate(store).revoke_device("ori-fw-bench0001")
+            await FirmwareTelemetryGate(store).revoke_device(
+                "ori-fw-bench0001", actor="test-operator", reason="test"
+            )
             await store.close()
 
         asyncio.run(go())
@@ -321,3 +327,83 @@ class TestRevocationSurvivesRegistration:
 
         assert _register(bench) == 2
         assert _publish(bench) == 2
+
+
+class TestActorIsAuthenticated:
+    """The contract requires the *authenticated* operator. A name typed on
+    the command line is an assertion; anyone can type any name."""
+
+    def test_actor_is_derived_from_the_os_principal(self) -> None:
+        from ori.firmware_provisioner import authenticated_actor
+
+        actor = authenticated_actor()
+        assert actor.startswith("uid=")
+        assert actor.strip() == actor and actor != ""
+
+    def test_actor_ignores_caller_controlled_environment(self, monkeypatch) -> None:
+        # getpass.getuser() trusts LOGNAME/USER, so it would be spoofable
+        # by the very caller being attributed. The real UID is not.
+        from ori.firmware_provisioner import authenticated_actor
+
+        before = authenticated_actor()
+        monkeypatch.setenv("USER", "someone-else")
+        monkeypatch.setenv("LOGNAME", "someone-else")
+        assert authenticated_actor() == before
+        assert "someone-else" not in authenticated_actor()
+
+    def test_label_annotates_but_never_replaces_the_principal(self) -> None:
+        from ori.firmware_provisioner import authenticated_actor
+
+        principal = authenticated_actor()
+        labelled = authenticated_actor("bench operator")
+        assert labelled.startswith(principal)
+        assert "bench operator" in labelled
+
+    def test_approve_records_the_authenticated_actor(self, bench) -> None:
+        import asyncio
+
+        from ori.firmware_provisioner import authenticated_actor
+        from ori.state.store import StateStore
+
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+
+        async def transitions():
+            store = StateStore(db_path=bench["db"])
+            await store.open()
+            rows = await store.list_firmware_anchor_transitions("ori-fw-bench0001")
+            await store.close()
+            return rows
+
+        promoted = [
+            t for t in asyncio.run(transitions()) if t["transition"] == "promoted"
+        ]
+        assert promoted[0]["actor"] == authenticated_actor()
+        assert promoted[0]["reason"] == "bench provisioning"
+
+    def test_fails_closed_without_a_real_uid(self, monkeypatch) -> None:
+        # On a platform with no real UID there is nothing to authenticate
+        # against. Recording a placeholder would put an unattributable row
+        # in the audit log while looking like attribution, so the
+        # operation is refused instead.
+        import os as os_module
+
+        from ori.firmware_provisioner import ProvisionerError, authenticated_actor
+
+        monkeypatch.delattr(os_module, "getuid", raising=False)
+        with pytest.raises(ProvisionerError, match="authenticated OS principal"):
+            authenticated_actor()
+
+    def test_uid_without_a_passwd_entry_still_authenticates(self, monkeypatch) -> None:
+        # A UID with no passwd entry is still an authenticated principal;
+        # only the display name is missing.
+        import pwd
+
+        from ori.firmware_provisioner import authenticated_actor
+
+        monkeypatch.setattr(
+            pwd, "getpwuid", lambda _uid: (_ for _ in ()).throw(KeyError("no entry"))
+        )
+        actor = authenticated_actor()
+        assert actor.startswith("uid=")
+        assert ":" not in actor

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -39,6 +39,8 @@ VECTORS = json.loads(
     (Path(__file__).parent / "fixtures" / "firmware_layer1_vectors.json").read_text()
 )
 PUBLIC_KEY_B64 = VECTORS["public_key_b64"]
+# The fixed TEST-ONLY seed the shared vectors are signed with.
+GOLDEN_SEED = bytes([0x42]) * 32
 CASES = {case["name"]: case for case in VECTORS["cases"]}
 
 SEALED_DEVICE = "ori-fw-7c9f2b3a"
@@ -660,7 +662,9 @@ async def provision_and_approve(gate: FirmwareTelemetryGate, manifest_case: str)
         posture=manifest["posture"],
         manifest_message=manifest_message(manifest_case),
     )
-    assert await gate.approve_device(manifest["device_id"])
+    assert await gate.approve_device(
+        manifest["device_id"], actor="test-operator", reason="test"
+    )
     return manifest_hash
 
 
@@ -706,7 +710,9 @@ class TestFirmwareTelemetryGate:
         before = await store.get_firmware_device(SEALED_DEVICE)
         assert before["approved"] is False
         assert before["capability_hash"] == SEALED_HASH
-        assert await store.approve_firmware_device(SEALED_DEVICE)
+        assert await store.approve_firmware_device(
+            SEALED_DEVICE, actor="test-operator", reason="test"
+        )
         after = await store.get_firmware_device(SEALED_DEVICE)
         assert after["approved"] is True
         assert after["capability_hash"] == SEALED_HASH
@@ -767,7 +773,9 @@ class TestFirmwareTelemetryGate:
             telemetry_message("telemetry_single_reading")
         )
         assert verification.error_code == "device_not_approved"
-        assert await gate.approve_device(SEALED_DEVICE)
+        assert await gate.approve_device(
+            SEALED_DEVICE, actor="test-operator", reason="test"
+        )
         verification, _ = await gate.ingest(
             telemetry_message("telemetry_single_reading")
         )
@@ -775,7 +783,9 @@ class TestFirmwareTelemetryGate:
 
     async def test_revoked_device_rejected(self, gate) -> None:
         await provision_and_approve(gate, "manifest_full_sealed")
-        assert await gate.revoke_device(SEALED_DEVICE)
+        assert await gate.revoke_device(
+            SEALED_DEVICE, actor="test-operator", reason="test"
+        )
         verification, _ = await gate.ingest(
             telemetry_message("telemetry_single_reading")
         )
@@ -853,7 +863,7 @@ class TestRegistrationLifecycle:
     @pytest.mark.asyncio
     async def test_exact_reregistration_is_idempotent(self, gate) -> None:
         await self._register(gate)
-        await gate.approve_device(DEV_DEVICE)
+        await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
         # Actually advance it, so a reset would be visible.
         await gate._store.advance_firmware_freshness(DEV_DEVICE, boot_id=3, seq=99)
         row_before = await gate._store.get_firmware_device(DEV_DEVICE)
@@ -870,8 +880,8 @@ class TestRegistrationLifecycle:
     @pytest.mark.asyncio
     async def test_revocation_survives_registration(self, gate) -> None:
         await self._register(gate)
-        await gate.approve_device(DEV_DEVICE)
-        await gate.revoke_device(DEV_DEVICE)
+        await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
+        await gate.revoke_device(DEV_DEVICE, actor="test-operator", reason="test")
 
         # The whole point: a device re-publishing its manifest is not a
         # decision to trust it again.
@@ -886,7 +896,7 @@ class TestRegistrationLifecycle:
     @pytest.mark.asyncio
     async def test_changed_key_is_refused(self, gate) -> None:
         await self._register(gate)
-        await gate.approve_device(DEV_DEVICE)
+        await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
 
         # The attacker shape: a manifest SIGNED BY A KEY THEY CONTROL,
         # claiming a device_id they do not own. It is internally
@@ -908,35 +918,515 @@ class TestRegistrationLifecycle:
         assert row["approved"] == 1
 
     @pytest.mark.asyncio
-    async def test_manifest_change_fails_closed_for_now(self, gate) -> None:
-        # The contract requires a same-key manifest change to become a
-        # PENDING candidate beside the still-active anchor. That state
-        # model is not implemented yet, so this refuses rather than
-        # overwriting the active anchor — the behaviour the contract
-        # forbids, and what this method used to do.
+    async def test_manifest_change_becomes_a_pending_candidate(self, gate) -> None:
+        # The contract: a same-key manifest change is a PENDING candidate
+        # beside the still-active anchor. Overwriting the active anchor
+        # would let a device replace its own accepted capability surface
+        # by publishing, and would reset a replay window that never left
+        # its key epoch.
         await gate.register_device(
             device_id=SEALED_DEVICE,
             public_key_b64=PUBLIC_KEY_B64,
             posture="sealed_flash",
             manifest_message=manifest_message("manifest_full_sealed"),
         )
-        await gate.approve_device(SEALED_DEVICE)
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
         await gate._store.advance_firmware_freshness(SEALED_DEVICE, boot_id=7, seq=1234)
         before = await gate._store.get_firmware_device(SEALED_DEVICE)
 
-        with pytest.raises(FirmwareVerificationError) as excinfo:
-            await gate.register_device(
-                device_id=SEALED_DEVICE,
-                public_key_b64=PUBLIC_KEY_B64,
-                posture="sealed_flash",
-                manifest_message=manifest_message("manifest_command_bench"),
-            )
-        assert excinfo.value.code == "manifest_epoch_unsupported"
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=manifest_message("manifest_command_bench"),
+        )
 
-        # Nothing moved: the active anchor, its approval, and the replay
-        # window are all exactly as they were.
+        # The ACTIVE anchor is untouched: same capability hash, still
+        # approved, replay window intact.
         after = await gate._store.get_firmware_device(SEALED_DEVICE)
         assert after["capability_hash"] == before["capability_hash"]
         assert after["approved"] == 1
         assert after["last_boot_id"] == 7
         assert after["last_seq"] == 1234
+        # The key epoch never changed, so freshness had no reason to move.
+        assert after["key_epoch_id"] == before["key_epoch_id"]
+
+        # The new manifest is recorded as a pending candidate.
+        pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+        assert pending is not None
+        assert pending["capability_hash"] != before["capability_hash"]
+        assert pending["state"] == "pending"
+        assert pending["key_epoch_id"] == before["key_epoch_id"]
+
+    @pytest.mark.asyncio
+    async def test_second_manifest_replaces_the_pending_candidate(self, gate) -> None:
+        # A pending anchor grants nothing, so replacing one loses no
+        # authority; refusing would strand a device whose earlier manifest
+        # nobody promoted.
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=manifest_message("manifest_full_sealed"),
+        )
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=manifest_message("manifest_command_bench"),
+        )
+        first_pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+
+        # A third manifest: same key, different hash again.
+        third = signed_manifest_for_key(
+            GOLDEN_SEED,
+            device_id=SEALED_DEVICE,
+            posture="sealed_flash",
+            secure_boot_enabled=True,
+            flash_encryption_enabled=True,
+            key_storage="nvs_encrypted",
+            firmware_version="9.9.9",
+        )
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=third,
+        )
+
+        now_pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+        assert now_pending["anchor_epoch_id"] != first_pending["anchor_epoch_id"]
+
+        # The replaced candidate is retained as discarded, never deleted:
+        # it was never active, so no evidence is attributed to it.
+        history = await gate._store.list_firmware_anchor_history(SEALED_DEVICE)
+        discarded = [a for a in history if a["state"] == "discarded"]
+        assert first_pending["anchor_epoch_id"] in {
+            a["anchor_epoch_id"] for a in discarded
+        }
+
+    @pytest.mark.asyncio
+    async def test_transitions_are_recorded(self, gate) -> None:
+        await self._register(gate)
+        transitions = await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        assert [t["transition"] for t in transitions] == ["registered"]
+        assert transitions[0]["to_epoch_id"].startswith("sha256:")
+        assert transitions[0]["key_epoch_id"].startswith("sha256:")
+
+
+class TestLifecycleMigration:
+    """A database created before the lifecycle must not become invisible
+    to it. The backfill derives epoch ids from what is already stored and
+    records the anchor, so existing devices keep working."""
+
+    @pytest.mark.asyncio
+    async def test_preexisting_approved_device_backfills_as_active(
+        self, tmp_path
+    ) -> None:
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / "legacy.db")
+        # Build the pre-lifecycle shape: a registry row with no epoch ids
+        # and no anchor history.
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM firmware_device_anchors")
+        conn.execute("DELETE FROM firmware_anchor_transitions")
+        conn.execute(
+            """
+            INSERT INTO firmware_device_registry
+                (device_id, public_key_b64, posture, capability_hash,
+                 manifest_json, channel_map_json, board_profile, approved,
+                 provisioned_at_ms, last_boot_id, last_seq, revoked,
+                 revoked_at_ms, anchor_epoch_id, key_epoch_id)
+            VALUES ('ori-fw-legacy01', ?, 'development', ?, '{}', '{}', '',
+                    1, 1000, 5, 500, 0, NULL, '', '')
+            """,
+            (PUBLIC_KEY_B64, "sha256:" + "ab" * 32),
+        )
+        conn.commit()
+        conn.close()
+
+        # Reopening runs the migration.
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            row = await store.get_firmware_device("ori-fw-legacy01")
+            assert row["anchor_epoch_id"].startswith("sha256:")
+            assert row["key_epoch_id"].startswith("sha256:")
+            # Approval and freshness are preserved by the migration.
+            assert row["approved"] is True
+            assert row["last_seq"] == 500
+
+            history = await store.list_firmware_anchor_history("ori-fw-legacy01")
+            assert len(history) == 1
+            assert history[0]["state"] == "active"
+            assert history[0]["anchor_epoch_id"] == row["anchor_epoch_id"]
+
+            transitions = await store.list_firmware_anchor_transitions(
+                "ori-fw-legacy01"
+            )
+            assert transitions[0]["actor"] == "migration"
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_preexisting_unapproved_device_backfills_as_pending(
+        self, tmp_path
+    ) -> None:
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / "legacy2.db")
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM firmware_device_anchors")
+        conn.execute(
+            """
+            INSERT INTO firmware_device_registry
+                (device_id, public_key_b64, posture, capability_hash,
+                 manifest_json, channel_map_json, board_profile, approved,
+                 provisioned_at_ms, last_boot_id, last_seq, revoked,
+                 revoked_at_ms, anchor_epoch_id, key_epoch_id)
+            VALUES ('ori-fw-legacy02', ?, 'development', ?, '{}', '{}', '',
+                    0, 1000, 0, 0, 0, NULL, '', '')
+            """,
+            (PUBLIC_KEY_B64, "sha256:" + "cd" * 32),
+        )
+        conn.commit()
+        conn.close()
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            # Never approved, so never trusted for acceptance: pending.
+            history = await store.list_firmware_anchor_history("ori-fw-legacy02")
+            assert history[0]["state"] == "pending"
+        finally:
+            await store.close()
+
+
+class TestAnchorStateInvariant:
+    """ "Two active anchors" is a state no amount of careful calling code
+    should be trusted to prevent, so the database enforces it."""
+
+    @pytest.mark.asyncio
+    async def test_database_refuses_a_second_active_or_pending(self, tmp_path) -> None:
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / "inv.db")
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+
+        conn = sqlite3.connect(db)
+
+        def insert(epoch_id: str, state: str, device: str = "d1") -> None:
+            conn.execute(
+                """
+                INSERT INTO firmware_device_anchors
+                    (anchor_epoch_id, device_id, key_epoch_id, public_key_b64,
+                     posture, capability_hash, state, created_at_ms,
+                     state_changed_at_ms)
+                VALUES (?, ?, 'k', 'p', 'development', 'h', ?, 1, 1)
+                """,
+                (epoch_id, device, state),
+            )
+
+        insert("a1", "active")
+        insert("p1", "pending")
+        conn.commit()
+
+        for epoch_id, state in (("a2", "active"), ("p2", "pending")):
+            with pytest.raises(sqlite3.IntegrityError):
+                insert(epoch_id, state)
+                conn.commit()
+            conn.rollback()
+
+        # History is append-only, so these repeat freely.
+        insert("s1", "superseded")
+        insert("s2", "superseded")
+        insert("x1", "discarded")
+        # A different identity is unaffected.
+        insert("b1", "active", device="d2")
+        conn.commit()
+        conn.close()
+
+
+class TestRegistryAndHistoryAgree:
+    """The legacy registry and the anchor history must never disagree
+    about which anchor is trusted. Each test here is a path where they
+    previously could."""
+
+    async def _register(self, gate, case):
+        c = CASES[case]
+        return await gate.register_device(
+            device_id=c["input"]["device_id"],
+            public_key_b64=PUBLIC_KEY_B64,
+            posture=c["input"]["posture"],
+            manifest_message=manifest_message(case),
+        )
+
+    @pytest.mark.asyncio
+    async def test_approval_promotes_the_anchor(self, gate) -> None:
+        await self._register(gate, "manifest_minimal_dev")
+        history = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        assert history[0]["state"] == "pending"
+
+        await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
+
+        # Approval is promotion: history says active, and the registry
+        # points at the same anchor. Accepting telemetry while history
+        # still said "pending" was the split-brain.
+        history = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        active = [a for a in history if a["state"] == "active"]
+        assert len(active) == 1
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["approved"] is True
+        assert row["anchor_epoch_id"] == active[0]["anchor_epoch_id"]
+
+        transitions = await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        assert [t["transition"] for t in transitions] == ["registered", "promoted"]
+
+    @pytest.mark.asyncio
+    async def test_promoting_a_manifest_epoch_supersedes_the_previous(
+        self, gate
+    ) -> None:
+        await self._register(gate, "manifest_full_sealed")
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
+        first = await gate._store.get_firmware_device(SEALED_DEVICE)
+
+        await self._register(gate, "manifest_command_bench")
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
+
+        history = await gate._store.list_firmware_anchor_history(SEALED_DEVICE)
+        states = {a["anchor_epoch_id"]: a["state"] for a in history}
+        assert states[first["anchor_epoch_id"]] == "superseded"
+        row = await gate._store.get_firmware_device(SEALED_DEVICE)
+        assert states[row["anchor_epoch_id"]] == "active"
+        # The superseded anchor is retained, never deleted: evidence
+        # outlives the anchor that authorised it.
+        assert first["anchor_epoch_id"] in states
+
+    @pytest.mark.asyncio
+    async def test_revocation_moves_the_anchor_and_discards_pending(self, gate) -> None:
+        await self._register(gate, "manifest_full_sealed")
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
+        active_id = (await gate._store.get_firmware_device(SEALED_DEVICE))[
+            "anchor_epoch_id"
+        ]
+        await self._register(gate, "manifest_command_bench")
+        pending_id = (await gate._store.get_pending_firmware_anchor(SEALED_DEVICE))[
+            "anchor_epoch_id"
+        ]
+
+        await gate.revoke_device(SEALED_DEVICE, actor="test-operator", reason="test")
+
+        history = await gate._store.list_firmware_anchor_history(SEALED_DEVICE)
+        states = {a["anchor_epoch_id"]: a["state"] for a in history}
+        # Retained so reinstatement has something to return to.
+        assert states[active_id] == "revoked"
+        # An unpromoted candidate must not survive a revocation and
+        # become promotable later.
+        assert states[pending_id] == "discarded"
+        assert await gate._store.get_pending_firmware_anchor(SEALED_DEVICE) is None
+
+        transitions = await gate._store.list_firmware_anchor_transitions(SEALED_DEVICE)
+        assert transitions[-1]["transition"] == "revoked"
+
+    @pytest.mark.asyncio
+    async def test_promotion_after_revocation_is_refused(self, gate) -> None:
+        await self._register(gate, "manifest_minimal_dev")
+        await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
+        await gate.revoke_device(DEV_DEVICE, actor="test-operator", reason="test")
+        # Nothing pending, identity revoked: there is nothing to promote
+        # and promotion must not invent an anchor.
+        assert (
+            await gate.approve_device(DEV_DEVICE, actor="test-operator", reason="test")
+            is False
+        )
+
+    @pytest.mark.asyncio
+    async def test_registry_never_points_at_a_discarded_anchor(self, gate) -> None:
+        # Pending A, then manifest B: A is discarded and B becomes the
+        # candidate. The registry must follow B — previously it still
+        # described A, so promotion would have activated the wrong
+        # manifest.
+        await self._register(gate, "manifest_full_sealed")
+        first_pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+
+        await self._register(gate, "manifest_command_bench")
+        row = await gate._store.get_firmware_device(SEALED_DEVICE)
+        second_pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+
+        assert second_pending["anchor_epoch_id"] != first_pending["anchor_epoch_id"]
+        assert row["capability_hash"] == second_pending["capability_hash"]
+
+        await gate.approve_device(SEALED_DEVICE, actor="test-operator", reason="test")
+        promoted = await gate._store.get_firmware_device(SEALED_DEVICE)
+        assert promoted["anchor_epoch_id"] == second_pending["anchor_epoch_id"]
+
+    @pytest.mark.asyncio
+    async def test_republishing_a_discarded_anchor_is_not_unchanged(self, gate) -> None:
+        # "unchanged" must be decided from the live anchor, not from the
+        # registry pointer: a discarded anchor re-published is a new
+        # candidate, not a no-op.
+        await self._register(gate, "manifest_full_sealed")
+        first = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+        await self._register(gate, "manifest_command_bench")
+        await self._register(gate, "manifest_full_sealed")
+
+        now_pending = await gate._store.get_pending_firmware_anchor(SEALED_DEVICE)
+        assert now_pending["anchor_epoch_id"] == first["anchor_epoch_id"]
+        assert now_pending["state"] == "pending"
+
+
+class TestRevokedLegacyMigration:
+    @pytest.mark.asyncio
+    async def test_revoked_legacy_row_does_not_become_promotable(
+        self, tmp_path
+    ) -> None:
+        """A revoked legacy identity must not acquire a pending anchor:
+        that would hand it a promotable candidate it never earned."""
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / "legacy_revoked.db")
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM firmware_device_anchors")
+        conn.execute(
+            """
+            INSERT INTO firmware_device_registry
+                (device_id, public_key_b64, posture, capability_hash,
+                 manifest_json, channel_map_json, board_profile, approved,
+                 provisioned_at_ms, last_boot_id, last_seq, revoked,
+                 revoked_at_ms, anchor_epoch_id, key_epoch_id)
+            VALUES ('ori-fw-legacy03', ?, 'development', ?, '{}', '{}', '',
+                    0, 1000, 0, 0, 1, 2000, '', '')
+            """,
+            (PUBLIC_KEY_B64, "sha256:" + "ef" * 32),
+        )
+        conn.commit()
+        conn.close()
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            history = await store.list_firmware_anchor_history("ori-fw-legacy03")
+            assert history[0]["state"] == "revoked"
+            # Nothing promotable exists.
+            assert await store.get_pending_firmware_anchor("ori-fw-legacy03") is None
+            assert (
+                await store.approve_firmware_device(
+                    "ori-fw-legacy03", actor="test-operator", reason="test"
+                )
+                is False
+            )
+        finally:
+            await store.close()
+
+
+class TestTrustTransitionsAreAttributed:
+    """ori-specs/device-provisioning/v1.md requires actor and reason on
+    every operator decision that changes acceptance. An unattributed
+    anchor change is indistinguishable from a compromise after the fact,
+    so it must be impossible rather than merely discouraged."""
+
+    async def _registered(self, gate):
+        c = CASES["manifest_minimal_dev"]
+        await gate.register_device(
+            device_id=DEV_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture=c["input"]["posture"],
+            manifest_message=manifest_message("manifest_minimal_dev"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_promotion_requires_actor_and_reason(self, gate) -> None:
+        await self._registered(gate)
+        for actor, reason in (("", "why"), ("op", ""), ("  ", "why"), ("op", "  ")):
+            with pytest.raises(ValueError, match="audited"):
+                await gate.approve_device(DEV_DEVICE, actor=actor, reason=reason)
+        # Nothing moved: the refusal happens before any state changes.
+        history = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        assert history[0]["state"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_revocation_requires_actor_and_reason(self, gate) -> None:
+        await self._registered(gate)
+        await gate.approve_device(DEV_DEVICE, actor="op", reason="bench")
+        with pytest.raises(ValueError, match="audited"):
+            await gate.revoke_device(DEV_DEVICE, actor="", reason="compromised")
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["revoked"] is False
+
+    @pytest.mark.asyncio
+    async def test_attribution_is_recorded(self, gate) -> None:
+        await self._registered(gate)
+        await gate.approve_device(
+            DEV_DEVICE, actor="alice@ops", reason="bench bring-up"
+        )
+        transitions = await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        promoted = [t for t in transitions if t["transition"] == "promoted"][0]
+        assert promoted["actor"] == "alice@ops"
+        assert promoted["reason"] == "bench bring-up"
+
+    @pytest.mark.asyncio
+    async def test_database_refuses_an_unattributed_trust_transition(
+        self, tmp_path
+    ) -> None:
+        # Belt and braces: even a direct INSERT cannot write one.
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / "audit.db")
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+        conn = sqlite3.connect(db)
+
+        def insert(transition: str, actor: str, reason: str) -> None:
+            conn.execute(
+                """
+                INSERT INTO firmware_anchor_transitions
+                    (device_id, transition, key_epoch_id, actor, reason,
+                     occurred_at_ms)
+                VALUES ('d1', ?, 'k', ?, ?, 1)
+                """,
+                (transition, actor, reason),
+            )
+
+        for transition in ("promoted", "revoked", "reinstated", "reprovisioned"):
+            with pytest.raises(sqlite3.IntegrityError):
+                insert(transition, "", "")
+                conn.commit()
+            conn.rollback()
+
+        # Whitespace is attribution in form only: `actor <> \'\'` would
+        # have accepted it.
+        for transition in ("promoted", "revoked"):
+            with pytest.raises(sqlite3.IntegrityError):
+                insert(transition, "   ", "   ")
+                conn.commit()
+            conn.rollback()
+
+        # Device-initiated events grant nothing, so they may be unattributed.
+        insert("registered", "", "")
+        insert("discarded", "", "")
+        conn.commit()
+        conn.close()


### PR DESCRIPTION
## What does this PR do?

Step 4 of #239: the storage foundation for the device provisioning lifecycle defined in [ori-specs/device-provisioning/v1.md](https://github.com/ori-platform/ori-specs/blob/main/device-provisioning/v1.md), plus the minimal promotion and revocation primitives needed to keep it consistent.

Operator-facing re-provisioning and reinstatement are **deliberately not exposed here** — they land next as thin commands over this state machine, rather than recreating implicit transitions inside it.

## Epoch identity

`key_epoch_id` and `anchor_epoch_id` are SHA-256 over canonical JSON of the identity and the full anchor, using the same construction as `capability_hash`. Deterministic derivation is the point: two independent stores compute the same value without coordinating, which is what will make *"runtime and Verity accepted the same epoch"* checkable rather than asserted.

A manifest change moves `anchor_epoch_id` while `key_epoch_id` holds — which is exactly why freshness, scoped to the key epoch, has no reason to reset.

## Anchor states

`firmware_device_anchors` is append-only and holds every anchor an identity has ever had: `pending`, `active`, `superseded`, `discarded`, `revoked`. Evidence outlives the anchor that authorised it, so nothing is deleted.

The `state` column is `CHECK`-constrained, and **partial unique indexes enforce at most one active and one pending per identity**. Two active anchors is a state no amount of careful calling code should be trusted to prevent, so the database refuses it — with a test that asserts exactly that.

## The registry and the history cannot disagree

This was the substance of the last review round. Every currently callable mutation now moves both in one transaction:

- **Approval IS promotion.** The pending candidate becomes active, any previously active anchor becomes superseded, and the registry is pointed at the promoted anchor. Approving while history still said "pending" would have let the runtime accept telemetry the lifecycle considered untrusted.
- **Revocation** retains the active anchor as `revoked` so reinstatement has something to return to, and **discards any pending candidate** — an unpromoted candidate must not survive a revocation and become promotable later.
- **Registration** decides "unchanged" from the live anchor rather than the registry pointer, and when nothing is active the registry follows the current pending candidate. Otherwise, after pending A was replaced by B, the registry still described A and promotion would have activated the wrong manifest.

## Trust transitions are attributed, and the attribution is authenticated

Promotion and revocation require a non-empty actor and reason, refused at the store boundary **before any state moves**. A `CHECK` using `length(trim(...))` means neither an empty nor a whitespace-only value can be written even by a direct `INSERT` — `actor <> ''` would have accepted `"   "`, which is attribution in form only.

The CLI takes **no `--actor` string**. A typed name is an assertion anyone can make; the actor derives from the real UID via the passwd database — deliberately *not* `getpass.getuser()`, which trusts the caller-controlled `LOGNAME`/`USER` variables and would let the very caller being attributed spoof it. Where no real UID exists the operation is **refused**, rather than audited to a placeholder that would look like attribution. An optional `--actor-label` annotates but never replaces the principal.

Only device-initiated registration and pending replacement may be blank, because they grant nothing.

## Manifest changes work again

Step 2 made a same-key manifest change fail closed because there was nowhere correct to put it. It now becomes a pending candidate beside the still-active anchor, which is untouched — capability hash, approval, and replay window all hold. A second differing manifest replaces the candidate and the replaced one is retained as `discarded`. The interim `manifest_epoch_unsupported` error is removed.

## Migration

Databases predating the lifecycle have no epoch ids and no anchor history, which would leave existing devices invisible to it. The backfill derives both ids from what is already stored:

| Legacy row | Anchor state |
|---|---|
| approved, unrevoked | `active` |
| **revoked** | **`revoked`** — never `pending`, which would hand a revoked identity a promotable anchor |
| anything else | `pending` |

Approval and freshness are preserved. All three mappings are tested against hand-built pre-lifecycle databases.

## Type of change

- [x] `feat` — new feature
- [x] `security` — anchor identity, revocation durability, audit integrity

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes — **1947 passed, 6 skipped**
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header *(no new files)*
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated — see below
- [x] PR description explains **why**, not just what

No matrix update: the guard covers `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py`, `ori/config.py`. This touches the store, the ingest gate, and the provisioning CLI.

### If you used AI assistance

- [x] I can explain every line in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in review

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #239
- [x] Every new Tier D code path has test coverage — none added
- [x] No new dependencies added

## Breaking changes for callers

`approve_device` / `revoke_device` (and the store equivalents) now **require** `actor` and `reason` keyword arguments. All in-tree callers are updated. The CLI's `approve` gains a required `--reason` and drops `--actor`.

## Testing notes

```
pytest tests/                        1947 passed, 6 skipped
pre-commit run --all-files           all hooks pass
scripts/typecheck-boundaries.sh      clean (the project's mypy gate)
mypy on the files touched here       clean
```

`mypy ori/` reports 27 pre-existing errors in 11 files; I verified the identical count on clean `main` with these changes stashed, so none are introduced here.

New coverage includes each split-brain path from review — approval promoting, manifest-epoch promotion superseding, revocation discarding a pending candidate, promotion after revocation refused, the registry never pointing at a discarded anchor, re-publishing a discarded anchor not counting as "unchanged" — plus the audit-integrity paths: whitespace-only attribution refused by the database, environment variables unable to spoof the principal, and the no-UID path failing closed.

Refs #239 — **not closed.** Operator operations, Verity's equivalent API, and shared cross-store lifecycle vectors remain.
