### PR TITLE
feat(security): reinstate and reprovision lifecycle operations

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,0 +1,121 @@
+# Ori Runtime — Unreleased
+
+Changes merged to `main` since `v2.0.0`, collected here until the next
+release is cut.
+
+## Breaking Changes — Device Provisioning Attribution
+
+Implements the anchor lifecycle in
+[`ori-specs/device-provisioning/v1.md`](https://github.com/ori-platform/ori-specs/blob/main/device-provisioning/v1.md).
+The contract requires every operator decision that changes what a receiver
+will accept to be attributed, so the APIs that perform those decisions can
+no longer be called without attribution.
+
+- **`FirmwareTelemetryGate.approve_device()` and `revoke_device()` now
+  require `actor` and `reason` keyword arguments.** The same applies to the
+  store-level `approve_firmware_device()` and `revoke_firmware_device()`.
+  Calls without them raise `TypeError`; blank or whitespace-only values
+  raise `ValueError` before any state changes.
+- **`ori-firmware-provisioner approve` now requires `--reason`.**
+- **`ori-firmware-provisioner approve` no longer accepts `--actor`.** The
+  actor is derived from the authenticated OS principal (the real UID via the
+  passwd database) rather than supplied on the command line. A typed name is
+  an assertion anyone can make; it is not attribution. An optional
+  `--actor-label` annotates the record but never replaces the principal. On
+  a platform with no real UID the operation is refused rather than audited
+  to a placeholder.
+
+Only device-initiated registration and the replacement of a pending
+candidate may be unattributed, because they grant nothing.
+
+### Migration
+
+Add `actor` and `reason` at every call site:
+
+```python
+await gate.approve_device(device_id, actor="alice@ops", reason="bench bring-up")
+await gate.revoke_device(device_id, actor="alice@ops", reason="key compromised")
+```
+
+```sh
+# before
+ori-firmware-provisioner approve --db … --device-id … --confirm-device-key … --actor alice
+# after
+ori-firmware-provisioner approve --db … --device-id … --confirm-device-key … \
+    --reason "bench bring-up" [--actor-label alice]
+```
+
+## Behaviour Changes — Registration
+
+Registration is now a decision rather than an overwrite, and refuses where
+it previously accepted:
+
+- **A revoked identity is refused** (`device_revoked`). Revocation belongs to
+  the identity and is never cleared as a side effect of a device
+  re-publishing its manifest. Returning one to service is `reinstate`.
+- **A changed device key is refused** (`key_change_requires_reprovisioning`).
+  A self-signed manifest proves internal consistency, never provenance, so
+  accepting a new key on that basis would let anyone able to publish take
+  over an identity. Use `reprovision`.
+- **A same-key manifest change becomes a pending candidate** beside the
+  still-active anchor rather than replacing it. Nothing is accepted against
+  the candidate until it is promoted, so a device cannot grant itself a new
+  capability surface by publishing.
+
+## Added — Lifecycle Operations
+
+`ori-firmware-provisioner` gains two commands, and the gate gains the
+matching methods:
+
+- **`reinstate`** — returns a revoked identity to service. Clears the revoked
+  flag and moves the retained anchor back to *pending*; it activates
+  nothing, because promotion is the only path to active.
+- **`reprovision`** — accepts a new device key as a pending anchor, with the
+  new key confirmed against the device itself. The previously active anchor
+  stays active until promotion.
+
+Both require `--reason` and record the authenticated principal.
+
+`reprovision` refuses a key that is not genuinely new:
+
+- **`same_key_not_a_rotation`** — the submitted key is the current one, so
+  nothing is being replaced.
+- **`key_epoch_reused`** — this identity has used that key before. An old key
+  may be exactly the one rotated away from because it was compromised, so
+  returning to it would make rotation reversible by whoever still holds it.
+
+Neither code appears in `ori-specs/device-provisioning/v1.md` yet; the
+contract's error table should adopt them.
+
+## Added — Anchor History and Audit
+
+- `firmware_device_anchors`: append-only, every anchor an identity has held
+  (`pending`, `active`, `superseded`, `discarded`, `revoked`). Evidence
+  outlives the anchor that authorised it, so nothing is deleted. At most one
+  active and one pending per identity, enforced by partial unique indexes.
+- `firmware_anchor_transitions`: append-only audit of every trust
+  transition, with actor, reason, and the epoch either side.
+- `key_epoch_id` and `anchor_epoch_id` on the registry, derived
+  deterministically so independent stores compute the same value without
+  coordinating.
+
+## Freshness Semantics
+
+- A **manifest-only change does not reset telemetry freshness** — the key
+  epoch is unchanged, so the replay window stays closed.
+- **Promoting a new key epoch does start a fresh window.** A re-keyed device
+  restarts its counters and would otherwise be refused as a replay against
+  its predecessor's high-water mark. The previous epoch's counters remain
+  historical and unusable.
+- **`cmd_seq` is never reset.** The command mark is per device, not per key,
+  and continues across rotation
+  (`ori-specs/firmware-commands/v1.md`).
+
+## Upgrade Notes
+
+Existing databases migrate automatically on open. Rows predating the
+lifecycle gain their epoch identifiers and an anchor-history entry: an
+approved, unrevoked row becomes `active`; a **revoked** row becomes
+`revoked`, never `pending`, so a revoked identity does not acquire a
+promotable anchor; anything else becomes `pending`. Approval and freshness
+are preserved.

--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -296,12 +296,21 @@ async def _approve(
                 f"device {device_id!r} is revoked; approving it here would contradict "
                 "the registry — re-provision deliberately instead"
             )
-        stored_key = str(row.get("public_key_b64", ""))
+        # Confirm the key of the anchor about to be ACTIVATED, not the one
+        # currently active. After re-provisioning they differ, and checking
+        # the active key would make a re-keyed device impossible to promote.
+        pending = await store.get_pending_firmware_anchor(device_id)
+        if pending is None:
+            raise ProvisionerError(
+                f"device {device_id!r} has no pending anchor to promote"
+            )
+        stored_key = str(pending.get("public_key_b64", ""))
         if confirmed_key != stored_key:
             raise ProvisionerError(
-                "the confirmed device key does not match the registered anchor.\n"
-                f"  registered: {stored_key}\n"
-                f"  confirmed : {confirmed_key}\n"
+                "the confirmed device key does not match the anchor awaiting "
+                "promotion.\n"
+                f"  awaiting promotion: {stored_key}\n"
+                f"  confirmed         : {confirmed_key}\n"
                 "Approving would bind authority to a device you did not verify."
             )
         gate = FirmwareTelemetryGate(store)
@@ -403,6 +412,98 @@ def cmd_publish(args: argparse.Namespace) -> int:
     return 0
 
 
+async def _reinstate(db_path: str, device_id: str, actor: str, reason: str) -> None:
+    from ori.security.firmware_ingest import FirmwareTelemetryGate
+
+    store = await _open_store(db_path)
+    try:
+        if not await FirmwareTelemetryGate(store).reinstate_device(
+            device_id, actor=actor, reason=reason
+        ):
+            raise ProvisionerError(
+                f"cannot reinstate {device_id!r}: it is unknown, or it is not revoked"
+            )
+    finally:
+        await store.close()
+
+
+def cmd_reinstate(args: argparse.Namespace) -> int:
+    asyncio.run(
+        _reinstate(
+            args.db,
+            args.device_id,
+            authenticated_actor(args.actor_label),
+            args.reason,
+        )
+    )
+    print(f"{args.device_id} reinstated; its retained anchor is PENDING")
+    print("Reinstatement activates nothing. Run `approve` to promote it.")
+    return 0
+
+
+async def _reprovision(
+    db_path: str,
+    manifest_path: str,
+    confirmed_key: str,
+    actor: str,
+    reason: str,
+) -> str:
+    from ori.security.firmware_ingest import FirmwareTelemetryGate
+
+    message = _load_manifest_message(manifest_path)
+    manifest = message["manifest"]
+    device_id = manifest.get("device_id")
+    device_pub = manifest.get("public_key_b64")
+    posture = manifest.get("posture")
+    if not all(isinstance(v, str) for v in (device_id, device_pub, posture)):
+        raise ProvisionerError(
+            "manifest is missing device_id, public_key_b64, or posture"
+        )
+
+    # The whole reason re-provisioning is a separate operation: the new key
+    # must be confirmed against the device itself, not against the manifest
+    # that asserts it.
+    if confirmed_key != device_pub:
+        raise ProvisionerError(
+            "the confirmed device key does not match the key in the manifest.\n"
+            f"  manifest : {device_pub}\n"
+            f"  confirmed: {confirmed_key}\n"
+            "Re-provisioning binds authority to a NEW key; confirm it from the "
+            "device's own console before proceeding."
+        )
+
+    store = await _open_store(db_path)
+    try:
+        return await FirmwareTelemetryGate(store).reprovision_device(
+            device_id=str(device_id),
+            public_key_b64=str(device_pub),
+            posture=str(posture),
+            manifest_message=message,
+            actor=actor,
+            reason=reason,
+        )
+    except FirmwareVerificationError as exc:
+        raise ProvisionerError(f"re-provisioning refused: {exc}") from exc
+    finally:
+        await store.close()
+
+
+def cmd_reprovision(args: argparse.Namespace) -> int:
+    capability_hash = asyncio.run(
+        _reprovision(
+            args.db,
+            args.manifest,
+            args.confirm_device_key,
+            authenticated_actor(args.actor_label),
+            args.reason,
+        )
+    )
+    print("new key accepted as a PENDING anchor; the previous anchor stays active")
+    print(f"  capability hash: {capability_hash}")
+    print("Run `approve` to promote it.")
+    return 0
+
+
 # ── contract diagnostic ──────────────────────────────────────────────
 
 
@@ -487,6 +588,30 @@ def main(argv: list[str] | None = None) -> int:
     p.add_argument("--runtime-command-seed", required=True)
     p.add_argument("--out")
     p.set_defaults(func=cmd_publish)
+
+    p = sub.add_parser(
+        "reinstate", help="return a revoked identity to service (anchor -> pending)"
+    )
+    p.add_argument("--db", required=True)
+    p.add_argument("--device-id", required=True)
+    p.add_argument("--reason", required=True, help="recorded in the audit log")
+    p.add_argument("--actor-label", default="", help="optional display name")
+    p.set_defaults(func=cmd_reinstate)
+
+    p = sub.add_parser(
+        "reprovision", help="accept a NEW device key (explicit, audited)"
+    )
+    p.add_argument("--db", required=True)
+    p.add_argument("--manifest", required=True)
+    p.add_argument(
+        "--confirm-device-key",
+        required=True,
+        metavar="B64",
+        help="the NEW device public key as observed on the device itself",
+    )
+    p.add_argument("--reason", required=True, help="recorded in the audit log")
+    p.add_argument("--actor-label", default="", help="optional display name")
+    p.set_defaults(func=cmd_reprovision)
 
     p = sub.add_parser("selfcheck", help="reproduce the shared golden vectors")
     p.set_defaults(func=cmd_selfcheck)

--- a/ori/security/firmware_ingest.py
+++ b/ori/security/firmware_ingest.py
@@ -32,7 +32,10 @@ from ori.network.events import SensorReading
 from ori.security.firmware_telemetry import (
     ERR_DEVICE_REVOKED,
     ERR_KEY_CHANGE_REQUIRES_REPROVISIONING,
+    ERR_KEY_EPOCH_REUSED,
+    ERR_SAME_KEY_NOT_A_ROTATION,
     ERR_SEQUENCE_REPLAY,
+    ERR_UNKNOWN_DEVICE,
     GRADE_REJECTED,
     FirmwareFaultVerification,
     FirmwareVerificationError,
@@ -162,6 +165,101 @@ class FirmwareTelemetryGate:
                 device_id, actor=actor, reason=reason
             )
         )
+
+    async def reinstate_device(
+        self, device_id: str, *, actor: str, reason: str
+    ) -> bool:
+        """Return a revoked identity to service.
+
+        Clears the revoked flag and returns the retained anchor to
+        **pending**. It activates nothing: promotion stays a separate,
+        separately audited act.
+        """
+        return bool(
+            await self._store.reinstate_firmware_device(
+                device_id, actor=actor, reason=reason
+            )
+        )
+
+    async def reprovision_device(
+        self,
+        *,
+        device_id: str,
+        public_key_b64: str,
+        posture: str,
+        manifest_message: dict[str, Any],
+        actor: str,
+        reason: str,
+        board_profile: str = "",
+    ) -> str:
+        """Accept a NEW key for an existing identity.
+
+        Ordinary registration refuses a changed key because a self-signed
+        manifest proves consistency, never provenance. This is the
+        deliberate path, and the caller is responsible for having
+        confirmed the device identity independently of the manifest.
+
+        Stores the new-key anchor as pending; the previously active anchor
+        stays active until promotion.
+        """
+        manifest_hash = verify_manifest_message(
+            manifest_message,
+            anchor_device_id=device_id,
+            anchor_public_key_b64=public_key_b64,
+        )
+        manifest = manifest_message["manifest"]
+        if manifest.get("posture") != posture:
+            raise FirmwareVerificationError(
+                "invalid_posture",
+                "manifest posture does not match provisioning posture",
+            )
+        channel_map = manifest_channel_map(manifest)
+        outcome = await self._store.reprovision_firmware_device(
+            device_id=device_id,
+            public_key_b64=public_key_b64,
+            posture=posture,
+            capability_hash=manifest_hash,
+            manifest_json=canonical_json_bytes(manifest).decode("utf-8"),
+            channel_map_json=json.dumps(
+                channel_map,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+                allow_nan=False,
+            ),
+            board_profile=str(manifest.get("board_profile", board_profile)),
+            actor=actor,
+            reason=reason,
+        )
+        if outcome == "unknown_device":
+            raise FirmwareVerificationError(
+                ERR_UNKNOWN_DEVICE, f"cannot re-provision unknown device {device_id!r}"
+            )
+        if outcome == "revoked":
+            raise FirmwareVerificationError(
+                ERR_DEVICE_REVOKED,
+                f"device {device_id!r} is revoked; reinstate it first, or it "
+                "would return to service without anyone saying so",
+            )
+        if outcome == "refused_same_key":
+            raise FirmwareVerificationError(
+                ERR_SAME_KEY_NOT_A_ROTATION,
+                f"device {device_id!r} submitted its CURRENT key; re-provisioning "
+                "replaces a key, and accepting this would move the active anchor "
+                "back to pending while the registry still trusted it",
+            )
+        if outcome == "refused_key_reuse":
+            raise FirmwareVerificationError(
+                ERR_KEY_EPOCH_REUSED,
+                f"device {device_id!r} has used that key before. An old key may "
+                "be the one rotated away from because it was compromised, so "
+                "returning to it would make rotation reversible",
+            )
+        logger.info(
+            "firmware device %s re-provisioned with a new key; pending promotion",
+            device_id,
+        )
+        return manifest_hash
 
     async def ingest(
         self,

--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -94,6 +94,11 @@ ERR_DEVICE_NOT_APPROVED = "device_not_approved"
 # ori-specs/device-provisioning/v1.md: a changed key may never arrive
 # through ordinary registration.
 ERR_KEY_CHANGE_REQUIRES_REPROVISIONING = "key_change_requires_reprovisioning"
+# Re-provisioning must actually replace the key. Submitting the current key
+# changes nothing, and returning to a previously used one would make
+# rotation reversible by whoever still holds the old key.
+ERR_SAME_KEY_NOT_A_ROTATION = "same_key_not_a_rotation"
+ERR_KEY_EPOCH_REUSED = "key_epoch_reused"
 
 
 def key_epoch_id(*, device_id: str, public_key_b64: str) -> str:

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -609,8 +609,11 @@ class StateStore:
         history entry.
 
         Databases created before the provisioning lifecycle hold an
-        active anchor in firmware_device_registry with no epoch ids and
-        no row in firmware_device_anchors. Derive the ids from what is
+        active anchor in firmware_device_registry with no row in
+        firmware_device_anchors. Absence of history is the detection
+        signal — NOT an empty anchor_epoch_id, which now legitimately
+        means "registered, nothing promoted yet" and would make the
+        backfill fire on every freshly registered device. Derive the ids from what is
         already stored and record the anchor, so existing devices are not
         invisible to the lifecycle.
 
@@ -628,11 +631,14 @@ class StateStore:
 
         rows = conn.execute(
             """
-            SELECT device_id, public_key_b64, posture, capability_hash,
-                   manifest_json, channel_map_json, board_profile,
-                   approved, revoked, provisioned_at_ms
-              FROM firmware_device_registry
-             WHERE anchor_epoch_id = '' OR key_epoch_id = ''
+            SELECT r.device_id, r.public_key_b64, r.posture, r.capability_hash,
+                   r.manifest_json, r.channel_map_json, r.board_profile,
+                   r.approved, r.revoked, r.provisioned_at_ms
+              FROM firmware_device_registry r
+             WHERE NOT EXISTS (
+                       SELECT 1 FROM firmware_device_anchors a
+                        WHERE a.device_id = r.device_id
+                   )
             """
         ).fetchall()
         for row in rows:
@@ -2931,7 +2937,8 @@ class StateStore:
         assert self._conn is not None
         _require_attribution("promotion", actor, reason)
         registry = self._conn.execute(
-            "SELECT revoked, anchor_epoch_id FROM firmware_device_registry "
+            "SELECT revoked, anchor_epoch_id, key_epoch_id "
+            "FROM firmware_device_registry "
             "WHERE device_id = ?",
             (device_id,),
         ).fetchone()
@@ -2967,10 +2974,19 @@ class StateStore:
             (occurred_at_ms, pending["anchor_epoch_id"]),
         )
 
-        # The registry now reflects the promoted anchor. Freshness is left
-        # alone: promotion within one key epoch must not re-open a replay
-        # window, and a key change cannot reach here (ordinary
-        # registration refuses it).
+        # Telemetry replay state is scoped to the KEY epoch. Promoting
+        # within one key epoch must not re-open a closed replay window, so
+        # freshness is preserved. Promoting a NEW key epoch — only
+        # reachable through re-provisioning — starts a fresh window,
+        # because a re-keyed device restarts its counters and would
+        # otherwise be refused as a replay against its predecessor's
+        # high-water mark. The old epoch's counters remain historical and
+        # unusable, since they belong to a key no longer active.
+        #
+        # last_cmd_seq is deliberately NOT reset: the command mark is per
+        # device, not per key, and must continue across rotation
+        # (ori-specs/firmware-commands/v1.md).
+        key_epoch_changed = pending["key_epoch_id"] != registry["key_epoch_id"]
         self._conn.execute(
             """
             UPDATE firmware_device_registry
@@ -2982,7 +2998,9 @@ class StateStore:
                    channel_map_json = ?,
                    board_profile = ?,
                    anchor_epoch_id = ?,
-                   key_epoch_id = ?
+                   key_epoch_id = ?,
+                   last_boot_id = CASE WHEN ? THEN 0 ELSE last_boot_id END,
+                   last_seq = CASE WHEN ? THEN 0 ELSE last_seq END
              WHERE device_id = ? AND revoked = 0
             """,
             (
@@ -2994,6 +3012,8 @@ class StateStore:
                 pending["board_profile"],
                 pending["anchor_epoch_id"],
                 pending["key_epoch_id"],
+                1 if key_epoch_changed else 0,
+                1 if key_epoch_changed else 0,
                 device_id,
             ),
         )
@@ -3099,6 +3119,246 @@ class StateStore:
         )
         self._conn.commit()
         return True
+
+    async def reinstate_firmware_device(
+        self,
+        device_id: str,
+        *,
+        actor: str,
+        reason: str,
+        occurred_at_ms: int | None = None,
+    ) -> bool:
+        """Return a revoked identity to service.
+
+        Clears the identity's revoked flag and moves the retained
+        ``revoked`` anchor back to **pending** — never to active.
+        Promotion remains the only path to active, so the operator's next
+        act is an explicit, separately audited promotion.
+        """
+        return await self._run_write(
+            self._reinstate_firmware_device_sync,
+            device_id,
+            actor,
+            reason,
+            occurred_at_ms if occurred_at_ms is not None else now_ms(),
+        )
+
+    def _reinstate_firmware_device_sync(
+        self, device_id: str, actor: str, reason: str, occurred_at_ms: int
+    ) -> bool:
+        assert self._conn is not None
+        _require_attribution("reinstatement", actor, reason)
+        row = self._conn.execute(
+            "SELECT revoked FROM firmware_device_registry WHERE device_id = ?",
+            (device_id,),
+        ).fetchone()
+        if row is None or not row["revoked"]:
+            # Nothing to reinstate. Clearing a flag that is not set would
+            # write an audit row describing an event that did not happen.
+            return False
+
+        retained = self._conn.execute(
+            "SELECT anchor_epoch_id, key_epoch_id FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'revoked'",
+            (device_id,),
+        ).fetchone()
+
+        self._conn.execute(
+            """
+            UPDATE firmware_device_registry
+               SET revoked = 0, revoked_at_ms = NULL, approved = 0
+             WHERE device_id = ?
+            """,
+            (device_id,),
+        )
+        to_epoch = None
+        key_epoch = ""
+        if retained is not None:
+            # Back to pending, not active: promotion is a separate act.
+            self._conn.execute(
+                "UPDATE firmware_device_anchors SET state = 'pending', "
+                "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+                (occurred_at_ms, retained["anchor_epoch_id"]),
+            )
+            to_epoch = retained["anchor_epoch_id"]
+            key_epoch = retained["key_epoch_id"]
+        self._conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'reinstated', ?, ?, ?, ?, ?, ?)
+            """,
+            (device_id, to_epoch, to_epoch, key_epoch, actor, reason, occurred_at_ms),
+        )
+        self._conn.commit()
+        return True
+
+    async def reprovision_firmware_device(
+        self,
+        *,
+        device_id: str,
+        public_key_b64: str,
+        posture: str,
+        capability_hash: str,
+        manifest_json: str,
+        channel_map_json: str,
+        board_profile: str = "",
+        actor: str,
+        reason: str,
+        occurred_at_ms: int | None = None,
+    ) -> str:
+        """Replace an identity's key: an explicit, audited transaction.
+
+        Ordinary registration refuses a changed key, because a self-signed
+        manifest proves consistency and never provenance. This is the path
+        that accepts one, and it exists so that acceptance is a deliberate
+        operator act with independent identity confirmation behind it.
+
+        The new-key anchor is stored **pending**; the previously active
+        anchor stays active until promotion. Historical anchors are
+        retained, and the command sequence is untouched — it is per device,
+        not per key, so rotation must not reset it.
+
+        Returns ``reprovisioned``, or a refusal: ``unknown_device``,
+        ``revoked``, ``refused_same_key`` (the submitted key is the
+        current one, so nothing is being replaced), or
+        ``refused_key_reuse`` (this identity has used that key before).
+        """
+        return await self._run_write(
+            self._reprovision_firmware_device_sync,
+            device_id,
+            public_key_b64,
+            posture,
+            capability_hash,
+            manifest_json,
+            channel_map_json,
+            board_profile,
+            actor,
+            reason,
+            occurred_at_ms if occurred_at_ms is not None else now_ms(),
+        )
+
+    def _reprovision_firmware_device_sync(  # noqa: PLR0913
+        self,
+        device_id: str,
+        public_key_b64: str,
+        posture: str,
+        capability_hash: str,
+        manifest_json: str,
+        channel_map_json: str,
+        board_profile: str,
+        actor: str,
+        reason: str,
+        occurred_at_ms: int,
+    ) -> str:
+        assert self._conn is not None
+        _require_attribution("re-provisioning", actor, reason)
+        from ori.security.firmware_telemetry import (
+            anchor_epoch_id as _anchor_epoch_id,
+        )
+        from ori.security.firmware_telemetry import (
+            key_epoch_id as _key_epoch_id,
+        )
+
+        row = self._conn.execute(
+            "SELECT revoked, anchor_epoch_id FROM firmware_device_registry "
+            "WHERE device_id = ?",
+            (device_id,),
+        ).fetchone()
+        if row is None:
+            return "unknown_device"
+        if row["revoked"]:
+            # Reinstate first: re-provisioning a revoked identity would
+            # return it to service without ever saying so.
+            return "revoked"
+
+        kid = _key_epoch_id(device_id=device_id, public_key_b64=public_key_b64)
+        aid = _anchor_epoch_id(
+            device_id=device_id,
+            public_key_b64=public_key_b64,
+            posture=posture,
+            capability_hash=capability_hash,
+        )
+
+        # Re-provisioning means REPLACING the key. Submitting the current
+        # key is not a key change: with INSERT OR REPLACE it would have
+        # overwritten the active anchor row with a pending one while the
+        # registry still said approved — a split-brain, and a violation of
+        # append-only history.
+        current_key_epoch = self._conn.execute(
+            "SELECT key_epoch_id FROM firmware_device_registry WHERE device_id = ?",
+            (device_id,),
+        ).fetchone()
+        if current_key_epoch is not None and current_key_epoch["key_epoch_id"] == kid:
+            return "refused_same_key"
+
+        # Nor may a key this identity has used before come back. An old key
+        # may be exactly the one that was rotated away from because it was
+        # compromised; allowing its return would make rotation reversible
+        # by whoever holds it.
+        reused = self._conn.execute(
+            "SELECT 1 FROM firmware_device_anchors "
+            "WHERE device_id = ? AND key_epoch_id = ?",
+            (device_id, kid),
+        ).fetchone()
+        if reused is not None:
+            return "refused_key_reuse"
+
+        # Any existing candidate is superseded by this one.
+        existing = self._conn.execute(
+            "SELECT anchor_epoch_id FROM firmware_device_anchors "
+            "WHERE device_id = ? AND state = 'pending'",
+            (device_id,),
+        ).fetchone()
+        if existing is not None and existing["anchor_epoch_id"] != aid:
+            self._conn.execute(
+                "UPDATE firmware_device_anchors SET state = 'discarded', "
+                "state_changed_at_ms = ? WHERE anchor_epoch_id = ?",
+                (occurred_at_ms, existing["anchor_epoch_id"]),
+            )
+
+        self._conn.execute(
+            """
+            INSERT INTO firmware_device_anchors
+                (anchor_epoch_id, device_id, key_epoch_id, public_key_b64,
+                 posture, capability_hash, manifest_json, channel_map_json,
+                 board_profile, state, created_at_ms, state_changed_at_ms)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)
+            """,
+            (
+                aid,
+                device_id,
+                kid,
+                public_key_b64,
+                posture,
+                capability_hash,
+                manifest_json,
+                channel_map_json,
+                board_profile,
+                occurred_at_ms,
+                occurred_at_ms,
+            ),
+        )
+        self._conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'reprovisioned', ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                device_id,
+                row["anchor_epoch_id"] or None,
+                aid,
+                kid,
+                actor,
+                reason,
+                occurred_at_ms,
+            ),
+        )
+        self._conn.commit()
+        return "reprovisioned"
 
     async def allocate_firmware_command_seq(self, device_id: str) -> int:
         """Allocate the next strictly increasing command sequence for a

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -407,3 +407,121 @@ class TestActorIsAuthenticated:
         actor = authenticated_actor()
         assert actor.startswith("uid=")
         assert ":" not in actor
+
+
+class TestPromotionConfirmsTheAnchorBeingActivated:
+    """`approve` must confirm the key of the anchor about to be ACTIVATED,
+    not the one currently active. After re-provisioning they differ, and
+    checking the active key made a re-keyed device impossible to promote."""
+
+    def _manifest_for(self, bench, seed, path):
+        message = signed_manifest(seed)
+        Path(path).write_text(json.dumps(message))
+        return message["manifest"]["public_key_b64"]
+
+    def test_reprovisioned_key_can_be_promoted(self, bench, tmp_path) -> None:
+        import os
+
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+
+        new_seed = os.urandom(32)
+        new_manifest = tmp_path / "m2.json"
+        new_key = self._manifest_for(bench, new_seed, new_manifest)
+
+        assert (
+            main(
+                [
+                    "reprovision",
+                    "--db",
+                    bench["db"],
+                    "--manifest",
+                    str(new_manifest),
+                    "--confirm-device-key",
+                    new_key,
+                    "--reason",
+                    "device re-keyed",
+                ]
+            )
+            == 0
+        )
+        # Confirming the NEW key promotes it.
+        assert _approve(bench, key=new_key) == 0
+
+    def test_confirming_the_superseded_key_is_refused(self, bench, tmp_path) -> None:
+        import os
+
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        new_seed = os.urandom(32)
+        new_manifest = tmp_path / "m3.json"
+        new_key = self._manifest_for(bench, new_seed, new_manifest)
+        main(
+            [
+                "reprovision",
+                "--db",
+                bench["db"],
+                "--manifest",
+                str(new_manifest),
+                "--confirm-device-key",
+                new_key,
+                "--reason",
+                "re-keyed",
+            ]
+        )
+        # The old key is no longer the one being activated.
+        assert _approve(bench, key=bench["device_key"]) == 2
+
+    def test_reprovision_requires_the_key_to_match_the_manifest(
+        self, bench, tmp_path
+    ) -> None:
+        import os
+
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        new_manifest = tmp_path / "m4.json"
+        self._manifest_for(bench, os.urandom(32), new_manifest)
+        # Confirming a key that is not the one in the manifest defeats the
+        # whole point of independent confirmation.
+        assert (
+            main(
+                [
+                    "reprovision",
+                    "--db",
+                    bench["db"],
+                    "--manifest",
+                    str(new_manifest),
+                    "--confirm-device-key",
+                    _pub_b64(os.urandom(32)),
+                    "--reason",
+                    "x",
+                ]
+            )
+            == 2
+        )
+
+
+class TestBackfillDoesNotFireOnNewDevices:
+    def test_reopening_does_not_add_a_migration_transition(self, bench) -> None:
+        """A freshly registered device has an empty anchor_epoch_id by
+        design — nothing is promoted yet. Detecting legacy rows by that
+        emptiness made the backfill fire on every new device and write a
+        spurious 'migration' audit row."""
+        import asyncio
+
+        from ori.state.store import StateStore
+
+        assert _register(bench) == 0
+
+        async def transitions():
+            store = StateStore(db_path=bench["db"])
+            await store.open()  # runs migrations again
+            rows = await store.list_firmware_anchor_transitions("ori-fw-bench0001")
+            await store.close()
+            return rows
+
+        first = asyncio.run(transitions())
+        second = asyncio.run(transitions())
+        assert len(first) == len(second) == 1
+        assert second[0]["actor"] == ""
+        assert "migration" not in {t["actor"] for t in second}

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -1430,3 +1430,242 @@ class TestTrustTransitionsAreAttributed:
         insert("discarded", "", "")
         conn.commit()
         conn.close()
+
+
+class TestLifecycleSequences:
+    """The three recovery sequences ori-specs/device-provisioning/v1.md
+    requires. Each was unexecutable before these operations existed."""
+
+    async def _registered_and_active(self, gate, case="manifest_minimal_dev"):
+        c = CASES[case]
+        await gate.register_device(
+            device_id=c["input"]["device_id"],
+            public_key_b64=PUBLIC_KEY_B64,
+            posture=c["input"]["posture"],
+            manifest_message=manifest_message(case),
+        )
+        await gate.approve_device(c["input"]["device_id"], actor="op", reason="initial")
+
+    @pytest.mark.asyncio
+    async def test_revoked_key_unchanged__reinstate_then_promote(self, gate) -> None:
+        await self._registered_and_active(gate)
+        await gate.revoke_device(DEV_DEVICE, actor="op", reason="suspected")
+        original = (await gate._store.list_firmware_anchor_history(DEV_DEVICE))[0]
+
+        assert await gate.reinstate_device(
+            DEV_DEVICE, actor="op", reason="cleared investigation"
+        )
+        # Reinstatement activates NOTHING: the anchor is pending.
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["revoked"] is False
+        assert row["approved"] is False
+        pending = await gate._store.get_pending_firmware_anchor(DEV_DEVICE)
+        assert pending["anchor_epoch_id"] == original["anchor_epoch_id"]
+
+        assert await gate.approve_device(DEV_DEVICE, actor="op", reason="back")
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["approved"] is True
+
+        names = [
+            t["transition"]
+            for t in await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        ]
+        assert names == ["registered", "promoted", "revoked", "reinstated", "promoted"]
+
+    @pytest.mark.asyncio
+    async def test_revoked_and_key_changed__all_three_operations(self, gate) -> None:
+        await self._registered_and_active(gate)
+        # Give the device a command-sequence history to protect.
+        assert await gate._store.allocate_firmware_command_seq(DEV_DEVICE) == 1
+        assert await gate._store.allocate_firmware_command_seq(DEV_DEVICE) == 2
+        await gate._store.advance_firmware_freshness(DEV_DEVICE, boot_id=4, seq=900)
+        await gate.revoke_device(DEV_DEVICE, actor="op", reason="key compromised")
+
+        # Re-provisioning a revoked identity is refused: reinstate first,
+        # or the device returns to service without anyone saying so.
+        new_seed = os.urandom(32)
+        new_manifest = signed_manifest_for_key(new_seed, device_id=DEV_DEVICE)
+        with pytest.raises(FirmwareVerificationError):
+            await gate.reprovision_device(
+                device_id=DEV_DEVICE,
+                public_key_b64=new_manifest["public_key_b64"],
+                posture="development",
+                manifest_message=new_manifest,
+                actor="op",
+                reason="new key",
+            )
+
+        assert await gate.reinstate_device(DEV_DEVICE, actor="op", reason="rebuild")
+        await gate.reprovision_device(
+            device_id=DEV_DEVICE,
+            public_key_b64=new_manifest["public_key_b64"],
+            posture="development",
+            manifest_message=new_manifest,
+            actor="op",
+            reason="nvs erased, device re-keyed",
+        )
+        # Still not active: the new key is pending.
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["public_key_b64"] == PUBLIC_KEY_B64
+
+        assert await gate.approve_device(DEV_DEVICE, actor="op", reason="confirmed")
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["public_key_b64"] == new_manifest["public_key_b64"]
+
+        # A re-keyed device restarts its counters, so the new key epoch
+        # starts a fresh replay window rather than refusing it.
+        assert row["last_boot_id"] == 0
+        assert row["last_seq"] == 0
+        # But cmd_seq is per DEVICE, not per key, and must continue.
+        assert await gate._store.allocate_firmware_command_seq(DEV_DEVICE) == 3
+
+        names = [
+            t["transition"]
+            for t in await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        ]
+        assert names == [
+            "registered",
+            "promoted",
+            "revoked",
+            "reinstated",
+            "reprovisioned",
+            "promoted",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_manifest_promotion_does_not_reset_freshness(self, gate) -> None:
+        # The contrast with the key-change case above: same key, so the
+        # replay window must NOT re-open.
+        await self._registered_and_active(gate, "manifest_full_sealed")
+        await gate._store.advance_firmware_freshness(SEALED_DEVICE, boot_id=4, seq=900)
+        await gate.register_device(
+            device_id=SEALED_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture="sealed_flash",
+            manifest_message=manifest_message("manifest_command_bench"),
+        )
+        await gate.approve_device(SEALED_DEVICE, actor="op", reason="new manifest")
+        row = await gate._store.get_firmware_device(SEALED_DEVICE)
+        assert row["last_boot_id"] == 4
+        assert row["last_seq"] == 900
+
+    @pytest.mark.asyncio
+    async def test_reinstating_a_live_identity_is_refused(self, gate) -> None:
+        await self._registered_and_active(gate)
+        # Clearing a flag that is not set would write an audit row
+        # describing an event that did not happen.
+        assert await gate.reinstate_device(DEV_DEVICE, actor="op", reason="x") is False
+
+    @pytest.mark.asyncio
+    async def test_operations_require_attribution(self, gate) -> None:
+        await self._registered_and_active(gate)
+        await gate.revoke_device(DEV_DEVICE, actor="op", reason="r")
+        with pytest.raises(ValueError, match="audited"):
+            await gate.reinstate_device(DEV_DEVICE, actor="", reason="r")
+        with pytest.raises(ValueError, match="audited"):
+            await gate.reinstate_device(DEV_DEVICE, actor="op", reason="  ")
+
+
+class TestReprovisioningMustActuallyRotate:
+    """Re-provisioning REPLACES a key. Submitting the current one changes
+    nothing, and it previously overwrote the active anchor row with a
+    pending one while the registry still said approved."""
+
+    async def _active(self, gate):
+        c = CASES["manifest_minimal_dev"]
+        await gate.register_device(
+            device_id=DEV_DEVICE,
+            public_key_b64=PUBLIC_KEY_B64,
+            posture=c["input"]["posture"],
+            manifest_message=manifest_message("manifest_minimal_dev"),
+        )
+        await gate.approve_device(DEV_DEVICE, actor="op", reason="init")
+
+    @pytest.mark.asyncio
+    async def test_same_key_is_refused_and_changes_nothing(self, gate) -> None:
+        await self._active(gate)
+        before = await gate._store.get_firmware_device(DEV_DEVICE)
+        history_before = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        audit_before = await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            await gate.reprovision_device(
+                device_id=DEV_DEVICE,
+                public_key_b64=PUBLIC_KEY_B64,
+                posture="development",
+                manifest_message=manifest_message("manifest_minimal_dev"),
+                actor="op",
+                reason="same key",
+            )
+        assert excinfo.value.code == "same_key_not_a_rotation"
+
+        # Registry, history and audit are all untouched.
+        after = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert after == before
+        history_after = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        assert [h["state"] for h in history_after] == [
+            h["state"] for h in history_before
+        ]
+        assert "active" in {h["state"] for h in history_after}
+        audit_after = await gate._store.list_firmware_anchor_transitions(DEV_DEVICE)
+        assert len(audit_after) == len(audit_before)
+
+    @pytest.mark.asyncio
+    async def test_previously_used_key_is_refused(self, gate) -> None:
+        # An old key may be exactly the one rotated away from because it
+        # was compromised. Returning to it would make rotation reversible
+        # by whoever still holds it.
+        await self._active(gate)
+        original = manifest_message("manifest_minimal_dev")
+
+        second = signed_manifest_for_key(os.urandom(32), device_id=DEV_DEVICE)
+        await gate.reprovision_device(
+            device_id=DEV_DEVICE,
+            public_key_b64=second["public_key_b64"],
+            posture="development",
+            manifest_message=second,
+            actor="op",
+            reason="rotate",
+        )
+        await gate.approve_device(DEV_DEVICE, actor="op", reason="promote")
+
+        history_before = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            await gate.reprovision_device(
+                device_id=DEV_DEVICE,
+                public_key_b64=PUBLIC_KEY_B64,
+                posture="development",
+                manifest_message=original,
+                actor="op",
+                reason="back to the old key",
+            )
+        assert excinfo.value.code == "key_epoch_reused"
+
+        history_after = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        assert len(history_after) == len(history_before)
+        row = await gate._store.get_firmware_device(DEV_DEVICE)
+        assert row["public_key_b64"] == second["public_key_b64"]
+
+    @pytest.mark.asyncio
+    async def test_history_is_append_only_across_rotation(self, gate) -> None:
+        await self._active(gate)
+        first_id = (await gate._store.get_firmware_device(DEV_DEVICE))[
+            "anchor_epoch_id"
+        ]
+        new = signed_manifest_for_key(os.urandom(32), device_id=DEV_DEVICE)
+        await gate.reprovision_device(
+            device_id=DEV_DEVICE,
+            public_key_b64=new["public_key_b64"],
+            posture="development",
+            manifest_message=new,
+            actor="op",
+            reason="rotate",
+        )
+        await gate.approve_device(DEV_DEVICE, actor="op", reason="promote")
+
+        history = await gate._store.list_firmware_anchor_history(DEV_DEVICE)
+        ids = {h["anchor_epoch_id"] for h in history}
+        # The original anchor is retained, not overwritten: evidence
+        # outlives the anchor that authorised it.
+        assert first_id in ids
+        assert len(history) == 2


### PR DESCRIPTION
## What does this PR do?

Step 3 of #239 — the operator operations, taken **after** the state machine so they are thin transitions over states that already exist rather than operations inventing their own.

## The two operations

**`reinstate`** returns a revoked identity to service: clears the revoked flag and moves the retained `revoked` anchor back to **pending**. It activates nothing, which keeps promotion the only path to active — and is precisely what makes the spec's recovery sequences executable, since promotion accepts only a pending anchor. Reinstating a live identity is refused rather than writing an audit row describing an event that did not happen.

**`reprovision`** accepts a NEW key for an existing identity, which ordinary registration refuses because a self-signed manifest proves consistency and never provenance. The new-key anchor is stored pending; the previously active anchor stays active until promotion. Re-provisioning a revoked identity is refused — reinstate first, or the device returns to service without anyone saying so.

All three sequences from the contract now execute end to end, with tests asserting the exact transition log:

| Situation | Sequence |
|---|---|
| Revoked, key unchanged | reinstate → promote |
| Revoked, manifest changed | reinstate → register → promote |
| Revoked **and** key changed | reinstate → reprovision → promote |

## Re-provisioning must actually rotate

Review caught a serious bug here. Submitting the **current** key was accepted, and `INSERT OR REPLACE` then overwrote the active anchor row with a pending one **while the registry still said approved** — a split-brain, and a violation of append-only history. I reproduced it before fixing:

```
before: registry approved = True | history: ['active']
after : registry approved = True | history: ['pending']
```

Now refused as `same_key_not_a_rotation`. A **previously used** key is refused too (`key_epoch_reused`): an old key may be exactly the one rotated away from after a compromise, so allowing its return would make rotation reversible by whoever still holds it. The insert no longer replaces, so a collision surfaces as a bug rather than silent data loss.

Neither code is in the spec's error table yet — noted in the release notes as something the contract should adopt.

## Freshness across a key epoch

Promotion now distinguishes the two cases, which matters because a re-keyed device restarts its counters:

- **Same key epoch** (manifest change): freshness preserved — the replay window never left its epoch and must not re-open.
- **New key epoch** (after re-provisioning): fresh window, or the device's restarted counters would be refused as a replay against its predecessor's high-water mark.
- **`cmd_seq` never resets** — the command mark is per device, not per key (`ori-specs/firmware-commands/v1.md`).

## Two bugs only the end-to-end run found

Both passed the unit tests and failed the moment I drove the real CLI:

- **`approve` compared the confirmed key against the registry's key**, which after re-provisioning is the *old active* one — so a re-keyed device could never be promoted. It now confirms the key of the anchor about to be **activated**, which is also the more meaningful check.
- **The migration backfill fired on every freshly registered device**, because it detected legacy rows by an empty `anchor_epoch_id` — now a legitimate state meaning "registered, nothing promoted yet". It wrote a spurious `migration` audit row. Absence of anchor history is the correct signal.

## Release notes

`docs/releases/unreleased.md` is added, recording the **breaking attribution change from #242** with migration guidance, the registration behaviour changes, these operations, the new error codes, and the freshness semantics.

## Type of change

- [x] `feat` — new feature
- [x] `security` — key rotation, revocation recovery, audit integrity

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes — **1959 passed, 6 skipped**
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header *(no new .py files)*
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated — see below
- [x] PR description explains **why**, not just what

No matrix update: the guard covers `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py`, `ori/config.py`. This touches the store, the ingest gate, and the provisioning CLI.

### If you used AI assistance

- [x] I can explain every line in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in review

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #239
- [x] Every new Tier D code path has test coverage — none added
- [x] No new dependencies added

## Testing notes

```
pytest tests/                     1959 passed, 6 skipped
pre-commit run --all-files        all hooks pass
mypy on the files touched here    clean
```

New coverage: the three recovery sequences with their exact transition logs; same-key and previously-used-key re-provisioning refused **without altering registry, history, or audit**; append-only history across rotation; promotion confirming the pending key; the backfill not firing on new devices; and attribution required on both operations.

Refs #239 — **not closed.** Verity's equivalent registry and epoch-transition API, then the shared cross-store lifecycle vectors, remain.
