### PR TITLE
test(provisioning): shared cross-store device lifecycle vectors

### DIFF
--- a/scripts/generate_device_lifecycle_vectors.py
+++ b/scripts/generate_device_lifecycle_vectors.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Generate the shared cross-store device-lifecycle vectors.
+
+The contract is ori-specs/device-provisioning/v1.md, which requires
+"shared cross-repo lifecycle vectors ... agreed byte-for-byte by every
+implementing repository" before an implementation may claim it.
+
+Two things are being pinned, and they are pinned differently.
+
+**Epoch identifiers** are *derived* here. ``key_epoch_id`` and
+``anchor_epoch_id`` exist so two stores that never talk to each other
+compute the same value for the same anchor; that is what makes "both
+accepted the same epoch" checkable rather than asserted. The canonical
+pre-image bytes are emitted alongside each identifier so a mismatch in
+another language localises to canonicalisation or to hashing, instead of
+presenting as an opaque hash difference.
+
+**Scenario expectations are hand-authored from the spec**, not recorded
+from this store. That distinction is the whole point. A corpus generated
+by running the implementation cannot detect that the implementation is
+wrong -- it certifies whatever the code does today, and a bug becomes the
+contract the moment it ships. Every ``expect`` and ``final_state`` below
+was written by reading the section named in ``contract_ref``, so a
+runtime that deviates from the spec fails its verifier rather than
+quietly rewriting the corpus.
+
+The keys are fixed test values. Nothing here needs a private key: the
+lifecycle operates on an anchor's *identity*, and signature verification
+happens a layer above, in the gate.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from ori.security.firmware_telemetry import (
+    anchor_epoch_id,
+    canonical_json_bytes,
+    key_epoch_id,
+)
+
+CONTRACT = "ori-specs/device-provisioning/v1.md"
+VERSION = 1
+
+DEVICE_ID = "ori-edge-lifecycle-01"
+
+# Fixed 32-byte test keys. Distinct, deterministic, and obviously
+# synthetic so no one mistakes one for a fleet key.
+KEYS = {
+    "K1": base64.b64encode(bytes([0x11] * 32)).decode(),
+    "K2": base64.b64encode(bytes([0x22] * 32)).decode(),
+    "K3": base64.b64encode(bytes([0x33] * 32)).decode(),
+}
+
+CAPS = {
+    "C1": "sha256:" + hashlib.sha256(b"ori-lifecycle-capability-1").hexdigest(),
+    "C2": "sha256:" + hashlib.sha256(b"ori-lifecycle-capability-2").hexdigest(),
+    "C3": "sha256:" + hashlib.sha256(b"ori-lifecycle-capability-3").hexdigest(),
+}
+
+# Named anchors, referenced by scenarios. An anchor is the triple the
+# lifecycle actually turns on: key, posture, capability hash.
+ANCHORS: dict[str, dict[str, str]] = {
+    # baseline
+    "A1": {"key": "K1", "posture": "development", "cap": "C1"},
+    # same key, new manifest -> same key epoch, new anchor epoch
+    "A2": {"key": "K1", "posture": "development", "cap": "C2"},
+    # a second manifest change, to exercise pending replacement
+    "A3": {"key": "K1", "posture": "development", "cap": "C3"},
+    # new key -> new key epoch
+    "A4": {"key": "K2", "posture": "development", "cap": "C1"},
+    # a third key, for the reuse case
+    "A5": {"key": "K3", "posture": "development", "cap": "C1"},
+    # same key and manifest, different posture: a different trust
+    # proposition, so a different anchor epoch under the same key epoch
+    "A6": {"key": "K1", "posture": "sealed_flash", "cap": "C1"},
+}
+
+
+def anchor_fields(name: str) -> dict[str, str]:
+    a = ANCHORS[name]
+    return {
+        "device_id": DEVICE_ID,
+        "public_key_b64": KEYS[a["key"]],
+        "posture": a["posture"],
+        "capability_hash": CAPS[a["cap"]],
+    }
+
+
+def epoch_ids(name: str) -> tuple[str, str]:
+    f = anchor_fields(name)
+    return (
+        key_epoch_id(device_id=f["device_id"], public_key_b64=f["public_key_b64"]),
+        anchor_epoch_id(**f),
+    )
+
+
+# ── Scenarios ────────────────────────────────────────────────────────
+#
+# Authored from the spec. `contract_ref` names the section each
+# expectation comes from, so a reviewer can check the corpus against the
+# contract without reading any implementation.
+#
+# `ops`:
+#   register     ordinary device-initiated registration
+#   promote      the operator act that makes a pending anchor active
+#   revoke       take the identity out of service
+#   reinstate    return a revoked identity to service
+#   reprovision  explicit, audited key replacement
+#   advance_freshness / allocate_cmd_seq   freshness bookkeeping
+#
+# `final_state.anchor_states` is the COMPLETE set of anchors the identity
+# has ever held, keyed by name. Requiring completeness is deliberate: an
+# implementation that silently deletes a superseded anchor would satisfy
+# a subset check while destroying the history evidence depends on.
+
+SCENARIOS: list[dict[str, Any]] = [
+    {
+        "name": "first_registration_is_pending",
+        "contract_ref": "Registration Lifecycle / Anchor States",
+        "why": (
+            "A device that has just published its manifest has proved "
+            "internal consistency and nothing else. It grants nothing "
+            "until an operator promotes it."
+        ),
+        "steps": [{"op": "register", "anchor": "A1", "expect": "registered"}],
+        "final_state": {
+            "approved": False,
+            "revoked": False,
+            "active": None,
+            "pending": "A1",
+            "anchor_states": {"A1": "pending"},
+            "transitions": [],
+        },
+    },
+    {
+        "name": "duplicate_registration_is_idempotent",
+        "contract_ref": "Registration Lifecycle -- anchor matches active exactly",
+        "why": (
+            "A device reconnecting and re-publishing an unchanged "
+            "manifest is the common case, not an event. Re-registration "
+            "must not re-open approval or disturb freshness."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "advance_freshness", "boot_id": 7, "seq": 42, "expect": True},
+            {"op": "register", "anchor": "A1", "expect": "unchanged"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": None,
+            "anchor_states": {"A1": "active"},
+            "last_boot_id": 7,
+            "last_seq": 42,
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "pending_registration_republished_is_idempotent",
+        "contract_ref": "Registration Lifecycle -- anchor matches pending exactly",
+        "why": "Re-publishing does not promote. Only an operator promotes.",
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "register", "anchor": "A1", "expect": "unchanged"},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": False,
+            "active": None,
+            "pending": "A1",
+            "anchor_states": {"A1": "pending"},
+            "transitions": [],
+        },
+    },
+    {
+        "name": "manifest_change_becomes_pending_candidate",
+        "contract_ref": "Registration Lifecycle -- same key, new capability_hash",
+        "why": (
+            "A device must not be able to grant itself a new capability "
+            "surface by publishing. The new manifest waits beside the "
+            "active anchor, which keeps operating untouched."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "advance_freshness", "boot_id": 3, "seq": 9, "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": "A2",
+            "anchor_states": {"A1": "active", "A2": "pending"},
+            # Freshness is scoped to the KEY epoch, which did not change.
+            "last_boot_id": 3,
+            "last_seq": 9,
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "posture_change_is_a_new_anchor_epoch",
+        "contract_ref": "Epoch Identity / anchor_epoch_id",
+        "why": (
+            "The same device in sealed_flash is a materially different "
+            "trust proposition from the same device in development, even "
+            "with an unchanged key and manifest, so it needs approving."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A6", "expect": "pending_manifest_epoch"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": "A6",
+            "anchor_states": {"A1": "active", "A6": "pending"},
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "replaced_pending_candidate_is_discarded",
+        "contract_ref": "Replacing a pending candidate",
+        "why": (
+            "Refusing instead would strand a device whose unpromoted "
+            "manifest was wrong. Discarding costs nothing because a "
+            "pending anchor never granted anything -- which is exactly "
+            "why it is recorded as discarded rather than superseded."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "register", "anchor": "A3", "expect": "pending_manifest_epoch"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": "A3",
+            "anchor_states": {"A1": "active", "A2": "discarded", "A3": "pending"},
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "promotion_supersedes_the_previous_anchor",
+        "contract_ref": "Anchor States / Promotion",
+        "why": (
+            "The previous anchor is retained, never deleted: evidence "
+            "outlives the anchor that authorised it."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "advance_freshness", "boot_id": 4, "seq": 11, "expect": True},
+            {"op": "promote", "expect": True},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A2",
+            "pending": None,
+            "anchor_states": {"A1": "superseded", "A2": "active"},
+            # Same key epoch throughout, so the replay window stays closed.
+            "last_boot_id": 4,
+            "last_seq": 11,
+            "transitions": ["promoted", "promoted"],
+        },
+    },
+    {
+        "name": "key_change_refused_through_registration",
+        "contract_ref": "Why a changed key cannot arrive through ordinary registration",
+        "why": (
+            "A self-signed manifest proves internal consistency, never "
+            "provenance. Accepting a new key on that basis would let "
+            "anyone able to publish take over the identity."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A4", "expect": "refused_key_change"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": None,
+            "anchor_states": {"A1": "active"},
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "revocation_retains_active_and_discards_pending",
+        "contract_ref": "Revocation",
+        "why": (
+            "The formerly active anchor is retained so reinstatement has "
+            "something to return to. A pending candidate is discarded, so "
+            "revocation cannot leave a promotable anchor behind."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "revoke", "expect": True},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": True,
+            "active": None,
+            "pending": None,
+            "anchor_states": {"A1": "revoked", "A2": "discarded"},
+            "transitions": ["promoted", "revoked"],
+        },
+    },
+    {
+        "name": "revocation_survives_registration",
+        "contract_ref": "Identity And Revocation",
+        "why": (
+            "Revocation belongs to the identity, not to an anchor. If "
+            "re-publishing a manifest cleared it, revocation would be "
+            "durable only until the device next reconnected."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "revoke", "expect": True},
+            {"op": "register", "anchor": "A1", "expect": "refused_revoked"},
+            {"op": "register", "anchor": "A2", "expect": "refused_revoked"},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": True,
+            "active": None,
+            "pending": None,
+            "anchor_states": {"A1": "revoked"},
+            "transitions": ["promoted", "revoked"],
+        },
+    },
+    {
+        "name": "revocation_survives_reprovision",
+        "contract_ref": "Identity And Revocation / Re-provisioning",
+        "why": (
+            "Key replacement is not a way around revocation. Returning a "
+            "revoked identity to service is reinstatement, which is "
+            "separately audited."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "revoke", "expect": True},
+            {"op": "reprovision", "anchor": "A4", "expect": "revoked"},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": True,
+            "active": None,
+            "pending": None,
+            "anchor_states": {"A1": "revoked"},
+            "transitions": ["promoted", "revoked"],
+        },
+    },
+    {
+        "name": "reinstatement_returns_to_pending_never_active",
+        "contract_ref": "Reinstatement",
+        "why": (
+            "Promotion is the only path to active. Reinstatement undoes "
+            "the revocation; it does not re-grant trust, so the operator "
+            "must still promote, and that promotion is audited on its own."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "revoke", "expect": True},
+            {"op": "reinstate", "expect": True},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": False,
+            "active": None,
+            "pending": "A1",
+            "anchor_states": {"A1": "pending"},
+            "transitions": ["promoted", "revoked", "reinstated"],
+        },
+    },
+    {
+        "name": "revocation_before_first_promotion_retains_nothing",
+        "contract_ref": "Revocation / Reinstatement",
+        "why": (
+            "Revoking an identity that was never promoted discards its "
+            "pending candidate and retains no anchor, because there was "
+            "never an active one. Reinstatement therefore has nothing to "
+            "return to pending: it clears the revocation and grants "
+            "nothing, and the device must register again before there is "
+            "anything to promote. This is a materially different "
+            "reinstatement state from the promoted case, and the one "
+            "where an implementation is most likely to resurrect a "
+            "discarded candidate."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "revoke", "expect": True},
+            {"op": "reinstate", "expect": True},
+        ],
+        "final_state": {
+            "approved": False,
+            "revoked": False,
+            "active": None,
+            "pending": None,
+            "anchor_states": {"A1": "discarded"},
+            "transitions": ["revoked", "reinstated"],
+        },
+    },
+    {
+        "name": "reinstated_unpromoted_identity_must_register_again",
+        "contract_ref": "Revocation / Reinstatement / Promotion",
+        "why": (
+            "The return path for a never-promoted identity runs through "
+            "registration, not promotion. The discarded candidate stays "
+            "discarded; the re-registered anchor is a new pending one."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "revoke", "expect": True},
+            {"op": "reinstate", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "promote", "expect": True},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A2",
+            "pending": None,
+            # A1 stays discarded. The history proves the candidate that was
+            # discarded at revocation was retained and never resurrected.
+            "anchor_states": {"A1": "discarded", "A2": "active"},
+            "transitions": ["revoked", "reinstated", "promoted"],
+        },
+    },
+    {
+        "name": "reinstated_identity_is_promotable_again",
+        "contract_ref": "Reinstatement / Promotion",
+        "why": "Reinstatement plus promotion is the full return to service.",
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "revoke", "expect": True},
+            {"op": "reinstate", "expect": True},
+            {"op": "promote", "expect": True},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": None,
+            "anchor_states": {"A1": "active"},
+            "transitions": ["promoted", "revoked", "reinstated", "promoted"],
+        },
+    },
+    {
+        "name": "key_rotation_via_reprovision",
+        "contract_ref": "Re-provisioning (key replacement) / Freshness Across Epochs",
+        "why": (
+            "The new key lands pending, so the device keeps operating "
+            "under the old anchor until an operator promotes. Promoting a "
+            "new KEY epoch resets telemetry freshness -- a re-keyed device "
+            "restarts its counters and would otherwise be refused as a "
+            "replay against its predecessor's high-water mark. cmd_seq is "
+            "per device, not per key, so it survives."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "advance_freshness", "boot_id": 5, "seq": 77, "expect": True},
+            {"op": "allocate_cmd_seq", "expect": 1},
+            {"op": "allocate_cmd_seq", "expect": 2},
+            {"op": "reprovision", "anchor": "A4", "expect": "reprovisioned"},
+            # The active anchor is untouched while the new key waits.
+            {"op": "assert_active", "anchor": "A1"},
+            {"op": "promote", "expect": True},
+            # The command mark continues from 2 rather than restarting.
+            # Asserting the next allocation proves continuation; reading
+            # the stored column would also pass if the counter had been
+            # reset and coincidentally rewritten.
+            {"op": "allocate_cmd_seq", "expect": 3},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A4",
+            "pending": None,
+            "anchor_states": {"A1": "superseded", "A4": "active"},
+            "last_boot_id": 0,
+            "last_seq": 0,
+            "transitions": ["promoted", "reprovisioned", "promoted"],
+        },
+    },
+    {
+        "name": "reprovision_with_the_current_key_refused",
+        "contract_ref": "Re-provisioning (key replacement)",
+        "why": (
+            "Nothing is being replaced. Accepting it would put a pending "
+            "anchor over an active one for the same key, leaving the "
+            "registry and the anchor history disagreeing about which "
+            "anchor is trusted."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "reprovision", "anchor": "A2", "expect": "refused_same_key"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": None,
+            "anchor_states": {"A1": "active"},
+            "transitions": ["promoted"],
+        },
+    },
+    {
+        "name": "reprovision_to_a_previously_used_key_refused",
+        "contract_ref": "Re-provisioning (key replacement)",
+        "why": (
+            "An old key may be exactly the one rotated away from because "
+            "it was compromised. Returning to it would make rotation "
+            "reversible by whoever still holds it."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "reprovision", "anchor": "A4", "expect": "reprovisioned"},
+            {"op": "promote", "expect": True},
+            # Back to K1 -- the key just rotated away from.
+            {"op": "reprovision", "anchor": "A2", "expect": "refused_key_reuse"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A4",
+            "pending": None,
+            "anchor_states": {"A1": "superseded", "A4": "active"},
+            "transitions": ["promoted", "reprovisioned", "promoted"],
+        },
+    },
+    {
+        "name": "second_rotation_to_a_fresh_key_accepted",
+        "contract_ref": "Re-provisioning (key replacement) / Anchor History",
+        "why": (
+            "Refusing key reuse must not refuse rotation itself. A "
+            "genuinely new key is still accepted after a previous "
+            "rotation, and every anchor stays in history."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "reprovision", "anchor": "A4", "expect": "reprovisioned"},
+            {"op": "promote", "expect": True},
+            {"op": "reprovision", "anchor": "A5", "expect": "reprovisioned"},
+            {"op": "promote", "expect": True},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A5",
+            "pending": None,
+            "anchor_states": {
+                "A1": "superseded",
+                "A4": "superseded",
+                "A5": "active",
+            },
+            "transitions": [
+                "promoted",
+                "reprovisioned",
+                "promoted",
+                "reprovisioned",
+                "promoted",
+            ],
+        },
+    },
+]
+
+
+def build() -> dict[str, Any]:
+    epoch_vectors = []
+    for name in sorted(ANCHORS):
+        f = anchor_fields(name)
+        key_pre = canonical_json_bytes(
+            {
+                "device_id": f["device_id"],
+                "public_key_b64": f["public_key_b64"],
+                "v": 1,
+            }
+        )
+        anchor_pre = canonical_json_bytes(
+            {
+                "capability_hash": f["capability_hash"],
+                "device_id": f["device_id"],
+                "posture": f["posture"],
+                "public_key_b64": f["public_key_b64"],
+                "v": 1,
+            }
+        )
+        kid, aid = epoch_ids(name)
+        epoch_vectors.append(
+            {
+                "anchor": name,
+                "input": f,
+                "key_epoch_canonical_hex": key_pre.hex(),
+                "key_epoch_id": kid,
+                "anchor_epoch_canonical_hex": anchor_pre.hex(),
+                "anchor_epoch_id": aid,
+            }
+        )
+
+    scenarios = []
+    for s in SCENARIOS:
+        entry = dict(s)
+        used = sorted(
+            {st["anchor"] for st in s["steps"] if "anchor" in st}
+            | set(s["final_state"]["anchor_states"])
+        )
+        entry["anchors_used"] = used
+        scenarios.append(entry)
+
+    return {
+        "contract": CONTRACT,
+        "version": VERSION,
+        "comment": (
+            "Shared cross-store device-lifecycle vectors. Epoch identifiers "
+            "are derived; scenario expectations are hand-authored from the "
+            "contract sections named in each contract_ref, so an "
+            "implementation that deviates fails rather than redefining the "
+            "corpus. Keys are fixed test values and are never used in "
+            "production."
+        ),
+        "device_id": DEVICE_ID,
+        "keys": KEYS,
+        "capability_hashes": CAPS,
+        "anchors": {
+            name: {
+                "public_key_b64": KEYS[a["key"]],
+                "posture": a["posture"],
+                "capability_hash": CAPS[a["cap"]],
+                "key_ref": a["key"],
+            }
+            for name, a in ANCHORS.items()
+        },
+        "epoch_vectors": epoch_vectors,
+        "scenarios": scenarios,
+    }
+
+
+def main() -> None:
+    out = Path(__file__).resolve().parents[1] / (
+        "tests/fixtures/device_lifecycle_vectors.json"
+    )
+    out.write_text(json.dumps(build(), indent=2, sort_keys=False) + "\n")
+    print(f"wrote {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/device_lifecycle_vectors.json
+++ b/tests/fixtures/device_lifecycle_vectors.json
@@ -1,0 +1,967 @@
+{
+  "contract": "ori-specs/device-provisioning/v1.md",
+  "version": 1,
+  "comment": "Shared cross-store device-lifecycle vectors. Epoch identifiers are derived; scenario expectations are hand-authored from the contract sections named in each contract_ref, so an implementation that deviates fails rather than redefining the corpus. Keys are fixed test values and are never used in production.",
+  "device_id": "ori-edge-lifecycle-01",
+  "keys": {
+    "K1": "ERERERERERERERERERERERERERERERERERERERERERE=",
+    "K2": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+    "K3": "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM="
+  },
+  "capability_hashes": {
+    "C1": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413",
+    "C2": "sha256:81f770c8d218e5685b6ec4213d2de3b9abfabb12850c715788c3f0f654752fa4",
+    "C3": "sha256:ebc9aae82a7cd579565eecd4a17722d42121a130fd49b65f8d2bf9e99cca10fd"
+  },
+  "anchors": {
+    "A1": {
+      "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+      "posture": "development",
+      "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413",
+      "key_ref": "K1"
+    },
+    "A2": {
+      "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+      "posture": "development",
+      "capability_hash": "sha256:81f770c8d218e5685b6ec4213d2de3b9abfabb12850c715788c3f0f654752fa4",
+      "key_ref": "K1"
+    },
+    "A3": {
+      "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+      "posture": "development",
+      "capability_hash": "sha256:ebc9aae82a7cd579565eecd4a17722d42121a130fd49b65f8d2bf9e99cca10fd",
+      "key_ref": "K1"
+    },
+    "A4": {
+      "public_key_b64": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+      "posture": "development",
+      "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413",
+      "key_ref": "K2"
+    },
+    "A5": {
+      "public_key_b64": "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM=",
+      "posture": "development",
+      "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413",
+      "key_ref": "K3"
+    },
+    "A6": {
+      "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+      "posture": "sealed_flash",
+      "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413",
+      "key_ref": "K1"
+    }
+  },
+  "epoch_vectors": [
+    {
+      "anchor": "A1",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+        "posture": "development",
+        "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "key_epoch_id": "sha256:034fcd8d1428a362217f41e735e6e475fea55688e1a481d6fd8b07af2b9be8d8",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a33303834626230383830663966363966633835373464363666343465663538663432376164303765616631373831383063366430356338303531326533343133222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a22646576656c6f706d656e74222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "anchor_epoch_id": "sha256:e82b1ccd0b23394e005d8c984e3855b665278091be76aaa1c239a9f7c9f8db31"
+    },
+    {
+      "anchor": "A2",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+        "posture": "development",
+        "capability_hash": "sha256:81f770c8d218e5685b6ec4213d2de3b9abfabb12850c715788c3f0f654752fa4"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "key_epoch_id": "sha256:034fcd8d1428a362217f41e735e6e475fea55688e1a481d6fd8b07af2b9be8d8",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a38316637373063386432313865353638356236656334323133643264653362396162666162623132383530633731353738386333663066363534373532666134222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a22646576656c6f706d656e74222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "anchor_epoch_id": "sha256:2db35ab3385cfd6b2bcfbdcc3b1d0a3cb9d2234e25d89ff8bc8290096255b842"
+    },
+    {
+      "anchor": "A3",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+        "posture": "development",
+        "capability_hash": "sha256:ebc9aae82a7cd579565eecd4a17722d42121a130fd49b65f8d2bf9e99cca10fd"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "key_epoch_id": "sha256:034fcd8d1428a362217f41e735e6e475fea55688e1a481d6fd8b07af2b9be8d8",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a65626339616165383261376364353739353635656563643461313737323264343231323161313330666434396236356638643262663965393963636131306664222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a22646576656c6f706d656e74222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "anchor_epoch_id": "sha256:2e2ded295dbb09307708f50a8545047bfad97c1e4ddd5d542e663bd98d2f3f91"
+    },
+    {
+      "anchor": "A4",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "IiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiIiI=",
+        "posture": "development",
+        "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a22496949694969496949694969496949694969496949694969496949694969496949694969496949694969493d222c2276223a317d",
+      "key_epoch_id": "sha256:1ddb036950a95acd99c75f39f7c1cd6dca216f51ba52b76961dbe37b1985dc94",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a33303834626230383830663966363966633835373464363666343465663538663432376164303765616631373831383063366430356338303531326533343133222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a22646576656c6f706d656e74222c227075626c69635f6b65795f623634223a22496949694969496949694969496949694969496949694969496949694969496949694969496949694969493d222c2276223a317d",
+      "anchor_epoch_id": "sha256:47f4207f6745711ae569f106cd0013402cd7ef69d25b5fe4c5e0db7582b24a89"
+    },
+    {
+      "anchor": "A5",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "MzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzMzM=",
+        "posture": "development",
+        "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a224d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d3d222c2276223a317d",
+      "key_epoch_id": "sha256:05c48120a7a900d5d4ad467998776245f9b2936c1ba25ecf99a89bc1ca954f91",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a33303834626230383830663966363966633835373464363666343465663538663432376164303765616631373831383063366430356338303531326533343133222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a22646576656c6f706d656e74222c227075626c69635f6b65795f623634223a224d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d7a4d3d222c2276223a317d",
+      "anchor_epoch_id": "sha256:7b447b135e6ba6074a73d1b2c1f3a841bc4c866c26445f72325d91e094f8895e"
+    },
+    {
+      "anchor": "A6",
+      "input": {
+        "device_id": "ori-edge-lifecycle-01",
+        "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+        "posture": "sealed_flash",
+        "capability_hash": "sha256:3084bb0880f9f69fc8574d66f44ef58f427ad07eaf178180c6d05c80512e3413"
+      },
+      "key_epoch_canonical_hex": "7b226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "key_epoch_id": "sha256:034fcd8d1428a362217f41e735e6e475fea55688e1a481d6fd8b07af2b9be8d8",
+      "anchor_epoch_canonical_hex": "7b226361706162696c6974795f68617368223a227368613235363a33303834626230383830663966363966633835373464363666343465663538663432376164303765616631373831383063366430356338303531326533343133222c226465766963655f6964223a226f72692d656467652d6c6966656379636c652d3031222c22706f7374757265223a227365616c65645f666c617368222c227075626c69635f6b65795f623634223a22455245524552455245524552455245524552455245524552455245524552455245524552455245524552453d222c2276223a317d",
+      "anchor_epoch_id": "sha256:d728703586daabd5dabf98dde96a1be3cf5126d8640352ce3191cba80bce62df"
+    }
+  ],
+  "scenarios": [
+    {
+      "name": "first_registration_is_pending",
+      "contract_ref": "Registration Lifecycle / Anchor States",
+      "why": "A device that has just published its manifest has proved internal consistency and nothing else. It grants nothing until an operator promotes it.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": false,
+        "active": null,
+        "pending": "A1",
+        "anchor_states": {
+          "A1": "pending"
+        },
+        "transitions": []
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "duplicate_registration_is_idempotent",
+      "contract_ref": "Registration Lifecycle -- anchor matches active exactly",
+      "why": "A device reconnecting and re-publishing an unchanged manifest is the common case, not an event. Re-registration must not re-open approval or disturb freshness.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "advance_freshness",
+          "boot_id": 7,
+          "seq": 42,
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "unchanged"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": null,
+        "anchor_states": {
+          "A1": "active"
+        },
+        "last_boot_id": 7,
+        "last_seq": 42,
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "pending_registration_republished_is_idempotent",
+      "contract_ref": "Registration Lifecycle -- anchor matches pending exactly",
+      "why": "Re-publishing does not promote. Only an operator promotes.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "unchanged"
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": false,
+        "active": null,
+        "pending": "A1",
+        "anchor_states": {
+          "A1": "pending"
+        },
+        "transitions": []
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "manifest_change_becomes_pending_candidate",
+      "contract_ref": "Registration Lifecycle -- same key, new capability_hash",
+      "why": "A device must not be able to grant itself a new capability surface by publishing. The new manifest waits beside the active anchor, which keeps operating untouched.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "advance_freshness",
+          "boot_id": 3,
+          "seq": 9,
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": "A2",
+        "anchor_states": {
+          "A1": "active",
+          "A2": "pending"
+        },
+        "last_boot_id": 3,
+        "last_seq": 9,
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "posture_change_is_a_new_anchor_epoch",
+      "contract_ref": "Epoch Identity / anchor_epoch_id",
+      "why": "The same device in sealed_flash is a materially different trust proposition from the same device in development, even with an unchanged key and manifest, so it needs approving.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A6",
+          "expect": "pending_manifest_epoch"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": "A6",
+        "anchor_states": {
+          "A1": "active",
+          "A6": "pending"
+        },
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A6"
+      ]
+    },
+    {
+      "name": "replaced_pending_candidate_is_discarded",
+      "contract_ref": "Replacing a pending candidate",
+      "why": "Refusing instead would strand a device whose unpromoted manifest was wrong. Discarding costs nothing because a pending anchor never granted anything -- which is exactly why it is recorded as discarded rather than superseded.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "register",
+          "anchor": "A3",
+          "expect": "pending_manifest_epoch"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": "A3",
+        "anchor_states": {
+          "A1": "active",
+          "A2": "discarded",
+          "A3": "pending"
+        },
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2",
+        "A3"
+      ]
+    },
+    {
+      "name": "promotion_supersedes_the_previous_anchor",
+      "contract_ref": "Anchor States / Promotion",
+      "why": "The previous anchor is retained, never deleted: evidence outlives the anchor that authorised it.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "advance_freshness",
+          "boot_id": 4,
+          "seq": 11,
+          "expect": true
+        },
+        {
+          "op": "promote",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A2",
+        "pending": null,
+        "anchor_states": {
+          "A1": "superseded",
+          "A2": "active"
+        },
+        "last_boot_id": 4,
+        "last_seq": 11,
+        "transitions": [
+          "promoted",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "key_change_refused_through_registration",
+      "contract_ref": "Why a changed key cannot arrive through ordinary registration",
+      "why": "A self-signed manifest proves internal consistency, never provenance. Accepting a new key on that basis would let anyone able to publish take over the identity.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A4",
+          "expect": "refused_key_change"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": null,
+        "anchor_states": {
+          "A1": "active"
+        },
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A4"
+      ]
+    },
+    {
+      "name": "revocation_retains_active_and_discards_pending",
+      "contract_ref": "Revocation",
+      "why": "The formerly active anchor is retained so reinstatement has something to return to. A pending candidate is discarded, so revocation cannot leave a promotable anchor behind.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": true,
+        "active": null,
+        "pending": null,
+        "anchor_states": {
+          "A1": "revoked",
+          "A2": "discarded"
+        },
+        "transitions": [
+          "promoted",
+          "revoked"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "revocation_survives_registration",
+      "contract_ref": "Identity And Revocation",
+      "why": "Revocation belongs to the identity, not to an anchor. If re-publishing a manifest cleared it, revocation would be durable only until the device next reconnected.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "refused_revoked"
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "refused_revoked"
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": true,
+        "active": null,
+        "pending": null,
+        "anchor_states": {
+          "A1": "revoked"
+        },
+        "transitions": [
+          "promoted",
+          "revoked"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "revocation_survives_reprovision",
+      "contract_ref": "Identity And Revocation / Re-provisioning",
+      "why": "Key replacement is not a way around revocation. Returning a revoked identity to service is reinstatement, which is separately audited.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A4",
+          "expect": "revoked"
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": true,
+        "active": null,
+        "pending": null,
+        "anchor_states": {
+          "A1": "revoked"
+        },
+        "transitions": [
+          "promoted",
+          "revoked"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A4"
+      ]
+    },
+    {
+      "name": "reinstatement_returns_to_pending_never_active",
+      "contract_ref": "Reinstatement",
+      "why": "Promotion is the only path to active. Reinstatement undoes the revocation; it does not re-grant trust, so the operator must still promote, and that promotion is audited on its own.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "reinstate",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": false,
+        "active": null,
+        "pending": "A1",
+        "anchor_states": {
+          "A1": "pending"
+        },
+        "transitions": [
+          "promoted",
+          "revoked",
+          "reinstated"
+        ]
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "revocation_before_first_promotion_retains_nothing",
+      "contract_ref": "Revocation / Reinstatement",
+      "why": "Revoking an identity that was never promoted discards its pending candidate and retains no anchor, because there was never an active one. Reinstatement therefore has nothing to return to pending: it clears the revocation and grants nothing, and the device must register again before there is anything to promote. This is a materially different reinstatement state from the promoted case, and the one where an implementation is most likely to resurrect a discarded candidate.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "reinstate",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": false,
+        "revoked": false,
+        "active": null,
+        "pending": null,
+        "anchor_states": {
+          "A1": "discarded"
+        },
+        "transitions": [
+          "revoked",
+          "reinstated"
+        ]
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "reinstated_unpromoted_identity_must_register_again",
+      "contract_ref": "Revocation / Reinstatement / Promotion",
+      "why": "The return path for a never-promoted identity runs through registration, not promotion. The discarded candidate stays discarded; the re-registered anchor is a new pending one.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "reinstate",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A2",
+        "pending": null,
+        "anchor_states": {
+          "A1": "discarded",
+          "A2": "active"
+        },
+        "transitions": [
+          "revoked",
+          "reinstated",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "reinstated_identity_is_promotable_again",
+      "contract_ref": "Reinstatement / Promotion",
+      "why": "Reinstatement plus promotion is the full return to service.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "revoke",
+          "expect": true
+        },
+        {
+          "op": "reinstate",
+          "expect": true
+        },
+        {
+          "op": "promote",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": null,
+        "anchor_states": {
+          "A1": "active"
+        },
+        "transitions": [
+          "promoted",
+          "revoked",
+          "reinstated",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1"
+      ]
+    },
+    {
+      "name": "key_rotation_via_reprovision",
+      "contract_ref": "Re-provisioning (key replacement) / Freshness Across Epochs",
+      "why": "The new key lands pending, so the device keeps operating under the old anchor until an operator promotes. Promoting a new KEY epoch resets telemetry freshness -- a re-keyed device restarts its counters and would otherwise be refused as a replay against its predecessor's high-water mark. cmd_seq is per device, not per key, so it survives.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "advance_freshness",
+          "boot_id": 5,
+          "seq": 77,
+          "expect": true
+        },
+        {
+          "op": "allocate_cmd_seq",
+          "expect": 1
+        },
+        {
+          "op": "allocate_cmd_seq",
+          "expect": 2
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A4",
+          "expect": "reprovisioned"
+        },
+        {
+          "op": "assert_active",
+          "anchor": "A1"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "allocate_cmd_seq",
+          "expect": 3
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A4",
+        "pending": null,
+        "anchor_states": {
+          "A1": "superseded",
+          "A4": "active"
+        },
+        "last_boot_id": 0,
+        "last_seq": 0,
+        "transitions": [
+          "promoted",
+          "reprovisioned",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A4"
+      ]
+    },
+    {
+      "name": "reprovision_with_the_current_key_refused",
+      "contract_ref": "Re-provisioning (key replacement)",
+      "why": "Nothing is being replaced. Accepting it would put a pending anchor over an active one for the same key, leaving the registry and the anchor history disagreeing about which anchor is trusted.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A2",
+          "expect": "refused_same_key"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": null,
+        "anchor_states": {
+          "A1": "active"
+        },
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "reprovision_to_a_previously_used_key_refused",
+      "contract_ref": "Re-provisioning (key replacement)",
+      "why": "An old key may be exactly the one rotated away from because it was compromised. Returning to it would make rotation reversible by whoever still holds it.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A4",
+          "expect": "reprovisioned"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A2",
+          "expect": "refused_key_reuse"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A4",
+        "pending": null,
+        "anchor_states": {
+          "A1": "superseded",
+          "A4": "active"
+        },
+        "transitions": [
+          "promoted",
+          "reprovisioned",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2",
+        "A4"
+      ]
+    },
+    {
+      "name": "second_rotation_to_a_fresh_key_accepted",
+      "contract_ref": "Re-provisioning (key replacement) / Anchor History",
+      "why": "Refusing key reuse must not refuse rotation itself. A genuinely new key is still accepted after a previous rotation, and every anchor stays in history.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A4",
+          "expect": "reprovisioned"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A5",
+          "expect": "reprovisioned"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A5",
+        "pending": null,
+        "anchor_states": {
+          "A1": "superseded",
+          "A4": "superseded",
+          "A5": "active"
+        },
+        "transitions": [
+          "promoted",
+          "reprovisioned",
+          "promoted",
+          "reprovisioned",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A4",
+        "A5"
+      ]
+    }
+  ]
+}

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -5,10 +5,11 @@
 The corpus (``tests/fixtures/device_lifecycle_vectors.json``) is the
 contract in executable form: ori-specs/device-provisioning/v1.md requires
 lifecycle vectors "agreed byte-for-byte by every implementing repository"
-before an implementation may claim the contract. The corpus is written
-to be shared with ori-verity, which must derive the same epoch
-identifiers from the same bytes; that adoption is a separate change and
-has not landed yet.
+before an implementation may claim the contract. ori-verity holds the
+same bytes and derives the same epoch identifiers from them with its own
+canonicalizer. It does not yet implement the anchor lifecycle, so it
+executes the epoch half of this corpus and declares the scenario half
+explicitly unimplemented.
 
 These tests drive the **real** ``StateStore``. No scenario expectation
 is derived from the store: the generator never observes it, and every
@@ -24,6 +25,7 @@ fixture is exactly what the generator produces.
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 from pathlib import Path
@@ -35,6 +37,14 @@ from ori.state.store import StateStore
 
 FIXTURE = Path(__file__).parent / "fixtures" / "device_lifecycle_vectors.json"
 VECTORS = json.loads(FIXTURE.read_text())
+
+# SHA-256 of the complete corpus. ori-verity pins this same constant over
+# its own copy, and both must be updated together. Pinning it in only one
+# repository would not catch drift: each copy would still match its own
+# stale constant while the two files diverged. Asserting the identical
+# digest on both sides means a regeneration that is not mirrored fails on
+# the side that moved.
+FIXTURE_SHA256 = "27b9418a9bf42abb4ae1fc50545661e730bc4b936edf70c22d28e35011bee79b"
 
 ANCHORS = VECTORS["anchors"]
 DEVICE_ID = VECTORS["device_id"]
@@ -78,10 +88,25 @@ async def store(tmp_path):
         await s.close()
 
 
+def test_fixture_digest_is_pinned():
+    """Changing the corpus must be a deliberate, cross-repo act.
+
+    ori-verity consumes these exact bytes. Regenerating here without
+    mirroring there would leave the two stores disagreeing about the
+    contract while both test suites stayed green.
+    """
+    digest = hashlib.sha256(FIXTURE.read_bytes()).hexdigest()
+    assert digest == FIXTURE_SHA256, (
+        "the lifecycle corpus changed. Copy it to ori-verity's "
+        "tests/fixtures/ and update the pinned digest in BOTH "
+        f"repositories to {digest}"
+    )
+
+
 def test_fixture_matches_its_generator():
     """The committed corpus must be exactly what the generator produces.
 
-    ori-verity is to consume this file byte-for-byte. If it could drift
+    ori-verity consumes this file byte-for-byte. If it could drift
     from its generator, a hand-edit would become the cross-store contract
     without anything noticing, and regenerating would then silently
     revert another repository's expectations.
@@ -129,8 +154,6 @@ def test_epoch_canonical_preimages_hash_to_the_declared_ids():
     every implementation reading only the hash would still pass, leaving
     another language no way to localise a mismatch.
     """
-    import hashlib
-
     for v in VECTORS["epoch_vectors"]:
         for pre_key, id_key in (
             ("key_epoch_canonical_hex", "key_epoch_id"),
@@ -273,6 +296,13 @@ async def test_lifecycle_scenario(store, scenario):
     for t in audited:
         assert t["actor"].strip(), f"{t['transition']} recorded without an actor"
         assert t["reason"].strip(), f"{t['transition']} recorded without a reason"
+
+
+def test_scenario_names_are_unique():
+    """Two scenarios sharing a name makes one invisible to every check
+    keyed on it, here and in ori-verity's unimplemented-scenario list."""
+    names = [s["name"] for s in VECTORS["scenarios"]]
+    assert len(names) == len(set(names))
 
 
 async def test_every_contract_operation_is_covered():

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -1,0 +1,316 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""The runtime's half of the shared cross-store lifecycle vectors.
+
+The corpus (``tests/fixtures/device_lifecycle_vectors.json``) is the
+contract in executable form: ori-specs/device-provisioning/v1.md requires
+lifecycle vectors "agreed byte-for-byte by every implementing repository"
+before an implementation may claim the contract. The corpus is written
+to be shared with ori-verity, which must derive the same epoch
+identifiers from the same bytes; that adoption is a separate change and
+has not landed yet.
+
+These tests drive the **real** ``StateStore``. No scenario expectation
+is derived from the store: the generator never observes it, and every
+``expect`` and ``final_state`` was written from the contract section
+named in the scenario's ``contract_ref``. A store that deviates
+therefore fails here instead of silently redefining the corpus, which a
+corpus recorded from the implementation could never do -- that kind
+certifies whatever the code does today, including its bugs.
+
+One test does call the generator, but only to confirm the committed
+fixture is exactly what the generator produces.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from ori.security.firmware_telemetry import anchor_epoch_id, key_epoch_id
+from ori.state.store import StateStore
+
+FIXTURE = Path(__file__).parent / "fixtures" / "device_lifecycle_vectors.json"
+VECTORS = json.loads(FIXTURE.read_text())
+
+ANCHORS = VECTORS["anchors"]
+DEVICE_ID = VECTORS["device_id"]
+
+# Transitions that change what a receiver will accept. These are the ones
+# the contract requires to be attributed; `registered`, `superseded` and
+# `discarded` are bookkeeping consequences, not operator decisions.
+AUDITED = {"promoted", "revoked", "reinstated", "reprovisioned"}
+
+ACTOR = "uid=0:test-operator (lifecycle vectors)"
+REASON = "cross-store lifecycle vector"
+
+
+def anchor_call_fields(name: str) -> dict[str, str]:
+    """The store arguments for a named anchor.
+
+    ``manifest_json`` carries the capability hash so the stored manifest
+    and the anchor cannot drift apart in a fixture, even though the
+    lifecycle itself treats the manifest as opaque.
+    """
+    a = ANCHORS[name]
+    return {
+        "public_key_b64": a["public_key_b64"],
+        "posture": a["posture"],
+        "capability_hash": a["capability_hash"],
+        "manifest_json": json.dumps(
+            {"capability_hash": a["capability_hash"], "posture": a["posture"]},
+            sort_keys=True,
+        ),
+        "channel_map_json": "{}",
+    }
+
+
+@pytest.fixture
+async def store(tmp_path):
+    s = StateStore(db_path=str(tmp_path / "lifecycle.db"))
+    await s.open()
+    try:
+        yield s
+    finally:
+        await s.close()
+
+
+def test_fixture_matches_its_generator():
+    """The committed corpus must be exactly what the generator produces.
+
+    ori-verity is to consume this file byte-for-byte. If it could drift
+    from its generator, a hand-edit would become the cross-store contract
+    without anything noticing, and regenerating would then silently
+    revert another repository's expectations.
+    """
+    # Loaded by path rather than imported: `scripts/` is not a package
+    # and is only importable because of where pytest happens to put the
+    # rootdir, which is not a property worth depending on.
+    spec = importlib.util.spec_from_file_location(
+        "_lifecycle_vector_generator",
+        Path(__file__).parents[1] / "scripts" / "generate_device_lifecycle_vectors.py",
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert VECTORS == module.build(), (
+        "tests/fixtures/device_lifecycle_vectors.json is stale; "
+        "re-run scripts/generate_device_lifecycle_vectors.py"
+    )
+
+
+# ── Epoch identifiers ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("vector", VECTORS["epoch_vectors"], ids=lambda v: v["anchor"])
+def test_epoch_ids_match_the_corpus(vector):
+    """Independent derivations must agree.
+
+    ``anchor_epoch_id`` is the value cross-store agreement is expressed
+    in, so if the runtime and Verity derive it differently, "both stores
+    accepted the same epoch" becomes unfalsifiable.
+    """
+    i = vector["input"]
+    assert (
+        key_epoch_id(device_id=i["device_id"], public_key_b64=i["public_key_b64"])
+        == vector["key_epoch_id"]
+    )
+    assert anchor_epoch_id(**i) == vector["anchor_epoch_id"]
+
+
+def test_epoch_canonical_preimages_hash_to_the_declared_ids():
+    """The recorded pre-image bytes must actually produce the recorded id.
+
+    Without this, the canonical bytes and the hash could disagree and
+    every implementation reading only the hash would still pass, leaving
+    another language no way to localise a mismatch.
+    """
+    import hashlib
+
+    for v in VECTORS["epoch_vectors"]:
+        for pre_key, id_key in (
+            ("key_epoch_canonical_hex", "key_epoch_id"),
+            ("anchor_epoch_canonical_hex", "anchor_epoch_id"),
+        ):
+            digest = hashlib.sha256(bytes.fromhex(v[pre_key])).hexdigest()
+            assert v[id_key] == f"sha256:{digest}", (v["anchor"], pre_key)
+
+
+def test_key_epoch_ignores_manifest_and_posture():
+    """Freshness is scoped to the key epoch, so it must not move when only
+    the manifest or posture changes -- otherwise a manifest update would
+    reopen the replay window."""
+    same_key = [
+        v
+        for v in VECTORS["epoch_vectors"]
+        if v["input"]["public_key_b64"] == ANCHORS["A1"]["public_key_b64"]
+    ]
+    assert len({v["key_epoch_id"] for v in same_key}) == 1
+    # ...while the anchor epoch does distinguish them.
+    assert len({v["anchor_epoch_id"] for v in same_key}) == len(same_key)
+
+
+# ── Lifecycle scenarios ──────────────────────────────────────────────
+
+
+async def run_step(store: StateStore, step: dict) -> None:
+    op = step["op"]
+
+    if op == "register":
+        outcome = await store.upsert_firmware_device_anchor(
+            device_id=DEVICE_ID, **anchor_call_fields(step["anchor"])
+        )
+    elif op == "reprovision":
+        outcome = await store.reprovision_firmware_device(
+            device_id=DEVICE_ID,
+            actor=ACTOR,
+            reason=REASON,
+            **anchor_call_fields(step["anchor"]),
+        )
+    elif op == "promote":
+        outcome = await store.approve_firmware_device(
+            DEVICE_ID, actor=ACTOR, reason=REASON
+        )
+    elif op == "revoke":
+        outcome = await store.revoke_firmware_device(
+            DEVICE_ID, actor=ACTOR, reason=REASON
+        )
+    elif op == "reinstate":
+        outcome = await store.reinstate_firmware_device(
+            DEVICE_ID, actor=ACTOR, reason=REASON
+        )
+    elif op == "advance_freshness":
+        outcome = await store.advance_firmware_freshness(
+            DEVICE_ID, boot_id=step["boot_id"], seq=step["seq"]
+        )
+    elif op == "allocate_cmd_seq":
+        outcome = await store.allocate_firmware_command_seq(DEVICE_ID)
+    elif op == "assert_active":
+        row = await store.get_firmware_device(DEVICE_ID)
+        expected = anchor_epoch_id(device_id=DEVICE_ID, **_epoch_input(step["anchor"]))
+        assert row["anchor_epoch_id"] == expected, (
+            f"active anchor should still be {step['anchor']}"
+        )
+        return
+    else:  # pragma: no cover - a typo in the corpus must not pass silently
+        raise AssertionError(f"unknown op {op!r}")
+
+    assert outcome == step["expect"], (
+        f"{op}: expected {step['expect']!r}, got {outcome!r}"
+    )
+
+
+def _epoch_input(name: str) -> dict[str, str]:
+    a = ANCHORS[name]
+    return {
+        "public_key_b64": a["public_key_b64"],
+        "posture": a["posture"],
+        "capability_hash": a["capability_hash"],
+    }
+
+
+def epoch_of(name: str) -> str:
+    return anchor_epoch_id(device_id=DEVICE_ID, **_epoch_input(name))
+
+
+@pytest.mark.parametrize("scenario", VECTORS["scenarios"], ids=lambda s: s["name"])
+async def test_lifecycle_scenario(store, scenario):
+    for step in scenario["steps"]:
+        await run_step(store, step)
+
+    expected = scenario["final_state"]
+    row = await store.get_firmware_device(DEVICE_ID)
+    assert row is not None
+
+    assert bool(row["approved"]) is expected["approved"]
+    assert bool(row["revoked"]) is expected["revoked"]
+
+    history = await store.list_firmware_anchor_history(DEVICE_ID)
+
+    # The registry must point at the active anchor, or at nothing when
+    # there is no active anchor. A registry pointing at a superseded or
+    # discarded anchor is the split-brain this contract exists to prevent.
+    actives = [h for h in history if h["state"] == "active"]
+    assert len(actives) <= 1, "an identity may hold at most one active anchor"
+    if expected["active"] is None:
+        assert actives == []
+    else:
+        assert len(actives) == 1
+        assert actives[0]["anchor_epoch_id"] == epoch_of(expected["active"])
+        assert row["anchor_epoch_id"] == actives[0]["anchor_epoch_id"]
+
+    pending = await store.get_pending_firmware_anchor(DEVICE_ID)
+    if expected["pending"] is None:
+        assert pending is None
+    else:
+        assert pending is not None
+        assert pending["anchor_epoch_id"] == epoch_of(expected["pending"])
+
+    # One row per anchor epoch. Keying the comparison below by epoch id
+    # would otherwise collapse duplicates and hide a store that inserted
+    # a second row for an anchor it already held.
+    ids = [h["anchor_epoch_id"] for h in history]
+    assert len(ids) == len(set(ids)), "duplicate anchor rows in history"
+
+    # Anchor history is compared as a COMPLETE mapping. A subset check
+    # would let an implementation delete a superseded anchor and still
+    # pass, destroying the history that evidence resolves against.
+    got = {h["anchor_epoch_id"]: h["state"] for h in history}
+    want = {epoch_of(n): s for n, s in expected["anchor_states"].items()}
+    assert got == want
+
+    if "last_boot_id" in expected:
+        assert row["last_boot_id"] == expected["last_boot_id"]
+    if "last_seq" in expected:
+        assert row["last_seq"] == expected["last_seq"]
+    transitions = await store.list_firmware_anchor_transitions(DEVICE_ID)
+    audited = [t for t in transitions if t["transition"] in AUDITED]
+    assert [t["transition"] for t in audited] == expected["transitions"]
+    for t in audited:
+        assert t["actor"].strip(), f"{t['transition']} recorded without an actor"
+        assert t["reason"].strip(), f"{t['transition']} recorded without a reason"
+
+
+async def test_every_contract_operation_is_covered():
+    """The corpus must exercise each lifecycle operation.
+
+    A vector set that quietly stopped covering revocation would still be
+    green, which is the failure mode golden corpora are most prone to.
+    """
+    ops = {step["op"] for s in VECTORS["scenarios"] for step in s["steps"]}
+    assert {
+        "register",
+        "promote",
+        "revoke",
+        "reinstate",
+        "reprovision",
+    } <= ops
+
+
+async def test_every_outcome_code_is_exercised():
+    """Every refusal code the store can return must appear in the corpus.
+
+    Refusals are the security-relevant half of this contract; an
+    unexercised refusal is an untested one.
+    """
+    expected_outcomes = {
+        step["expect"]
+        for s in VECTORS["scenarios"]
+        for step in s["steps"]
+        if isinstance(step.get("expect"), str)
+    }
+    assert {
+        "registered",
+        "unchanged",
+        "pending_manifest_epoch",
+        "refused_revoked",
+        "refused_key_change",
+        "reprovisioned",
+        "revoked",
+        "refused_same_key",
+        "refused_key_reuse",
+    } <= expected_outcomes


### PR DESCRIPTION
## What does this PR do?

Adds the shared cross-store device-lifecycle corpus required by
`ori-specs/device-provisioning/v1.md`, and the runtime's half of it.

The contract says an implementation may not claim it without "shared cross-repo
lifecycle vectors ... agreed byte-for-byte by every implementing repository"
and "`key_epoch_id` and `anchor_epoch_id` vectors, so independent derivations
are proven identical rather than assumed". This is that artifact.

**Why it matters beyond coverage.** The contract forbids publishing an approval
until the runtime and the evidence store have accepted the *same*
`anchor_epoch_id`. If the two derive that identifier differently, the check is
not merely weakened — it is unfalsifiable, because the stores would never agree
on the value they are supposed to be comparing. ori-verity's companion PR
re-derives every identifier here with its own Rust canonicalizer.

**Expectations are authored from the spec, not recorded from the store.** Every
`expect` and `final_state` was written by reading the section named in that
scenario's `contract_ref`. This direction is the whole point: a corpus produced
by running the implementation certifies whatever the code does today, including
its bugs, and can never detect that the store is wrong. Here a deviation fails
the test instead of silently redefining the contract.

Seventeen scenarios cover first registration, duplicate registration of active
and pending anchors, manifest change as a pending candidate, pending
replacement, posture change as a new anchor epoch, promotion and supersession,
key rotation, revocation from both the promoted and never-promoted states,
reinstatement from both, and every refusal code the store can return.

### Anti-drift, in three layers

- The committed fixture is asserted equal to what the generator produces, so a
  hand-edit cannot quietly become the cross-store contract.
- The corpus SHA-256 is pinned here **and identically in ori-verity**. Pinning
  it in one repository alone would not catch divergence: each copy would still
  match its own stale constant while the two files drifted apart.
- Anchor history is compared as a **complete** mapping, so an implementation
  that deleted a superseded anchor could not pass a subset check.

### Verified by mutation, not assumed

Each guard was confirmed to bite by injecting the regression it exists to
catch:

| Injected regression | Result |
| --- | --- |
| Registration silently un-revokes (the original #239 bug) | `revocation_survives_registration` fails |
| Promotion deletes the superseded anchor | 4 scenarios fail |
| A scenario body edited in one repo only | only the pinned digest catches it; the other 6 Verity tests stay green |

The store was restored and `git diff` confirmed clean after each.

## Type of change

- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures — 1991 passed, 6 skipped
- [x] `ruff check --fix ori/ tests/ skills/` is clean (full `pre-commit run --all-files` passes)
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — tests and a fixture only; no capability behaviour changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Issue discussed first — #239
- [x] No new dependencies added

No production code changes: additions are a generator script, a fixture, and a
test module.

## Related issue

Part of #239.

## Testing notes

Two findings surfaced while authoring the corpus and are worth a reviewer's
attention:

1. **Outcome vocabulary does not match the contract.** The store returns
   `revoked`, `refused_same_key` and `refused_key_reuse`, while the spec names
   these conditions `device_revoked`, `same_key_not_a_rotation` and
   `key_epoch_reused`. These are internal return values rather than reported
   errors, so nothing is wrong today, but whatever the runtime surfaces at the
   contract boundary must use the normative names. The companion ori-specs PR
   makes that requirement explicit.

2. **A re-registered anchor reuses its discarded history row.** Registering an
   anchor whose epoch was previously discarded moves that row back to pending
   rather than retaining the discarded record and inserting a new one. The
   corpus deliberately avoids depending on this, and the scenario that probes
   the area registers a *different* anchor so it proves the discarded candidate
   is retained. Flagging rather than encoding it, since the contract does not
   say which is correct.

The Verity companion pins the identical digest
`27b9418a9bf42abb4ae1fc50545661e730bc4b936edf70c22d28e35011bee79b`, so the two
PRs must land together or the second to merge will fail.
