### PR TITLE
feat(provisioning): derive anchor activation intervals from the log

### DIFF
--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -450,6 +450,41 @@ CREATE TABLE IF NOT EXISTS firmware_fault_events (
 """
 
 
+# Marks a migrated identity whose activation history cannot be
+# reconstructed. Revocation sets `approved = 0`, so a pre-lifecycle
+# revoked row is identical whether it was revoked after being promoted or
+# before ever being promoted. Compared as a constant rather than matched
+# as text, so the marker and its reader cannot drift apart.
+_MIGRATION_ACTIVATION_UNPROVABLE = (
+    "backfilled from a pre-lifecycle revoked registry row; whether this "
+    "anchor was ever promoted cannot be determined, because revocation "
+    "cleared the approval flag"
+)
+
+# The reason written by the first lifecycle release's backfill. Databases
+# upgraded by that release already hold an anchor row, so the backfill
+# skips them; this constant is how the follow-up migration recognises
+# them and completes their activation history.
+_MIGRATION_BACKFILL_REASON = "backfilled from a pre-lifecycle registry row"
+
+# Appended by the follow-up migration when an already-backfilled anchor's
+# activation cannot be safely reconstructed.
+_MIGRATION_ACTIVATION_UNRECONSTRUCTABLE = (
+    "already backfilled by an earlier release; whether this anchor was "
+    "ever promoted cannot be reconstructed from the recorded history"
+)
+
+# Recorded for an approved legacy row. Being approved proves the anchor is
+# active when the migration observes it; it does not prove when the
+# approval happened. `provisioned_at_ms` is when the device was
+# provisioned, which can be long before it was approved, so using it as
+# the start would vouch for evidence produced in between.
+_MIGRATION_ACTIVATION_START_UNKNOWN = (
+    "observed active at the migration boundary; the original approval was "
+    "never recorded, so activation before this point is unknown"
+)
+
+
 def _require_attribution(operation: str, actor: str, reason: str) -> None:
     """Mandatory audit fields for a trust transition.
 
@@ -589,6 +624,10 @@ class StateStore:
                 conn, "firmware_device_registry", col, typedef
             )
         self._backfill_firmware_anchor_epochs_on_conn(conn)
+        # Runs after, and independently: it repairs identities the first
+        # lifecycle release already backfilled, which the call above skips
+        # because they now have an anchor row.
+        self._complete_backfilled_activation_history_on_conn(conn)
         conn.execute(
             """
             CREATE INDEX IF NOT EXISTS idx_remote_command_log_sender_rejections
@@ -629,11 +668,16 @@ class StateStore:
             key_epoch_id as _key_epoch_id,
         )
 
+        # The receiver-anchored boundary: the moment this store observed
+        # these rows. Every inferred activation starts here, never at a
+        # timestamp carried over from the old schema.
+        migration_at_ms = now_ms()
+
         rows = conn.execute(
             """
             SELECT r.device_id, r.public_key_b64, r.posture, r.capability_hash,
                    r.manifest_json, r.channel_map_json, r.board_profile,
-                   r.approved, r.revoked, r.provisioned_at_ms
+                   r.approved, r.revoked, r.provisioned_at_ms, r.revoked_at_ms
               FROM firmware_device_registry r
              WHERE NOT EXISTS (
                        SELECT 1 FROM firmware_device_anchors a
@@ -696,10 +740,212 @@ class StateStore:
                 INSERT INTO firmware_anchor_transitions
                     (device_id, transition, from_epoch_id, to_epoch_id,
                      key_epoch_id, actor, reason, occurred_at_ms)
-                VALUES (?, 'registered', NULL, ?, ?, 'migration',
-                        'backfilled from a pre-lifecycle registry row', ?)
+                VALUES (?, 'registered', NULL, ?, ?, 'migration', ?, ?)
                 """,
-                (row["device_id"], aid, kid, row["provisioned_at_ms"]),
+                (
+                    row["device_id"],
+                    aid,
+                    kid,
+                    _MIGRATION_ACTIVATION_UNPROVABLE
+                    if state == "revoked"
+                    else _MIGRATION_BACKFILL_REASON,
+                    row["provisioned_at_ms"],
+                ),
+            )
+
+            # An approved, unrevoked legacy row IS active, so it was
+            # promoted at some point. Recording that is what stops the
+            # derived activation history from reporting the anchor as
+            # never active and losing the attribution for everything it
+            # authorised before the upgrade.
+            #
+            # A REVOKED row is deliberately excluded. Revocation sets
+            # `approved = 0`, so a revoked legacy row reads
+            # `approved=0, revoked=1` whether it was revoked after being
+            # promoted or before ever being promoted. The two are
+            # indistinguishable in a pre-lifecycle database, and inventing
+            # a promotion for both would manufacture authorisation for an
+            # identity that may never have had any — failing open on
+            # exactly the question this history exists to answer. Its
+            # activation history is unprovable, and is recorded as such
+            # rather than guessed.
+            #
+            # The interval opens at the MIGRATION BOUNDARY, not at
+            # `provisioned_at_ms`. Approval proves the anchor is active
+            # when the migration observes it; it says nothing about when
+            # the approval happened, and a device is often provisioned
+            # long before it is approved. Starting the interval at
+            # provisioning would vouch for evidence produced in between,
+            # which is precisely the window nobody can account for.
+            if state == "active":
+                conn.execute(
+                    """
+                    INSERT INTO firmware_anchor_transitions
+                        (device_id, transition, from_epoch_id, to_epoch_id,
+                         key_epoch_id, actor, reason, occurred_at_ms)
+                    VALUES (?, 'promoted', NULL, ?, ?, 'migration', ?, ?)
+                    """,
+                    (
+                        row["device_id"],
+                        aid,
+                        kid,
+                        _MIGRATION_ACTIVATION_START_UNKNOWN,
+                        migration_at_ms,
+                    ),
+                )
+
+    def _complete_backfilled_activation_history_on_conn(
+        self, conn: sqlite3.Connection
+    ) -> None:
+        """Finish the activation history of rows an earlier release already
+        backfilled.
+
+        The first lifecycle release gave pre-lifecycle rows an anchor and a
+        generic ``registered`` transition. Those identities therefore have
+        an anchor row, so the backfill above — which only fires when there
+        is none — never revisits them, and they would keep an activation
+        history that says an approved device was never active.
+
+        The transition log is append-only, so nothing here rewrites the
+        earlier entry; this appends what was missing.
+
+        Idempotent: each branch first checks whether its entry is already
+        present, so reopening a database adds nothing.
+        """
+        migration_at_ms = now_ms()
+
+        rows = conn.execute(
+            """
+            SELECT a.device_id, a.anchor_epoch_id, a.key_epoch_id, a.state,
+                   a.created_at_ms,
+                   (SELECT MIN(t.id) FROM firmware_anchor_transitions t
+                     WHERE t.device_id = a.device_id
+                       AND t.actor = 'migration'
+                       AND t.reason = ?
+                       AND t.to_epoch_id = a.anchor_epoch_id) AS backfill_id
+              FROM firmware_device_anchors a
+             WHERE backfill_id IS NOT NULL
+            """,
+            (_MIGRATION_BACKFILL_REASON,),
+        ).fetchall()
+
+        for row in rows:
+            aid = row["anchor_epoch_id"]
+
+            already_repaired = conn.execute(
+                """
+                SELECT 1 FROM firmware_anchor_transitions
+                 WHERE device_id = ? AND actor = 'migration' AND reason IN (?, ?)
+                 LIMIT 1
+                """,
+                (
+                    row["device_id"],
+                    _MIGRATION_ACTIVATION_START_UNKNOWN,
+                    _MIGRATION_ACTIVATION_UNRECONSTRUCTABLE,
+                ),
+            ).fetchone()
+            if already_repaired is not None:
+                continue
+
+            # The earlier release wrote the same generic reason whichever
+            # state it chose, so the log does not say directly whether this
+            # anchor was backfilled `active` or `pending`. The first
+            # transition to touch the anchor afterwards does say.
+            #
+            # An anchor backfilled PENDING leaves that state one of two
+            # ways, and both are provable:
+            #   `promoted to=A`    a real, recorded first activation
+            #   `discarded from=A` replaced as a candidate. Only a PENDING
+            #                      anchor is ever discarded, so this proves
+            #                      it was never active.
+            #
+            # An anchor backfilled ACTIVE must first LEAVE active, so its
+            # first subsequent mention carries it in from_epoch_id
+            # (`revoked from=A`, or `promoted from=A` when another anchor
+            # superseded it). Its pre-migration activation was never
+            # recorded, and a later re-promotion does not make that earlier
+            # interval provable.
+            first_after = conn.execute(
+                """
+                SELECT transition, from_epoch_id, to_epoch_id
+                  FROM firmware_anchor_transitions
+                 WHERE device_id = ? AND id > ?
+                   AND (from_epoch_id = ? OR to_epoch_id = ?)
+                 ORDER BY id ASC LIMIT 1
+                """,
+                (row["device_id"], row["backfill_id"], aid, aid),
+            ).fetchone()
+
+            if first_after is not None:
+                if (
+                    first_after["transition"] == "promoted"
+                    and first_after["to_epoch_id"] == aid
+                ):
+                    # Backfilled pending, then genuinely promoted. Nothing
+                    # is missing and nothing is uncertain.
+                    continue
+                if (
+                    first_after["transition"] == "discarded"
+                    and first_after["from_epoch_id"] == aid
+                ):
+                    # Backfilled pending, then replaced as a candidate.
+                    # Provably never active, which is a stronger answer
+                    # than "cannot say" — marking it unprovable would
+                    # discard a fact the log does establish.
+                    continue
+                # Backfilled active. Fall through to the marker below: the
+                # promotion that would have to be reconstructed sits before
+                # entries already in the log, and an append cannot express
+                # that without misordering the interval.
+                row = dict(row)
+                row["state"] = "_was_active_before_migration"
+
+            if row["state"] == "active":
+                # It is active now, so it is known active from this
+                # boundary onward. When it BECAME active is unknown, and
+                # `created_at_ms` is the backfill's own timestamp rather
+                # than an approval, so the interval opens here and not
+                # there. Nothing closes it, so appending cannot misorder.
+                conn.execute(
+                    """
+                    INSERT INTO firmware_anchor_transitions
+                        (device_id, transition, from_epoch_id, to_epoch_id,
+                         key_epoch_id, actor, reason, occurred_at_ms)
+                    VALUES (?, 'promoted', NULL, ?, ?, 'migration', ?, ?)
+                    """,
+                    (
+                        row["device_id"],
+                        aid,
+                        row["key_epoch_id"],
+                        _MIGRATION_ACTIVATION_START_UNKNOWN,
+                        migration_at_ms,
+                    ),
+                )
+                continue
+
+            if row["state"] == "pending":
+                # Provably never promoted: the earlier backfill only chose
+                # `pending` for a row that was never approved.
+                continue
+
+            # `revoked`, an anchor that was active before the migration, or
+            # `superseded`/`discarded` reached by later activity. None of
+            # these can say when — or whether — the anchor was active
+            # before the upgrade, so all fail closed.
+            conn.execute(
+                """
+                INSERT INTO firmware_anchor_transitions
+                    (device_id, transition, from_epoch_id, to_epoch_id,
+                     key_epoch_id, actor, reason, occurred_at_ms)
+                VALUES (?, 'registered', NULL, ?, ?, 'migration', ?, ?)
+                """,
+                (
+                    row["device_id"],
+                    aid,
+                    row["key_epoch_id"],
+                    _MIGRATION_ACTIVATION_UNRECONSTRUCTABLE,
+                    migration_at_ms,
+                ),
             )
 
     def _add_column_if_missing_on_conn(
@@ -2863,6 +3109,183 @@ class StateStore:
             (device_id,),
         ).fetchall()
         return [dict(r) for r in rows]
+
+    async def firmware_anchor_activation_intervals(
+        self, device_id: str, anchor_epoch_id: str
+    ) -> list[dict]:
+        """Every interval during which an anchor epoch was active.
+
+        ori-specs/device-provisioning/v1.md requires implementations to be
+        able to determine, for any anchor epoch, whether it was ever
+        active and over which intervals.
+
+        The anchor's ``state`` column cannot answer this. An anchor that
+        was active, was superseded, and has since been re-registered
+        reads ``pending`` today, because an anchor epoch has exactly one
+        record whose state is its *current* state. Evidence produced
+        while it was active is still legitimately attributed to it, so a
+        consumer reading only the current state would treat correctly
+        signed history as never having been authorised.
+
+        The transition log is the append-only record, and this derives
+        the intervals from it rather than storing them, so there is one
+        source of truth.
+
+        Ordering is receiver-anchored: ``seq`` is the log's own append
+        order and ``at_ms`` is assigned by this store when the transition
+        is recorded. Device wall-clock time is never consulted — a device
+        supplying its own timestamps could otherwise place its evidence
+        inside an interval when its anchor was active, which is the very
+        question being decided.
+
+        An interval with ``deactivated_seq`` of ``None`` is still open:
+        the anchor is active now.
+        """
+        return await self._run_read(
+            self._firmware_anchor_activation_intervals_sync,
+            device_id,
+            anchor_epoch_id,
+        )
+
+    def _firmware_anchor_activation_intervals_sync(
+        self, conn: sqlite3.Connection, device_id: str, anchor_epoch_id: str
+    ) -> list[dict]:
+        rows = conn.execute(
+            """
+            SELECT id, transition, from_epoch_id, to_epoch_id, occurred_at_ms
+              FROM firmware_anchor_transitions
+             WHERE device_id = ?
+             ORDER BY id ASC
+            """,
+            (device_id,),
+        ).fetchall()
+
+        intervals: list[dict] = []
+        open_interval: dict | None = None
+
+        for r in rows:
+            # Promotion is the only thing that makes an anchor active, so
+            # it is the only thing that opens an interval.
+            if r["transition"] == "promoted" and r["to_epoch_id"] == anchor_epoch_id:
+                if open_interval is None:
+                    open_interval = {
+                        "activated_seq": int(r["id"]),
+                        "activated_at_ms": int(r["occurred_at_ms"]),
+                        "deactivated_seq": None,
+                        "deactivated_at_ms": None,
+                    }
+                    intervals.append(open_interval)
+                continue
+
+            # Two things end an interval: another anchor being promoted
+            # over this one, and the identity being revoked.
+            #
+            # `reprovisioned` deliberately does NOT, even though it also
+            # carries this anchor in from_epoch_id: re-provisioning stores
+            # the new key as PENDING and leaves the current anchor active
+            # until it is promoted. Treating it as a deactivation would
+            # report a gap in which the device was in fact still trusted.
+            ends = r["transition"] in ("promoted", "revoked")
+            if ends and r["from_epoch_id"] == anchor_epoch_id:
+                if open_interval is not None:
+                    open_interval["deactivated_seq"] = int(r["id"])
+                    open_interval["deactivated_at_ms"] = int(r["occurred_at_ms"])
+                    open_interval = None
+
+        return intervals
+
+    async def firmware_anchor_was_active_at(
+        self, device_id: str, anchor_epoch_id: str, *, at_ms: int
+    ) -> bool:
+        """Whether this anchor was *known* active at a receiver-anchored
+        instant.
+
+        ``at_ms`` MUST be a time this receiver assigned — its record of
+        when evidence arrived, or a position derived from the Verity
+        chain. It must never be a device-reported timestamp: a device
+        choosing its own would place its evidence inside an interval when
+        its anchor was active, which is the question being decided.
+
+        Returns ``False`` outside every known interval. For a migrated
+        identity that means anything before the migration boundary is
+        refused, because when its approval originally happened was never
+        recorded — see ``firmware_activation_history_is_provable``.
+        """
+        intervals = await self.firmware_anchor_activation_intervals(
+            device_id, anchor_epoch_id
+        )
+        for iv in intervals:
+            if at_ms < iv["activated_at_ms"]:
+                continue
+            if iv["deactivated_at_ms"] is None or at_ms < iv["deactivated_at_ms"]:
+                return True
+        return False
+
+    async def firmware_activation_history_is_provable(self, device_id: str) -> bool:
+        """Whether this identity's activation history can be trusted as
+        complete.
+
+        ``False`` for an identity migrated from a pre-lifecycle database
+        while revoked. Revocation sets ``approved = 0``, so such a row is
+        identical whether it was revoked after being promoted or before
+        ever being promoted, and the migration refuses to guess.
+
+        Also ``False`` for an identity this store has never heard of.
+        Absence of a marker is not evidence of a complete history when
+        there is no history at all, and a caller asking about an unknown
+        device must not be told its records are trustworthy.
+
+        Callers deciding historical authorisation MUST treat ``False`` as
+        "unknown", not as "never active", and fail closed. An empty
+        interval list means *provably never promoted* only when this
+        returns ``True``.
+        """
+        return await self._run_read(
+            self._firmware_activation_history_is_provable_sync, device_id
+        )
+
+    def _firmware_activation_history_is_provable_sync(
+        self, conn: sqlite3.Connection, device_id: str
+    ) -> bool:
+        known = conn.execute(
+            "SELECT 1 FROM firmware_device_registry WHERE device_id = ? LIMIT 1",
+            (device_id,),
+        ).fetchone()
+        if known is None:
+            return False
+
+        row = conn.execute(
+            """
+            SELECT 1 FROM firmware_anchor_transitions
+             WHERE device_id = ? AND actor = 'migration' AND reason IN (?, ?, ?)
+             LIMIT 1
+            """,
+            (
+                device_id,
+                _MIGRATION_ACTIVATION_UNPROVABLE,
+                _MIGRATION_ACTIVATION_UNRECONSTRUCTABLE,
+                _MIGRATION_ACTIVATION_START_UNKNOWN,
+            ),
+        ).fetchone()
+        return row is None
+
+    async def firmware_anchor_was_ever_active(
+        self, device_id: str, anchor_epoch_id: str
+    ) -> bool:
+        """Whether this anchor epoch is *known* to have been active.
+
+        Distinct from ``state == 'active'``, which is only true right
+        now, and from ``state == 'superseded'``, which a re-registration
+        clears. Evidence resolution needs this question, not that one.
+
+        ``False`` means "no recorded activation", which is not the same
+        as "never active" for an identity migrated while revoked — see
+        ``firmware_activation_history_is_provable``.
+        """
+        intervals = await self.firmware_anchor_activation_intervals(
+            device_id, anchor_epoch_id
+        )
+        return bool(intervals)
 
     async def get_firmware_device(self, device_id: str) -> dict | None:
         return await self._run_read(self._get_firmware_device_sync, device_id)

--- a/scripts/generate_device_lifecycle_vectors.py
+++ b/scripts/generate_device_lifecycle_vectors.py
@@ -136,6 +136,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": "A1",
             "anchor_states": {"A1": "pending"},
+            "activation_counts": {},
             "transitions": [],
         },
     },
@@ -159,6 +160,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": None,
             "anchor_states": {"A1": "active"},
+            "activation_counts": {"A1": 1},
             "last_boot_id": 7,
             "last_seq": 42,
             "transitions": ["promoted"],
@@ -178,6 +180,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": "A1",
             "anchor_states": {"A1": "pending"},
+            "activation_counts": {},
             "transitions": [],
         },
     },
@@ -201,6 +204,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": "A2",
             "anchor_states": {"A1": "active", "A2": "pending"},
+            "activation_counts": {"A1": 1},
             # Freshness is scoped to the KEY epoch, which did not change.
             "last_boot_id": 3,
             "last_seq": 9,
@@ -226,6 +230,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": "A6",
             "anchor_states": {"A1": "active", "A6": "pending"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted"],
         },
     },
@@ -250,6 +255,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": "A3",
             "anchor_states": {"A1": "active", "A2": "discarded", "A3": "pending"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted"],
         },
     },
@@ -273,10 +279,80 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A2",
             "pending": None,
             "anchor_states": {"A1": "superseded", "A2": "active"},
+            "activation_counts": {"A1": 1, "A2": 1},
             # Same key epoch throughout, so the replay window stays closed.
             "last_boot_id": 4,
             "last_seq": 11,
             "transitions": ["promoted", "promoted"],
+        },
+    },
+    {
+        "name": "superseded_anchor_re_registered_stays_ever_active",
+        "contract_ref": (
+            "Anchor History / Re-registering an anchor the identity has held before"
+        ),
+        "why": (
+            "An anchor epoch has one record whose state is its CURRENT "
+            "state, so re-registering a superseded anchor returns it to "
+            "pending and the state field stops showing it was ever "
+            "active. Evidence produced while it WAS active is still "
+            "attributed to it. An implementation that answered "
+            "'was this authorised' from current state would read "
+            "correctly signed history as never authorised, so the "
+            "active intervals must survive the re-registration."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "promote", "expect": True},
+            # A1 is superseded here; registering it again returns it to
+            # pending, which is what erases "was active" from the state.
+            {"op": "register", "anchor": "A1", "expect": "pending_manifest_epoch"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A2",
+            "pending": "A1",
+            "anchor_states": {"A1": "pending", "A2": "active"},
+            # The point of the scenario: A1 reads pending, and is still
+            # identifiable as having been active.
+            "activation_counts": {"A1": 1, "A2": 1},
+            "transitions": ["promoted", "promoted"],
+        },
+    },
+    {
+        "name": "discarded_anchor_re_registered_returns_to_pending",
+        "contract_ref": ("Re-registering an anchor the identity has held before"),
+        "why": (
+            "A discarded candidate was never active, so returning it to "
+            "pending attributes no evidence and grants nothing. It is "
+            "still not neutral: it displaces whatever candidate was "
+            "pending, which is recorded discarded in its place. The "
+            "judgement belongs at promotion, which has not happened."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+            {"op": "register", "anchor": "A3", "expect": "pending_manifest_epoch"},
+            # A2 is discarded here; registering it again brings it back
+            # and displaces A3 in turn.
+            {"op": "register", "anchor": "A2", "expect": "pending_manifest_epoch"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": "A2",
+            "anchor_states": {
+                "A1": "active",
+                "A2": "pending",
+                "A3": "discarded",
+            },
+            "activation_counts": {"A1": 1},
+            "transitions": ["promoted"],
         },
     },
     {
@@ -298,6 +374,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": None,
             "anchor_states": {"A1": "active"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted"],
         },
     },
@@ -321,6 +398,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": None,
             "anchor_states": {"A1": "revoked", "A2": "discarded"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted", "revoked"],
         },
     },
@@ -345,6 +423,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": None,
             "anchor_states": {"A1": "revoked"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted", "revoked"],
         },
     },
@@ -368,6 +447,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": None,
             "anchor_states": {"A1": "revoked"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted", "revoked"],
         },
     },
@@ -391,6 +471,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": "A1",
             "anchor_states": {"A1": "pending"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted", "revoked", "reinstated"],
         },
     },
@@ -419,6 +500,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": None,
             "pending": None,
             "anchor_states": {"A1": "discarded"},
+            "activation_counts": {},
             "transitions": ["revoked", "reinstated"],
         },
     },
@@ -445,6 +527,7 @@ SCENARIOS: list[dict[str, Any]] = [
             # A1 stays discarded. The history proves the candidate that was
             # discarded at revocation was retained and never resurrected.
             "anchor_states": {"A1": "discarded", "A2": "active"},
+            "activation_counts": {"A2": 1},
             "transitions": ["revoked", "reinstated", "promoted"],
         },
     },
@@ -465,7 +548,36 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": None,
             "anchor_states": {"A1": "active"},
+            "activation_counts": {"A1": 2},
             "transitions": ["promoted", "revoked", "reinstated", "promoted"],
+        },
+    },
+    {
+        "name": "reprovision_leaves_the_previous_anchor_active",
+        "contract_ref": "Re-provisioning (key replacement)",
+        "why": (
+            "Re-provisioning stores the new key as PENDING and leaves the "
+            "current anchor active until an operator promotes. The device "
+            "keeps working under its existing key throughout. This "
+            "scenario deliberately ENDS at the re-provisioning: every "
+            "other rotation case promotes afterwards, which would close "
+            "the old anchor's active interval anyway and hide an "
+            "implementation that ended it too early."
+        ),
+        "steps": [
+            {"op": "register", "anchor": "A1", "expect": "registered"},
+            {"op": "promote", "expect": True},
+            {"op": "reprovision", "anchor": "A4", "expect": "reprovisioned"},
+        ],
+        "final_state": {
+            "approved": True,
+            "revoked": False,
+            "active": "A1",
+            "pending": "A4",
+            "anchor_states": {"A1": "active", "A4": "pending"},
+            # A1's interval is still OPEN here: it is active now.
+            "activation_counts": {"A1": 1},
+            "transitions": ["promoted", "reprovisioned"],
         },
     },
     {
@@ -501,6 +613,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A4",
             "pending": None,
             "anchor_states": {"A1": "superseded", "A4": "active"},
+            "activation_counts": {"A1": 1, "A4": 1},
             "last_boot_id": 0,
             "last_seq": 0,
             "transitions": ["promoted", "reprovisioned", "promoted"],
@@ -526,6 +639,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A1",
             "pending": None,
             "anchor_states": {"A1": "active"},
+            "activation_counts": {"A1": 1},
             "transitions": ["promoted"],
         },
     },
@@ -551,6 +665,7 @@ SCENARIOS: list[dict[str, Any]] = [
             "active": "A4",
             "pending": None,
             "anchor_states": {"A1": "superseded", "A4": "active"},
+            "activation_counts": {"A1": 1, "A4": 1},
             "transitions": ["promoted", "reprovisioned", "promoted"],
         },
     },
@@ -580,6 +695,7 @@ SCENARIOS: list[dict[str, Any]] = [
                 "A4": "superseded",
                 "A5": "active",
             },
+            "activation_counts": {"A1": 1, "A4": 1, "A5": 1},
             "transitions": [
                 "promoted",
                 "reprovisioned",

--- a/tests/fixtures/device_lifecycle_vectors.json
+++ b/tests/fixtures/device_lifecycle_vectors.json
@@ -151,6 +151,7 @@
         "anchor_states": {
           "A1": "pending"
         },
+        "activation_counts": {},
         "transitions": []
       },
       "anchors_used": [
@@ -191,6 +192,9 @@
         "anchor_states": {
           "A1": "active"
         },
+        "activation_counts": {
+          "A1": 1
+        },
         "last_boot_id": 7,
         "last_seq": 42,
         "transitions": [
@@ -225,6 +229,7 @@
         "anchor_states": {
           "A1": "pending"
         },
+        "activation_counts": {},
         "transitions": []
       },
       "anchors_used": [
@@ -266,6 +271,9 @@
           "A1": "active",
           "A2": "pending"
         },
+        "activation_counts": {
+          "A1": 1
+        },
         "last_boot_id": 3,
         "last_seq": 9,
         "transitions": [
@@ -305,6 +313,9 @@
         "anchor_states": {
           "A1": "active",
           "A6": "pending"
+        },
+        "activation_counts": {
+          "A1": 1
         },
         "transitions": [
           "promoted"
@@ -349,6 +360,9 @@
           "A1": "active",
           "A2": "discarded",
           "A3": "pending"
+        },
+        "activation_counts": {
+          "A1": 1
         },
         "transitions": [
           "promoted"
@@ -399,6 +413,10 @@
           "A1": "superseded",
           "A2": "active"
         },
+        "activation_counts": {
+          "A1": 1,
+          "A2": 1
+        },
         "last_boot_id": 4,
         "last_seq": 11,
         "transitions": [
@@ -409,6 +427,111 @@
       "anchors_used": [
         "A1",
         "A2"
+      ]
+    },
+    {
+      "name": "superseded_anchor_re_registered_stays_ever_active",
+      "contract_ref": "Anchor History / Re-registering an anchor the identity has held before",
+      "why": "An anchor epoch has one record whose state is its CURRENT state, so re-registering a superseded anchor returns it to pending and the state field stops showing it was ever active. Evidence produced while it WAS active is still attributed to it. An implementation that answered 'was this authorised' from current state would read correctly signed history as never authorised, so the active intervals must survive the re-registration.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "pending_manifest_epoch"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A2",
+        "pending": "A1",
+        "anchor_states": {
+          "A1": "pending",
+          "A2": "active"
+        },
+        "activation_counts": {
+          "A1": 1,
+          "A2": 1
+        },
+        "transitions": [
+          "promoted",
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2"
+      ]
+    },
+    {
+      "name": "discarded_anchor_re_registered_returns_to_pending",
+      "contract_ref": "Re-registering an anchor the identity has held before",
+      "why": "A discarded candidate was never active, so returning it to pending attributes no evidence and grants nothing. It is still not neutral: it displaces whatever candidate was pending, which is recorded discarded in its place. The judgement belongs at promotion, which has not happened.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "register",
+          "anchor": "A3",
+          "expect": "pending_manifest_epoch"
+        },
+        {
+          "op": "register",
+          "anchor": "A2",
+          "expect": "pending_manifest_epoch"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": "A2",
+        "anchor_states": {
+          "A1": "active",
+          "A2": "pending",
+          "A3": "discarded"
+        },
+        "activation_counts": {
+          "A1": 1
+        },
+        "transitions": [
+          "promoted"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A2",
+        "A3"
       ]
     },
     {
@@ -438,6 +561,9 @@
         "pending": null,
         "anchor_states": {
           "A1": "active"
+        },
+        "activation_counts": {
+          "A1": 1
         },
         "transitions": [
           "promoted"
@@ -480,6 +606,9 @@
         "anchor_states": {
           "A1": "revoked",
           "A2": "discarded"
+        },
+        "activation_counts": {
+          "A1": 1
         },
         "transitions": [
           "promoted",
@@ -528,6 +657,9 @@
         "anchor_states": {
           "A1": "revoked"
         },
+        "activation_counts": {
+          "A1": 1
+        },
         "transitions": [
           "promoted",
           "revoked"
@@ -570,6 +702,9 @@
         "anchor_states": {
           "A1": "revoked"
         },
+        "activation_counts": {
+          "A1": 1
+        },
         "transitions": [
           "promoted",
           "revoked"
@@ -611,6 +746,9 @@
         "anchor_states": {
           "A1": "pending"
         },
+        "activation_counts": {
+          "A1": 1
+        },
         "transitions": [
           "promoted",
           "revoked",
@@ -648,6 +786,7 @@
         "anchor_states": {
           "A1": "discarded"
         },
+        "activation_counts": {},
         "transitions": [
           "revoked",
           "reinstated"
@@ -693,6 +832,9 @@
         "anchor_states": {
           "A1": "discarded",
           "A2": "active"
+        },
+        "activation_counts": {
+          "A2": 1
         },
         "transitions": [
           "revoked",
@@ -740,6 +882,9 @@
         "anchor_states": {
           "A1": "active"
         },
+        "activation_counts": {
+          "A1": 2
+        },
         "transitions": [
           "promoted",
           "revoked",
@@ -749,6 +894,48 @@
       },
       "anchors_used": [
         "A1"
+      ]
+    },
+    {
+      "name": "reprovision_leaves_the_previous_anchor_active",
+      "contract_ref": "Re-provisioning (key replacement)",
+      "why": "Re-provisioning stores the new key as PENDING and leaves the current anchor active until an operator promotes. The device keeps working under its existing key throughout. This scenario deliberately ENDS at the re-provisioning: every other rotation case promotes afterwards, which would close the old anchor's active interval anyway and hide an implementation that ended it too early.",
+      "steps": [
+        {
+          "op": "register",
+          "anchor": "A1",
+          "expect": "registered"
+        },
+        {
+          "op": "promote",
+          "expect": true
+        },
+        {
+          "op": "reprovision",
+          "anchor": "A4",
+          "expect": "reprovisioned"
+        }
+      ],
+      "final_state": {
+        "approved": true,
+        "revoked": false,
+        "active": "A1",
+        "pending": "A4",
+        "anchor_states": {
+          "A1": "active",
+          "A4": "pending"
+        },
+        "activation_counts": {
+          "A1": 1
+        },
+        "transitions": [
+          "promoted",
+          "reprovisioned"
+        ]
+      },
+      "anchors_used": [
+        "A1",
+        "A4"
       ]
     },
     {
@@ -806,6 +993,10 @@
           "A1": "superseded",
           "A4": "active"
         },
+        "activation_counts": {
+          "A1": 1,
+          "A4": 1
+        },
         "last_boot_id": 0,
         "last_seq": 0,
         "transitions": [
@@ -846,6 +1037,9 @@
         "pending": null,
         "anchor_states": {
           "A1": "active"
+        },
+        "activation_counts": {
+          "A1": 1
         },
         "transitions": [
           "promoted"
@@ -893,6 +1087,10 @@
         "anchor_states": {
           "A1": "superseded",
           "A4": "active"
+        },
+        "activation_counts": {
+          "A1": 1,
+          "A4": 1
         },
         "transitions": [
           "promoted",
@@ -948,6 +1146,11 @@
           "A1": "superseded",
           "A4": "superseded",
           "A5": "active"
+        },
+        "activation_counts": {
+          "A1": 1,
+          "A4": 1,
+          "A5": 1
         },
         "transitions": [
           "promoted",

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -44,7 +44,7 @@ VECTORS = json.loads(FIXTURE.read_text())
 # stale constant while the two files diverged. Asserting the identical
 # digest on both sides means a regeneration that is not mirrored fails on
 # the side that moved.
-FIXTURE_SHA256 = "27b9418a9bf42abb4ae1fc50545661e730bc4b936edf70c22d28e35011bee79b"
+FIXTURE_SHA256 = "360f240ab321941bbb8134bbb6e82ac4bdea086cd03fc6013e8b2929a9a8bfac"
 
 ANCHORS = VECTORS["anchors"]
 DEVICE_ID = VECTORS["device_id"]
@@ -286,6 +286,44 @@ async def test_lifecycle_scenario(store, scenario):
     want = {epoch_of(n): s for n, s in expected["anchor_states"].items()}
     assert got == want
 
+    # "Was this anchor ever active, and over which intervals" must survive
+    # the anchor's current state changing. This is compared as a COMPLETE
+    # mapping over every anchor the scenario touches: an anchor absent
+    # from the expectation must have no activation intervals at all, so a
+    # store that invented one could not pass by omission.
+    want_counts = expected["activation_counts"]
+    for name in scenario["anchors_used"]:
+        epoch = epoch_of(name)
+        intervals = await store.firmware_anchor_activation_intervals(DEVICE_ID, epoch)
+        assert len(intervals) == want_counts.get(name, 0), (
+            f"{name}: expected {want_counts.get(name, 0)} activation "
+            f"interval(s), got {len(intervals)}"
+        )
+
+        ever = await store.firmware_anchor_was_ever_active(DEVICE_ID, epoch)
+        assert ever is (name in want_counts)
+
+        for iv in intervals:
+            # Receiver-anchored ordering: the log's own append order and a
+            # timestamp this store assigned. The contract forbids deciding
+            # this from device wall-clock time.
+            assert iv["activated_seq"] is not None
+            assert iv["activated_at_ms"] is not None
+            if iv["deactivated_seq"] is not None:
+                assert iv["deactivated_seq"] > iv["activated_seq"]
+
+        # An interval must be open exactly while the anchor is active, and
+        # closed otherwise. Without this the intervals could end at the
+        # wrong moment and still have the right count -- an implementation
+        # that closed one at re-provisioning rather than at the promotion
+        # that followed would look identical in every scenario that
+        # promotes afterwards.
+        open_intervals = [i for i in intervals if i["deactivated_seq"] is None]
+        is_active_now = expected["active"] == name
+        assert len(open_intervals) == (1 if is_active_now else 0), (
+            f"{name}: active={is_active_now} but {len(open_intervals)} open interval(s)"
+        )
+
     if "last_boot_id" in expected:
         assert row["last_boot_id"] == expected["last_boot_id"]
     if "last_seq" in expected:
@@ -296,6 +334,24 @@ async def test_lifecycle_scenario(store, scenario):
     for t in audited:
         assert t["actor"].strip(), f"{t['transition']} recorded without an actor"
         assert t["reason"].strip(), f"{t['transition']} recorded without a reason"
+
+
+def test_every_scenario_declares_activation_counts():
+    """No scenario may opt out of the ever-active assertion.
+
+    Without this, a scenario could quietly drop the field and stop
+    checking the property #245 exists to protect.
+    """
+    for s in VECTORS["scenarios"]:
+        assert "activation_counts" in s["final_state"], s["name"]
+
+
+def test_a_superseded_anchor_that_is_re_registered_is_covered():
+    """The contract requires evidence for this specific case, and it is
+    the one where current state and history disagree."""
+    names = {s["name"] for s in VECTORS["scenarios"]}
+    assert "superseded_anchor_re_registered_stays_ever_active" in names
+    assert "discarded_anchor_re_registered_returns_to_pending" in names
 
 
 def test_scenario_names_are_unique():

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -1110,6 +1110,529 @@ class TestLifecycleMigration:
             # Never approved, so never trusted for acceptance: pending.
             history = await store.list_firmware_anchor_history("ori-fw-legacy02")
             assert history[0]["state"] == "pending"
+
+            # ...and never active, so no activation interval is invented.
+            epoch = history[0]["anchor_epoch_id"]
+            assert not await store.firmware_anchor_was_ever_active(
+                "ori-fw-legacy02", epoch
+            )
+        finally:
+            await store.close()
+
+    async def _legacy_db(self, tmp_path, name, device_id, *, approved, revoked):
+        """A pre-lifecycle registry row: no epoch ids, no anchor history."""
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / name)
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM firmware_device_anchors")
+        conn.execute("DELETE FROM firmware_anchor_transitions")
+        conn.execute(
+            """
+            INSERT INTO firmware_device_registry
+                (device_id, public_key_b64, posture, capability_hash,
+                 manifest_json, channel_map_json, board_profile, approved,
+                 provisioned_at_ms, last_boot_id, last_seq, revoked,
+                 revoked_at_ms, anchor_epoch_id, key_epoch_id)
+            VALUES (?, ?, 'development', ?, '{}', '{}', '',
+                    ?, 1000, 0, 0, ?, ?, '', '')
+            """,
+            (
+                device_id,
+                PUBLIC_KEY_B64,
+                "sha256:" + "ef" * 32,
+                1 if approved else 0,
+                1 if revoked else 0,
+                2000 if revoked else None,
+            ),
+        )
+        conn.commit()
+        conn.close()
+        return db
+
+    @pytest.mark.asyncio
+    async def test_migrated_approved_device_is_still_ever_active(
+        self, tmp_path
+    ) -> None:
+        """A device approved before the lifecycle existed WAS active.
+
+        The migration is the only place that knows this: pre-lifecycle
+        databases recorded no promotion, so without an inferred one the
+        activation history would report the anchor as never active and
+        evidence it legitimately authorised would read as unauthorised.
+        """
+        from ori.state.store import StateStore
+
+        db = await self._legacy_db(
+            tmp_path, "legacy3.db", "ori-fw-legacy03", approved=True, revoked=False
+        )
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            history = await store.list_firmware_anchor_history("ori-fw-legacy03")
+            assert history[0]["state"] == "active"
+            epoch = history[0]["anchor_epoch_id"]
+
+            assert await store.firmware_anchor_was_ever_active("ori-fw-legacy03", epoch)
+            intervals = await store.firmware_anchor_activation_intervals(
+                "ori-fw-legacy03", epoch
+            )
+            assert len(intervals) == 1
+            # Still active, so the interval is open.
+            assert intervals[0]["deactivated_seq"] is None
+
+            # It opens at the migration boundary, NOT at provisioned_at_ms
+            # (1000). A device is often provisioned long before it is
+            # approved, and starting there would vouch for evidence
+            # produced in a window nobody can account for.
+            boundary = intervals[0]["activated_at_ms"]
+            assert boundary > 1000
+            assert not await store.firmware_anchor_was_active_at(
+                "ori-fw-legacy03", epoch, at_ms=1500
+            )
+            assert await store.firmware_anchor_was_active_at(
+                "ori-fw-legacy03", epoch, at_ms=boundary + 1
+            )
+
+            # ...so the complete historical record is not provable, even
+            # though the anchor is provably active now.
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-legacy03"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_migrated_revoked_device_invents_no_activation(
+        self, tmp_path
+    ) -> None:
+        """A revoked legacy row must not be credited with an activation.
+
+        Revocation sets ``approved = 0``, so the stored shape is
+        ``approved=0, revoked=1`` whether the identity was revoked after
+        being promoted or before it was ever promoted. The two are
+        indistinguishable in a pre-lifecycle database. Inventing a
+        promotion would manufacture authorisation for an identity that may
+        never have had any, so the migration records the history as
+        unprovable and fails closed.
+        """
+        from ori.state.store import StateStore
+
+        db = await self._legacy_db(
+            tmp_path, "legacy4.db", "ori-fw-legacy04", approved=False, revoked=True
+        )
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            history = await store.list_firmware_anchor_history("ori-fw-legacy04")
+            assert history[0]["state"] == "revoked"
+            epoch = history[0]["anchor_epoch_id"]
+
+            assert (
+                await store.firmware_anchor_activation_intervals(
+                    "ori-fw-legacy04", epoch
+                )
+                == []
+            )
+            assert not await store.firmware_anchor_was_ever_active(
+                "ori-fw-legacy04", epoch
+            )
+
+            # ...but that emptiness means "cannot say", not "never active",
+            # and a caller deciding authorisation must be able to tell.
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-legacy04"
+            )
+        finally:
+            await store.close()
+
+    async def _already_backfilled_db(self, tmp_path, name, device_id, *, state):
+        """The state the FIRST lifecycle release's migration produced.
+
+        Such a database already has an anchor row, so the pre-lifecycle
+        backfill never revisits it -- which is exactly why the follow-up
+        migration exists.
+        """
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db = str(tmp_path / name)
+        store = StateStore(db_path=db)
+        await store.open()
+        await store.close()
+
+        conn = sqlite3.connect(db)
+        conn.execute("DELETE FROM firmware_device_anchors")
+        conn.execute("DELETE FROM firmware_anchor_transitions")
+        aid = "sha256:" + "11" * 32
+        kid = "sha256:" + "22" * 32
+        conn.execute(
+            """
+            INSERT INTO firmware_device_registry
+                (device_id, public_key_b64, posture, capability_hash,
+                 manifest_json, channel_map_json, board_profile, approved,
+                 provisioned_at_ms, last_boot_id, last_seq, revoked,
+                 revoked_at_ms, anchor_epoch_id, key_epoch_id)
+            VALUES (?, ?, 'development', ?, '{}', '{}', '', ?, 1000, 0, 0,
+                    ?, ?, ?, ?)
+            """,
+            (
+                device_id,
+                PUBLIC_KEY_B64,
+                "sha256:" + "ef" * 32,
+                1 if state == "active" else 0,
+                1 if state == "revoked" else 0,
+                2000 if state == "revoked" else None,
+                aid,
+                kid,
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO firmware_device_anchors
+                (anchor_epoch_id, device_id, key_epoch_id, public_key_b64,
+                 posture, capability_hash, manifest_json, channel_map_json,
+                 board_profile, state, created_at_ms, state_changed_at_ms)
+            VALUES (?, ?, ?, ?, 'development', ?, '{}', '{}', '', ?, 1000, 1000)
+            """,
+            (aid, device_id, kid, PUBLIC_KEY_B64, "sha256:" + "ef" * 32, state),
+        )
+        # The generic transition the earlier release wrote, and nothing else.
+        conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'registered', NULL, ?, ?, 'migration',
+                    'backfilled from a pre-lifecycle registry row', 1000)
+            """,
+            (device_id, aid, kid),
+        )
+        conn.commit()
+        conn.close()
+        return db, aid
+
+    @pytest.mark.asyncio
+    async def test_already_backfilled_approved_row_gains_its_activation(
+        self, tmp_path
+    ) -> None:
+        """An identity the first lifecycle release migrated is repaired.
+
+        It already has an anchor row, so the pre-lifecycle backfill skips
+        it, and without the follow-up migration an approved device would
+        keep an activation history saying it was never active.
+        """
+        from ori.state.store import StateStore
+
+        db, aid = await self._already_backfilled_db(
+            tmp_path, "upgraded1.db", "ori-fw-upgraded01", state="active"
+        )
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            assert await store.firmware_anchor_was_ever_active("ori-fw-upgraded01", aid)
+            intervals = await store.firmware_anchor_activation_intervals(
+                "ori-fw-upgraded01", aid
+            )
+            assert len(intervals) == 1
+            assert intervals[0]["deactivated_seq"] is None
+
+            # The interval opens at the migration boundary, not at the
+            # backfill's carried-over timestamp. Being approved proves the
+            # anchor is active NOW; it says nothing about when it became
+            # active, so the full record is not provable.
+            assert intervals[0]["activated_at_ms"] > 1000
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded01"
+            )
+
+            # Evidence the receiver timed before the boundary fails closed;
+            # evidence after it resolves.
+            boundary = intervals[0]["activated_at_ms"]
+            assert not await store.firmware_anchor_was_active_at(
+                "ori-fw-upgraded01", aid, at_ms=boundary - 1
+            )
+            assert await store.firmware_anchor_was_active_at(
+                "ori-fw-upgraded01", aid, at_ms=boundary + 1
+            )
+        finally:
+            await store.close()
+
+        # Reopening must not append a second inferred promotion.
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            transitions = await store.list_firmware_anchor_transitions(
+                "ori-fw-upgraded01"
+            )
+            assert [t["transition"] for t in transitions].count("promoted") == 1
+            assert (
+                len(
+                    await store.firmware_anchor_activation_intervals(
+                        "ori-fw-upgraded01", aid
+                    )
+                )
+                == 1
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_already_backfilled_revoked_row_stays_explicitly_unknown(
+        self, tmp_path
+    ) -> None:
+        """A revoked identity migrated by the earlier release stays unknown.
+
+        Its stored shape cannot say whether it was ever promoted, so the
+        follow-up migration marks it rather than inventing an activation.
+        """
+        from ori.state.store import StateStore
+
+        db, aid = await self._already_backfilled_db(
+            tmp_path, "upgraded2.db", "ori-fw-upgraded02", state="revoked"
+        )
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            assert not await store.firmware_anchor_was_ever_active(
+                "ori-fw-upgraded02", aid
+            )
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded02"
+            )
+        finally:
+            await store.close()
+
+        # Reopening must not append a second marker.
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            transitions = await store.list_firmware_anchor_transitions(
+                "ori-fw-upgraded02"
+            )
+            markers = [
+                t for t in transitions if "cannot be reconstructed" in t["reason"]
+            ]
+            assert len(markers) == 1
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded02"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_re_promotion_does_not_make_pre_migration_history_provable(
+        self, tmp_path
+    ) -> None:
+        """A later real promotion says nothing about the earlier interval.
+
+        Sequence: active before the lifecycle existed, backfilled by the
+        first release, then revoked, reinstated and promoted again -- all
+        before this repair runs. The anchor now has a genuine `promoted`
+        transition, but when it was active *before* the migration was
+        never recorded, so the history must stay unprovable rather than
+        being credited by the later promotion.
+        """
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db, aid = await self._already_backfilled_db(
+            tmp_path, "upgraded3.db", "ori-fw-upgraded03", state="active"
+        )
+
+        # Post-backfill lifecycle activity, written directly so it lands
+        # before the repair ever sees the database.
+        conn = sqlite3.connect(db)
+        for transition, frm, to in (
+            ("revoked", aid, None),
+            ("reinstated", aid, aid),
+            ("promoted", None, aid),
+        ):
+            conn.execute(
+                """
+                INSERT INTO firmware_anchor_transitions
+                    (device_id, transition, from_epoch_id, to_epoch_id,
+                     key_epoch_id, actor, reason, occurred_at_ms)
+                VALUES ('ori-fw-upgraded03', ?, ?, ?, ?, 'op', 'r', 3000)
+                """,
+                (transition, frm, to, "sha256:" + "22" * 32),
+            )
+        conn.execute(
+            "UPDATE firmware_device_anchors SET state = 'active' "
+            "WHERE anchor_epoch_id = ?",
+            (aid,),
+        )
+        conn.commit()
+        conn.close()
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            # The recorded re-promotion is real, so there IS an interval.
+            assert await store.firmware_anchor_was_ever_active("ori-fw-upgraded03", aid)
+            # ...but the pre-migration interval was never recorded, so the
+            # complete record is not provable.
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded03"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_backfilled_pending_row_promoted_later_is_provable(
+        self, tmp_path
+    ) -> None:
+        """The other side of the same distinction.
+
+        An anchor the earlier release backfilled as `pending` was never
+        approved before the lifecycle, so a promotion after the upgrade is
+        its genuine first activation and the history is complete.
+        """
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db, aid = await self._already_backfilled_db(
+            tmp_path, "upgraded4.db", "ori-fw-upgraded04", state="pending"
+        )
+
+        conn = sqlite3.connect(db)
+        conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES ('ori-fw-upgraded04', 'promoted', NULL, ?, ?, 'op', 'r', 3000)
+            """,
+            (aid, "sha256:" + "22" * 32),
+        )
+        conn.execute(
+            "UPDATE firmware_device_anchors SET state = 'active' "
+            "WHERE anchor_epoch_id = ?",
+            (aid,),
+        )
+        conn.commit()
+        conn.close()
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            assert await store.firmware_anchor_was_ever_active("ori-fw-upgraded04", aid)
+            assert await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded04"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_backfilled_pending_row_later_discarded_stays_provable(
+        self, tmp_path
+    ) -> None:
+        """Being discarded proves an anchor was pending, never active.
+
+        Only a pending candidate is ever discarded, so a backfilled anchor
+        whose first subsequent transition discards it is provably never
+        active. Marking it "cannot say" would throw away a fact the log
+        does establish, and fail closed where failing closed is not
+        warranted.
+        """
+        import sqlite3
+
+        from ori.state.store import StateStore
+
+        db, aid = await self._already_backfilled_db(
+            tmp_path, "upgraded5.db", "ori-fw-upgraded05", state="pending"
+        )
+
+        other = "sha256:" + "33" * 32
+        conn = sqlite3.connect(db)
+        conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES ('ori-fw-upgraded05', 'discarded', ?, ?, ?, '', '', 3000)
+            """,
+            (aid, other, "sha256:" + "22" * 32),
+        )
+        conn.execute(
+            "UPDATE firmware_device_anchors SET state = 'discarded' "
+            "WHERE anchor_epoch_id = ?",
+            (aid,),
+        )
+        conn.commit()
+        conn.close()
+
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            assert not await store.firmware_anchor_was_ever_active(
+                "ori-fw-upgraded05", aid
+            )
+            # Provably never active, so the history is complete.
+            assert await store.firmware_activation_history_is_provable(
+                "ori-fw-upgraded05"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_activation_history_is_not_provable_for_an_unknown_device(
+        self, tmp_path
+    ) -> None:
+        """Absence of a marker is not evidence when there are no records."""
+        from ori.state.store import StateStore
+
+        store = StateStore(db_path=str(tmp_path / "empty.db"))
+        await store.open()
+        try:
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-does-not-exist"
+            )
+        finally:
+            await store.close()
+
+    @pytest.mark.asyncio
+    async def test_migration_marks_the_inferred_promotion_as_inferred(
+        self, tmp_path
+    ) -> None:
+        """The inferred promotion must not read as a recorded operator act.
+
+        Pre-lifecycle databases never stored when a promotion happened, so
+        it is reconstructed from the registry's flags. An operator reading
+        the audit trail has to be able to tell.
+        """
+        from ori.state.store import StateStore
+
+        db = await self._legacy_db(
+            tmp_path, "legacy5.db", "ori-fw-legacy05", approved=True, revoked=False
+        )
+        store = StateStore(db_path=db)
+        await store.open()
+        try:
+            transitions = await store.list_firmware_anchor_transitions(
+                "ori-fw-legacy05"
+            )
+            promoted = [t for t in transitions if t["transition"] == "promoted"]
+            assert len(promoted) == 1
+            assert promoted[0]["actor"] == "migration"
+            assert "never recorded" in promoted[0]["reason"]
+            assert "unknown" in promoted[0]["reason"]
+
+            # Active now, but when it became active was never recorded, so
+            # the complete record is not provable.
+            assert not await store.firmware_activation_history_is_provable(
+                "ori-fw-legacy05"
+            )
         finally:
             await store.close()
 


### PR DESCRIPTION
## What does this PR do?

Closes #245. An anchor epoch has exactly one record whose `state` is its
**current** state, so re-registering a superseded anchor returns it to
`pending` and the state column stops showing the anchor was ever active.
Evidence produced while it *was* active is still attributed to it, so a consumer
answering "was this authorised" from current state would read correctly signed
history as never having been authorised.

The transition log already holds what is needed, so intervals are **derived**
from it rather than stored: one source of truth, no schema change.

## Why the details matter

**Ordering is receiver-anchored.** `firmware_anchor_was_active_at` takes only an
instant this receiver assigned. Device wall-clock is never consulted —
`emitted_at_ms` is optional, advisory, and supplied by the same party whose
authorisation is being decided, so a device could otherwise place its own
evidence inside an interval when its anchor was active.

**Re-provisioning does not end an interval**, even though it carries the anchor
in `from_epoch_id`. It stores the new key as *pending* and leaves the current
anchor active until promotion; ending the interval there would report a gap in
which the device was in fact still trusted.

## Migration: record only what is provable

| Legacy shape | Recorded | Why |
| --- | --- | --- |
| approved, unrevoked | interval opening at the **migration boundary** | Approval proves the anchor is active *when observed*, not when it became active |
| revoked | nothing; marked unprovable | Revocation sets `approved = 0`, so the shape is identical whether it was revoked after being promoted or before it ever was |
| never approved | nothing | Provably never promoted |

The interval deliberately does **not** open at `provisioned_at_ms`. A device is
often provisioned long before it is approved, and starting there would vouch for
evidence from a window nobody can account for. Anything the receiver timed
before the boundary fails closed.

### Databases the first lifecycle release already upgraded

Those identities already have an anchor row, so the backfill — which only fires
when there is none — never revisits them. An idempotent follow-up migration
completes them, appending rather than rewriting since the log is append-only.

That release wrote the same reason whichever state it chose, so the log does not
directly say whether an anchor was backfilled `active` or `pending`. **The first
transition to touch the anchor afterwards does:**

| First subsequent transition | Conclusion |
| --- | --- |
| `promoted to=A` | Was pending; this is its recorded first activation → **provable** |
| `discarded from=A` | Was pending; only a pending candidate is ever discarded → **provably never active** |
| `revoked from=A` / `promoted from=A` | Must have been active to leave active; the earlier interval was never recorded → **fail closed** |

A later re-promotion does not make the unrecorded earlier interval provable.

`firmware_activation_history_is_provable` separates "provably never promoted"
from "this database cannot say", and returns `False` for an unknown device:
absence of a marker is not evidence of a complete history when there is no
history at all.

## Verified by mutation

Every guard was confirmed to bite by injecting the regression it exists to
catch, restoring the tree and re-verifying clean each time:

| Injected regression | Caught by |
| --- | --- |
| Answer "ever active" from current state | 5 lifecycle scenarios |
| Treat re-provisioning as a deactivation | `reprovision_leaves_the_previous_anchor_active` |
| Fabricate activation for revoked legacy rows | `test_migrated_revoked_device_invents_no_activation` |
| Anchor the interval at `provisioned_at_ms` | `test_migrated_approved_device_is_still_ever_active` |
| Follow-up migration never runs / not idempotent | 2 tests each |
| Any existing promotion skips the repair | `test_re_promotion_does_not_make_pre_migration_history_provable` |
| Drop the `discarded` classification | `test_backfilled_pending_row_later_discarded_stays_provable` |
| `provable` returns True for an unknown device | its own test |

One of these found a hole in **this PR's own tests**: treating re-provisioning as
a deactivation passed all 36 tests, because every rotation scenario promoted
afterwards, which closed the interval anyway. That is why
`reprovision_leaves_the_previous_anchor_active` deliberately *ends* at the
re-provisioning.

## Type of change

- [x] `feat` — new feature
- [x] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures — 2005 passed, 6 skipped
- [x] `ruff check --fix ori/ tests/ skills/` is clean (full `pre-commit run --all-files` passes)
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — provisioning history; no capability behaviour changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Issue discussed first — #245, contract resolved in ori-specs#33
- [x] Every new code path has test coverage
- [x] No new dependencies added

## Related issue

Closes #245. Part of #239. Contract: ori-platform/ori-specs#33.

## Testing notes

**Must land together with ori-platform/ori-verity#17**, which carries the
identical corpus and pinned digest
`360f240ab321941bbb8134bbb6e82ac4bdea086cd03fc6013e8b2929a9a8bfac`. Whichever
merges second fails if the corpora diverge — that is the pin working.

This unblocks step 5 of #239: Verity's own lifecycle implementation, with the
22 names in its `UNIMPLEMENTED_SCENARIOS` as the checklist.

#246 (outcome-string normalisation) remains open and non-blocking.
