### PR TITLE
fix(firmware): enforce closed contract vocabularies

### DIFF
--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -71,6 +71,7 @@ SUPPORTED_CHANNEL_PROTOCOLS = frozenset(
     {"adc", "gpio", "i2c", "uart", "modbus_rtu", "rs232", "pulse", "one_wire"}
 )
 SUPPORTED_ACTION_AUTHORITIES = frozenset({"local_interlock_only", "runtime_commanded"})
+SUPPORTED_FIRMWARE_ACTIONS = frozenset({"relay_open", "relay_close"})
 
 GRADE_ATTESTED = "attested"
 GRADE_ATTESTED_DEV = "attested_dev"
@@ -161,6 +162,22 @@ FIRMWARE_FAULT_CODES = frozenset(
         "sensor_fault",
         "brownout_relay_fault",
         "ingress_degraded",
+    }
+)
+
+# firmware-commands/v1: command rejection details are a closed wire
+# vocabulary. Accepting an invented token would make a valid signature look
+# contract-compliant even though no conforming firmware command verifier can
+# emit it.
+COMMAND_REJECTION_VERDICTS = frozenset(
+    {
+        "malformed",
+        "wrong_device",
+        "bad_signature",
+        "replayed",
+        "capability_mismatch",
+        "unknown_action",
+        "storage_failure",
     }
 )
 
@@ -328,6 +345,10 @@ def _validate_manifest_actions(manifest: dict[str, Any]) -> None:
                 ERR_INVALID_ENVELOPE, f"action {index} is not an object"
             )
         name = _require_str(action, "action", ERR_INVALID_ENVELOPE)
+        if name not in SUPPORTED_FIRMWARE_ACTIONS:
+            raise FirmwareVerificationError(
+                ERR_INVALID_ENVELOPE, f"unsupported firmware action {name!r}"
+            )
         _require_str(action, "channel", ERR_INVALID_ENVELOPE)
         authority = _require_str(action, "authority", ERR_INVALID_ENVELOPE)
         if authority not in SUPPORTED_ACTION_AUTHORITIES:
@@ -823,6 +844,11 @@ def verify_fault_message(
                     ERR_INVALID_ENVELOPE,
                     f"fault {_name} leaves the fleet-safe token alphabet",
                 )
+        if code == "command_rejected" and detail not in COMMAND_REJECTION_VERDICTS:
+            raise FirmwareVerificationError(
+                ERR_INVALID_ENVELOPE,
+                f"unsupported command rejection verdict {detail!r}",
+            )
 
         canonical = canonical_json_bytes(fault)
         public_key = _decode_public_key(anchor_public_key_b64)

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -266,6 +266,20 @@ class TestGoldenVectors:
             )
         assert excinfo.value.code == "invalid_envelope"
 
+    @pytest.mark.parametrize("action", ["", "relay_toggle", "tier_d_cutoff"])
+    def test_manifest_rejects_action_outside_closed_vocabulary(
+        self, action: str
+    ) -> None:
+        message = manifest_message("manifest_full_sealed")
+        message["manifest"]["actions"][0]["action"] = action
+        with pytest.raises(FirmwareVerificationError) as excinfo:
+            verify_manifest_message(
+                message,
+                anchor_device_id=SEALED_DEVICE,
+                anchor_public_key_b64=PUBLIC_KEY_B64,
+            )
+        assert excinfo.value.code == "invalid_envelope"
+
     def test_tampered_envelope_rejected(self) -> None:
         message = telemetry_message("telemetry_single_reading")
         message["envelope"]["readings"][0]["value"] = 9.21
@@ -413,7 +427,9 @@ class TestGoldenFaultVectors:
     @pytest.mark.parametrize("field", ["subject", "detail"])
     def test_token_at_max_length_accepted(self, field: str) -> None:
         result = verify_fault_message(
-            signed_fault_message(**{field: "x" * FAULT_TOKEN_MAX_LEN}),
+            signed_fault_message(
+                code="sensor_fault", **{field: "x" * FAULT_TOKEN_MAX_LEN}
+            ),
             anchor_device_id=SEALED_DEVICE,
             anchor_public_key_b64=PUBLIC_KEY_B64,
             anchor_posture="sealed_flash",
@@ -600,6 +616,44 @@ class TestFailClosed:
         assert result.code == "command_rejected"
         assert result.subject == "relay0"
         assert result.detail == "replayed"
+
+    @pytest.mark.parametrize(
+        "detail",
+        [
+            "malformed",
+            "wrong_device",
+            "bad_signature",
+            "replayed",
+            "capability_mismatch",
+            "unknown_action",
+            "storage_failure",
+        ],
+    )
+    def test_command_rejected_fault_accepts_closed_verdicts(self, detail: str) -> None:
+        result = verify_fault_message(
+            signed_fault_message(detail=detail),
+            anchor_device_id=SEALED_DEVICE,
+            anchor_public_key_b64=PUBLIC_KEY_B64,
+            anchor_posture="sealed_flash",
+            accepted_manifest_hash=SEALED_HASH,
+            last_boot_id=0,
+            last_seq=0,
+        )
+        assert result.accepted
+        assert result.detail == detail
+
+    @pytest.mark.parametrize("detail", ["", "invented_verdict"])
+    def test_command_rejected_fault_rejects_unknown_verdict(self, detail: str) -> None:
+        result = verify_fault_message(
+            signed_fault_message(detail=detail),
+            anchor_device_id=SEALED_DEVICE,
+            anchor_public_key_b64=PUBLIC_KEY_B64,
+            anchor_posture="sealed_flash",
+            accepted_manifest_hash=SEALED_HASH,
+            last_boot_id=0,
+            last_seq=0,
+        )
+        assert result.error_code == "invalid_envelope"
 
     def test_ingress_degraded_fault_verifies_with_each_detail(self) -> None:
         # firmware-telemetry/v1: ingress loss is never silent. Each


### PR DESCRIPTION
## What does this PR do?

Hardens the Runtime Layer 1 consumer against two signed-wire vocabulary drifts already closed by `ori-specs`:

- Manifest actions now accept only `relay_open` and `relay_close`.
- `command_rejected` fault details now accept only the seven verdicts defined by `firmware-commands/v1.md`.

The verifier previously treated both fields as arbitrary non-empty fleet-safe strings. That allowed a correctly signed but contract-invalid manifest or fault to cross the Runtime boundary. Other fault detail tokens remain bounded but open where the specification permits them.

This is consumer hardening only. It adds no wire fields, dependencies, authority, or capability behavior. The matching firmware producer hardening is submitted separately, and SDK PR #21 is being corrected against the same contract.

[skip-cap-matrix] This tightens validation of an existing Layer 1 contract and does not change Runtime capability support.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean for changed files
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage (no Tier D path added)
- [x] No new dependencies added without prior issue discussion

## Related issue

Related to ori-platform/ori-sdk-python#21 and ori-platform/ori-sdk-python#15.

## Testing notes

- Full suite: `2017 passed, 6 skipped`
- Focused firmware telemetry suite: `151 passed`
- MyPy on the changed verifier: clean
- Ruff check and format check on changed files: clean
- `git diff --check`: clean