### PR TITLE
feat(evidence): attribute the evidence-chain promotion to the real approval

### DIFF
--- a/ori/reasoning/action_dispatcher.py
+++ b/ori/reasoning/action_dispatcher.py
@@ -19,6 +19,7 @@ must never crash the runtime.
 
 import asyncio
 import datetime
+import json
 import logging
 import secrets
 import string
@@ -1455,6 +1456,31 @@ class ActionDispatcher:
             input_firmware_boot_id,
             input_firmware_seq,
         ) = _input_firmware_freshness(context)
+        # Build the registration snapshot with approval provenance BEFORE
+        # logging, so it lands in the same insert as the action row. A
+        # follow-up write would leave a crash window in which a pending
+        # action has no provenance and can never be reconciled.
+        #
+        # A store read failure here must not stop the action being logged:
+        # the evidence gap should fail visibly (an unsigned or
+        # provenance-less row a verifier can see) rather than silently
+        # losing the action record itself.
+        try:
+            firmware_registration = await self._build_firmware_registration_snapshot(
+                store, input_firmware_device_id
+            )
+        except Exception:
+            logger.exception(
+                "ActionDispatcher: failed to build firmware registration "
+                "snapshot for device=%r; logging action without it",
+                input_firmware_device_id,
+            )
+            firmware_registration = None
+        firmware_registration_json = (
+            json.dumps(firmware_registration, sort_keys=True)
+            if firmware_registration is not None
+            else ""
+        )
         try:
             if hasattr(store, "log_action_for_event"):
                 reading = context.event.reading if context.event else None
@@ -1470,6 +1496,7 @@ class ActionDispatcher:
                     input_firmware_device_id=input_firmware_device_id,
                     input_firmware_boot_id=input_firmware_boot_id,
                     input_firmware_seq=input_firmware_seq,
+                    input_firmware_registration=firmware_registration_json,
                     attestation_pending=attest,
                 )
             else:
@@ -1495,7 +1522,32 @@ class ActionDispatcher:
                 input_firmware_device_id,
                 input_firmware_boot_id,
                 input_firmware_seq,
+                firmware_registration,
             )
+
+    async def _build_firmware_registration_snapshot(
+        self, store: Any, device_id: str
+    ) -> dict | None:
+        """The provisioning registration plus the approval provenance.
+
+        Returns ``None`` when there is no firmware source or the store
+        cannot supply one. The approval provenance is the actor and reason
+        of the promotion that made the device's current anchor active --
+        the SAME operator decision, resolved by the store, never invented
+        here.
+        """
+        if not device_id or not hasattr(store, "get_firmware_device"):
+            return None
+        registration = await store.get_firmware_device(device_id)
+        if registration is None:
+            return None
+        registration = dict(registration)
+        if hasattr(store, "firmware_active_promotion_attribution"):
+            attribution = await store.firmware_active_promotion_attribution(device_id)
+            if attribution is not None:
+                registration["approval_actor"] = attribution["actor"]
+                registration["approval_reason"] = attribution["reason"]
+        return registration
 
     async def _attest_action(
         self,
@@ -1509,6 +1561,7 @@ class ActionDispatcher:
         input_firmware_device_id: str,
         input_firmware_boot_id: int,
         input_firmware_seq: int,
+        firmware_registration: dict | None = None,
     ) -> None:
         """Sign a Tier C/D action into the evidence chain (append-after-log).
 
@@ -1535,10 +1588,10 @@ class ActionDispatcher:
             "input_firmware_seq": input_firmware_seq,
             "timestamp": action_result.timestamp,
         }
-        if input_firmware_device_id and hasattr(store, "get_firmware_device"):
-            row["input_firmware_registration"] = await store.get_firmware_device(
-                input_firmware_device_id
-            )
+        # The snapshot was built and stored in the action row's own insert
+        # (see _log_action), so it is already durable. Reuse it here rather
+        # than re-querying, so what is attested is exactly what was logged.
+        row["input_firmware_registration"] = firmware_registration
         try:
             seq = await self._evidence_attestor.attest_action(row)
             status = "signed" if seq is not None else "failed"

--- a/ori/security/evidence.py
+++ b/ori/security/evidence.py
@@ -426,6 +426,20 @@ class EvidenceAttestor:
         if not registration.get("approved") or registration.get("revoked"):
             raise ValueError("Layer 1 source device is not approved")
 
+        # The approval is a register-AND-PROMOTE in the evidence chain, and
+        # promotion there requires attribution. It must be the SAME operator
+        # decision recorded when this device was approved in the runtime, so
+        # it is read from the durable snapshot rather than invented here. A
+        # snapshot without it cannot be mirrored honestly, so refuse.
+        approval_actor = str(registration.get("approval_actor", "") or "").strip()
+        approval_reason = str(registration.get("approval_reason", "") or "").strip()
+        if not approval_actor or not approval_reason:
+            raise ValueError(
+                "Layer 1 source device registration lacks approval provenance "
+                "(approval_actor / approval_reason); cannot attribute the "
+                "evidence-chain promotion"
+            )
+
         public_key_hex = _public_key_b64_to_hex(registration.get("public_key_b64"))
         expected = {
             "device_id": source_device_id,
@@ -462,6 +476,8 @@ class EvidenceAttestor:
             expected["hardware_profile"],
             int(registration.get("provisioned_at_ms", 0) or 0),
             True,
+            approval_actor,
+            approval_reason,
         )
 
     async def chain_head_hash(self) -> str | None:

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -107,6 +107,12 @@ CREATE TABLE IF NOT EXISTS action_log (
     input_firmware_device_id TEXT NOT NULL DEFAULT '',
     input_firmware_boot_id INTEGER NOT NULL DEFAULT 0,
     input_firmware_seq INTEGER NOT NULL DEFAULT 0,
+    -- The provisioning registration snapshot, including approval
+    -- provenance, captured at attestation time. Persisted so a crash or
+    -- signing outage does not lose it: reconciliation reloads the exact
+    -- decision that was published rather than re-querying a registry that
+    -- may have moved on. '' when the action had no firmware source.
+    input_firmware_registration TEXT NOT NULL DEFAULT '',
     correlation_id    TEXT    NOT NULL DEFAULT '',
     trigger_name      TEXT    NOT NULL,
     timestamp         INTEGER NOT NULL
@@ -586,6 +592,7 @@ class StateStore:
             ("input_firmware_device_id", "TEXT    NOT NULL DEFAULT ''"),
             ("input_firmware_boot_id", "INTEGER NOT NULL DEFAULT 0"),
             ("input_firmware_seq", "INTEGER NOT NULL DEFAULT 0"),
+            ("input_firmware_registration", "TEXT    NOT NULL DEFAULT ''"),
             ("correlation_id", "TEXT    NOT NULL DEFAULT ''"),
             # Evidence attestation (Option B append-after-log): '' means the
             # row predates evidence signing or signing is disabled; rows
@@ -1653,9 +1660,16 @@ class StateStore:
         input_firmware_device_id: str = "",
         input_firmware_boot_id: int = 0,
         input_firmware_seq: int = 0,
+        input_firmware_registration: str = "",
         attestation_pending: bool = False,
     ) -> int:
-        """Persist action result with sensor/device context for reporting."""
+        """Persist action result with sensor/device context for reporting.
+
+        ``input_firmware_registration`` is the provisioning snapshot with
+        approval provenance, stored in the SAME insert as the action row so
+        a crash cannot leave a pending action whose provenance was to be
+        written by a later transaction.
+        """
         return await self._run_write(
             self._log_action_sync,
             result,
@@ -1669,6 +1683,7 @@ class StateStore:
                 "input_firmware_device_id": input_firmware_device_id,
                 "input_firmware_boot_id": input_firmware_boot_id,
                 "input_firmware_seq": input_firmware_seq,
+                "input_firmware_registration": input_firmware_registration,
                 "attestation_pending": attestation_pending,
             },
         )
@@ -1698,8 +1713,9 @@ class StateStore:
                  operator_response, proposal_id, safe_default_used, device_id,
                  sensor_id, sensor_type, input_attestation_grade, input_posture,
                  input_firmware_device_id, input_firmware_boot_id, input_firmware_seq,
+                 input_firmware_registration,
                  correlation_id, trigger_name, timestamp, attestation_status)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 result.action_name,
@@ -1718,6 +1734,7 @@ class StateStore:
                 str(context_fields.get("input_firmware_device_id", "") or ""),
                 int(context_fields.get("input_firmware_boot_id", 0) or 0),
                 int(context_fields.get("input_firmware_seq", 0) or 0),
+                str(context_fields.get("input_firmware_registration", "") or ""),
                 result.correlation_id,
                 trigger_name,
                 result.timestamp,
@@ -1768,6 +1785,7 @@ class StateStore:
                    proposal_id, safe_default_used, device_id, sensor_id,
                    sensor_type, input_attestation_grade, input_posture, correlation_id,
                    input_firmware_device_id, input_firmware_boot_id, input_firmware_seq,
+                   input_firmware_registration,
                    trigger_name, timestamp, attestation_status
             FROM action_log
             WHERE attestation_status IN ('pending', 'failed')
@@ -1776,7 +1794,15 @@ class StateStore:
             """,
             (int(limit),),
         ).fetchall()
-        return [dict(row) for row in rows]
+        out: list[dict] = []
+        for row in rows:
+            d = dict(row)
+            # Restore the persisted registration snapshot so reconciliation
+            # has the same durable provenance the original attestation did.
+            raw = d.pop("input_firmware_registration", "") or ""
+            d["input_firmware_registration"] = json.loads(raw) if raw else None
+            out.append(d)
+        return out
 
     async def get_attestation_summary(self) -> dict:
         """Aggregate evidence-signing state for health snapshots."""
@@ -3096,6 +3122,53 @@ class StateStore:
         return await self._run_read(
             self._list_firmware_anchor_transitions_sync, device_id
         )
+
+    async def firmware_active_promotion_attribution(
+        self, device_id: str
+    ) -> dict | None:
+        """The actor and reason of the promotion that made the CURRENT
+        active anchor active.
+
+        This is the provenance a coordinating store (ori-verity) must
+        record when it mirrors the approval: the same operator decision,
+        not a fresh or generic one. It is resolved precisely -- the latest
+        ``promoted`` transition whose ``to_epoch_id`` is the registry's
+        currently active ``anchor_epoch_id`` -- so a later re-provisioning
+        or an unrelated promotion cannot be mistaken for it.
+
+        ``None`` if the device is unknown, not approved, or has no such
+        promotion (e.g. a legacy row whose activation was inferred by the
+        migration -- that attribution is ``migration``, which is returned
+        as recorded rather than hidden).
+        """
+        return await self._run_read(
+            self._firmware_active_promotion_attribution_sync, device_id
+        )
+
+    def _firmware_active_promotion_attribution_sync(
+        self, conn: sqlite3.Connection, device_id: str
+    ) -> dict | None:
+        row = conn.execute(
+            """
+            SELECT t.actor, t.reason, t.occurred_at_ms, t.to_epoch_id
+              FROM firmware_anchor_transitions t
+              JOIN firmware_device_registry r
+                ON r.device_id = t.device_id
+               AND r.anchor_epoch_id = t.to_epoch_id
+             WHERE t.device_id = ?
+               AND t.transition = 'promoted'
+               AND r.approved = 1
+               AND r.revoked = 0
+             -- The transition id is this store's append order: the
+             -- receiver-anchored ordering. occurred_at_ms is a recorded
+             -- wall-clock that can regress or collide, so it must not
+             -- decide which promotion is latest.
+             ORDER BY t.id DESC
+             LIMIT 1
+            """,
+            (device_id,),
+        ).fetchone()
+        return dict(row) if row is not None else None
 
     def _list_firmware_anchor_transitions_sync(
         self, conn: sqlite3.Connection, device_id: str

--- a/tests/test_action_dispatcher.py
+++ b/tests/test_action_dispatcher.py
@@ -1655,3 +1655,103 @@ class TestOfflineTokenApproval:
         assert result.approved is False
         assert result.action_taken == "log_to_dashboard"
         safe_default.assert_awaited_once()
+
+
+class TestFirmwareProvenanceAtomicity:
+    """The registration snapshot with approval provenance must be inserted
+    in the SAME transaction as the action row, so a crash between logging
+    and attestation cannot strand a pending action without provenance."""
+
+    async def test_snapshot_is_in_the_initial_action_row_insert(self, tmp_path):
+        from ori.state.store import StateStore
+
+        store = StateStore(db_path=str(tmp_path / "state.db"))
+        await store.open()
+        try:
+            snapshot = json.dumps(
+                {
+                    "device_id": "fw-1",
+                    "approval_actor": "uid=3:dana",
+                    "approval_reason": "commissioning",
+                    "approved": True,
+                },
+                sort_keys=True,
+            )
+            # log_action_for_event is the single insert. The snapshot is a
+            # parameter of THAT call, not a follow-up update.
+            result = ActionResult(
+                action_name="emergency_cutoff",
+                tier="D",
+                executed=True,
+                approved=None,
+                action_taken="emergency_cutoff",
+                timestamp=1_760_000_000_000,
+            )
+            action_id = await store.log_action_for_event(
+                result,
+                trigger_name="dangerous_overcurrent",
+                input_firmware_device_id="fw-1",
+                input_firmware_registration=snapshot,
+                attestation_pending=True,
+            )
+
+            # Read the raw column directly: it is already populated, with no
+            # intervening write.
+            row = await store._run_read(
+                lambda conn, _id: conn.execute(
+                    "SELECT input_firmware_registration FROM action_log WHERE id = ?",
+                    (_id,),
+                ).fetchone(),
+                action_id,
+            )
+            assert row[0] == snapshot
+        finally:
+            await store.close()
+
+
+class TestSnapshotBuildFailureIsContained:
+    """A store read failure while building the provenance snapshot must not
+    stop the action being logged. The evidence gap should fail visibly, not
+    take the action record down with it."""
+
+    async def test_action_is_still_logged_when_snapshot_build_raises(self):
+        store = _mock_store()
+        store.log_action_for_event = AsyncMock(return_value=101)
+        # The snapshot build reads the firmware device; make it explode.
+        store.get_firmware_device = AsyncMock(side_effect=RuntimeError("db down"))
+        store.firmware_active_promotion_attribution = AsyncMock(return_value=None)
+
+        reading = SensorReading(
+            sensor_id="load-current",
+            sensor_type="current_clamp",
+            value=9.0,
+            unit="ampere",
+            timestamp=_ms(),
+            quality=1.0,
+            metadata={
+                "source": "firmware",
+                "firmware_device_id": "fw-1",
+                "boot_id": 3,
+                "seq": 7,
+                "attestation": "attested",
+                "posture": "sealed_flash",
+            },
+        )
+        event = OriEvent.from_reading(reading, "dev-01")
+        ctx = SkillContext(skill=FakeSkill(), event=event, state_store=store)
+
+        d = ActionDispatcher()
+        # Tier D executes immediately and logs; no attestor wired, so no
+        # attestation is attempted -- we only assert the action was logged
+        # despite the snapshot build failing.
+        await d.dispatch(
+            "emergency_cutoff",
+            ActionTier.SAFETY_CRITICAL,
+            ctx,
+            _result(action_tier="D"),
+        )
+
+        store.log_action_for_event.assert_awaited()
+        # The snapshot could not be built, so nothing spurious was logged.
+        _, kwargs = store.log_action_for_event.await_args
+        assert kwargs["input_firmware_registration"] == ""

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -400,3 +400,68 @@ async def test_every_outcome_code_is_exercised():
         "refused_same_key",
         "refused_key_reuse",
     } <= expected_outcomes
+
+
+async def test_active_promotion_attribution_is_the_exact_transition(store):
+    """The provenance a coordinating store mirrors must be the promotion
+    that made the CURRENT active anchor active -- not a later one, and not
+    a generic latest transition."""
+    d = "ori-edge-attrib-01"
+
+    async def reg(anchor):
+        a = ANCHORS[anchor]
+        return await store.upsert_firmware_device_anchor(
+            device_id=d,
+            public_key_b64=a["public_key_b64"],
+            posture=a["posture"],
+            capability_hash=a["capability_hash"],
+            manifest_json="{}",
+            channel_map_json="{}",
+        )
+
+    # Unknown device: no attribution.
+    assert await store.firmware_active_promotion_attribution(d) is None
+
+    await reg("A1")
+    # Registered but not promoted: still none.
+    assert await store.firmware_active_promotion_attribution(d) is None
+
+    await store.approve_firmware_device(d, actor="uid=1:alice", reason="bring-up")
+    got = await store.firmware_active_promotion_attribution(d)
+    assert got["actor"] == "uid=1:alice"
+    assert got["reason"] == "bring-up"
+
+    # Promote a new manifest epoch with different attribution. The active
+    # anchor is now A2, so the attribution must follow it.
+    await reg("A2")
+    await store.approve_firmware_device(d, actor="uid=2:bob", reason="manifest update")
+    got = await store.firmware_active_promotion_attribution(d)
+    assert got["actor"] == "uid=2:bob"
+    assert got["reason"] == "manifest update"
+
+    # The query is anchored to the ACTIVE anchor, not merely the latest
+    # promotion. Inject a spurious later `promoted` transition targeting a
+    # DIFFERENT epoch than the registry's active one -- the kind of split
+    # this model exists to refuse -- and confirm the attribution still
+    # follows the active anchor (A2/bob), not the newer row.
+    def _inject() -> None:
+        store._conn.execute(
+            """
+            INSERT INTO firmware_anchor_transitions
+                (device_id, transition, from_epoch_id, to_epoch_id,
+                 key_epoch_id, actor, reason, occurred_at_ms)
+            VALUES (?, 'promoted', NULL, 'sha256:deadbeef', '',
+                    'uid=9:intruder', 'not the active anchor', 99999999999999)
+            """,
+            (d,),
+        )
+        store._conn.commit()
+
+    await store._run_write(_inject)
+    got = await store.firmware_active_promotion_attribution(d)
+    assert got is not None
+    assert got["actor"] == "uid=2:bob", "attribution must follow the active anchor"
+
+    # Revoked: no active anchor, so no attribution to mirror.
+    await store.revoke_firmware_device(d, actor="uid=2:bob", reason="compromised")
+    assert await store.firmware_active_promotion_attribution(d) is None

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -110,7 +110,14 @@ class _FakeEvidenceChain:
         hardware_profile: str,
         provisioned_at_ms: int,
         approved: bool = False,
+        actor: str = "",
+        reason: str = "",
     ) -> None:
+        # The lifecycle FFI requires attribution when approved: a promotion
+        # is an operator decision. The mock records it so tests can assert
+        # the runtime forwarded the persisted provenance.
+        if approved and (not actor.strip() or not reason.strip()):
+            raise ValueError("approved registration requires actor and reason")
         self.layer1_devices[device_id] = {
             "device_id": device_id,
             "public_key": public_key,
@@ -119,6 +126,8 @@ class _FakeEvidenceChain:
             "capability_hash": capability_hash,
             "hardware_profile": hardware_profile,
             "approved": approved,
+            "approval_actor": actor,
+            "approval_reason": reason,
             "provisioned_at_ms": provisioned_at_ms,
             "last_boot_id": 0,
             "last_seq": 0,
@@ -968,5 +977,145 @@ class TestEvidenceTrustProperties:
             assert exported["attestation_seq"] == 9
             assert exported["input_attestation_grade"] == "attested_dev"
             assert exported["input_posture"] == "development"
+        finally:
+            await store.close()
+
+
+class TestLayer1RegistrationProvenance:
+    """The evidence-chain approval is a register-and-promote, and promotion
+    there requires attribution. It must be the SAME operator decision the
+    runtime recorded, carried in the durable snapshot -- not invented at
+    the boundary."""
+
+    def _registration(self, **overrides) -> dict:
+        reg = {
+            "device_id": "fw-node-01",
+            "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+            "alg": "ed25519",
+            "posture": "sealed_flash",
+            "capability_hash": "sha256:" + "ab" * 32,
+            "board_profile": "esp32-s3-pzem-v1",
+            "provisioned_at_ms": 1_751_500_900_000,
+            "approved": True,
+            "revoked": False,
+            "approval_actor": "uid=42:alice",
+            "approval_reason": "bench bring-up",
+        }
+        reg.update(overrides)
+        return reg
+
+    async def _attestor(self, monkeypatch, tmp_path):
+        attestor = await _started_attestor(monkeypatch, tmp_path)
+        attestor._chain = _FakeEvidenceChain(
+            str(tmp_path / "chain.db"), str(tmp_path / "chain.key"), "secret"
+        )
+        return attestor
+
+    async def test_forwards_persisted_provenance_to_the_chain(
+        self, monkeypatch, tmp_path
+    ):
+        attestor = await self._attestor(monkeypatch, tmp_path)
+        try:
+            await attestor._sync_layer1_device_registration(
+                {
+                    "input_firmware_device_id": "fw-node-01",
+                    "input_firmware_registration": self._registration(),
+                }
+            )
+            recorded = attestor._chain.layer1_devices["fw-node-01"]
+            assert recorded["approved"] is True
+            # The exact operator decision, not a constant.
+            assert recorded["approval_actor"] == "uid=42:alice"
+            assert recorded["approval_reason"] == "bench bring-up"
+        finally:
+            attestor.close()
+
+    async def test_snapshot_without_provenance_is_refused(self, monkeypatch, tmp_path):
+        attestor = await self._attestor(monkeypatch, tmp_path)
+        try:
+            reg = self._registration()
+            del reg["approval_actor"]
+            with pytest.raises(ValueError, match="approval provenance"):
+                await attestor._sync_layer1_device_registration(
+                    {
+                        "input_firmware_device_id": "fw-node-01",
+                        "input_firmware_registration": reg,
+                    }
+                )
+            # Nothing was mirrored.
+            assert "fw-node-01" not in attestor._chain.layer1_devices
+        finally:
+            attestor.close()
+
+    async def test_blank_provenance_is_refused(self, monkeypatch, tmp_path):
+        attestor = await self._attestor(monkeypatch, tmp_path)
+        try:
+            with pytest.raises(ValueError, match="approval provenance"):
+                await attestor._sync_layer1_device_registration(
+                    {
+                        "input_firmware_device_id": "fw-node-01",
+                        "input_firmware_registration": self._registration(
+                            approval_actor="   ", approval_reason="x"
+                        ),
+                    }
+                )
+        finally:
+            attestor.close()
+
+
+class TestReconciliationProvenanceRecovery:
+    """A failed attestation of firmware-sourced evidence must stay
+    recoverable: the registration snapshot and its approval provenance
+    are persisted with the action row, not held only in memory."""
+
+    async def test_persisted_snapshot_survives_reload(self, tmp_path):
+        import json as _json
+
+        store = StateStore(db_path=str(tmp_path / "state.db"))
+        await store.open()
+        try:
+            snapshot = {
+                "device_id": "fw-node-01",
+                "public_key_b64": "ERERERERERERERERERERERERERERERERERERERERERE=",
+                "alg": "ed25519",
+                "posture": "sealed_flash",
+                "capability_hash": "sha256:" + "ab" * 32,
+                "board_profile": "esp32-s3-pzem-v1",
+                "provisioned_at_ms": 1,
+                "approved": True,
+                "revoked": False,
+                "approval_actor": "uid=7:carol",
+                "approval_reason": "field commissioning",
+            }
+            # Logged atomically with the snapshot -- the same insert the
+            # dispatcher uses, not a follow-up mutation.
+            action_id = await store.log_action_for_event(
+                _result("D"),
+                trigger_name="dangerous_overcurrent",
+                input_firmware_device_id="fw-node-01",
+                input_firmware_registration=_json.dumps(snapshot, sort_keys=True),
+                attestation_pending=True,
+            )
+
+            # Reconciliation reloads from the database, not memory.
+            reloaded = await store.get_actions_needing_attestation()
+            row = next(r for r in reloaded if r["id"] == action_id)
+            reg = row["input_firmware_registration"]
+            assert reg is not None, "snapshot must survive the reload"
+            assert reg["approval_actor"] == "uid=7:carol"
+            assert reg["approval_reason"] == "field commissioning"
+        finally:
+            await store.close()
+
+    async def test_actions_without_firmware_reload_with_no_snapshot(self, tmp_path):
+        store = StateStore(db_path=str(tmp_path / "state.db"))
+        await store.open()
+        try:
+            action_id = await store.log_action(
+                _result("C"), "trigger", attestation_pending=True
+            )
+            reloaded = await store.get_actions_needing_attestation()
+            row = next(r for r in reloaded if r["id"] == action_id)
+            assert row["input_firmware_registration"] is None
         finally:
             await store.close()

--- a/tests/test_evidence_artifact.py
+++ b/tests/test_evidence_artifact.py
@@ -101,6 +101,12 @@ def _firmware_tier_d_row(row_id: int) -> dict:
                 "approved": True,
                 "provisioned_at_ms": 1_760_000_000_000,
                 "revoked": False,
+                # The evidence-chain approval is a register-and-promote and
+                # requires the promotion's provenance. The real dispatcher
+                # captures it from the runtime's transition log; the smoke
+                # fixture supplies it directly.
+                "approval_actor": "uid=0:artifact-smoke",
+                "approval_reason": "ffi smoke provisioning",
             },
         }
     )


### PR DESCRIPTION
## What does this PR do?

The runtime half of the coordinated ori-verity anchor-model change
(ori-platform/ori-verity#18). Verity's evidence-chain `approved=true` is
now an atomic register-**and-promote** that requires attribution, so the runtime
must supply the **same operator decision** that approved the device — not a
fresh or generic one, and never invented.

**Coordinated merge: ori-verity first, then this PR** immediately after. On its
own, Verity would break the Evidence FFI smoke path until this lands.

## How the attribution is resolved

`firmware_active_promotion_attribution(device_id)` returns the actor and reason
of the `promoted` transition whose `to_epoch_id` is the registry's **currently
active** `anchor_epoch_id`.

- Anchored to the active anchor, not merely the latest promotion, so a later
  re-provisioning or an unrelated promotion cannot be mistaken for it. Verified
  by injecting a spurious later `promoted` row for a different epoch and
  asserting the attribution still follows the active anchor.
- Ordered by transition **id** — the receiver's append order — because
  `occurred_at_ms` is a recorded wall-clock that can regress or collide, so it
  must not decide which promotion is latest.
- A revoked or unapproved identity yields `None`: nothing to mirror.

## Durable, point-in-time provenance

The dispatcher builds the registration snapshot with its actor and reason and
logs it in the **same insert** as the action row (`log_action_for_event` gains
the field; a new `action_log.input_firmware_registration` column carries it). A
crash between logging and attestation therefore cannot strand a pending action
without provenance.

- Building the snapshot is wrapped: a store read failure logs the action
  **without** it rather than losing the action record — an evidence gap must
  fail visibly, not silently drop the row.
- Reconciliation reloads the snapshot from the action row. It previously
  selected no registration at all, so a failed attestation of firmware-sourced
  evidence could never be repaired; now it re-signs the exact decision that was
  published.
- The evidence sync forwards the provenance to the FFI and **refuses** a
  snapshot lacking it: a promotion the runtime cannot attribute must not be
  mirrored under invented attribution.

There is no post-insert mutation path — the earlier `set_action_firmware_registration`
was removed, because it contradicted the atomic, point-in-time guarantee.

## Type of change

- [x] `feat` — new feature
- [x] `security` — touches a safety invariant (evidence attribution)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes — 2025 passed, 6 skipped
- [x] `ruff check` / `ruff format` clean (full `pre-commit run --all-files` passes)
- [x] Apache-2.0 headers present
- [x] PR description explains **why**

`[skip-cap-matrix]` — evidence attribution; no capability behaviour change.

### If you used AI assistance

- [x] I can explain every line
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in review

### If this touches `/ori/` (core runtime)

- [x] Issue discussed first — #239
- [x] Every new code path has test coverage
- [x] No new dependencies

## Related issue

Part of #239. Coordinated with ori-platform/ori-verity#18 (merge that
first).

## Testing notes

Verified by mutation, tree restored after each: dropped the active-anchor join
(attribution follows the wrong promotion), reload not selecting the snapshot
column (reconciliation loses provenance), snapshot not in the initial insert
(atomicity gap), and the snapshot-build failure not contained (action logging
breaks). Each fails the intended test.
