### PR TITLE
fix: enforce MQTT broker port range

### DIFF
--- a/ori/security/firmware_mqtt_provisioning.py
+++ b/ori/security/firmware_mqtt_provisioning.py
@@ -48,7 +48,7 @@ _CERTIFICATE_SHA256 = _ANCHOR_EPOCH
 _BROKER_URI = re.compile(
     r"^mqtts://(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*"
     r"[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
-    r"(?::[0-9]{1,5})?$"
+    r"(?::(?P<port>[0-9]{1,5}))?$"
 )
 _DNS_HOST = re.compile(
     r"^(?=.{1,255}$)"
@@ -186,11 +186,13 @@ def _canonical_pem_b64(value: str, field: str) -> str:
 
 
 def validate_broker_uri(value: str) -> str:
-    if (
-        not isinstance(value, str)
-        or len(value.encode("utf-8")) > 255
-        or _BROKER_URI.fullmatch(value) is None
-    ):
+    match = _BROKER_URI.fullmatch(value) if isinstance(value, str) else None
+    if match is None or len(value.encode("utf-8")) > 255:
+        raise FirmwareMqttProvisioningError(
+            "broker_uri is not an eligible MQTT TLS URI"
+        )
+    port = match.group("port")
+    if port is not None and not 1 <= int(port) <= 65535:
         raise FirmwareMqttProvisioningError(
             "broker_uri is not an eligible MQTT TLS URI"
         )

--- a/tests/test_firmware_mqtt_provisioning.py
+++ b/tests/test_firmware_mqtt_provisioning.py
@@ -21,6 +21,7 @@ from ori.security.firmware_mqtt_provisioning import (
     build_install_request,
     build_revoke_request,
     build_status_request,
+    validate_broker_uri,
     verify_device_message,
 )
 from ori.state.store import StateStore
@@ -212,6 +213,20 @@ def test_install_broker_uri_enforces_the_255_byte_contract_bound() -> None:
             **common,
             broker_uri=uri_256,
         )
+
+
+@pytest.mark.parametrize("port", [1, 65535])
+def test_broker_uri_accepts_valid_tcp_port_bounds(port: int) -> None:
+    assert (
+        validate_broker_uri(f"mqtts://broker.example:{port}")
+        == f"mqtts://broker.example:{port}"
+    )
+
+
+@pytest.mark.parametrize("port", [0, 65536, 99999])
+def test_broker_uri_rejects_invalid_tcp_port_bounds(port: int) -> None:
+    with pytest.raises(FirmwareMqttProvisioningError, match="broker_uri"):
+        validate_broker_uri(f"mqtts://broker.example:{port}")
 
 
 async def _insert_registry_row(store: StateStore, device_id: str) -> None:


### PR DESCRIPTION
## What does this PR do?

Closes a cross-repo validation drift in signed firmware MQTT provisioning. The runtime previously accepted any one-to-five-digit broker port, including `0`, `65536`, and `99999`, while the firmware correctly enforces the valid TCP range.

The broker URI validator now captures an optional port and requires it to be within `1..65535`. Requests without an explicit port remain valid, and the existing URI grammar and 255-byte bound are unchanged.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

[skip-cap-matrix] This tightens one existing MQTT provisioning field validator to the standard TCP port range. It does not add, remove, or change an advertised runtime capability.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

This is a follow-up under #254, discovered while independently validating the firmware implementation against the shared provisioning contract. No Tier D path is introduced or modified.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

Relates to #254.

## Testing notes

- Full suite: `2113 passed, 6 skipped`.
- Focused MQTT provisioning/operator/certificate suites: `62 passed`.
- Regression coverage accepts ports `1` and `65535`, and rejects `0`, `65536`, and `99999`.
- Ruff, pre-commit, runtime boundary typecheck, workflow guard, Python supply-chain guard and Rust supply-chain guard pass.
