### PR TITLE
feat(security): accept the storage_degraded fault code

### DIFF
--- a/ori/security/firmware_telemetry.py
+++ b/ori/security/firmware_telemetry.py
@@ -162,6 +162,13 @@ FIRMWARE_FAULT_CODES = frozenset(
         "sensor_fault",
         "brownout_relay_fault",
         "ingress_degraded",
+        # firmware-telemetry/v1: reported late, from a latch outside the store
+        # that failed, so its own (boot_id, seq) describe when it was reported
+        # rather than what was lost. Absence proves nothing — a device whose
+        # storage is failing badly enough may never emit it — and sequence
+        # gaps are not a substitute signal, because reservation ceilings make
+        # gaps expected across a reboot.
+        "storage_degraded",
     }
 )
 

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -123,9 +123,13 @@ FAULT_VECTORS = json.loads(
 )
 FAULT_CASES = {case["name"]: case for case in FAULT_VECTORS["cases"]}
 
-# The closed vocabulary of ori-specs/firmware-telemetry/v1.md. Additions
-# are additive contract changes and land in all three repos together.
-FAULT_CODE_VOCABULARY = {
+# The codes carried by the shared golden fault vectors. This is not the whole
+# closed vocabulary: `storage_degraded` is defined in
+# ori-specs/firmware-telemetry/v1.md and accepted by the verifier, but no
+# producer emits it yet, so it has no cross-repo vector. The gap is asserted
+# below rather than left to drift silently — a vector lands with the firmware
+# implementation (ori-edge-firmware #62).
+VECTORED_FAULT_CODES = {
     "brownout_relay_fault",
     "command_rejected",
     "ingress_degraded",
@@ -373,9 +377,18 @@ class TestGoldenFaultVectors:
         )
         assert result.grade == "rejected"
 
-    def test_vectors_cover_the_closed_vocabulary(self) -> None:
+    def test_vectors_cover_every_emitted_code(self) -> None:
         covered = {case["input"]["code"] for case in FAULT_CASES.values()}
-        assert covered == FAULT_CODE_VOCABULARY
+        assert covered == VECTORED_FAULT_CODES
+
+    def test_only_storage_degraded_lacks_a_shared_vector(self) -> None:
+        # The verifier's vocabulary and the vector corpus may differ by
+        # exactly the codes no producer emits yet. Anything else means a code
+        # was added to one side and forgotten on the other.
+        from ori.security.firmware_telemetry import FIRMWARE_FAULT_CODES
+
+        assert FIRMWARE_FAULT_CODES - VECTORED_FAULT_CODES == {"storage_degraded"}
+        assert VECTORED_FAULT_CODES - FIRMWARE_FAULT_CODES == set()
 
     def test_fixture_metadata_is_self_consistent(self) -> None:
         # The fault corpus carries its own key metadata; the runtime must
@@ -677,6 +690,30 @@ class TestFailClosed:
             )
             assert result.accepted
             assert result.code == "ingress_degraded"
+            assert result.detail == detail
+
+    def test_storage_degraded_fault_verifies_with_each_detail(self) -> None:
+        # firmware-telemetry/v1: a device that could not make evidence durable
+        # reports it late, from a latch outside the failed store. The verifier
+        # must accept it before any device emits it, or the fault a failing
+        # device finally manages to send would be rejected on arrival.
+        for i, detail in enumerate(["buffer_write_failed", "buffer_mount_failed"]):
+            result = verify_fault_message(
+                signed_fault_message(
+                    seq=130_600 + i,
+                    code="storage_degraded",
+                    subject="evidence_buffer",
+                    detail=detail,
+                ),
+                anchor_device_id=SEALED_DEVICE,
+                anchor_public_key_b64=PUBLIC_KEY_B64,
+                anchor_posture="sealed_flash",
+                accepted_manifest_hash=SEALED_HASH,
+                last_boot_id=0,
+                last_seq=0,
+            )
+            assert result.accepted
+            assert result.code == "storage_degraded"
             assert result.detail == detail
 
     def test_fault_event_rejects_unknown_code(self) -> None:


### PR DESCRIPTION
Implements the runtime side of `ori-specs` #42 / ori-specs#41.

## Summary

Adds `storage_degraded` to the verifier's closed `FIRMWARE_FAULT_CODES` vocabulary, so a device reporting that it could not make signed evidence durable is accepted rather than refused as an unknown code.

This lands **before** any firmware emits it, deliberately. A consumer that rejects unknown codes would refuse exactly the fault a failing device finally managed to send — the one message that matters most from a device with storage trouble.

## Why the code exists

A firmware node that cannot append a signed envelope to its offline buffer has already consumed a `(boot_id, seq)` pair, and the reading then vanishes.

A receiver cannot infer this from freshness: `seq` comes from an NVS reservation ceiling, so a reboot legitimately skips a range and gaps in `(boot_id, seq)` are **expected rather than diagnostic**. Nothing else in the contract carries the fact that a durability failure occurred.

## Consumer-facing semantics worth knowing

All three are normative in the contract and noted at the vocabulary entry:

- **Reported late**, from a latch outside the failed store — a report written at the moment of failure is destroyed by the condition causing it.
- **Its own `(boot_id, seq)` describe reporting, not loss.** Nothing downstream may read the affected range from them.
- **Absence is not health.** A device failing badly enough may never emit it.

## The vector gap is asserted, not hidden

No producer emits `storage_degraded` yet, so it has no shared golden vector, and `test_vectors_cover_the_closed_vocabulary` would have failed if the code were simply added to both sets.

Rather than weaken that test, the test-local set is renamed to `VECTORED_FAULT_CODES` (what it actually was) and a new assertion states the gap exactly:

```python
assert FIRMWARE_FAULT_CODES - VECTORED_FAULT_CODES == {"storage_degraded"}
assert VECTORED_FAULT_CODES - FIRMWARE_FAULT_CODES == set()
```

Adding a code to one side and forgetting the other now fails rather than drifts. Verified by mutation: inserting a second unvectored code into `FIRMWARE_FAULT_CODES` fails `test_only_storage_degraded_lacks_a_shared_vector`.

The vector lands with the firmware implementation (`ori-edge-firmware` #62), at which point the exception in this assertion is removed.

## Testing

- `tests/test_firmware_telemetry.py` — 153 passed, including a new case verifying `storage_degraded` with both `detail` tokens (`buffer_write_failed`, `buffer_mount_failed`).
- Full firmware-related suite: 299 passed, 1 skipped.
- `pre-commit` on both changed files: all hooks pass.

## Observation, not addressed here

The verifier enforces a closed `detail` vocabulary for `command_rejected` only. `ingress_degraded` details are specified in the contract but not enforced, and `storage_degraded` follows that same precedent for consistency. Tightening both is a separate change — worth doing, but it would alter existing acceptance behaviour and does not belong in an additive vocabulary PR.