### PR TITLE
feat(gateway): emit named degradation reasons in the runtime node heartbeat

### DIFF
--- a/ori/gateway/node_heartbeat.py
+++ b/ori/gateway/node_heartbeat.py
@@ -31,6 +31,69 @@ except ImportError:  # pragma: no cover - exercised by monkeypatch in tests
 
 logger = logging.getLogger(__name__)
 
+# ── degradation_reasons (gateway-api/v1) ─────────────────────────────
+#
+# The closed v1 vocabulary lives at the wire boundary because that is where
+# the contract is enforced. A gateway refuses an unrecognised token, so
+# emitting one would make a conforming receiver reject the entire heartbeat —
+# the same failure the ratified rollout order (specs, then gateway, then
+# runtime) exists to prevent. Adding a token here before gateways accept it
+# would recreate exactly that.
+DEGRADATION_REASON_FIRMWARE_LIVENESS = "firmware_liveness_degraded"
+
+DEGRADATION_REASONS: frozenset[str] = frozenset(
+    {
+        DEGRADATION_REASON_FIRMWARE_LIVENESS,
+    }
+)
+
+DEGRADATION_REASONS_MAX = 16
+
+
+def _wire_degradation_reasons(raw: Any) -> list[str]:
+    """Validates snapshot reasons at the wire boundary.
+
+    Refuses rather than coerces. An earlier version ran ``str()`` over
+    whatever the snapshot held, deduplicated and published it — which would
+    happily emit a token no gateway can accept, and manufacture a plausible
+    string from an object that was never a reason at all.
+
+    Anything unusable is dropped with a warning and the field is omitted, so
+    a malformed snapshot degrades to "no named reason" rather than to a
+    heartbeat a conforming receiver must reject in full.
+    """
+    if not isinstance(raw, list) or not raw:
+        return []
+
+    accepted: set[str] = set()
+    for item in raw:
+        if not isinstance(item, str):
+            logger.warning(
+                "[runtime-heartbeat] dropping non-string degradation reason %r", item
+            )
+            continue
+        if item not in DEGRADATION_REASONS:
+            # Never emitted: a receiver is contractually required to refuse
+            # an unratified token, and refusing it here costs one reason
+            # while emitting it costs the whole heartbeat.
+            logger.warning(
+                "[runtime-heartbeat] dropping unratified degradation reason %r", item
+            )
+            continue
+        accepted.add(item)
+
+    tokens = sorted(accepted)
+    if len(tokens) > DEGRADATION_REASONS_MAX:
+        logger.error(
+            "[runtime-heartbeat] %d degradation reasons exceeds the contract "
+            "maximum of %d; omitting the field",
+            len(tokens),
+            DEGRADATION_REASONS_MAX,
+        )
+        return []
+    return tokens
+
+
 RUNTIME_HEARTBEAT_TOPIC_TEMPLATE = "ori/{device_id}/runtime/heartbeat"
 RUNTIME_HEARTBEAT_MESSAGE_TYPE = "runtime.heartbeat"
 DEFAULT_RUNTIME_HEARTBEAT_INTERVAL_S = 30.0
@@ -160,6 +223,33 @@ class MqttRuntimeNodeHeartbeatPublisher:
             "gateway_seen_ms": 0,
             "active_triggers": [str(item) for item in active_triggers],
         }
+
+        # degradation_reasons names which subsystem is degraded, so a site
+        # view can tell why a node reports degraded rather than only that it
+        # does. Deliberately separate from active_triggers: a trigger is a
+        # physical or automation trigger and a degraded subsystem is neither,
+        # and overloading that field would inflate its count.
+        #
+        # Omitted entirely when empty. An empty array is malformed under
+        # gateway-api/v1 — absent and present-empty are different states, and
+        # a receiver is required to refuse the latter.
+        tokens = _wire_degradation_reasons(snapshot.get("degradation_reasons"))
+        if tokens:
+            # The contract's implication rule runs the other way too: reasons
+            # are only meaningful alongside a degraded status. Anything that
+            # named a reason has already contributed critical/degraded to the
+            # snapshot, so this is a guard against a future caller that
+            # forgets, not an expected branch — the composition tests prove
+            # it is unreachable in normal operation.
+            if status == "degraded":
+                payload["degradation_reasons"] = tokens
+            else:
+                logger.warning(
+                    "[runtime-heartbeat] dropping degradation_reasons %s on a %s "
+                    "heartbeat: reasons require a degraded status",
+                    tokens,
+                    status,
+                )
 
         # Evidence-chain truncation signal: the heartbeat carries the chain
         # head so the site can spot a truncated/reset local chain in near

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -50,7 +50,10 @@ from ori.gateway.firmware_commands import (
 from ori.gateway.firmware_liveness_publisher import FirmwareLivenessScheduler
 from ori.gateway.firmware_telemetry import MqttFirmwareTelemetrySubscriber
 from ori.gateway.heartbeat import MqttGatewayHeartbeatSubscriber
-from ori.gateway.node_heartbeat import MqttRuntimeNodeHeartbeatPublisher
+from ori.gateway.node_heartbeat import (
+    DEGRADATION_REASON_FIRMWARE_LIVENESS,
+    MqttRuntimeNodeHeartbeatPublisher,
+)
 from ori.gateway.reasoning import MqttGatewayReasoner
 from ori.hal.base import AdapterReadError, BaseAdapter
 from ori.hal.protocol_registry import UnknownProtocolError, make_adapter
@@ -2340,12 +2343,20 @@ class OriRuntime:
             "firmware_liveness": firmware_liveness_health,
         }
         if firmware_liveness_health["degraded"]:
-            # A stopped or stalled liveness loop expires every supervised
-            # device's runtime authority while the rest of the runtime looks
-            # healthy. Contributed rather than assigned, so this never
-            # clears a critical condition another subsystem has raised.
+            # A stopped or stalled liveness loop puts timely publication at
+            # risk for one or more supervised devices while the rest of the
+            # runtime looks healthy. Contributed rather than assigned, so this
+            # never clears a critical condition another subsystem has raised.
             snapshot["critical"] = True
             snapshot["status"] = "degraded"
+
+        # Named reasons for the site view. The rich diagnostics above stay
+        # local: fleet counts reveal deployment topology and per-device
+        # identity is a disclosure this contract does not make. Only closed,
+        # non-sensitive tokens cross the boundary.
+        snapshot["degradation_reasons"] = _degradation_reasons(
+            firmware_liveness_degraded=bool(firmware_liveness_health["degraded"]),
+        )
         return snapshot
 
     def _firmware_liveness_health(self) -> dict[str, Any]:
@@ -4067,6 +4078,24 @@ def _build_firmware_command_service(
         logger.exception("[runtime] invalid firmware command egress configuration")
         raise
     return publisher, service
+
+
+def _degradation_reasons(*, firmware_liveness_degraded: bool) -> list[str]:
+    """Named degradation reasons for the node heartbeat.
+
+    Returns an empty list when nothing is degraded; the heartbeat omits the
+    field entirely in that case. An empty array on the wire is malformed —
+    absent and present-empty are different states, and encoding one as the
+    other is the ambiguity the contract exists to remove.
+
+    The vocabulary is owned by ``ori.gateway.node_heartbeat``, the wire
+    boundary that enforces it, so a token cannot be named here without also
+    being publishable there.
+    """
+    reasons: list[str] = []
+    if firmware_liveness_degraded:
+        reasons.append(DEGRADATION_REASON_FIRMWARE_LIVENESS)
+    return sorted(set(reasons))
 
 
 def _build_firmware_liveness_stack(

--- a/tests/test_firmware_liveness_composition.py
+++ b/tests/test_firmware_liveness_composition.py
@@ -494,3 +494,149 @@ def test_a_configured_interval_above_the_contract_ceiling_fails_startup(
     cfg.gateway.firmware_commands["liveness_interval_s"] = 30.0
     with pytest.raises(ValueError, match="at most"):
         _build_firmware_liveness_stack(cfg, _FakeBus(), store, None)
+
+
+# --- The health snapshot derives the degradation reason ---
+#
+# The publisher tests inject degradation_reasons directly, so none of them
+# would notice if the runtime stopped deriving the token from scheduler
+# health. These cover that seam: the composition, not the transport.
+
+
+class _StubScheduler:
+    """Minimal stand-in exposing only what the health path reads."""
+
+    def __init__(self, *, degraded: bool) -> None:
+        self._degraded = degraded
+
+    def health(self) -> dict[str, object]:
+        return {
+            "running": not self._degraded,
+            "degraded": self._degraded,
+            "supervised_device_count": 3,
+            "expiring_devices": ["ori-fw-secret-01"] if self._degraded else [],
+        }
+
+
+def _runtime_with_scheduler(scheduler):
+    """A real OriRuntime, so _build_health_snapshot() is the code under test.
+
+    Constructing the helper's inputs by hand would prove only that the helper
+    works — it would not notice the runtime ceasing to call it, which is the
+    defect this seam exists to catch.
+    """
+    from ori.runtime import OriRuntime
+
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._device_id = "dev-01"
+    runtime._firmware_liveness_scheduler = scheduler
+    return runtime
+
+
+async def _reasons_from_real_snapshot(scheduler) -> list[str]:
+    runtime = _runtime_with_scheduler(scheduler)
+    snapshot = await runtime._build_health_snapshot()
+    return snapshot["degradation_reasons"]
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_named_by_the_real_health_snapshot() -> None:
+    """Through _build_health_snapshot, not the helper.
+
+    Deleting the assignment in _build_health_snapshot must fail here. Every
+    publisher test injects degradation_reasons directly, so none of them
+    would notice the runtime no longer deriving it.
+    """
+    assert await _reasons_from_real_snapshot(_StubScheduler(degraded=True)) == [
+        "firmware_liveness_degraded"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_empty_from_the_real_snapshot_when_healthy() -> None:
+    assert await _reasons_from_real_snapshot(_StubScheduler(degraded=False)) == []
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_empty_from_the_real_snapshot_without_a_scheduler() -> (
+    None
+):
+    """No command egress means this runtime is not the authority for any
+    device, so there is no obligation it could be failing."""
+    assert await _reasons_from_real_snapshot(None) == []
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_accompany_critical_and_degraded_status() -> None:
+    """The named reason and the status must agree: a receiver refuses
+    reasons carried alongside a healthy status."""
+    runtime = _runtime_with_scheduler(_StubScheduler(degraded=True))
+    snapshot = await runtime._build_health_snapshot()
+    assert snapshot["degradation_reasons"] == ["firmware_liveness_degraded"]
+    assert snapshot["critical"] is True
+    assert snapshot["status"] == "degraded"
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_keep_rich_diagnostics_local() -> None:
+    """Fleet counts and per-device identity stay in the local health
+    interface; only closed tokens cross the wire boundary."""
+    runtime = _runtime_with_scheduler(_StubScheduler(degraded=True))
+    snapshot = await runtime._build_health_snapshot()
+    assert snapshot["firmware_liveness"]["supervised_device_count"] == 3
+    assert snapshot["degradation_reasons"] == ["firmware_liveness_degraded"]
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_reach_the_wire_from_the_real_snapshot() -> None:
+    """Genuinely end to end: the runtime's own snapshot method is the
+    publisher's provider.
+
+    Reconstructing the snapshot by hand would leave the two halves joined
+    only by this test's belief about their shape — the same gap that let
+    the composition seam go untested in the first place. Passing the bound
+    method means a change to either side has to survive the other.
+    """
+    import json
+
+    from ori.gateway.node_heartbeat import MqttRuntimeNodeHeartbeatPublisher
+
+    class _Client:
+        def __init__(self) -> None:
+            self.published: list[tuple[str, bytes, int, bool]] = []
+
+        def publish(self, topic, payload, qos=0, retain=False):
+            self.published.append((topic, payload, qos, retain))
+
+            class _Info:
+                rc = 0
+
+            return _Info()
+
+    for degraded, expect_field in ((True, True), (False, False)):
+        runtime = _runtime_with_scheduler(_StubScheduler(degraded=degraded))
+        client = _Client()
+        publisher = MqttRuntimeNodeHeartbeatPublisher(
+            broker_url="mqtt://localhost",
+            device_id="dev-01",
+            health_snapshot_provider=runtime._build_health_snapshot,
+            interval_seconds=30,
+            authenticator=None,
+            client_factory=lambda **_: client,
+        )
+
+        await publisher._publish_once(client)
+
+        raw = client.published[0][1]
+        payload = json.loads(raw)
+        assert ("degradation_reasons" in payload) is expect_field
+        if expect_field:
+            assert payload["degradation_reasons"] == ["firmware_liveness_degraded"]
+            assert payload["status"] == "degraded"
+
+        # Rich diagnostics stay in the local health interface: a fleet count
+        # reveals deployment topology and a device id is a disclosure this
+        # contract does not make.
+        assert b"ori-fw-secret-01" not in raw
+        assert "supervised_device_count" not in payload
+        assert "firmware_liveness" not in payload

--- a/tests/test_runtime_node_heartbeat.py
+++ b/tests/test_runtime_node_heartbeat.py
@@ -161,3 +161,280 @@ async def test_runtime_node_heartbeat_serve_until_uses_mqtts_tls(monkeypatch):
     assert client.loop_stopped is True
     assert client.disconnected is True
     assert len(client.published) == 1
+
+
+# ── degradation_reasons (gateway-api/v1) ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_omitted_when_nothing_is_degraded(monkeypatch):
+    """Absent, never an empty array.
+
+    An empty array is malformed under gateway-api/v1: absent and
+    present-empty are different states, and a conforming gateway refuses
+    the latter with degradation_reasons_length_invalid.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "healthy",
+            "active_triggers": [],
+            "degradation_reasons": [],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert "degradation_reasons" not in payload
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_omitted_when_empty_even_if_degraded(monkeypatch):
+    """Isolates the emptiness guard from the status guard.
+
+    The healthy-status test above cannot prove this on its own: with a
+    healthy status the status check also suppresses the field, so a
+    regression that emitted `[]` would still pass. A node degraded for some
+    unrelated reason, carrying no named reasons, is the case that separates
+    them — and it is a real state, since other subsystems can degrade a node
+    without naming anything.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": [],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert payload["status"] == "degraded"
+    assert "degradation_reasons" not in payload
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_emitted_on_a_degraded_heartbeat(monkeypatch):
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": ["firmware_liveness_degraded"],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert payload["status"] == "degraded"
+    assert payload["degradation_reasons"] == ["firmware_liveness_degraded"]
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_are_unique_and_ordered(monkeypatch):
+    """Uniqueness and ordering, without teaching production to emit junk.
+
+    An earlier version of this test used invented tokens and therefore
+    asserted that the publisher emits values a conforming gateway is
+    required to reject — encoding the opposite of the rollout rule. The
+    vocabulary is extended for the duration of the test instead, so the
+    ordering behaviour is exercised with tokens the boundary accepts.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    monkeypatch.setattr(
+        node_heartbeat_module,
+        "DEGRADATION_REASONS",
+        frozenset({"aa_test_only", "zz_test_only"}),
+    )
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": ["zz_test_only", "aa_test_only", "zz_test_only"],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    reasons = json.loads(client.published[0][1])["degradation_reasons"]
+    assert reasons == ["aa_test_only", "zz_test_only"]
+    assert reasons == sorted(set(reasons))
+
+
+@pytest.mark.asyncio
+async def test_unratified_tokens_are_never_emitted(monkeypatch):
+    """A receiver must refuse an unratified token, so never send one.
+
+    Refusing here costs one reason; emitting costs the whole heartbeat.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": ["not_ratified_yet"],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    assert "degradation_reasons" not in json.loads(client.published[0][1])
+
+
+@pytest.mark.asyncio
+async def test_ratified_tokens_survive_alongside_unratified_ones(monkeypatch):
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": ["not_ratified_yet", "firmware_liveness_degraded"],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert payload["degradation_reasons"] == ["firmware_liveness_degraded"]
+
+
+@pytest.mark.asyncio
+async def test_non_string_reasons_are_refused_not_coerced(monkeypatch):
+    """str() over an arbitrary object manufactures a plausible token."""
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    for junk in ({"a": 1}, 42, None, ["nested"]):
+        client = _FakeClient()
+        publisher = _publisher(
+            client=client,
+            snapshot={
+                "status": "degraded",
+                "active_triggers": [],
+                "degradation_reasons": [junk],
+            },
+        )
+        await publisher._publish_once(client)
+        assert "degradation_reasons" not in json.loads(client.published[0][1])
+
+
+@pytest.mark.asyncio
+async def test_over_the_contract_maximum_omits_the_field(monkeypatch):
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    oversized = frozenset(f"tok_{i:02d}" for i in range(17))
+    monkeypatch.setattr(node_heartbeat_module, "DEGRADATION_REASONS", oversized)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": sorted(oversized),
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    assert "degradation_reasons" not in json.loads(client.published[0][1])
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_dropped_rather_than_sent_with_healthy_status(
+    monkeypatch, caplog
+):
+    """Reasons imply degraded. Sending both would be malformed on the wire.
+
+    A caller that names a reason has already contributed critical/degraded
+    to the snapshot, so this guards a future caller that forgets — and it
+    warns rather than failing silently.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        snapshot={
+            "status": "healthy",
+            "active_triggers": [],
+            "degradation_reasons": ["firmware_liveness_degraded"],
+        },
+    )
+
+    with caplog.at_level("WARNING"):
+        await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert "degradation_reasons" not in payload
+    assert "degradation_reasons" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_degradation_reasons_are_inside_the_signed_payload(monkeypatch):
+    """Signed content, not metadata.
+
+    Tampering after signing must break authentication, which is what makes
+    a reordered list a transport failure rather than a semantic one.
+    """
+    monkeypatch.setattr(node_heartbeat_module, "now_ms", lambda: 1_000_000)
+    authenticator = _auth()
+    client = _FakeClient()
+    publisher = _publisher(
+        client=client,
+        authenticator=authenticator,
+        snapshot={
+            "status": "degraded",
+            "active_triggers": [],
+            "degradation_reasons": ["firmware_liveness_degraded"],
+        },
+    )
+
+    await publisher._publish_once(client)
+
+    payload = json.loads(client.published[0][1])
+    assert payload["degradation_reasons"] == ["firmware_liveness_degraded"]
+    assert "auth" in payload
+
+    verifier = GatewayMessageAuthenticator(
+        GatewayMessageAuthConfig(shared_secret="site-test-secret")
+    )
+    # Unmodified: authenticates.
+    verifier.verify(
+        payload,
+        message_type=RUNTIME_HEARTBEAT_MESSAGE_TYPE,
+        expected_device_id="dev-01",
+    )
+    # Reordered after signing: the canonical bytes changed, so this must
+    # fail authentication rather than reach semantic validation.
+    tampered = dict(payload)
+    tampered["degradation_reasons"] = ["zz_tampered"]
+    with pytest.raises(Exception):
+        verifier.verify(
+            tampered,
+            message_type=RUNTIME_HEARTBEAT_MESSAGE_TYPE,
+            expected_device_id="dev-01",
+        )
+
+
+def test_degradation_reasons_helper_omits_and_names():
+    from ori.runtime import (
+        DEGRADATION_REASON_FIRMWARE_LIVENESS,
+        _degradation_reasons,
+    )
+
+    assert _degradation_reasons(firmware_liveness_degraded=False) == []
+    assert _degradation_reasons(firmware_liveness_degraded=True) == [
+        DEGRADATION_REASON_FIRMWARE_LIVENESS
+    ]


### PR DESCRIPTION
## What does this PR do?

Emits `degradation_reasons` on the runtime node heartbeat — the **last** of three repos implementing the ratified `gateway-api/v1` field.

| Repo | State |
|---|---|
| `ori-specs` | Contract ratified — #57 merged (issue #56) |
| `ori-gateway` | Receiver merged — ori-gateway#73 |
| `ori-runtime` | **This PR** — the emitter |

That order was normative, not stylistic. Unknown tokens are refused, so emitting before gateways accept would make a conforming older gateway reject the *entire* heartbeat, turning an additive contract change into fleet-wide loss of health reporting.

**The gap:** a stalled firmware-liveness scheduler set `critical` and `degraded` on the health snapshot but named nothing, so the heartbeat carried `status: degraded` with an empty `active_triggers` and the site view showed a degraded node with a trigger count of zero — indistinguishable from any other degradation.

### The closed vocabulary lives at the wire boundary

Defined in `node_heartbeat`, imported by `runtime`. The module that publishes the wire format owns the closed set — otherwise a token can be nameable in one place and unpublishable in the other, and the two drift.

### The boundary refuses rather than coerces

An earlier version ran `str()` over whatever the snapshot held, deduplicated and published it. That would emit tokens no gateway can accept, and manufacture a plausible reason from an object that was never one. Non-strings, unratified tokens, and lists over the contract maximum of 16 are now dropped with a warning and the field omitted — a malformed snapshot degrades to "no named reason" rather than to a heartbeat a receiver must reject in full.

The field is omitted entirely when empty: absent and present-empty are different states, and an empty array is malformed. Tokens are emitted unique and lexicographically ordered because the receiver validates both as separate checks.

### Rich diagnostics stay local

`supervised_device_count`, expiring-device identity and publish latency remain in the runtime's local health interface. Counts reveal deployment topology and per-device identifiers are a disclosure this contract does not make. A test asserts neither reaches the wire.

## Type of change

- [x] `feat` — new feature
- [x] `security` — changes the documented posture of what crosses the runtime→gateway boundary

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures — `2308 passed, 6 skipped`
- [x] `ruff check --fix ori/ tests/ skills/` is clean — full `pre-commit run --all-files` clean
- [x] Every new `.py` file has the Apache-2.0 license header — no new files
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated — **[skip-cap-matrix]**: no capability behaviour changed. This adds a diagnostic field to an existing heartbeat; no tier, authority or action path is touched.
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Every new Tier D code path has test coverage — no Tier D path touched
- [x] No new dependencies added

## Related issue

Implements `ori-specs/gateway-api/v1.md` per ori-specs#56 / #57. Prerequisite for `ori-edge-firmware#68`, the `runtime_reachable` switchover: after that change the scheduler decides when a physical backstop may act alone, and an operator who cannot see it degrade cannot see the fleet approaching loss of runtime reachability.

## Testing notes

Nine mutations, each turning the suite red:

```text
remove the snapshot assignment            5 tests fail
never name a reason                       5 tests fail
publish unratified tokens                 2 tests fail
coerce non-strings with str()             1 test  fails
drop the 16-token bound                   1 test  fails
emit an empty array instead of omitting   1 test  fails
drop the sort and dedupe                  1 test  fails
emit reasons regardless of status         1 test  fails
```

Three tests needed a second attempt, all for the same reason — the assertion could not distinguish the mechanism under test from a neighbouring one:

- **omit-when-empty** passed with its guard removed, because the status guard also suppressed the field. Separated by a *degraded* heartbeat carrying no named reasons.
- **composition** called the helper directly, so deleting the runtime's call to it changed nothing. Now goes through the real `_build_health_snapshot()`.
- **end-to-end** reconstructed the snapshot by hand. Now passes `runtime._build_health_snapshot` as the publisher's provider, so a change to either side must survive the other.

The composition tests were also renamed: they were `test_snapshot_*`, so `pytest -k degradation` — the obvious filter for this feature — missed all five. Coverage only the author can find is close to no coverage. `-k degradation` now collects 13 across both files, and that subset alone catches the production mutation.

```text
pytest -q                     2308 passed, 6 skipped
pytest -k degradation -q      13 passed, 1 skipped
pre-commit run --all-files    clean
git diff --check              clean
```
