### PR TITLE
docs: correct stale release channel and bundled-skill list

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,10 @@ updates:
       - dependency-name: "twilio"
         update-types: ["version-update:semver-major"]
     commit-message:
-      prefix: "build(deps)"
+      # Dependabot appends its own scope, so the prefix must not contain one —
+      # "build(deps)" + scope yields "build(deps)(deps-dev):", which is not a
+      # valid Conventional Commit subject.
+      prefix: "build"
       include: scope
 
   - package-ecosystem: github-actions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Built for the world's majority condition — unreliable power, intermittent conn
 
 ## Release Status
 
-**Current channel: Stable (`2.0.x`)**
+**Current channel: Stable (`2.2.x`)**
 
 - Runtime core is stable for PoC, demo API, and controlled field deployment,
   with a fail-closed production security posture: staging/production configs
@@ -266,7 +266,7 @@ triggers:
     action_tier: D # → cuts power. no waiting.
 ```
 
-Bundled skills: **pc-system-health** (runs on any laptop), **energy-anomaly-detector**, **retail-occupancy-optimizer**, **solar-performance-monitor**, **battery-lifecycle-observer**, **hvac-refrigerant-monitor**, and **site-safety-ppe**.
+Bundled skills: **pc-system-health** (runs on any laptop), **pc-network-threat-monitor**, **energy-anomaly-detector**, **prosumer-energy-advisor**, **retail-occupancy-optimizer**, **solar-performance-monitor**, **battery-lifecycle-observer**, **hvac-refrigerant-monitor**, and **site-safety-ppe**.
 
 Community skills live at **[ori-platform/ori-skills](https://github.com/ori-platform/ori-skills)**. The runtime enforces strict skill validation and sandboxed hook loading for community-installed skills.
 
@@ -482,7 +482,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting, supported versions, 
 
 | Phase             | Status           | Milestone                                                                 |
 | ----------------- | ---------------- | ------------------------------------------------------------------------- |
-| Runtime core      | ✅ Stable v2.0    | Production posture, typed integration boundary, and evidence Layer 2 hooks |
+| Runtime core      | ✅ Stable v2.2    | Production posture, typed integration boundary, and evidence Layer 2 hooks |
 | Product wedge     | ✅ Shipping       | Ori Energy demo/API integration, private APK path, and Phone Starter flows |
 | Evidence hardware | 🔨 In Progress   | Evidence Layer 1 contract and `ori-edge-firmware` bootstrap                |
 | Safety kernel     | 🗓️ Planned       | Rust-owned Tier D kernel after shadow-mode evidence, not a broad rewrite   |


### PR DESCRIPTION
## What does this PR do?

Corrects three claims in `README.md` that had drifted from the repository, and fixes the Dependabot commit prefix.

## Type of change

- [x] `docs` — documentation only

## README corrections

| Line | Was | Now |
|---|---|---|
| 27 | `Current channel: Stable (2.0.x)` | `Stable (2.2.x)` |
| 485 | Roadmap `✅ Stable v2.0` | `✅ Stable v2.2` |
| 269 | Bundled skills, 7 listed | adds `pc-network-threat-monitor` and `prosumer-energy-advisor` |

`pyproject.toml`, the latest git tag, the release badge, and the newest file in `docs/releases/` all say **2.2.0**. The two places that spell out the channel in prose said 2.0, so a reader checking which channel they are on got the wrong answer from both.

Both missing skills ship with a `skill.yaml` in `skills/`, so the list understated what the runtime installs. `skills/template/` is a scaffold and stays excluded.

## Dependabot prefix

`prefix: "build(deps)"` plus `include: scope` produces `build(deps)(deps-dev):` — two scope groups, not a valid Conventional Commit subject. Now `build`, yielding `build(deps):` and `build(deps-dev):`. The `github-actions` block was already correct.

This repo has no commit-message check, so nothing failed; the history simply carries the malformed form.

## What was checked and found correct

Rather than assume the rest was current:

- Every referenced path resolves — `SECURITY.md`, `CONTRIBUTING.md`, `PRINCIPLES.md`, `AGENTS.md`, `CLAUDE.md`, `ori/py.typed`, all four `scripts/*.sh`, `pc_health_report.py`, `docs/linux-setup.md`, `ori.linux.yaml.example`, `docs/architecture.svg`, `docs/releases/v2.2.0.md`
- The `[eval]` extra is declared in `pyproject.toml`
- `SkillLoader.load_one` and `LocalLLM` exist as the quick-start snippets use them
- Tier A–D descriptions match the Action Tier Framework, including Tier B's execution-policy wording
- The bundled-skill list now matches `skills/` in both directions

## Testing notes

Documentation and a Dependabot config value; no code paths touched. `dependabot.yml` parses.