### PR TITLE
fix(release): install the runtime package before building bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,6 +178,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      # build-wheelhouse.sh invokes scripts/build_release_bundle.py, which
+      # imports ori. `python scripts/x.py` puts scripts/ on sys.path[0], not
+      # the repository root, so the package must be importable here.
+      - name: Install build dependencies
+        run: python -m pip install --no-deps -e .
+
       - name: Resolve release identity
         id: identity
         run: |

--- a/tests/test_release_publication.py
+++ b/tests/test_release_publication.py
@@ -439,15 +439,6 @@ def test_tag_pushes_cannot_reach_signing_without_the_release_gates(
     assert gate in commands
 
 
-@pytest.mark.parametrize("job", ["test", "sign", "publish", "reverify"])
-def test_jobs_running_repository_scripts_install_the_package(
-    workflow: dict[str, Any], job: str
-) -> None:
-    commands = "\n".join(str(step.get("run", "")) for step in _steps(workflow, job))
-
-    assert "pip install --no-deps -e ." in commands
-
-
 @pytest.mark.parametrize("job", ["test", "build", "sign", "publish", "reverify"])
 def test_every_release_job_is_time_bounded(workflow: dict[str, Any], job: str) -> None:
     assert isinstance(workflow["jobs"][job]["timeout-minutes"], int)
@@ -1174,3 +1165,47 @@ def test_the_workflow_never_reads_the_administration_scoped_endpoint(
 def test_the_temporary_diagnostic_workflow_is_gone() -> None:
     # It answered its question: GITHUB_TOKEN gets 403 on /immutable-releases.
     assert not Path(".github/workflows/diagnose-protection-reads.yml").exists()
+
+
+def _scripts_importing_ori() -> set[str]:
+    """Return repository scripts that import the `ori` package directly."""
+    importing = set()
+    for path in Path("scripts").glob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        if re.search(r"^\s*(from ori[. ]|import ori\b)", text, re.MULTILINE):
+            importing.add(path.as_posix())
+    return importing
+
+
+def _scripts_needing_the_package() -> set[str]:
+    """Expand to scripts that invoke an ori-importing script in turn."""
+    needing = _scripts_importing_ori()
+    for path in Path("scripts").glob("*"):
+        if not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if any(script in text for script in _scripts_importing_ori()):
+            needing.add(path.as_posix())
+    return needing
+
+
+def test_every_job_invoking_an_ori_importing_script_installs_the_package(
+    workflow: dict[str, Any],
+) -> None:
+    """Derive the requirement rather than trusting a hand-listed set of jobs.
+
+    `python scripts/x.py` puts `scripts/` on `sys.path[0]`, not the repository
+    root, so a job that runs an ori-importing script without installing the
+    package fails with ModuleNotFoundError. A hardcoded job list previously
+    missed `build`, whose wheelhouse script invokes the bundle builder.
+    """
+    needing = _scripts_needing_the_package()
+    assert needing, "expected to find scripts that import ori"
+
+    for job in workflow["jobs"]:
+        commands = "\n".join(str(step.get("run", "")) for step in _steps(workflow, job))
+        invoked = sorted(script for script in needing if script in commands)
+        if invoked:
+            assert "pip install --no-deps -e ." in commands, (
+                f"job {job!r} runs {invoked} but never installs the package"
+            )


### PR DESCRIPTION
## What does this PR do?

Makes the release build job able to import the runtime package, and replaces the guard that was supposed to prevent this class of failure.

`scripts/build-wheelhouse.sh` invokes `scripts/build_release_bundle.py`, which imports `ori.security.release_bundles`. Running `python scripts/x.py` puts `scripts/` on `sys.path[0]` rather than the repository root, so the package is not importable unless it is installed. The build job never installed it, and the v2.3.0 run failed with `ModuleNotFoundError: No module named 'ori'` after successfully assembling the wheelhouse.

The failure was contained: it happened before signing, so no release was published, KMS was never called, and the protected signing environment was never reached. The pipeline failed closed, which is the intended behaviour — but it should not have been reachable.

The more important change is to the test. The previous guard asserted the package install across a hardcoded list of jobs, `["test", "sign", "publish", "reverify"]`, which omitted `build`. A test that only covers the cases its author thought of provides confidence without cover, and it passed while the defect shipped.

It is replaced by a test that derives the requirement: it scans `scripts/*.py` for direct `ori` imports, expands transitively through shell scripts that invoke them, then asserts that every workflow job running such a script installs the package. It was confirmed to fail against the unfixed workflow before the fix was applied, so it detects the defect rather than restating the remedy. A new ori-importing script, or a new job that runs one, is covered without anyone remembering to extend a list.

Resulting coverage: `test`, `build`, `sign`, `publish`, and `reverify` install the package; `preflight`, `promote`, and `incident` correctly do not, because they run no script that imports it.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. The release pipeline's described behaviour is unchanged; this restores the build stage's ability to execute it.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`
- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
- [ ] No `subprocess` calls in hooks

## Related issue

Part of #273.

## Testing notes

- Full suite: `2607 passed, 6 skipped`
- Focused release publication: `111 passed`
- Full pre-commit suite, including `ruff format`: all hooks pass
- Runtime boundary typecheck: 27 modules clean
- Supply-chain guard and `git diff --check`: clean
- The new derived test was run against the unfixed workflow and failed on the `build` job, then passed after the install step was added
- Job coverage was verified directly from the workflow rather than asserted: five jobs install the package, three do not and run no script that needs it
