### PR TITLE
ci(release): show the release version without weakening the signing gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,15 +39,15 @@ jobs:
       - name: Show pip version
         run: python -m pip --version
 
-      - name: Guard supply-chain invariants
-        run: |
-          python scripts/check_workflows.py
-          bash scripts/check_rust_supply_chain.sh
-
       - name: Install hash-locked dependencies
         run: |
           python -m pip install --require-hashes -r requirements/dev.txt
           python -m pip install --no-deps -e .
+
+      - name: Guard supply-chain invariants
+        run: |
+          python scripts/check_workflows.py
+          bash scripts/check_rust_supply_chain.sh
 
       - name: Type check runtime contract boundaries
         run: bash scripts/typecheck-boundaries.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release
 
+# The signing environment must stay literally `release-signing` — its
+# protection rules, environment-scoped signer variables, and the AWS OIDC
+# subject binding all key off that exact name. Version visibility therefore
+# lives in the run name and job name, never in the environment.
+run-name: Release ${{ github.ref_name }}
+
 on:
   push:
     tags:
@@ -233,14 +239,18 @@ jobs:
           retention-days: 7
 
   sign:
-    name: Sign release bundles
+    name: Sign release bundles (${{ github.ref_name }})
     needs: build
     runs-on: ubuntu-24.04
     # A short ceiling bounds how long this job can hold signing credentials.
     timeout-minutes: 20
     # The protected environment is what keeps signing off pull-request and
     # branch runs: only this tag-triggered job can assume the signer role.
-    environment: release-signing
+    environment:
+      name: release-signing
+      # Before publication this link 404s; it resolves once the draft is
+      # published in the job that follows.
+      url: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}
     permissions:
       contents: read
       id-token: write

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,8 +49,16 @@ repos:
 
       - id: supply-chain-guard
         name: Supply-chain guard
-        language: python
-        entry: python scripts/check_workflows.py
+        # `system`, like the boundary typecheck below. Declaring PyYAML as a
+        # hook dependency would make pre-commit resolve it live and unhashed;
+        # the launcher instead selects an interpreter whose dependencies were
+        # installed from the repository's hash-locked requirements.
+        language: system
+        # A launcher, not `python` directly: `system` runs whatever the PATH
+        # resolves to, which locally is often not the virtualenv holding the
+        # hash-installed dependencies. The launcher selects .venv/bin/python
+        # when present and plain `python` in CI, and never installs anything.
+        entry: bash scripts/run-workflow-guard.sh
         pass_filenames: false
 
       - id: runtime-boundary-typecheck

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -9,6 +9,8 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
+
 WORKFLOW_DIR = Path(".github/workflows")
 PRE_COMMIT_CONFIG = Path(".pre-commit-config.yaml")
 SHA_RE = re.compile(r"uses:\s*[^\s#]+@[0-9a-f]{40}(?:\s*#.*)?$")
@@ -28,6 +30,190 @@ def _workflow_files() -> list[Path]:
 
 def _line_number(text: str, index: int) -> int:
     return text.count("\n", 0, index) + 1
+
+
+# Naming the signing environment after the version would create a *new*
+# environment on every tag. GitHub creates a referenced environment without
+# protection rules, so required reviewers, self-review prevention, the
+# tag-only deployment policy, the environment-scoped signer variables, and the
+# AWS OIDC subject binding would all silently cease to apply — while the
+# protection preflight, which checks `release-signing` by name, stayed green.
+SIGNING_ENVIRONMENT = "release-signing"
+SIGNING_PERMISSIONS = {"contents": "read", "id-token": "write"}
+
+
+class WorkflowError(Exception):
+    """The workflow could not be resolved well enough to check."""
+
+
+class _StrictLoader(yaml.SafeLoader):
+    """A loader that refuses duplicate keys.
+
+    GitHub resolves a duplicate mapping key to the last occurrence. A checker
+    that reads the first would approve `environment: release-signing` while the
+    workflow actually deploys somewhere else, so ambiguity is rejected outright
+    rather than resolved by guesswork.
+    """
+
+
+def _no_duplicate_keys(
+    loader: _StrictLoader, node: yaml.MappingNode, deep: bool = False
+) -> dict[object, object]:
+    mapping: dict[object, object] = {}
+    for key_node, value_node in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in mapping:
+            raise WorkflowError(f"duplicate key {key!r}")
+        mapping[key] = loader.construct_object(value_node, deep=deep)
+    return mapping
+
+
+_StrictLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _no_duplicate_keys
+)
+
+
+def _load_workflow(text: str) -> dict[str, object]:
+    """Resolve a workflow the way GitHub does, or refuse to guess.
+
+    PyYAML is used rather than a hand-written scanner. Quoted keys, explicit
+    tags, anchors, aliases, block scalars and reused job configurations are all
+    supported workflow syntax, and a partial parser cannot prove what any of
+    them resolve to — it can only fail to notice them.
+    """
+    try:
+        document = yaml.load(text, Loader=_StrictLoader)  # noqa: S506 - strict subclass
+    except WorkflowError:
+        raise
+    except yaml.YAMLError as exc:
+        raise WorkflowError(
+            f"is not parseable YAML ({exc.__class__.__name__})"
+        ) from exc
+    if not isinstance(document, dict):
+        raise WorkflowError("is not a YAML mapping")
+    return document
+
+
+def _grants_id_token_write(permissions: object) -> bool:
+    """Whether a resolved permissions value grants the credential."""
+    if permissions == "write-all":
+        return True
+    return isinstance(permissions, dict) and permissions.get("id-token") == "write"
+
+
+def _has_exact_signing_permissions(permissions: object) -> bool:
+    """Whether the sign job has only the authority required to sign.
+
+    Merely finding ``id-token: write`` is insufficient: ``write-all``,
+    ``contents: write``, or an additional write scope would all broaden the
+    short-lived signing job's authority while satisfying that weaker check.
+    """
+    return permissions == SIGNING_PERMISSIONS
+
+
+def _environment_name(environment: object) -> str | None:
+    """The environment name from either the scalar or mapping form."""
+    if isinstance(environment, str):
+        return environment
+    if isinstance(environment, dict):
+        name = environment.get("name")
+        return name if isinstance(name, str) else None
+    return None
+
+
+def _check_signing_environment(path: Path, text: str, failures: list[str]) -> None:
+    """The sign job must name the protected environment and hold the credential."""
+    try:
+        document = _load_workflow(text)
+    except WorkflowError as exc:
+        failures.append(f"{path}: {exc}")
+        return
+
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        failures.append(f"{path}: declares no jobs")
+        return
+    sign = jobs.get("sign")
+    if not isinstance(sign, dict):
+        failures.append(f"{path}: no sign job found; the signing guard cannot apply")
+        return
+
+    name = _environment_name(sign.get("environment"))
+    if name is None:
+        failures.append(f"{path}: the sign job declares no environment name")
+    elif "${{" in name:
+        failures.append(
+            f"{path}: the sign job environment name is an expression ({name!r}); "
+            f"it must be the literal {SIGNING_ENVIRONMENT!r}, or its protection "
+            "rules and OIDC subject binding will not apply"
+        )
+    elif name != SIGNING_ENVIRONMENT:
+        failures.append(
+            f"{path}: the sign job uses environment {name!r}, "
+            f"expected {SIGNING_ENVIRONMENT!r}"
+        )
+
+    # Local and inherited authority are computed separately. Resolving the sign
+    # job's permissions with a fallback to the workflow's would accept a
+    # workflow-level grant as if the job had declared it — the opposite of
+    # confining the credential, since every job added later would inherit it.
+    if not _has_exact_signing_permissions(sign.get("permissions")):
+        failures.append(
+            f"{path}: the sign job permissions must be exactly "
+            "contents: read and id-token: write, declared on the job; "
+            "inherited, missing, or additional authority is forbidden"
+        )
+
+    workflow_permissions = document.get("permissions")
+    if _grants_id_token_write(workflow_permissions):
+        failures.append(
+            f"{path}: id-token: write is granted at workflow level; any job "
+            "added later would inherit it"
+        )
+
+    for job_name, job in sorted(jobs.items(), key=lambda item: str(item[0])):
+        if job_name == "sign":
+            continue
+        if not isinstance(job, dict):
+            continue
+        effective = job.get("permissions", workflow_permissions)
+        if _grants_id_token_write(effective):
+            inherited = "permissions" not in job
+            failures.append(
+                f"{path}: id-token: write must be confined to the sign job, "
+                f"found {'inherited by' if inherited else 'in'} {job_name!r}"
+            )
+
+
+def _check_non_release_permissions(path: Path, text: str, failures: list[str]) -> None:
+    """Reject OIDC authority in every workflow other than release signing."""
+    try:
+        document = _load_workflow(text)
+    except WorkflowError as exc:
+        failures.append(f"{path}: {exc}")
+        return
+
+    if "permissions" not in document:
+        failures.append(f"{path}: missing explicit workflow permissions")
+    workflow_permissions = document.get("permissions")
+    if _grants_id_token_write(workflow_permissions):
+        failures.append(
+            f"{path}: id-token: write is allowed only in release.yml's sign job"
+        )
+
+    jobs = document.get("jobs")
+    if not isinstance(jobs, dict):
+        failures.append(f"{path}: declares no jobs")
+        return
+    for job_name, job in sorted(jobs.items(), key=lambda item: str(item[0])):
+        if not isinstance(job, dict):
+            continue
+        effective = job.get("permissions", workflow_permissions)
+        if _grants_id_token_write(effective):
+            failures.append(
+                f"{path}: id-token: write is allowed only in release.yml's "
+                f"sign job, found in or inherited by {job_name!r}"
+            )
 
 
 def _check_pre_commit_config(failures: list[str]) -> None:
@@ -60,8 +246,6 @@ def main() -> int:
         text = path.read_text()
         if "pull_request_target" in text:
             failures.append(f"{path}: contains forbidden trigger pull_request_target")
-        if path.name != "release.yml" and re.search(r"\bid-token:\s*write\b", text):
-            failures.append(f"{path}: id-token: write is allowed only in release.yml")
         for match in MUTABLE_ACTION_RE.finditer(text):
             line = _line_number(text, match.start())
             # A full SHA pin with a version comment is allowed; mutable refs are not.
@@ -75,8 +259,10 @@ def main() -> int:
             failures.append(
                 f"{path}:{line}: remote script download/execution is forbidden"
             )
-        if "permissions:" not in text:
-            failures.append(f"{path}: missing explicit workflow permissions")
+        if path.name == "release.yml":
+            _check_signing_environment(path, text, failures)
+        else:
+            _check_non_release_permissions(path, text, failures)
     _check_pre_commit_config(failures)
     if failures:
         print("Supply-chain guard failed:", file=sys.stderr)

--- a/scripts/run-workflow-guard.sh
+++ b/scripts/run-workflow-guard.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Launch the supply-chain guard with an interpreter that has the repository's
+# hash-installed dependencies.
+#
+# pre-commit's `system` language runs whatever `python` the PATH resolves to,
+# which locally is often not the virtualenv. Declaring the dependency in the
+# hook instead would make pre-commit resolve it live and unhashed on every run.
+# So the interpreter is selected here, and nothing is ever downloaded:
+#
+#   .venv/bin/python  — local development, where dependencies were installed
+#                       from requirements/dev.txt
+#   python            — CI, which installs the same file with --require-hashes
+#                       before running pre-commit
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ -x "${REPO_ROOT}/.venv/bin/python" ]; then
+    INTERPRETER="${REPO_ROOT}/.venv/bin/python"
+elif [ -n "${VIRTUAL_ENV:-}" ] && [ -x "${VIRTUAL_ENV}/bin/python" ]; then
+    INTERPRETER="${VIRTUAL_ENV}/bin/python"
+else
+    INTERPRETER="python"
+fi
+
+if ! "${INTERPRETER}" -c "import yaml" >/dev/null 2>&1; then
+    echo "supply-chain guard: PyYAML is unavailable to ${INTERPRETER}." >&2
+    echo "Install the development dependencies first:" >&2
+    echo "    bash scripts/bootstrap.sh" >&2
+    echo "or, matching CI:" >&2
+    echo "    pip install --require-hashes -r requirements/dev.txt" >&2
+    echo "The guard will not install anything itself." >&2
+    exit 1
+fi
+
+exec "${INTERPRETER}" "${REPO_ROOT}/scripts/check_workflows.py" "$@"

--- a/scripts/typecheck-boundaries.sh
+++ b/scripts/typecheck-boundaries.sh
@@ -27,6 +27,7 @@ fi
   ori/installer/cli.py \
   scripts/verify_published_release.py \
   scripts/check_release_protections.py \
+  scripts/check_workflows.py \
   scripts/sign-release-bundle-aws-kms.py \
   ori/network/sms_webhook.py \
   ori/actions/sms.py \

--- a/tests/test_release_publication.py
+++ b/tests/test_release_publication.py
@@ -395,7 +395,13 @@ def test_only_the_protected_signing_job_can_federate_to_aws(
     sign = workflow["jobs"]["sign"]
 
     assert sign["permissions"]["id-token"] == "write"
-    assert sign["environment"] == "release-signing"
+    # The environment may be a bare name or a mapping carrying a url; what must
+    # never change is the name, which the protection rules, the
+    # environment-scoped signer variables and the AWS OIDC subject all key off.
+    environment = sign["environment"]
+    name = environment if isinstance(environment, str) else environment["name"]
+    assert name == "release-signing"
+    assert "${{" not in name
     assert sign["permissions"]["contents"] == "read"
     federation = [
         step

--- a/tests/test_release_signing_environment.py
+++ b/tests/test_release_signing_environment.py
@@ -1,0 +1,383 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The signing environment name must stay literal.
+
+Naming it after the version would create a new environment on every tag.
+GitHub creates a referenced environment *without* protection rules, so
+required reviewers, self-review prevention, the tag-only deployment policy,
+the environment-scoped signer variables and the AWS OIDC subject binding would
+all silently stop applying — while the protection preflight, which checks
+`release-signing` by name, stayed green.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import check_workflows as guard  # noqa: E402
+
+RELEASE = (
+    Path(__file__).resolve().parent.parent / ".github" / "workflows" / "release.yml"
+)
+
+
+@pytest.fixture(scope="module")
+def workflow() -> str:
+    return RELEASE.read_text(encoding="utf-8")
+
+
+def _check(text: str) -> list[str]:
+    failures: list[str] = []
+    guard._check_signing_environment(Path("release.yml"), text, failures)
+    return failures
+
+
+def _check_non_release(text: str) -> list[str]:
+    failures: list[str] = []
+    guard._check_non_release_permissions(Path("ci.yml"), text, failures)
+    return failures
+
+
+def test_the_shipped_workflow_passes(workflow: str) -> None:
+    assert _check(workflow) == []
+
+
+@pytest.mark.parametrize(
+    ("label", "replacement"),
+    [
+        ("ref_name", "${{ github.ref_name }}"),
+        ("interpolated", "release-signing-${{ github.ref_name }}"),
+    ],
+)
+def test_a_dynamic_environment_name_is_rejected(
+    workflow: str, label: str, replacement: str
+) -> None:
+    mutated = workflow.replace(
+        "      name: release-signing", f"      name: {replacement}"
+    )
+    failures = _check(mutated)
+    assert failures, f"{label} was accepted"
+    assert any("expression" in f for f in failures)
+
+
+def test_an_inline_dynamic_environment_is_rejected(workflow: str) -> None:
+    # Replace the whole block: leaving its `url:` line orphaned would make the
+    # workflow unparseable, and the test would pass for the wrong reason.
+    mutated = re.sub(
+        r"    environment:\n(?:      .*\n)+",
+        "    environment: ${{ github.ref_name }}\n",
+        workflow,
+        count=1,
+    )
+    assert mutated != workflow, "fixture did not replace the environment block"
+    assert any("expression" in f for f in _check(mutated))
+
+
+def test_a_different_literal_environment_is_rejected(workflow: str) -> None:
+    mutated = workflow.replace("      name: release-signing", "      name: other")
+    assert any("expected 'release-signing'" in f for f in _check(mutated))
+
+
+def test_a_duplicate_key_is_refused_rather_than_resolved(workflow: str) -> None:
+    """GitHub takes the last occurrence; a checker reading the first would
+    approve one environment while the workflow deploys to another."""
+    mutated = workflow.replace(
+        "      name: release-signing\n",
+        "      name: release-signing\n      name: ${{ github.ref_name }}\n",
+        1,
+    )
+    assert any("duplicate key" in f for f in _check(mutated))
+
+
+def test_an_aliased_sign_job_cannot_leak_the_credential(workflow: str) -> None:
+    """GitHub supports reusing whole job configurations through anchors.
+
+    Aliasing the sign job copies its `id-token: write` into another job, which
+    a parser that never resolves aliases would not see at all.
+    """
+    mutated = workflow.replace("  sign:\n", "  sign: &signcfg\n", 1)
+    mutated = mutated.replace("  publish:\n", "  leaked: *signcfg\n\n  publish:\n", 1)
+    assert mutated != workflow, "fixture did not alias the sign job"
+    resolved = yaml.safe_load(mutated)
+    assert resolved["jobs"]["leaked"]["permissions"]["id-token"] == "write"
+    failures = _check(mutated)
+    assert failures, "an aliased sign job leaked the credential unnoticed"
+    assert any("confined to the sign job" in f for f in failures)
+
+
+@pytest.mark.parametrize(
+    ("label", "replacement"),
+    [
+        ("quoted key", '    "permissions":\n      id-token: write\n'),
+        ("tagged key", "    !!str permissions:\n      id-token: write\n"),
+        ("anchored key", "    &key permissions:\n      id-token: write\n"),
+        ("quoted value", '    permissions:\n      id-token: "write"\n'),
+        ("tagged value", "    permissions:\n      id-token: !!str write\n"),
+        ("anchored value", "    permissions:\n      id-token: &grant write\n"),
+        ("folded scalar", "    permissions:\n      id-token: >-\n        write\n"),
+        ("literal scalar", "    permissions:\n      id-token: |-\n        write\n"),
+        ("flow mapping", "    permissions: {contents: read, id-token: write}\n"),
+        ("write-all", "    permissions: write-all\n"),
+    ],
+)
+def test_every_encoding_of_a_grant_is_caught(
+    workflow: str, label: str, replacement: str
+) -> None:
+    """These are all valid YAML resolving to `id-token: write`.
+
+    Seven rounds of a hand-written scanner missed one class after another —
+    quoted keys, tags, anchors, aliases, flow mappings, block scalars. A real
+    parser resolves them all, so this is coverage of the contract rather than
+    of syntax the checker happens to recognise.
+    """
+    failures = _check(_replace_publish_permissions(workflow, replacement))
+    assert failures, f"{label} slipped through"
+    assert any("confined to the sign job" in f for f in failures)
+
+
+def test_a_benign_flow_mapping_still_passes(workflow: str) -> None:
+    assert (
+        _check(
+            _replace_publish_permissions(
+                workflow, "    permissions: {contents: write}\n"
+            )
+        )
+        == []
+    )
+
+
+def test_an_inherited_grant_does_not_satisfy_the_sign_job(workflow: str) -> None:
+    """The sign job must hold the credential itself."""
+    document = yaml.safe_load(workflow)
+    document["permissions"] = {"contents": "read", "id-token": "write"}
+    document["jobs"]["sign"].pop("permissions", None)
+    for name, job in document["jobs"].items():
+        if name != "sign":
+            job["permissions"] = {"contents": "read", "id-token": "none"}
+    failures = _check(yaml.safe_dump(document))
+    assert any("declared on the job" in f for f in failures)
+    assert any("any job added later would inherit" in f for f in failures)
+
+
+@pytest.mark.parametrize(
+    ("label", "permissions"),
+    [
+        ("write-all", "write-all"),
+        ("contents write", {"contents": "write", "id-token": "write"}),
+        ("missing contents", {"id-token": "write"}),
+        (
+            "additional write scope",
+            {"contents": "read", "id-token": "write", "actions": "write"},
+        ),
+        (
+            "additional read scope",
+            {"contents": "read", "id-token": "write", "actions": "read"},
+        ),
+    ],
+)
+def test_the_sign_job_rejects_broader_or_incomplete_permissions(
+    workflow: str, label: str, permissions: object
+) -> None:
+    document = yaml.safe_load(workflow)
+    document["jobs"]["sign"]["permissions"] = permissions
+    failures = _check(yaml.safe_dump(document))
+    assert failures, f"{label} was accepted"
+    assert any("permissions must be exactly" in failure for failure in failures)
+
+
+def test_the_sign_job_accepts_only_the_least_privilege_mapping(
+    workflow: str,
+) -> None:
+    document = yaml.safe_load(workflow)
+    document["jobs"]["sign"]["permissions"] = dict(guard.SIGNING_PERMISSIONS)
+    assert _check(yaml.safe_dump(document)) == []
+
+
+@pytest.mark.parametrize(
+    "permissions",
+    [
+        "write-all",
+        {"contents": "read", "id-token": "write"},
+    ],
+)
+def test_non_release_workflows_reject_every_workflow_level_oidc_grant(
+    permissions: object,
+) -> None:
+    document = {
+        "permissions": permissions,
+        "jobs": {"test": {"runs-on": "ubuntu-latest", "steps": []}},
+    }
+    failures = _check_non_release(yaml.safe_dump(document))
+    assert any("allowed only" in failure for failure in failures)
+
+
+@pytest.mark.parametrize(
+    "permissions_yaml",
+    [
+        '    permissions: {contents: read, id-token: "write"}\n',
+        "    permissions: &oidc\n      contents: read\n      id-token: write\n",
+        "    permissions: write-all\n",
+    ],
+)
+def test_non_release_workflows_reject_encoded_job_oidc_grants(
+    permissions_yaml: str,
+) -> None:
+    workflow = (
+        "permissions:\n  contents: read\n  id-token: none\n"
+        "jobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        f"{permissions_yaml}"
+        "    steps: []\n"
+    )
+    failures = _check_non_release(workflow)
+    assert any("allowed only" in failure for failure in failures)
+
+
+def test_non_release_workflow_requires_top_level_permissions() -> None:
+    workflow = (
+        "jobs:\n  test:\n    runs-on: ubuntu-latest\n"
+        "    permissions:\n      contents: read\n"
+        "    steps:\n      - run: 'permissions: is only text here'\n"
+    )
+    assert any(
+        "missing explicit" in failure for failure in _check_non_release(workflow)
+    )
+
+
+def test_a_workflow_level_grant_is_a_hazard_even_when_overridden(
+    workflow: str,
+) -> None:
+    document = yaml.safe_load(workflow)
+    document["permissions"] = {"contents": "read", "id-token": "write"}
+    for name, job in document["jobs"].items():
+        if name != "sign":
+            job["permissions"] = {"contents": "read", "id-token": "none"}
+    assert any(
+        "any job added later would inherit" in f
+        for f in _check(yaml.safe_dump(document))
+    )
+
+
+def test_a_run_block_body_is_not_read_as_structure(workflow: str) -> None:
+    mutated = workflow.replace(
+        "      - name: Harden runner",
+        "      - name: Explain\n        run: |\n"
+        "          permissions:\n            id-token: write\n"
+        "      - name: Harden runner",
+        1,
+    )
+    assert mutated != workflow
+    assert _check(mutated) == []
+
+
+def test_unparseable_yaml_is_refused(workflow: str) -> None:
+    assert any("not parseable YAML" in f for f in _check(workflow + "\n  : : :\n"))
+
+
+def _replace_publish_permissions(workflow: str, replacement: str) -> str:
+    """Swap publish's existing permissions block.
+
+    Inserting a second `permissions:` key would be a duplicate, which the
+    strict loader now refuses — so the mutation would test the wrong thing.
+    """
+    match = re.search(
+        r"(  publish:\n(?:    .*\n)*?)    permissions:\n(?:      .*\n)+", workflow
+    )
+    assert match, "publish permissions block not found"
+    return (
+        workflow[: match.start()]
+        + match.group(1)
+        + replacement
+        + workflow[match.end() :]
+    )
+
+
+def test_the_shipped_workflow_grants_it_only_in_sign(workflow: str) -> None:
+    document = yaml.safe_load(workflow)
+    assert document["permissions"]["id-token"] == "none"
+    assert document["jobs"]["sign"]["permissions"]["id-token"] == "write"
+    for name, job in document["jobs"].items():
+        if name != "sign":
+            assert job.get("permissions", {}).get("id-token") != "write", name
+
+
+def test_the_guard_hook_installs_nothing() -> None:
+    """The launcher selects an interpreter; it never downloads a dependency."""
+    repo = Path(__file__).resolve().parent.parent
+    config = yaml.safe_load((repo / ".pre-commit-config.yaml").read_text())
+    guard = next(
+        hook
+        for entry in config["repos"]
+        if entry["repo"] == "local"
+        for hook in entry["hooks"]
+        if hook["id"] == "supply-chain-guard"
+    )
+    assert guard["language"] == "system"
+    assert "additional_dependencies" not in guard
+    launcher = (repo / "scripts" / "run-workflow-guard.sh").read_text()
+    assert ".venv/bin/python" in launcher
+    # It may *name* an install command in its guidance; it must not run one.
+    executable = [
+        line
+        for line in launcher.splitlines()
+        if line.strip() and not line.lstrip().startswith(("#", "echo "))
+    ]
+    for installer in ("pip install", "pip3 ", "easy_install", "curl ", "wget "):
+        assert not any(installer in line for line in executable), (
+            f"the launcher must not run {installer}"
+        )
+
+
+@pytest.mark.parametrize("workflow_name", ["ci.yml", "release.yml"])
+def test_ci_installs_hash_locked_pyyaml_before_running_the_guard(
+    workflow_name: str,
+) -> None:
+    repo = Path(__file__).resolve().parent.parent
+    document = yaml.safe_load(
+        (repo / ".github" / "workflows" / workflow_name).read_text(encoding="utf-8")
+    )
+    test_job = document["jobs"]["test"]
+    steps = test_job["steps"]
+    install_index = next(
+        index
+        for index, step in enumerate(steps)
+        if "pip install --require-hashes -r requirements/dev.txt"
+        in str(step.get("run", ""))
+    )
+    guard_index = next(
+        index
+        for index, step in enumerate(steps)
+        if "python scripts/check_workflows.py" in str(step.get("run", ""))
+    )
+    assert install_index < guard_index
+
+
+def test_the_environment_name_matches_what_preflight_verifies() -> None:
+    preflight = (
+        Path(__file__).resolve().parent.parent
+        / "scripts"
+        / "check_release_protections.py"
+    ).read_text(encoding="utf-8")
+    assert f'ENVIRONMENT = "{guard.SIGNING_ENVIRONMENT}"' in preflight
+
+
+def test_the_oidc_subject_binding_is_documented_for_this_environment() -> None:
+    signing = (
+        Path(__file__).resolve().parent.parent / "docs" / "RELEASE_SIGNING.md"
+    ).read_text(encoding="utf-8")
+    assert f"environment:{guard.SIGNING_ENVIRONMENT}" in signing
+
+
+def test_the_version_is_visible_without_touching_the_environment(
+    workflow: str,
+) -> None:
+    assert "run-name: Release ${{ github.ref_name }}" in workflow
+    assert "name: Sign release bundles (${{ github.ref_name }})" in workflow
+    assert "      name: release-signing" in workflow


### PR DESCRIPTION
## What does this PR do?

GitHub Deployments are keyed by environment name, so the release deployment card read `release-signing` rather than the version being signed.

Naming the environment after the version would fix the display and remove the gate. GitHub creates a referenced environment **without** protection rules, so a per-tag environment would arrive with no required reviewers, no self-review prevention, no tag-only deployment policy, no environment-scoped signer variables, and no match for the AWS OIDC subject bound to `repo:ori-platform/ori-runtime:environment:release-signing`. The protection preflight checks that environment *by name*, so it would have stayed green while signing ran unprotected.

So the version goes in the run name, the signing job name, and a deployment URL pointing at the release. The environment name stays literal:

```yaml
run-name: Release ${{ github.ref_name }}
  sign:
    name: Sign release bundles (${{ github.ref_name }})
    environment:
      name: release-signing
      url: .../releases/tag/${{ github.ref_name }}
```

Before publication that URL 404s; it resolves once the draft is published in the following job.

### Guarding the trade

The supply-chain guard now requires:

- the sign job to declare **exactly** `release-signing` — expressions, other literals and a missing environment are rejected;
- the sign job to hold **exactly** `contents: read` and `id-token: write` in its own permissions. Finding the credential is not the same as confining the authority around it: `write-all`, `contents: write`, or an extra scope would all satisfy a weaker check while broadening what the signing job can do;
- no other job to reach `id-token: write`, by declaration or inheritance, in `release.yml` or any other workflow.

### Why a real parser

Workflows are parsed with PyYAML under a loader that refuses duplicate keys, rather than scanned. Quoted keys, explicit tags, anchors, [aliases and reused job configurations](https://docs.github.com/en/actions/reference/workflows-and-actions/reusing-workflow-configurations), flow mappings and block scalars are all supported workflow syntax. A partial parser cannot prove what any of them resolve to — it can only fail to notice them, which is a fail-open guard.

Duplicate keys are refused outright: GitHub resolves them to the last occurrence, so a checker reading the first would approve `environment: release-signing` while the workflow deployed somewhere else.

### Why a launcher

The guard needs PyYAML, and neither obvious way to supply it is safe. Declaring a hook dependency makes pre-commit resolve it **live and unhashed** on every run. Relying on the ambient interpreter makes the documented local gate fail wherever `python` is not the virtualenv.

`scripts/run-workflow-guard.sh` selects the interpreter instead — the repository virtualenv when present, plain `python` in CI where dependencies are installed with `--require-hashes` — and **refuses with instructions rather than installing anything**. CI now runs the guard after that install, and the guard joins the strict typecheck boundary.

### Also

`pre-commit install` was never run in this working tree. The configuration already ran ruff and ruff-format exactly as CI does, but nothing invoked it on commit, so formatting reached CI unchecked more than once. That is a local setup step, not a repository change — `scripts/bootstrap.sh` already does it, and `CONTRIBUTING.md` already recommends it.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

Marked `security`: this constrains where OIDC signing authority can be obtained. It does not change the AWS trust policy, the environment's protection rules, or the signing ceremony.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime capability changes. This touches the release workflow, a CI guard and its tests. The signed-release-bundle row already records protected OIDC signing and the reviewer-gated environment, and both are unchanged.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable — no files under `/ori/` are modified.

## Related issue

None. Follows the v2.4.0 preparation in #303.

## Testing notes

| Check | Result |
| --- | --- |
| Full suite | 3000 passed, 6 skipped |
| `.venv/bin/pre-commit run --all-files` | clean |
| Ruff (`ori`, `tests`, `scripts`) | clean |
| `scripts/typecheck-boundaries.sh` | 28 files clean |
| `bash scripts/run-workflow-guard.sh` | OK |

The guard was verified against every representation of a grant that resolves to `id-token: write` — quoted, tagged, anchored, aliased, flow-mapped, block-scalar, `write-all`, workflow-level and inherited — with the shipped workflow, a benign flow mapping, and a `run: |` block body containing lookalike text all still passing.

The launcher was verified in a clean container with no virtualenv: without PyYAML it exits 1 naming the install command without running it; after `pip install --require-hashes -r requirements/dev.txt` it exits 0.