### PR TITLE
docs(contributing): correct the bundled-skill checklist for the skill boundary

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -43,9 +43,18 @@
 - [ ] I opened an issue and got maintainer approval before writing this skill
 - [ ] `action_tier` is declared on every trigger
 - [ ] `bypass_llm: true` is only paired with `action_tier: D`
-- [ ] Tier C triggers declare `safe_default_action`
-- [ ] `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)
+- [ ] Tier C triggers declare `safe_default_action`, and it is a non-actuating action
+- [ ] Every action is declared at or above its minimum tier in `ori/reasoning/action_registry.py`
+- [ ] Any new executable action has a matching registry entry (registration is refused without one)
+- [ ] The skill is within the workload budgets — triggers, sensors, the trigger × sensor product, and default actions per trigger
+- [ ] `hooks.py` is clean and minimal
 - [ ] No `subprocess` calls in hooks
+
+> **Packaged skills run with the runtime's own authority.** Their `hooks.py` is
+> imported directly into the runtime interpreter, and only packaged skills may
+> declare `action_tier: D`. There is no sandbox standing between a bundled hook
+> and the process — the previous in-process one was removed in v2.4.0 because it
+> could be escaped. Review bundled hooks as runtime code, not as skill content.
 
 ## Related issue
 


### PR DESCRIPTION
## What does this PR do?

The bundled-skill checklist in the PR template made a claim that stopped being true when #305 merged:

> `hooks.py` is clean and minimal (bundled skills bypass the sandbox — they are implicitly trusted)

There is no sandbox to bypass. The in-process one was removed in v2.4.0 because it could be escaped — it filtered `builtins` by denylist while leaving the object graph reachable, and its import finder implemented only `find_module`, a protocol removed in Python 3.12, so on Ubuntu 24.04 it was ignored entirely.

Left alone, that line tells a contributor the wrong thing in the one place they are most likely to read carefully, and it understates what a bundled hook actually is: code imported directly into the runtime interpreter, running with the runtime's own authority.

The checklist also predates the load-time refusals #305 added. A contributor following it exactly could still write a skill the runtime rejects — a Tier C `safe_default_action` that actuates, an action declared below its registry minimum, an executable action with no registry entry, or one over the workload budgets. A checklist that misses the failures it exists to prevent is doing the opposite of its job, so those items are added rather than left for the author to discover at load time.

Every claim in the new text was verified against the merged code rather than written from memory:

| Claim | Enforced by |
|---|---|
| Safe defaults must be non-actuating | `SkillLoader._parse_triggers` |
| Actions declared at or above the registry minimum | `SkillLoader._validate_actions` |
| Executable actions need a registry entry | `ActionDispatcher.register_executor` |
| Workload budgets | `SkillLoader._validate_workload_budgets` |
| Only packaged skills may declare Tier D | `SkillLoader._parse_triggers` |
| Packaged hooks are imported directly | `SkillLoader._load_hooks_direct` |

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header — no `.py` files in this PR
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime behaviour changes here. Only `.github/PULL_REQUEST_TEMPLATE.md` is touched. The capability matrix was already updated for these behaviours in #305.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable — no runtime file is modified.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no skill is added or modified.

## Related issue

Follow-on to #305, which introduced the behaviour this checklist now describes.

## Testing notes

Documentation only; no code paths change. The claims were checked against the merged implementation rather than asserted, and the pre-commit gates pass.
