### PR TITLE
chore(types): clear the mypy debt outside the contract boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Type check runtime contract boundaries
         run: bash scripts/typecheck-boundaries.sh
 
+      # Whole-package mypy runs here rather than in pre-commit because this job
+      # installs requirements/dev.txt with --require-hashes. Several optional
+      # dependencies change which `type: ignore` comments are needed, so the
+      # result is only reproducible in a pinned environment; a developer's local
+      # set is not one. That is a reason to scope the check, not to skip it.
+      - name: Type check the whole package
+        run: python -m mypy ori/
+
       - name: Pre-commit (lint + format + hygiene)
         env:
           SKIP: no-commit-to-branch

--- a/ori/actions/alert_failover.py
+++ b/ori/actions/alert_failover.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any
+from typing import Any, cast
 
 from ori.reasoning.capability_posture import CapabilityPosture
 
@@ -218,14 +218,19 @@ class AlertFailoverSender:
         from_number: str,
         timeout_seconds: int,
     ) -> str | None:
+        # cast rather than coerce: the listener is caller-supplied and untyped,
+        # and this is a typing correction, not a behaviour change.
         try:
-            return await listener(
-                from_number=from_number,
-                timeout_seconds=timeout_seconds,
+            return cast(
+                "str | None",
+                await listener(
+                    from_number=from_number,
+                    timeout_seconds=timeout_seconds,
+                ),
             )
         except TypeError:
             try:
-                return await listener(from_number, timeout_seconds)
+                return cast("str | None", await listener(from_number, timeout_seconds))
             except Exception:
                 logger.exception(
                     "AlertFailoverSender: %s listener failed",

--- a/ori/actions/coap.py
+++ b/ori/actions/coap.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 logger = logging.getLogger(__name__)
 
 try:
-    import aiocoap as _aiocoap  # type: ignore[import-untyped]
+    import aiocoap as _aiocoap  # pyright: ignore[reportMissingImports]
 
     _AIOCOAP_AVAILABLE = True
 except ImportError:

--- a/ori/actions/relay.py
+++ b/ori/actions/relay.py
@@ -50,8 +50,30 @@ Usage
 
 import asyncio
 import logging
+from typing import Protocol
 
 logger = logging.getLogger(__name__)
+
+
+class _RelayDevice(Protocol):
+    """The gpiozero ``OutputDevice`` surface this module actually uses.
+
+    gpiozero ships no stubs, but that is a reason to describe the three members
+    touched here — not to type the handle as ``Any``. This is the boundary that
+    energises a physical relay: an invalid call or a missed ``None`` check is
+    exactly what should fail type checking rather than at a Tier D dispatch.
+    """
+
+    @property
+    def value(self) -> float:
+        """Current pin value; non-zero while the relay is energised."""
+
+    def on(self) -> None:
+        """Energise the pin."""
+
+    def off(self) -> None:
+        """De-energise the pin."""
+
 
 # Valid BCM GPIO pin numbers on Raspberry Pi 4 (pins 0–1 are reserved for
 # I2C ID EEPROM; 28–53 are not exposed on the 40-pin header).
@@ -72,7 +94,8 @@ class RelayAction:
     def __init__(self) -> None:
         self._pin: int | None = None
         self._active_high: bool = True
-        self._device = None  # gpiozero OutputDevice, or None in sim mode
+        # The gpiozero OutputDevice, or None in simulation mode.
+        self._device: _RelayDevice | None = None
         self._simulated: bool = False
         self._connected: bool = False
         self._sim_state: bool = False  # logical active state used in simulation
@@ -108,7 +131,9 @@ class RelayAction:
         self._active_high = active_high
 
         try:
-            from gpiozero import OutputDevice  # type: ignore[import-untyped]
+            from gpiozero import (  # pyright: ignore[reportMissingImports]
+                OutputDevice,
+            )
 
             # initial_value=False → relay starts de-energised
             self._device = OutputDevice(
@@ -173,7 +198,7 @@ class RelayAction:
                 return True
 
             # Real GPIO
-            self._device.on()
+            self._require_device().on()
             logger.info(
                 "RelayAction.trigger: GPIO pin %d activated (duration=%s)",
                 self._pin,
@@ -181,7 +206,7 @@ class RelayAction:
             )
             if duration_seconds is not None:
                 await asyncio.sleep(duration_seconds)
-                self._device.off()
+                self._require_device().off()
                 logger.info(
                     "RelayAction.trigger: GPIO pin %d released after %.2fs",
                     self._pin,
@@ -219,7 +244,7 @@ class RelayAction:
                 )
                 return True
 
-            self._device.off()
+            self._require_device().off()
             logger.info("RelayAction.release: GPIO pin %d deactivated", self._pin)
             return True
 
@@ -232,6 +257,23 @@ class RelayAction:
             # directly — always route through ActionDispatcher.
             logger.exception("RelayAction.release: error on GPIO pin %d", self._pin)
             return False
+
+    def _require_device(self) -> _RelayDevice:
+        """Return the GPIO handle, or fail loudly.
+
+        Unreachable by construction: ``connect()`` sets a device unless it fell
+        back to simulation, and every caller checks ``_simulated`` first. It
+        raises rather than returning None so a broken invariant surfaces as a
+        failed action instead of a silently skipped one — ``trigger()`` and
+        ``release()`` catch it and return ``False``, which is what they already
+        did when this state produced an ``AttributeError``.
+        """
+        device = self._device
+        if device is None:
+            raise RuntimeError(
+                "RelayAction: GPIO device is unavailable outside simulation mode"
+            )
+        return device
 
     # ── State ─────────────────────────────────────────────────────────────────
 
@@ -247,4 +289,4 @@ class RelayAction:
             return False
         if self._simulated:
             return self._sim_state
-        return bool(self._device.value)
+        return bool(self._require_device().value)

--- a/ori/actions/whatsapp.py
+++ b/ori/actions/whatsapp.py
@@ -156,7 +156,7 @@ class TwilioProvider:
             return False
 
         try:
-            from twilio.rest import Client  # type: ignore[import-untyped]
+            from twilio.rest import Client
 
             client = Client(self._sid, self._token)
             # Twilio's Python SDK is synchronous — run in executor to avoid
@@ -203,7 +203,7 @@ class TwilioProvider:
         try:
             import datetime
 
-            from twilio.rest import Client  # type: ignore[import-untyped]
+            from twilio.rest import Client
 
             # Convert ms timestamp to a datetime for the Twilio filter
             since_dt = datetime.datetime.fromtimestamp(

--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -79,6 +79,8 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
 
     command = ""
     public_command = ""
+    # Most commands return a mapping; the state reads return a list of rows.
+    result: dict[str, Any] | list[dict[str, Any]]
     try:
         command, public_command, args = _parse_command(argv)
 

--- a/ori/config.py
+++ b/ori/config.py
@@ -1911,9 +1911,8 @@ def _validate_production_security_posture(
                 "production posture requires "
                 "security.remote_commands.allowed_senders when remote commands are enabled"
             )
-        lockout = (
-            remote.get("lockout") if isinstance(remote.get("lockout"), dict) else {}
-        )
+        lockout_raw = remote.get("lockout")
+        lockout: dict[str, Any] = lockout_raw if isinstance(lockout_raw, dict) else {}
         if not is_truthy(lockout.get("enforcement_enabled", False)):
             raise ConfigValidationError(
                 "production posture requires "

--- a/ori/gateway/firmware_telemetry.py
+++ b/ori/gateway/firmware_telemetry.py
@@ -26,6 +26,9 @@ from ori.security.firmware_ingest import FirmwareTelemetryGate
 from ori.security.firmware_liveness import FirmwareLivenessSupervisor
 from ori.state.store import StateStore
 
+# Annotated Any so the fallback assignment needs no ignore, which would be
+# reported unused in whichever environment does not match it.
+mqtt: Any
 try:
     import paho.mqtt.client as mqtt
 

--- a/ori/phone_doctor.py
+++ b/ori/phone_doctor.py
@@ -380,7 +380,7 @@ def _sensor_check(config: Config) -> DoctorCheck:
         device_path = str(sensor.metadata.get("device_path", "") or "").strip()
         auto_detect = is_truthy(sensor.metadata.get("auto_detect_device_path", False))
 
-        detail = {
+        detail: dict[str, Any] = {
             "id": sensor.id,
             "type": sensor.type,
             "protocol": sensor.protocol,

--- a/ori/reasoning/local_llm.py
+++ b/ori/reasoning/local_llm.py
@@ -12,7 +12,7 @@ from ori.utils.time_utils import now_ms
 logger = logging.getLogger(__name__)
 
 try:
-    from llama_cpp import Llama  # type: ignore[import-untyped]
+    from llama_cpp import Llama  # pyright: ignore[reportMissingImports]
 
     _LLAMA_AVAILABLE = True
 except ImportError:
@@ -151,7 +151,8 @@ class LocalLLM:
         )
 
     def _infer(self, prompt: str, max_tokens: int) -> dict:
-        return self._llm(  # type: ignore[operator]
+        # _llm is populated by load(); _infer is unreachable before that.
+        return self._llm(  # type: ignore[operator, misc, no-any-return]
             prompt,
             max_tokens=max_tokens,
             temperature=0.0,

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -706,12 +706,12 @@ class OriRuntime:
         if relay_action is not None:
 
             async def _exec_trip_relay(*_: Any) -> None:
-                await relay_action.trigger(duration_seconds=None)  # type: ignore[union-attr]
+                await relay_action.trigger(duration_seconds=None)
                 if status_indicator is not None:
                     status_indicator.set_relay_energized(True)
 
             async def _exec_release_relay(*_: Any) -> None:
-                await relay_action.release()  # type: ignore[union-attr]
+                await relay_action.release()
                 if status_indicator is not None:
                     status_indicator.set_relay_energized(False)
 
@@ -3763,7 +3763,7 @@ def _maybe_autoload_dotenv(config_path: str) -> None:
         return
 
     try:
-        from dotenv import load_dotenv  # type: ignore[import-not-found]
+        from dotenv import load_dotenv
     except ImportError:
         logger.warning(
             "[runtime] ORI_AUTOLOAD_DOTENV is enabled but python-dotenv is not installed"

--- a/ori/telemetry/http_export.py
+++ b/ori/telemetry/http_export.py
@@ -17,8 +17,11 @@ from ori.utils.time_utils import now_ms
 
 logger = logging.getLogger(__name__)
 
+# Annotated Any so the fallback assignment below needs no ignore: an ignore
+# here would be reported unused in whichever environment does not match it.
+_httpx: Any
 try:
-    import httpx as _httpx  # type: ignore[import-untyped]
+    import httpx as _httpx
 
     _HTTPX_AVAILABLE = True
 except ImportError:
@@ -197,7 +200,9 @@ def _serialize_event(event: OriEvent) -> dict[str, Any]:
 def _serialize_reading(reading: SensorReading) -> dict[str, Any]:
     data = asdict(reading)
     data.pop("raw", None)
-    return _json_safe(data)
+    # _json_safe is Any-in/Any-out by design; a dict in yields a dict out.
+    safe: dict[str, Any] = _json_safe(data)
+    return safe
 
 
 def _json_safe(value: Any) -> Any:


### PR DESCRIPTION
## What does this PR do?

Clears the mypy debt tracked for v2.4.0 and **gates it in CI** so it stays cleared.

`scripts/typecheck-boundaries.sh` covers 30 contract-critical modules and was already clean. Running mypy across the whole package reported **27 errors in 11 files**. That number is worth stating: the debt was previously carried as "~161 findings, sampled not audited". Measured, it is 27.

Every source change is an annotation, a Protocol, a cast, or an ignore-comment correction. **No control flow changes, no coerced values.**

## The changes

| Change | Reasoning |
|---|---|
| `RelayAction._device` typed against a `_RelayDevice` Protocol | see below |
| Bridge `result` declared as mapping-or-rows | `_read_state_*` return row lists; the type was being fixed by the first assignment |
| Alert-failover reply `cast`, not coerced | see below |
| `lockout` narrowed through a local | avoids calling `.get` twice and dereferencing a possible `None` |
| `httpx` / `paho` fallbacks annotated | so neither try/except branch needs an ignore |
| Whole-package mypy added to CI | see below |

### The relay handle gets a Protocol, not `Any`

gpiozero ships no stubs. An earlier revision of this PR typed `_device` as `Any`, which silences mypy by removing type safety from the boundary that energises a physical relay — an invalid call or a missed `None` check would then surface at a Tier D dispatch rather than at type-check time.

It is now a local Protocol declaring exactly the three members this module uses:

```python
class _RelayDevice(Protocol):
    @property
    def value(self) -> float: ...
    def on(self) -> None: ...
    def off(self) -> None: ...
```

Narrowing goes through one `_require_device()` helper rather than guards scattered across the actuation paths. The invariant is real: `connect()` sets a device unless it fell back to simulation, and every caller checks `_simulated` first.

**One behavioural difference, verified by exercising the paths directly:**

| Path | Before | After |
|---|---|---|
| Simulated trigger / release / `is_active` | works | unchanged |
| Not connected | `False` / `False` / `False` | unchanged |
| Broken invariant → `trigger`, `release` | `False` (AttributeError caught) | `False` — same |
| Broken invariant → `is_active` | raises `AttributeError` | raises `RuntimeError` |

`trigger` and `release` catch inside the same `try`, so they return `False` exactly as before. `is_active` has no `try`, so the exception *type* changes — in a state unreachable by construction. A named error seemed better than an `AttributeError`; flagging it because it is a difference.

### The listener reply is cast, not coerced

An earlier revision wrapped the alert-failover reply in `str()`. That satisfies the `str | None` annotation but **changes what a non-string reply becomes at runtime** — wrong for a debt-clearing PR. It is a `cast`, which does nothing at execution.

### Ignore comments were reviewed, not deleted on sight

This was the substantive part. Several `# type: ignore` comments are **environment-dependent**: one required when an optional dependency is installed is reported *unused* when it is absent. With `warn_unused_ignores = true` and optional dependencies, `mypy ori/` cannot be clean in every environment at once. Confirmed across three:

| Environment | Result |
|---|---|
| Nothing optional installed | 12 errors — including ignores added moments earlier, now reported unused |
| `requirements/dev.txt` (what CI installs) | clean |
| Local venv — dev.txt plus llama-cpp-python | clean |

**Three dependencies need a different tool's directive.** `gpiozero`, `aiocoap` and `llama-cpp-python` are deliberately absent from `requirements/dev.txt`, so their imports are unresolved for *every* correctly configured developer. Their `# type: ignore` comments were incidentally suppressing Pylance's `reportMissingImports` too; removing them surfaced editor warnings that were not there before. Putting the `type: ignore` back is not the fix — mypy would then report it unused in the same environment, failing the CI gate added here. They carry `# pyright: ignore[reportMissingImports]`, which Pylance acts on and mypy does not parse.

### Whole-package mypy now runs in CI

The debt returns silently without a gate. It runs in the job that installs `requirements/dev.txt` with `--require-hashes` — the pinned, reviewed environment where the result is reproducible. Dependency variability is a reason to scope the check to that environment, not to omit it. It is a distinct step, so a failure names itself rather than hiding inside the boundary check.

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [x] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header — no new files
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. Annotations, a Protocol, one cast, ignore-comment corrections, and a CI step.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — the v2.4.0 mypy debt item
- [x] Every new Tier D code path has test coverage — no new paths; the relay change is typing plus one narrowing helper, covered by the relay, dispatcher and Tier D relay-bypass suites
- [x] No new dependencies added

## Related issue

Part of the v2.4.0 scope agreed before tagging. The `runtime.py` / `store.py` seam extraction is **not** in this PR and is deferred to v2.5.0.

## Testing notes

| | |
|---|---|
| macOS | 3104 passed, 6 skipped |
| Linux 3.12, hash-locked dev deps | 3080 passed, 30 skipped |
| `mypy ori/` | clean, 124 files, in both the pinned CI environment and a denser local one |
| `typecheck-boundaries.sh` | clean, 30 files |
| relay / coap / local_llm focused | 47 passed, 1 skipped |
| relay / dispatcher / Tier D bypass | 111 passed, 1 skipped |

The relay behavioural table above was produced by exercising the simulated, not-connected and broken-invariant paths directly, rather than inferred from the diff.
