### PR TITLE
docs(reasoning): remove the inert offline_fallback key and pin the invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -664,7 +664,6 @@ reasoning:
   default_tier: local
   local_model: qwen2.5-0.5b-instruct-q4_k_m
   model_path: /home/pi/models/
-  offline_fallback: rule
 
 gateway:
   enabled: false

--- a/README.md
+++ b/README.md
@@ -388,7 +388,6 @@ curl -L https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen
 #   local_model: qwen2.5-0.5b-instruct-q4_k_m
 #   model_path: /Users/<you>/models       # macOS
 #   # model_path: /home/<you>/models     # Linux
-#   offline_fallback: local_slm
 
 # 5) Optional dev convenience: auto-load .env before config parse
 export ORI_AUTOLOAD_DOTENV=true

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -75,7 +75,24 @@ These fields are **required** by the runtime. Missing any of them will cause a `
 | `reasoning.default_tier`     | No       | string | Defaults to `rule` (`rule \| local`) |
 | `reasoning.local_model`      | No       | string | GGUF model filename (only needed for `local` tier)       |
 | `reasoning.model_path`       | No       | string | Directory containing GGUF models                         |
-| `reasoning.offline_fallback` | No       | string | Defaults to `rule`                                       |
+
+### Reasoning tier selection and availability
+
+The Intelligence Elevator evaluates the rule engine first and selects the
+cheapest reasoning tier capable of handling the event. Tier D returns
+immediately from the rule path and never depends on an LLM. The local SLM
+provides offline reasoning; deterministic escalation signals reach the gateway
+when local reasoning is insufficient.
+
+Availability cannot remove or weaken a matched rule's action decision. Ordinary
+gateway escalation falls back to the local SLM when the gateway is unavailable.
+A trigger that explicitly declares `escalate_to: gateway` establishes a minimum
+reasoning tier: if the gateway is unavailable, the runtime returns a
+gateway-unavailable stub rather than substituting local reasoning. In either
+case, the matched rule's action tier and proposed action remain authoritative.
+If local inference is unavailable, only explanatory reasoning is lost.
+Low-battery operation may cap reasoning to the rule path. These behaviours are
+structural and cannot be disabled through configuration.
 
 Optional but recommended:
 
@@ -106,7 +123,6 @@ reasoning:
   default_tier: local
   local_model: qwen2.5-0.5b-instruct-q4_k_m
   model_path: /home/$USER/models/
-  offline_fallback: rule
 ```
 
 > **macOS users:** use `/Users/$USER/models/` instead of `/home/$USER/models/`.

--- a/ori.yaml.phone.example
+++ b/ori.yaml.phone.example
@@ -44,7 +44,6 @@ reasoning:
   default_tier: local
   local_model: qwen2.5-0.5b-instruct-q4_k_m  # basename or full .gguf filename/path
   model_path: /data/data/com.termux/files/home/models/
-  offline_fallback: rule
 
 gateway:
   enabled: false

--- a/ori.yaml.phone.growatt.example
+++ b/ori.yaml.phone.growatt.example
@@ -63,7 +63,6 @@ reasoning:
   default_tier: local
   local_model: qwen2.5-0.5b-instruct-q4_k_m
   model_path: /data/data/com.termux/files/home/models/
-  offline_fallback: rule
 
 gateway:
   enabled: false

--- a/ori.yaml.phone.victron.example
+++ b/ori.yaml.phone.victron.example
@@ -74,7 +74,6 @@ reasoning:
   default_tier: local
   local_model: qwen2.5-0.5b-instruct-q4_k_m
   model_path: /data/data/com.termux/files/home/models/
-  offline_fallback: rule
 
 gateway:
   enabled: false

--- a/tests/test_elevator.py
+++ b/tests/test_elevator.py
@@ -527,6 +527,7 @@ class TestReason:
                     "name": "needs_gateway",
                     "condition": "value > 3.0",
                     "action_tier": "C",
+                    "action": "open_safety_circuit",
                     "escalate_to": "gateway",
                     "bypass_llm": False,
                     "cooldown_seconds": 0,
@@ -546,6 +547,7 @@ class TestReason:
         assert result.tier == "gateway"
         assert result.model == "stub"
         assert result.action_tier == "C"
+        assert result.proposed_action == "open_safety_circuit"
         assert "gateway unavailable" in result.text
         ctx = event.context[GATEWAY_ESCALATION_CONTEXT_KEY]
         assert ctx["selected"] is True
@@ -567,6 +569,7 @@ class TestReason:
                     "name": "needs_gateway",
                     "condition": "value > 3.0",
                     "action_tier": "C",
+                    "action": "open_safety_circuit",
                     "escalate_to": "gateway",
                     "bypass_llm": False,
                     "cooldown_seconds": 0,
@@ -587,6 +590,7 @@ class TestReason:
         assert result.tier == "gateway"
         assert result.model == "stub"
         assert result.action_tier == "C"
+        assert result.proposed_action == "open_safety_circuit"
         assert "gateway unavailable" in result.text
 
     async def test_causal_memory_hit_short_circuits_local_llm(self):
@@ -988,6 +992,119 @@ class TestReason:
         result = await elevator.reason(_event(), skill, None)
 
         assert result.model == "stub"
+
+    async def test_matched_rule_survives_missing_local_llm(self):
+        """A matched rule's decision is authoritative when no LLM exists.
+
+        The rule engine is the floor of the elevator: reasoning availability
+        may cost the explanatory text, never the action. Nothing pinned this
+        before — the existing stub tests use a skill with no triggers, so the
+        carry-through never executed.
+        """
+        elevator = IntelligenceElevator(
+            local_llm=None, config=type("obj", (object,), {})()
+        )
+        skill = FakeSkill(
+            triggers=[
+                {
+                    "name": "anomalous_draw",
+                    "condition": "value > 3.0",
+                    "action_tier": "C",
+                    "action": "open_safety_circuit",
+                    "bypass_llm": False,
+                    "cooldown_seconds": 0,
+                }
+            ],
+            actions={
+                "available": [{"name": "open_safety_circuit", "tier": "C"}],
+                "defaults": {"anomalous_draw": ["open_safety_circuit"]},
+            },
+        )
+
+        result = await elevator.reason(_event(value=5.0), skill, None)
+
+        assert result.model == "stub"
+        assert result.action_tier == "C"
+        assert result.proposed_action == "open_safety_circuit"
+
+    async def test_matched_rule_survives_local_inference_failure(self):
+        """An exception inside inference must not weaken the rule decision."""
+        local_llm = AsyncMock()
+        local_llm.reason.side_effect = RuntimeError("model crashed")
+        elevator = IntelligenceElevator(
+            local_llm=local_llm, config=type("obj", (object,), {})()
+        )
+        skill = FakeSkill(
+            triggers=[
+                {
+                    "name": "anomalous_draw",
+                    "condition": "value > 3.0",
+                    "action_tier": "B",
+                    "action": "switch_power_source",
+                    "requires_approval": True,
+                    "bypass_llm": False,
+                    "cooldown_seconds": 0,
+                }
+            ],
+            actions={
+                "available": [{"name": "switch_power_source", "tier": "B"}],
+                "defaults": {"anomalous_draw": ["switch_power_source"]},
+            },
+        )
+
+        result = await elevator.reason(_event(value=5.0), skill, None)
+
+        local_llm.reason.assert_awaited_once()
+        assert result.model == "stub"
+        assert result.action_tier == "B"
+        assert result.proposed_action == "switch_power_source"
+
+    async def test_ordinary_gateway_failure_falls_back_to_local_slm(self):
+        """Gateway reached by escalation signals settles to the local SLM.
+
+        Distinct from an explicit `escalate_to: gateway` floor, which declares
+        a *minimum* tier and therefore must not substitute local reasoning.
+
+        Escalation is driven through the real selection path — a sensor with no
+        24h average and no history raises `no_baseline_available` — rather than
+        by patching tier selection. Patching would keep this test green even if
+        tier selection or escalation-context handling stopped routing ordinary
+        escalation correctly, which is precisely what it exists to prove.
+        """
+        local_llm = AsyncMock()
+        local_llm.reason.return_value = ReasoningResult(
+            text="local answered",
+            tier="local_slm",
+            model="qwen.gguf",
+            tokens_used=1,
+            latency_ms=1,
+        )
+        gateway = AsyncMock()
+        gateway.reason.side_effect = RuntimeError("mqtt unavailable")
+        elevator = IntelligenceElevator(
+            local_llm=local_llm,
+            gateway_reasoner=gateway,
+            config=type("obj", (object,), {})(),
+        )
+        elevator.update_capability_posture(_fresh_gateway_posture())
+        event = _event(value=5.0)
+        store = _mock_state_store(avg=None, history=[])
+
+        result = await elevator.reason(event, _tier_a_skill(), store)
+
+        gateway.reason.assert_awaited()
+        local_llm.reason.assert_awaited_once()
+
+        ctx = event.context[GATEWAY_ESCALATION_CONTEXT_KEY]
+        codes = {signal["code"] for signal in ctx["signals"]}
+        assert "no_baseline_available" in codes
+        assert "trigger_declares_gateway" not in codes, (
+            "this must exercise ordinary escalation, not a declared floor"
+        )
+
+        assert result.tier == "local_slm"
+        assert result.model == "qwen.gguf"
+        assert result.text == "local answered"
 
     async def test_returns_reasoning_result_instance(self):
         elevator = IntelligenceElevator()


### PR DESCRIPTION


## What does this PR do?

`reasoning.offline_fallback` was documented as a config field and shipped in example configs, but appeared in **zero Python files** — the runtime never read it. The surface had also drifted: `README.md` documented `local_slm` while the field table and three phone examples documented `rule`, for a key nothing consulted.

The key dates from the earliest wiring of the runtime and expressed a real intent — the rule engine is the floor that keeps Tier D alive whatever happens above it. That intent became **structural** rather than configurable, and the key was never removed.

## Why delete rather than implement

A safety fallback a config file can switch off is not a fallback. Making it configurable implies the alternative is selectable, and the alternative is a matched Tier D rule producing no action because an LLM is missing. Tier D fires from the rule path with `bypass_llm` precisely so reasoning availability can never affect it.

An inert key that looks load-bearing is worse than no key — a provisioning backend reading `docs/linux-setup.md` would reasonably generate it and believe it selected something. Same defect class as configuration written as though a protection exists.

## What replaces it

`docs/linux-setup.md` documents the behaviour under *Reasoning tier selection and availability*:

- The elevator evaluates rules first and selects the **cheapest tier capable of handling the event**. Tier D returns immediately from the rule path and never depends on an LLM.
- **Ordinary** gateway escalation falls back to the local SLM when the gateway is unavailable.
- A trigger declaring `escalate_to: gateway` sets a **minimum** tier: if the gateway is unavailable it returns a gateway-unavailable stub rather than substituting local reasoning.
- In both cases the matched rule's action tier and proposed action remain authoritative. Only explanatory reasoning is lost.
- Low-battery operation may cap reasoning to the rule path. None of this is configurable.

## Tests

Promoting behaviour to documentation requires it to be pinned, and it wasn't — the existing stub tests use a skill with **no triggers**, so the carry-through never executed:

| Test | Pins |
|---|---|
| `test_matched_rule_survives_missing_local_llm` | matched Tier C rule, no LLM → stub keeps `action_tier` **and** `proposed_action` |
| `test_matched_rule_survives_local_inference_failure` | inference raises → same preservation, Tier B |
| `test_ordinary_gateway_failure_falls_back_to_local_slm` | gateway tried and failed → local SLM invoked, its real result returned |
| the two existing gateway-floor tests | now assert `proposed_action` too, and that local is **not** called |

Two things worth calling out.

**The ordinary-escalation test drives the real path.** An earlier revision patched `_select_tier_from_rule_result` to return `"gateway"`, which bypassed the policy whose distinction the test claims to prove — it would have stayed green if escalation routing broke. It now reaches gateway through `no_baseline_available` with a fresh capability posture, and asserts `trigger_declares_gateway` is **absent**, so the scenario cannot silently become a floor case.

**The existing gateway-floor tests were vacuous in the half being added.** Their triggers declared no `action`, so `proposed_action` was `None` and the new assertion would have compared against nothing. They now declare one.

Mutation-checked — each behaviour's removal fails a specific test:

```
carry-through removed (stub path)     -> 2 failed
gateway floor descends to local       -> 1 failed
descent to local removed              -> 1 failed
no_baseline signal never raised       -> 1 failed   ← the patched version could not catch this
```

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header — no new files
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. A never-read config key is removed and existing behaviour is documented and tested; no runtime code path is modified.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #309
- [x] Every new Tier D code path has test coverage — no new paths; the Tier D independence this documents is what the new tests pin
- [x] No new dependencies added

## Related issue

Closes #309. `ori-specs` needs no amendment — the key appears nowhere in the contracts.

## Testing notes

| | |
|---|---|
| Full suite | 3124 passed, 6 skipped |
| Focused elevator | 74 passed |
| Boundary typecheck | 30 modules clean |
| ruff, `git diff --check` | clean |
