### PR TITLE
feat(gateway): report broker readiness for co-located deployments

### DIFF
--- a/docs/MQTT_SECURITY.md
+++ b/docs/MQTT_SECURITY.md
@@ -9,6 +9,48 @@ Ori uses MQTT as the LAN transport between the runtime and the site gateway for:
 This document covers deployment hardening for the broker layer. It complements,
 but does not replace, runtime-gateway HMAC envelopes.
 
+## Where the broker runs
+
+The runtime and the gateway normally run on the **same device**. The gateway is
+the site coordinator for every Ori deployment at that site; `ori-cloud` is the
+fleet coordinator across sites. So a site has one coordinator device, and the
+broker runs there.
+
+That produces two client positions with different requirements:
+
+| | Broker reached over | Requirements |
+|---|---|---|
+| Coordinator device | loopback (`mqtt://127.0.0.1:1883`) | HMAC auth **and** payload encryption |
+| Other devices at the site | site LAN | the above, **plus** TLS and a declared `broker_posture` |
+
+Production posture requires `gateway.auth.enabled` and
+`gateway.encryption.enabled` for **every** enabled broker, loopback included.
+Co-location removes the network attacker, not the local-process one — any
+process on the device can reach a loopback listener, so payload protections
+still carry the weight. TLS and declared broker posture relax on loopback
+because there is no wire to intercept.
+
+**The broker is operator-managed infrastructure.** The runtime does not install,
+start, or supervise one, and the installer will not: an MQTT broker is a shared
+system component, and installing those is not the installer's authority to take.
+A config declaring `gateway.enabled: true` asserts that a broker exists.
+`ori doctor` reports whether one actually answers, as a warning rather than a
+failure — a broker may legitimately start after the runtime, and gateway
+reasoning is discretionary, since Tier D fires from the rule path regardless.
+
+**The shared secret is supplied by the environment, never by the config.**
+`gateway.auth.shared_secret_env` names a variable; the value belongs in the
+service environment. A config that enables auth without that variable present
+fails at runtime startup, so config generation and secret delivery have to land
+together.
+
+`ori doctor` reports the *configured variable name* and nothing more. It cannot
+establish whether the secret was delivered: a system service reads its
+environment from `/etc/ori/runtime.env` and a user service from
+`~/.config/ori/runtime.env`, neither of which `ori doctor` inherits, so any
+claim about presence would describe the caller rather than the service. Delivery
+is enforced where it is observable — at runtime startup.
+
 ## Security Model
 
 Use layered controls:

--- a/docs/linux-install.md
+++ b/docs/linux-install.md
@@ -78,6 +78,29 @@ unsigned or tampered bundle can never reach a package prompt.
 
 ---
 
+### If you enable the gateway
+
+The installer does not enable the gateway, and a default installation needs no
+broker. If you later install a config with `gateway.enabled: true` — the site
+coordinator role — that config asserts an MQTT broker exists on the device.
+
+The installer will not install one. A broker is shared system infrastructure,
+the same reason `openssl` and `ca-certificates` are reported rather than
+installed. Provide it with your distribution's package manager and harden it as
+described in [MQTT_SECURITY.md](MQTT_SECURITY.md).
+
+`ori doctor` warns when no broker answers at the configured address. That is
+advisory: a broker may start after the runtime, and Tier D safety actions fire
+from the rule path regardless of broker availability.
+
+Doctor also reports which environment variable the gateway reads its shared
+secret from, but not whether the secret arrived — the service environment is not
+one `ori doctor` inherits. A missing secret prevents runtime startup, which is
+where it becomes visible.
+
+An enabled gateway with an unusable `broker_url` — bad scheme, no host, invalid
+port — fails config validation rather than being reported later.
+
 ## Install
 
 ### Interactive

--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -21,10 +21,12 @@ from urllib.parse import urlparse
 import yaml
 
 from ori.config import Config, ConfigValidationError, SensorConfig
+from ori.gateway.mqtt_security import parse_gateway_broker_endpoint
 from ori.network.events import SensorReading
 from ori.skills.loader import Skill, SkillLoader, SkillValidationError
 from ori.skills.sandbox import SkillSecurityError
 from ori.state.store import StateStore
+from ori.utils.bool_utils import is_truthy
 
 _SCHEMA_VERSION = 1
 _DEFAULT_HEALTH_TIMEOUT_MS = 3000
@@ -275,6 +277,7 @@ def _summarize_config(config: Config) -> dict[str, Any]:
             for skill in config.skills
         ],
         "config_signature": _config_signature_posture(config),
+        "gateway": _gateway_posture(config),
         "telemetry_export": _telemetry_export_posture(config),
         "device_policy": _device_policy_posture(config),
         "phone_runtime_mobile": _phone_runtime_mobile_posture(config),
@@ -317,6 +320,65 @@ def _config_signature_posture(config: Config) -> dict[str, Any]:
         "signed_at_ms": signature.get("signed_at_ms"),
         "trust_anchor_env": _optional_str(signature.get("trust_anchor_env")),
     }
+
+
+def _gateway_posture(config: Config) -> dict[str, Any]:
+    """Describe the gateway broker a deployment expects to reach.
+
+    The runtime and the gateway normally run on the same device, so an enabled
+    gateway asserts that a broker exists — usually on loopback. Nothing else
+    reports whether one is actually there, and a config declaring
+    ``gateway.enabled: true`` validates happily with no broker running.
+
+    Normalisation comes from :func:`parse_gateway_broker_endpoint`, the same
+    parser the transport uses, so diagnostics cannot disagree with the runtime
+    about default ports or a bare host. A `broker_url` that cannot be parsed is
+    reported as a structured error rather than raising out of the command.
+
+    Only the *name* of the shared-secret variable is reported. Whether the
+    secret is present cannot be answered here: the service receives it from its
+    own environment file, which this process does not inherit, so any answer
+    would describe the caller rather than the service.
+    """
+    broker_url = str(config.gateway.broker_url or "").strip()
+    posture: dict[str, Any] = {
+        "enabled": bool(config.gateway.enabled),
+        "broker_configured": bool(broker_url),
+        "auth_enabled": is_truthy(config.gateway.auth.get("enabled", False)),
+        "encryption_enabled": is_truthy(
+            config.gateway.encryption.get("enabled", False)
+        ),
+        "tls_enabled": is_truthy(config.gateway.tls.get("enabled", False)),
+        "shared_secret_env": str(
+            config.gateway.auth.get("shared_secret_env", "") or ""
+        ).strip(),
+    }
+
+    if not broker_url:
+        posture.update(
+            broker_scheme="", broker_host="", broker_port=None, broker_is_loopback=False
+        )
+        return posture
+
+    try:
+        endpoint = parse_gateway_broker_endpoint(broker_url)
+    except ValueError as exc:
+        posture.update(
+            broker_scheme="",
+            broker_host="",
+            broker_port=None,
+            broker_is_loopback=False,
+            broker_error=str(exc),
+        )
+        return posture
+
+    posture.update(
+        broker_scheme=endpoint.scheme,
+        broker_host=endpoint.host,
+        broker_port=endpoint.port,
+        broker_is_loopback=endpoint.host in _LOOPBACK_HOSTS,
+    )
+    return posture
 
 
 def _telemetry_export_posture(config: Config) -> dict[str, Any]:

--- a/ori/config.py
+++ b/ori/config.py
@@ -1109,9 +1109,23 @@ def _parse_gateway(data: Any) -> GatewayConfig:
 
     broker_posture = _parse_gateway_broker_posture(data.get("broker_posture"))
 
+    enabled = bool(data.get("enabled", False))
+    broker_url = str(data.get("broker_url", ""))
+    if enabled:
+        # An enabled gateway with an unusable endpoint is invalid configuration,
+        # not a runtime availability problem. Validated with the same parser the
+        # transport uses, so a config that loads is one the transport can act on;
+        # whether a broker actually answers stays advisory in `ori doctor`.
+        from ori.gateway.mqtt_security import parse_gateway_broker_endpoint
+
+        try:
+            parse_gateway_broker_endpoint(broker_url)
+        except ValueError as exc:
+            raise ConfigValidationError(str(exc)) from exc
+
     return GatewayConfig(
-        enabled=bool(data.get("enabled", False)),
-        broker_url=str(data.get("broker_url", "")),
+        enabled=enabled,
+        broker_url=broker_url,
         reasoning=reasoning,
         node_heartbeat=node_heartbeat,
         firmware_telemetry=firmware_telemetry,

--- a/ori/doctor.py
+++ b/ori/doctor.py
@@ -19,6 +19,7 @@ import json
 import os
 import pwd
 import shutil
+import socket
 import stat
 import subprocess
 import sys
@@ -851,6 +852,140 @@ def check_prerequisites() -> list[DoctorCheck]:
     return checks
 
 
+def check_gateway(
+    identity: InstallIdentity, runner: CommandRunner
+) -> list[DoctorCheck]:
+    """Report whether an enabled gateway has a broker to reach.
+
+    The runtime and the gateway normally run on the same device — the gateway
+    is the site coordinator, and its broker is usually on loopback. Config
+    validation accepts ``gateway.enabled: true`` without one, so nothing else
+    tells an operator that the broker is missing until an export request or a
+    Tier 3 reasoning call quietly fails.
+
+    Advisory rather than mandatory, deliberately. A broker may legitimately
+    start after the runtime, so failing an installation on it would create a
+    startup race; and gateway reasoning is discretionary — Tier D fires from
+    the rule path and is unaffected by broker availability.
+
+    Secret presence is deliberately **not** reported. The service reads its
+    shared secret from its own environment file, which this process does not
+    inherit, so any answer here would describe the caller rather than the
+    service. A missing secret fails runtime startup, where it is visible and
+    accurate.
+    """
+    posture = _gateway_posture_from_config(identity, runner)
+    if posture is None or not posture.get("enabled"):
+        return []
+
+    checks: list[DoctorCheck] = []
+    broker_error = str(posture.get("broker_error") or "")
+    host = str(posture.get("broker_host") or "")
+    port = posture.get("broker_port")
+
+    if broker_error:
+        checks.append(
+            DoctorCheck(
+                name="gateway.broker",
+                status=WARN,
+                message=f"Gateway is enabled but broker_url is unusable: {broker_error}",
+                remedy="Set gateway.broker_url, e.g. mqtt://127.0.0.1:1883.",
+            )
+        )
+    elif not host or not isinstance(port, int):
+        checks.append(
+            DoctorCheck(
+                name="gateway.broker",
+                status=WARN,
+                message="Gateway is enabled but no broker_url is configured.",
+                remedy="Set gateway.broker_url, e.g. mqtt://127.0.0.1:1883.",
+            )
+        )
+    else:
+        reachable = _tcp_reachable(host, port)
+        checks.append(
+            DoctorCheck(
+                name="gateway.broker",
+                status=PASS if reachable else WARN,
+                message=(
+                    f"Gateway broker reachable at {host}:{port}."
+                    if reachable
+                    else f"Gateway is enabled but no broker answers at {host}:{port}."
+                ),
+                remedy=(
+                    "Install and start an MQTT broker on this device, then harden "
+                    "it as described in docs/MQTT_SECURITY.md."
+                ),
+                details={
+                    "host": host,
+                    "port": port,
+                    "loopback": posture.get("broker_is_loopback"),
+                },
+            )
+        )
+
+    # The verified property is the *binding*, not the secret. Naming this
+    # `gateway.shared_secret` would read as "the secret is fine", which this
+    # cannot establish — the service reads it from an environment file this
+    # process does not inherit.
+    secret_env = str(posture.get("shared_secret_env") or "")
+    if posture.get("auth_enabled") and secret_env:
+        checks.append(
+            DoctorCheck(
+                name="gateway.shared_secret_reference",
+                status=PASS,
+                message=(
+                    f"Gateway auth is configured to read its secret from "
+                    f"{secret_env}; delivery is enforced when the runtime starts."
+                ),
+                details={"shared_secret_env": secret_env},
+            )
+        )
+    return checks
+
+
+def _gateway_posture_from_config(
+    identity: InstallIdentity, runner: CommandRunner
+) -> dict[str, Any] | None:
+    """Read the gateway posture the bridge reports for the installed config."""
+    if not identity.config_path.is_file():
+        return None
+    result = _run(
+        [
+            str(interpreter_path(identity)),
+            "-m",
+            "ori.cli_bridge",
+            "config",
+            "show",
+            "--path",
+            str(identity.config_path),
+        ],
+        runner,
+    )
+    if result.returncode != 0:
+        return None
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+    config = payload.get("result", {}).get("config", {})
+    gateway = config.get("gateway") if isinstance(config, dict) else None
+    return gateway if isinstance(gateway, dict) else None
+
+
+def _tcp_reachable(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Whether something accepts a TCP connection at *host*:*port*.
+
+    A connect probe only. It proves a listener exists, not that it speaks MQTT
+    or will accept these credentials — those fail later and visibly.
+    """
+    try:
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError:
+        return False
+
+
 def run_doctor(
     identity: InstallIdentity,
     expected_device_id: str,
@@ -864,6 +999,7 @@ def run_doctor(
     checks.extend(check_paths(identity))
     checks.extend(check_prerequisites())
     checks.extend(check_config(identity, active))
+    checks.extend(check_gateway(identity, active))
     checks.extend(check_service(identity, active))
     checks.extend(check_runtime(identity, expected_device_id, active))
     checks.extend(check_permissions(identity))

--- a/ori/gateway/mqtt_security.py
+++ b/ori/gateway/mqtt_security.py
@@ -13,6 +13,53 @@ from urllib.parse import urlparse
 
 
 @dataclass(frozen=True)
+class GatewayBrokerEndpoint:
+    """Where a gateway broker lives, with nothing constructed.
+
+    Split out of :class:`GatewayBrokerConfig` so diagnostics can ask the same
+    question the transport asks without building a TLS context. Reporting and
+    connecting previously parsed `broker_url` separately and disagreed:
+    `mqtt://localhost` has no explicit port, so a raw `urlparse()` reported no
+    port at all while the transport used 1883, and a bare `localhost` looked
+    like it had no host.
+    """
+
+    host: str
+    port: int
+    scheme: str
+    username: str = ""
+    password: str = ""
+
+
+def parse_gateway_broker_endpoint(broker_url: str) -> GatewayBrokerEndpoint:
+    """Normalise `gateway.broker_url` into host, port and scheme.
+
+    Accepts a bare host, applies the scheme's default port, and raises
+    ``ValueError`` for anything it cannot resolve — including a non-numeric
+    port, which :func:`urlparse` only rejects when the port is read.
+    """
+    raw = str(broker_url or "").strip()
+    if not raw:
+        raise ValueError("gateway.broker_url is required when gateway.enabled is true")
+    parsed = urlparse(raw if "://" in raw else f"mqtt://{raw}")
+    if parsed.scheme not in {"mqtt", "tcp", "mqtts"}:
+        raise ValueError("gateway.broker_url must use mqtt://, tcp://, or mqtts://")
+    if not parsed.hostname:
+        raise ValueError("gateway.broker_url must include a broker host")
+    try:
+        port = parsed.port
+    except ValueError as exc:  # non-numeric or out-of-range port
+        raise ValueError(f"gateway.broker_url has an invalid port: {exc}") from exc
+    return GatewayBrokerEndpoint(
+        host=parsed.hostname,
+        port=port or (8883 if parsed.scheme == "mqtts" else 1883),
+        scheme=parsed.scheme,
+        username=parsed.username or "",
+        password=parsed.password or "",
+    )
+
+
+@dataclass(frozen=True)
 class GatewayBrokerConfig:
     host: str
     port: int
@@ -28,23 +75,14 @@ def parse_gateway_broker_url(
     tls_config: Mapping[str, Any] | None = None,
 ) -> GatewayBrokerConfig:
     """Parse `gateway.broker_url` and optional TLS config."""
-    raw = str(broker_url or "").strip()
-    if not raw:
-        raise ValueError("gateway.broker_url is required when gateway.enabled is true")
-    parsed = urlparse(raw if "://" in raw else f"mqtt://{raw}")
-    if parsed.scheme not in {"mqtt", "tcp", "mqtts"}:
-        raise ValueError("gateway.broker_url must use mqtt://, tcp://, or mqtts://")
-    if not parsed.hostname:
-        raise ValueError("gateway.broker_url must include a broker host")
-
-    tls_context = build_gateway_tls_context(parsed.scheme, tls_config)
-    default_port = 8883 if parsed.scheme == "mqtts" else 1883
+    endpoint = parse_gateway_broker_endpoint(broker_url)
+    tls_context = build_gateway_tls_context(endpoint.scheme, tls_config)
     return GatewayBrokerConfig(
-        host=parsed.hostname,
-        port=parsed.port or default_port,
-        username=parsed.username or "",
-        password=parsed.password or "",
-        scheme=parsed.scheme,
+        host=endpoint.host,
+        port=endpoint.port,
+        username=endpoint.username,
+        password=endpoint.password,
+        scheme=endpoint.scheme,
         tls_context=tls_context,
     )
 

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -7,6 +7,7 @@ import json
 import textwrap
 from pathlib import Path
 
+import pytest
 import yaml
 
 from ori import cli_bridge
@@ -535,3 +536,143 @@ def test_cli_bridge_public_group_requires_supported_subcommand(capsys):
     assert payload["ok"] is False
     assert payload["error"]["code"] == "unknown_command"
     assert "expected one of: show, validate" in payload["error"]["detail"]
+
+
+# ─── Gateway posture in `config show` ─────────────────────────────────────────
+
+
+_GATEWAY_CONFIG_BASE = """\
+device:
+  id: gw-device-01
+  name: Gateway Device
+  location: Lagos
+sensors:
+  - id: cpu
+    type: cpu_percent
+    protocol: psutil
+    poll_interval_ms: 1000
+skills: []
+reasoning:
+  default_tier: rule
+gateway:
+"""
+
+
+def _config_with_gateway(tmp_path: Path, gateway: str) -> Path:
+    """Write a config whose ``gateway:`` block is *gateway*.
+
+    Composed rather than interpolated into a ``textwrap.dedent`` block: dedent
+    runs after substitution, so an injected block's own indentation becomes the
+    common prefix and silently mangles the surrounding YAML.
+    """
+    cfg = tmp_path / "ori.yaml"
+    cfg.write_text(_GATEWAY_CONFIG_BASE + gateway + "\n", encoding="utf-8")
+    return cfg
+
+
+def _gateway_from_show(capsys, cfg: Path) -> dict:
+    rc = cli_bridge.main(["config", "show", "--path", str(cfg)])
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    return payload["result"]["config"]["gateway"]
+
+
+def test_config_show_reports_disabled_gateway(tmp_path, capsys):
+    cfg = _config_with_gateway(tmp_path, "  enabled: false\n  broker_url: ''")
+    gateway = _gateway_from_show(capsys, cfg)
+
+    assert gateway["enabled"] is False
+    assert gateway["broker_configured"] is False
+
+
+@pytest.mark.parametrize(
+    ("broker_url", "host", "port", "scheme"),
+    [
+        ("mqtt://localhost", "localhost", 1883, "mqtt"),
+        ("localhost", "localhost", 1883, "mqtt"),
+        ("mqtts://localhost", "localhost", 8883, "mqtts"),
+        ("mqtt://127.0.0.1:1884", "127.0.0.1", 1884, "mqtt"),
+    ],
+    ids=["default_port", "bare_host", "mqtts_default_port", "explicit_port"],
+)
+def test_config_show_normalises_broker_url_like_the_runtime(
+    tmp_path, capsys, broker_url, host, port, scheme
+):
+    """Diagnostics must agree with the transport about defaults and bare hosts.
+
+    A raw `urlparse()` reported no port for `mqtt://localhost` and no host for a
+    bare `localhost`, so doctor warned about a broker the runtime would have
+    reached. Both now use `parse_gateway_broker_endpoint`.
+    """
+    cfg = _config_with_gateway(tmp_path, f"  enabled: true\n  broker_url: {broker_url}")
+    gateway = _gateway_from_show(capsys, cfg)
+
+    assert gateway["broker_host"] == host
+    assert gateway["broker_port"] == port
+    assert gateway["broker_scheme"] == scheme
+    assert "broker_error" not in gateway
+
+
+@pytest.mark.parametrize(
+    ("broker_url", "expected"),
+    [
+        ("mqtt://localhost:notaport", "invalid port"),
+        ("mqtt://", "must include a broker host"),
+        ("http://localhost", "must use mqtt://"),
+        ("''", "is required when gateway.enabled is true"),
+    ],
+    ids=["bad_port", "no_host", "bad_scheme", "empty"],
+)
+def test_enabled_gateway_with_unusable_broker_url_fails_validation(
+    tmp_path, capsys, broker_url, expected
+):
+    """An unusable endpoint is invalid configuration, not broker unavailability.
+
+    An earlier revision returned success with a `broker_error` field, which made
+    a config the transport cannot act on look merely degraded. It now fails
+    validation, so doctor's mandatory `config.valid` check catches it.
+    """
+    cfg = _config_with_gateway(tmp_path, f"  enabled: true\n  broker_url: {broker_url}")
+
+    rc = cli_bridge.main(["config", "show", "--path", str(cfg)])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "config_validation_error"
+    assert expected in payload["error"]["detail"]
+
+
+def test_disabled_gateway_tolerates_an_unusable_broker_url(tmp_path, capsys):
+    """A disabled gateway never connects, so its stale URL is not an error."""
+    cfg = _config_with_gateway(
+        tmp_path, "  enabled: false\n  broker_url: mqtt://localhost:notaport"
+    )
+    gateway = _gateway_from_show(capsys, cfg)
+
+    assert gateway["enabled"] is False
+    assert "invalid port" in gateway["broker_error"]
+
+
+def test_config_show_names_the_secret_variable_but_never_its_value(
+    tmp_path, capsys, monkeypatch
+):
+    """The variable name is useful; the value is not this command's to emit.
+
+    Presence is not reported at all — the service reads the secret from its own
+    environment file, which this process does not inherit.
+    """
+    monkeypatch.setenv("GATEWAY_SHARED_SECRET", "super-secret-value")
+    cfg = _config_with_gateway(
+        tmp_path,
+        "  enabled: true\n  broker_url: mqtt://127.0.0.1:1883\n"
+        "  auth:\n    enabled: true\n    shared_secret_env: GATEWAY_SHARED_SECRET",
+    )
+    rc = cli_bridge.main(["config", "show", "--path", str(cfg)])
+    raw = capsys.readouterr().out
+    gateway = json.loads(raw)["result"]["config"]["gateway"]
+
+    assert rc == 0
+    assert gateway["shared_secret_env"] == "GATEWAY_SHARED_SECRET"
+    assert "shared_secret_env_set" not in gateway
+    assert "super-secret-value" not in raw

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1271,7 +1271,32 @@ class TestLoadExample:
             """,
         )
 
-        with pytest.raises(ConfigValidationError, match="include a hostname"):
+        # Now rejected by endpoint parsing rather than by the posture check, so
+        # a hostless broker fails for any enabled gateway rather than only under
+        # production posture. The message comes from the shared parser.
+        with pytest.raises(ConfigValidationError, match="include a broker host"):
+            Config.load(yaml_path)
+
+    def test_enabled_gateway_rejects_hostless_broker_in_any_profile(self, tmp_path):
+        """The endpoint must be usable before posture is considered."""
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+              deployment_profile: development
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway:
+              enabled: true
+              broker_url: mqtt://
+            """,
+        )
+
+        with pytest.raises(ConfigValidationError, match="include a broker host"):
             Config.load(yaml_path)
 
     def test_production_posture_rejects_plain_non_loopback_gateway(self, tmp_path):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import json
 import os
 import pwd
+import socket
 import subprocess
 from pathlib import Path
 from typing import Sequence
@@ -608,3 +609,145 @@ def test_json_report_is_a_single_document(
     payload = json.loads(capsys.readouterr().out)
     assert payload["identity"]["scope"] == "user"
     assert payload["checks"] == []
+
+
+# ─── Gateway broker ───────────────────────────────────────────────────────────
+
+
+def _gateway_runner(posture: dict, tmp_path: Path):
+    """A runner returning the bridge's config-show payload for *posture*."""
+
+    def run(command):
+        payload = {"result": {"config": {"gateway": posture}}}
+        return subprocess.CompletedProcess(
+            command, 0, stdout=json.dumps(payload), stderr=""
+        )
+
+    return run
+
+
+def _with_config(root: Path) -> None:
+    (root / "data").mkdir(parents=True, exist_ok=True)
+    (root / "data" / "ori.yaml").write_text("device: {}\n", encoding="utf-8")
+
+
+def test_gateway_check_is_silent_when_gateway_is_disabled(tmp_path):
+    """Most deployments never enable the gateway; they should see nothing."""
+    _with_config(tmp_path)
+    checks = doctor.check_gateway(
+        _identity(tmp_path), _gateway_runner({"enabled": False}, tmp_path)
+    )
+    assert checks == []
+
+
+def test_gateway_check_warns_when_no_broker_answers(tmp_path):
+    """An enabled gateway with no broker is invisible until something fails.
+
+    Advisory, not mandatory: a broker may start after the runtime, and gateway
+    reasoning is discretionary — Tier D fires from the rule path regardless.
+    """
+    _with_config(tmp_path)
+    posture = {
+        "enabled": True,
+        "broker_host": "127.0.0.1",
+        "broker_port": 1,  # nothing listens here
+        "broker_is_loopback": True,
+        "auth_enabled": False,
+    }
+    checks = doctor.check_gateway(
+        _identity(tmp_path), _gateway_runner(posture, tmp_path)
+    )
+
+    broker = next(c for c in checks if c.name == "gateway.broker")
+    assert broker.status == doctor.WARN
+    assert broker.mandatory is False
+    assert "no broker answers" in broker.message
+
+
+def test_gateway_check_passes_when_a_listener_answers(tmp_path):
+    """Probe a real listener so the pass path is not asserted by construction."""
+    _with_config(tmp_path)
+    with socket.socket() as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        posture = {
+            "enabled": True,
+            "broker_host": "127.0.0.1",
+            "broker_port": port,
+            "broker_is_loopback": True,
+            "auth_enabled": False,
+        }
+        checks = doctor.check_gateway(
+            _identity(tmp_path), _gateway_runner(posture, tmp_path)
+        )
+
+    broker = next(c for c in checks if c.name == "gateway.broker")
+    assert broker.status == doctor.PASS
+
+
+def test_gateway_check_reports_the_secret_variable_without_claiming_presence(
+    tmp_path,
+):
+    """Naming the variable helps; claiming to know whether it is set does not.
+
+    The service reads its secret from its own environment file, which `ori
+    doctor` does not inherit. An earlier revision warned from `os.environ` and
+    so reported a false "not set" against correctly configured, running
+    deployments.
+    """
+    _with_config(tmp_path)
+    posture = {
+        "enabled": True,
+        "broker_host": "127.0.0.1",
+        "broker_port": 1,
+        "auth_enabled": True,
+        "shared_secret_env": "GATEWAY_SHARED_SECRET",
+    }
+    checks = doctor.check_gateway(
+        _identity(tmp_path), _gateway_runner(posture, tmp_path)
+    )
+
+    secret = next(c for c in checks if c.name == "gateway.shared_secret_reference")
+    assert secret.status == doctor.PASS
+    assert "GATEWAY_SHARED_SECRET" in secret.message
+    assert "delivery is enforced when the runtime starts" in secret.message
+    assert all(c.status != doctor.FAIL for c in checks)
+
+
+def test_gateway_check_reports_both_conditions_independently(tmp_path):
+    """A broker problem must not suppress the other diagnostic."""
+    _with_config(tmp_path)
+    posture = {
+        "enabled": True,
+        "broker_host": "",
+        "broker_port": None,
+        "auth_enabled": True,
+        "shared_secret_env": "GATEWAY_SHARED_SECRET",
+    }
+    checks = doctor.check_gateway(
+        _identity(tmp_path), _gateway_runner(posture, tmp_path)
+    )
+
+    assert [c.name for c in checks] == [
+        "gateway.broker",
+        "gateway.shared_secret_reference",
+    ]
+    assert checks[0].status == doctor.WARN
+
+
+def test_gateway_check_surfaces_an_unusable_broker_url(tmp_path):
+    _with_config(tmp_path)
+    posture = {
+        "enabled": True,
+        "broker_host": "",
+        "broker_port": None,
+        "broker_error": "gateway.broker_url has an invalid port",
+        "auth_enabled": False,
+    }
+    checks = doctor.check_gateway(
+        _identity(tmp_path), _gateway_runner(posture, tmp_path)
+    )
+
+    assert checks[0].status == doctor.WARN
+    assert "unusable" in checks[0].message


### PR DESCRIPTION
## What does this PR do?

The runtime and the gateway normally run on the **same device** — the gateway is the site coordinator for a site, and its broker is usually on loopback. Config validation accepted `gateway.enabled: true` with no broker anywhere, and nothing reported the gap until an export request or a Tier 3 reasoning call quietly failed.

## Diagnostics and transport now share one parser

`parse_gateway_broker_endpoint()` is split out of `parse_gateway_broker_url()` as a pure function, so a report can ask where the broker is without building a TLS context.

They previously parsed `broker_url` separately and **disagreed**:

| `broker_url` | Transport used | Diagnostics saw |
|---|---|---|
| `mqtt://localhost` | `localhost:1883` | no port → warned about a broker the runtime would have reached |
| `localhost` | `localhost:1883` | no host at all |
| `mqtt://localhost:notaport` | `ValueError` | **raised out of the command** |

`urlparse` only rejects a bad port when `.port` is *read*, which is why the third case crashed rather than reporting.

## An unusable endpoint is now a config error

An enabled gateway with a bad scheme, missing host, or invalid port fails validation, so doctor's **mandatory** `config.valid` check catches it rather than it surfacing as advisory broker unavailability later.

```
enabled + bad port     -> ConfigValidationError: has an invalid port
enabled + no host      -> ConfigValidationError: must include a broker host
enabled + bad scheme   -> ConfigValidationError: must use mqtt://, tcp://, or mqtts://
enabled + empty url    -> ConfigValidationError: is required when gateway.enabled is true
enabled + bare host    -> loads
disabled + bad port    -> loads
```

**Behaviour widening worth noting:** a hostless broker was previously rejected only under production posture. It is now rejected whenever the gateway is enabled. `test_production_posture_rejects_gateway_broker_without_hostname` was updated for the new message, and a development-profile test added, rather than the string being patched over.

A disabled gateway still tolerates a stale URL, since it never connects.

## Broker reachability is advisory

`ori doctor` warns when nothing answers at the configured address. Deliberately not mandatory: a broker may legitimately start after the runtime, so failing an installation would create a startup race, and gateway reasoning is discretionary — **Tier D fires from the rule path and is unaffected by broker availability.**

## Secret presence is deliberately not reported

An earlier revision warned when the shared-secret variable was unset, read from `os.environ` in the doctor process. That is the wrong environment: a system service reads `/etc/ori/runtime.env` and a user service `~/.config/ori/runtime.env`, neither of which `ori doctor` inherits. It would have warned against correctly configured, running deployments.

Doctor now reports the configured variable name as **`gateway.shared_secret_reference`** — named for the property it can actually verify, the binding rather than the secret:

```
PASS  Gateway auth is configured to read its secret from GATEWAY_SHARED_SECRET;
      delivery is enforced when the runtime starts.
```

`gateway.shared_secret` as a PASS would have read as "the secret arrived", which this cannot establish. Delivery is enforced at runtime startup, where it is observable.

## The installer allowlist is unchanged — deliberately

#310 proposed adding a broker package to the prerequisite allowlist. Reading `prerequisites.py` shows that contradicts a rationale already recorded there: `openssl` and `ca-certificates` were removed because *"shared operating system components that unrelated software depends on… installing them is not this installer's authority to take"*. A broker is squarely that class, and the installer never enables the gateway, so the entry would be unreachable.

Instead the broker is documented as operator-managed — which is how `MQTT_SECURITY.md` already treats it — and the runtime reports on it.

## Documentation

`MQTT_SECURITY.md` gains the site topology:

| | Broker reached over | Requirements |
|---|---|---|
| Coordinator device | loopback | HMAC auth **and** payload encryption |
| Other devices at the site | site LAN | the above, **plus** TLS and declared `broker_posture` |

Co-location removes the network attacker, not the local-process one — any process on the device can reach a loopback listener, so payload protections still carry the weight.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header — no new files
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

Capability rows are unchanged: no capability is added or removed. Gateway MQTT rows already describe the transport; this adds reporting and tightens validation of an existing surface.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #310
- [x] Every new Tier D code path has test coverage — no new Tier D paths; this documents and tests that Tier D is unaffected by broker availability
- [x] No new dependencies added

## Related issue

Closes #310.

## Testing notes

| | |
|---|---|
| Full suite | 3142 passed, 6 skipped |
| Boundary typecheck | 30 modules clean |
| ruff, `git diff --check` | clean |

Eight behavioural tests drive `_gateway_posture()` through the real `config show` command rather than fabricating posture: disabled, default port, bare host, mqtts default, explicit port, structured validation failure for each malformed shape, and one that sets a real secret value in the environment and asserts it appears **nowhere** in the emitted JSON.

Mutation-checked — each behaviour fails a specific test when reverted:

```
bridge reverts to raw urlparse             -> 3 failed
default port dropped                       -> 3 failed
malformed port raises instead of reporting -> 1 failed
secret presence re-added                   -> 1 failed
broker failure returns early               -> 1 failed
enabled-gateway URL validation removed     -> 4 failed
check renamed back to shared_secret        -> 2 failed
```

**One environment note:** the broker-reachable test binds a real listener on `127.0.0.1:0` rather than asserting the pass path by construction. In a socket-restricted sandbox that test will not run; it is the only one here that needs a listener, and can be gated behind a marker if that is a problem.
