### PR TITLE
ci(release): resolve tag, wheel and bundle versions through one authority

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,19 @@ jobs:
             --tag "${GITHUB_REF_NAME}" \
             --commit "${GITHUB_SHA}"
 
+      # Only after the protections above have passed, and only then, is code
+      # from the tagged commit executed in this job.
+      - name: Install build dependencies
+        run: python -m pip install --no-deps -e .
+
+      # The trigger is a glob and admits any `v*.*.*-*` tag, so this is where a
+      # tag that cannot produce a coherent release is refused — before a bundle
+      # exists and before any signing credential is issued. Deferring it to the
+      # build job is how v2.4.0-rc.1 and v2.4.0-rc.2 were spent: both passed
+      # this job, then failed at a point where the tag was already immutable.
+      - name: Verify the tag and the packaged version name one build
+        run: python scripts/check_release_identity.py --tag "${GITHUB_REF_NAME}"
+
   # ci.yml only runs on branch pushes and pull requests, so a tag can point at
   # any commit. Signing must never happen without the release gates passing.
   test:
@@ -194,21 +207,12 @@ jobs:
         id: identity
         run: |
           set -euo pipefail
-          version="${GITHUB_REF_NAME#v}"
-          # A pre-release tag carries the version it is a candidate for, plus a
-          # suffix: v2.4.0-rc.1 is a candidate for 2.4.0. Comparing the whole
-          # tag would reject it, even though the workflow trigger accepts
-          # pre-release tags — so the two disagreed and a candidate could be
-          # tagged but never built. Only the release portion is compared; the
-          # full version, suffix included, still names the bundle so a candidate
-          # is never mistaken for the final artifact.
-          base="${version%%-*}"
-          declared="$(python -c 'import tomllib,pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
-          if [ "${base}" != "${declared}" ]; then
-            echo "tag ${GITHUB_REF_NAME} does not match pyproject version ${declared}" >&2
-            exit 1
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          # Preflight has already refused a tag that names no coherent release.
+          # This repeats the check rather than trusting it: the version the
+          # bundle is built with must come from the same authority that admitted
+          # the tag, not from a second reading of the ref in shell.
+          python scripts/check_release_identity.py \
+            --tag "${GITHUB_REF_NAME}" >> "${GITHUB_OUTPUT}"
           echo "epoch=$(git log -1 --format=%ct)" >> "${GITHUB_OUTPUT}"
 
       # build-wheelhouse.sh assembles the hash-locked wheelhouse and the

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -25,6 +25,50 @@ its three fixes are included here.
 **If you are running v2.3.0, upgrade.** If you tried to install v2.3.0 on a
 Raspberry Pi and it failed, that was the extraction defect below.
 
+## Release candidates
+
+`v2.4.0-rc.1` and `v2.4.0-rc.2` are published tags that produced no artifacts.
+Both are retained. Neither was moved or deleted, and neither should be
+installed — nothing was ever built, signed, or published from either.
+
+| Tag | Reached | Failed because |
+|---|---|---|
+| `v2.4.0-rc.1` | protection preflight, full test matrix | the build compared the whole tag against the packaged version, so no pre-release tag could ever match |
+| `v2.4.0-rc.2` | protection preflight, full test matrix | the wheel version and the bundle version were compared as strings, and a candidate spells them differently |
+
+Both failures share a cause. The release pipeline carries two version
+vocabularies — SemVer for the git tag, the signature envelope, the bundle
+manifest and the artifact name; PEP 440 for the wheel, its metadata and the
+version the installer reads back on the device. They agree for every final
+release and diverge for every candidate, so no release before this one
+exercised the difference.
+
+Both failures also landed in the build job, after the tag was immutable. A tag
+cannot be rebuilt, and a tag-triggered run resolves the workflow at its own ref,
+so neither candidate could be recovered by fixing `main`.
+
+A candidate now identifies itself consistently:
+
+| | `v2.4.0-rc.3` | `v2.4.0` |
+|---|---|---|
+| Git tag | `v2.4.0-rc.3` | `v2.4.0` |
+| Packaged version | `2.4.0rc3` | `2.4.0` |
+| Wheel metadata | `2.4.0rc3` | `2.4.0` |
+| Bundle and artifact name | `2.4.0-rc.3` | `2.4.0` |
+
+`-rc.N` is the only accepted pre-release form, and it maps to exactly one PEP 440
+spelling. `2.4.0-rc3` is refused rather than treated as a synonym, so one build
+can never be published under two identities. Every comparison between the two
+vocabularies resolves through a single authority, and the tag is now checked
+against the packaged version in the preflight job — before a bundle exists and
+before any signing credential is issued.
+
+The final release is its own commit changing the packaged version from a
+candidate to `2.4.0`, and runs the full pipeline again. It is not byte-identical
+to the last candidate, because the version metadata legitimately differs: the
+candidate validates the code and the deployment, and the final run validates the
+artifact that ships.
+
 ## What was broken in v2.3.0
 
 ### The installer could not run on stock Raspberry Pi OS Bookworm

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -22,7 +22,7 @@ from typing import Callable, Literal, Sequence
 import yaml
 
 from ori.installer import identity
-from ori.security.release_bundles import ExtractedReleaseBundle
+from ori.security.release_bundles import ExtractedReleaseBundle, distribution_version
 
 _VERSION_RE = re.compile(
     r"^(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)"
@@ -1458,13 +1458,18 @@ class OfflineReleasePreparer:
             raise LinuxInstallError(
                 "offline_install_failed", "release interpreter is missing"
             )
+        # `importlib.metadata` reports the PEP 440 spelling and the bundle
+        # declares the SemVer one, so a candidate reads back as `2.4.0rc3`
+        # against a bundle identified as `2.4.0-rc.3`. Both name the same build;
+        # comparing them directly would fail every pre-release install on the
+        # device, after signature verification had already passed.
         self._run(
             [
                 str(python),
                 "-c",
                 "import importlib.metadata as m; import ori.runtime; print(m.version('ori-runtime'))",
             ],
-            expected_stdout=self._bundle.runtime_version,
+            expected_stdout=distribution_version(self._bundle.runtime_version),
         )
         # Execute a console script rather than stat it. A relocated venv leaves
         # every entry point with a dangling interpreter while the interpreter

--- a/ori/security/release_bundles.py
+++ b/ori/security/release_bundles.py
@@ -39,8 +39,15 @@ _MANIFEST_FIELDS = {"files", "python", "runtime_version", "schema", "target"}
 _KEY_REGISTRY_FIELDS = {"keys", "schema"}
 _KEY_FIELDS = {"key_id", "public_key_b64", "purpose", "status"}
 _SHA256_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
+# One canonical release identity, and exactly one spelling of it. The release
+# pipeline carries two version vocabularies — SemVer for the git tag, the
+# signature envelope and the artifact name; PEP 440 for the wheel, its metadata
+# and `importlib.metadata` — and they diverge only for pre-releases, which is
+# why every final release hid the disagreement. Admitting more than one SemVer
+# spelling would put that ambiguity back inside the signed identity itself:
+# `2.4.0-rc2` and `2.4.0-rc.2` are one candidate under two artifact names.
 _VERSION_RE = re.compile(
-    r"^[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z]+(?:[.-][0-9A-Za-z]+)*)?$"
+    r"^(?:0|[1-9][0-9]*)(?:\.(?:0|[1-9][0-9]*)){2}(?:-rc\.[1-9][0-9]*)?$"
 )
 _TARGET_RE = re.compile(r"^linux-(?:x86_64|aarch64)-python3\.(?:11|12)$")
 _KEY_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,127}$")
@@ -86,6 +93,25 @@ class ExtractedReleaseBundle:
     target: str
     python: str
     file_count: int
+
+
+def distribution_version(runtime_version: str) -> str:
+    """Return the PEP 440 distribution version for a canonical release identity.
+
+    A candidate tagged ``v2.4.0-rc.3`` is built from a package declaring
+    ``2.4.0rc3``, so its wheel, its wheel metadata and the version the installer
+    reads back from ``importlib.metadata`` all use the PEP 440 spelling, while
+    the tag, the signature envelope, the bundle manifest and the artifact name
+    use the SemVer one. Both name the same build.
+
+    Every comparison that crosses between the two vocabularies resolves here.
+    Normalising separately at each site is how a candidate ends up validated
+    under one spelling and installed under another — the build rejecting a
+    wheel it built, or an installer rejecting the bundle it just verified.
+    """
+    if not _VERSION_RE.fullmatch(runtime_version):
+        _fail("invalid_signature_envelope", "runtime_version is malformed")
+    return runtime_version.replace("-rc.", "rc")
 
 
 def release_artifact_name(runtime_version: str, target: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0"
+version = "2.4.0rc3"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/build_release_bundle.py
+++ b/scripts/build_release_bundle.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from ori.security.release_bundles import (
     MANIFEST_SCHEMA,
     ReleaseBundleError,
+    distribution_version,
     release_artifact_name,
 )
 
@@ -135,6 +136,12 @@ def _validate_wheelhouse(wheelhouse: Path, runtime_version: str) -> None:
     if "sha256:" not in requirements.read_text(encoding="utf-8"):
         raise BundleBuildError("wheelhouse requirements.txt is not hash-locked")
 
+    # The bundle declares a SemVer identity and carries a PEP 440 wheel, so the
+    # candidate's two spellings are reconciled through the release-identity
+    # authority. Comparing them as strings rejects `2.4.0rc3` against a bundle
+    # built for `2.4.0-rc.3` — the wheel this build just produced.
+    expected_wheel_version = distribution_version(runtime_version)
+
     wheel_identities: set[tuple[str, str]] = set()
     runtime_wheels: list[Path] = []
     for wheel in wheelhouse.glob("*.whl"):
@@ -143,7 +150,7 @@ def _validate_wheelhouse(wheelhouse: Path, runtime_version: str) -> None:
         wheel_identities.add((normalized_name, version))
         if normalized_name == "ori-runtime":
             runtime_wheels.append(wheel)
-            if version != runtime_version:
+            if version != expected_wheel_version:
                 raise BundleBuildError(
                     "runtime wheel version does not match requested release version"
                 )

--- a/scripts/check_release_identity.py
+++ b/scripts/check_release_identity.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove a release tag and the packaged version name the same build.
+
+The workflow trigger is a glob and admits any `v*.*.*-*` tag. This is the
+authority that decides whether such a tag may be built and signed, and it runs
+in the preflight job — before a bundle exists and before any signing credential
+is issued — so a tag that cannot produce a coherent release fails while the tag
+is the only thing that has been published.
+
+`v2.4.0-rc.1` and `v2.4.0-rc.2` were spent proving this: both passed the
+protection preflight and the full test matrix, and both failed later, at a
+point where the tag was already immutable.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import tomllib
+from pathlib import Path
+from typing import Sequence
+
+from ori.security.release_bundles import ReleaseBundleError, distribution_version
+
+
+def resolve_release_identity(tag: str, pyproject: Path) -> str:
+    """Return the runtime version *tag* names, or raise if it names none.
+
+    The tag is the SemVer spelling and the packaged version is the PEP 440 one,
+    so they are compared through the single conversion authority rather than as
+    strings — `v2.4.0-rc.3` and `2.4.0rc3` are the same build, `v2.4.0-rc.3` and
+    `2.4.0` are not.
+    """
+    if not tag.startswith("v"):
+        raise ValueError(f"release tag {tag!r} does not start with 'v'")
+    runtime_version = tag[1:]
+
+    try:
+        expected = distribution_version(runtime_version)
+    except ReleaseBundleError as exc:
+        raise ValueError(
+            f"release tag {tag!r} is not a canonical release identity "
+            f"(expected vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-rc.N): "
+            f"{exc.detail}"
+        ) from exc
+
+    try:
+        declared = tomllib.loads(pyproject.read_text(encoding="utf-8"))["project"][
+            "version"
+        ]
+    except (OSError, KeyError, tomllib.TOMLDecodeError) as exc:
+        raise ValueError(f"could not read a project version from {pyproject}") from exc
+
+    if declared != expected:
+        raise ValueError(
+            f"release tag {tag!r} needs {pyproject.name} version {expected!r}, "
+            f"found {declared!r}"
+        )
+    return runtime_version
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="release tag, including the 'v'")
+    parser.add_argument("--pyproject", default="pyproject.toml", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        runtime_version = resolve_release_identity(args.tag, args.pyproject)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    # Consumed as a step output; the bundle, the artifact name and the
+    # signature envelope all take their version from here.
+    print(f"version={runtime_version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -1219,6 +1219,62 @@ def test_offline_preparer_rejects_missing_or_ambiguous_runtime_wheel(
         preparer.prepare(tmp_path / "release")
 
 
+def test_offline_preparer_accepts_a_candidate_reporting_its_pep440_version(
+    tmp_path: Path,
+) -> None:
+    """A `2.4.0-rc.3` bundle installs a wheel that reports `2.4.0rc3`.
+
+    The bundle carries the SemVer identity and `importlib.metadata` reports the
+    PEP 440 one. Comparing them as strings fails every candidate install on the
+    device, after the signature has already been verified — which is the point
+    at which the operator has no fallback.
+    """
+    root = tmp_path / "bundle"
+    root.mkdir()
+    bundle = ExtractedReleaseBundle(
+        root, "2.4.0-rc.3", "linux-x86_64-python3.12", "3.12", 1
+    )
+    release = tmp_path / "release"
+    interpreter = release / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_bytes(b"python")
+    for name in ENTRY_POINTS:
+        (interpreter.parent / name).write_text("", encoding="utf-8")
+    preparer = OfflineReleasePreparer(
+        bundle=bundle,
+        runner=lambda command: subprocess.CompletedProcess(
+            command, 0, "2.4.0rc3\n", ""
+        ),
+    )
+
+    preparer.validate(release)
+
+
+def test_offline_preparer_rejects_a_candidate_reporting_the_final_version(
+    tmp_path: Path,
+) -> None:
+    """`2.4.0` is not what a `2.4.0-rc.3` bundle installs.
+
+    Reconciling the two spellings must not blur the two builds together.
+    """
+    root = tmp_path / "bundle"
+    root.mkdir()
+    bundle = ExtractedReleaseBundle(
+        root, "2.4.0-rc.3", "linux-x86_64-python3.12", "3.12", 1
+    )
+    release = tmp_path / "release"
+    interpreter = release / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_bytes(b"python")
+    preparer = OfflineReleasePreparer(
+        bundle=bundle,
+        runner=lambda command: subprocess.CompletedProcess(command, 0, "2.4.0\n", ""),
+    )
+
+    with pytest.raises(LinuxInstallError, match="version mismatch"):
+        preparer.validate(release)
+
+
 def test_offline_preparer_rejects_installed_runtime_version_mismatch(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_release_bundle_build.py
+++ b/tests/test_release_bundle_build.py
@@ -243,6 +243,70 @@ def test_rejects_runtime_wheel_version_mismatch(tmp_path: Path) -> None:
         )
 
 
+def test_builds_a_candidate_whose_wheel_carries_the_pep440_spelling(
+    tmp_path: Path,
+) -> None:
+    """A candidate bundle is `2.4.0-rc.3` and its wheel is `2.4.0rc3`.
+
+    The two are the same build under the two version vocabularies the pipeline
+    carries. Comparing them as strings rejected the wheel the build had just
+    produced, which is what failed v2.4.0-rc.2 after its tag was immutable.
+    """
+    wheelhouse, config, service = _inputs(tmp_path)
+    next(wheelhouse.glob("ori_runtime*.whl")).unlink()
+    _write_runtime_wheel(
+        wheelhouse / "ori_runtime-2.4.0rc3-py3-none-any.whl", "2.4.0rc3"
+    )
+
+    artifact = build_release_bundle(
+        wheelhouse=wheelhouse,
+        runtime_version="2.4.0-rc.3",
+        target=TARGET,
+        config_template=config,
+        service_template=service,
+        output_dir=tmp_path / "dist",
+    )
+
+    assert artifact.name == f"ori-runtime-2.4.0-rc.3-{TARGET}.tar.gz"
+
+
+def test_rejects_a_candidate_bundle_carrying_the_final_wheel(tmp_path: Path) -> None:
+    """`2.4.0` is not the wheel for a `2.4.0-rc.3` bundle.
+
+    Loosening the comparison to the release portion would admit this, and the
+    installer would then refuse the bundle on the device — after signature
+    verification had already passed.
+    """
+    wheelhouse, config, service = _inputs(tmp_path)
+    next(wheelhouse.glob("ori_runtime*.whl")).unlink()
+    _write_runtime_wheel(wheelhouse / "ori_runtime-2.4.0-py3-none-any.whl", "2.4.0")
+
+    with pytest.raises(BundleBuildError, match="does not match"):
+        build_release_bundle(
+            wheelhouse=wheelhouse,
+            runtime_version="2.4.0-rc.3",
+            target=TARGET,
+            config_template=config,
+            service_template=service,
+            output_dir=tmp_path / "dist",
+        )
+
+
+def test_rejects_a_non_canonical_release_identity(tmp_path: Path) -> None:
+    """`2.4.0-rc3` and `2.4.0-rc.3` must not both name one candidate."""
+    wheelhouse, config, service = _inputs(tmp_path)
+
+    with pytest.raises(BundleBuildError, match="runtime_version is malformed"):
+        build_release_bundle(
+            wheelhouse=wheelhouse,
+            runtime_version="2.4.0-rc3",
+            target=TARGET,
+            config_template=config,
+            service_template=service,
+            output_dir=tmp_path / "dist",
+        )
+
+
 def test_rejects_wheelhouse_missing_locked_dependency_wheel(tmp_path: Path) -> None:
     wheelhouse, config, service = _inputs(tmp_path)
     (wheelhouse / "PyYAML-6.0.2-py3-none-any.whl").unlink()

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -1,22 +1,27 @@
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0
 
-"""The release workflow must build every tag its trigger accepts.
+"""A release tag and the packaged version must name exactly one build.
 
-`release.yml` triggers on `v*.*.*` **and** `v*.*.*-*`, so a release candidate
-is a tag the workflow invites. Its identity step compared the whole tag against
-the version in `pyproject.toml`, which no pre-release tag can equal — so
-`v2.4.0-rc.1` passed the protection preflight, ran the tests, and then failed
-all four bundle builds. Tags are immutable, so that spent the candidate.
+The release pipeline carries two version vocabularies — SemVer for the git tag,
+the signature envelope, the bundle manifest and the artifact name; PEP 440 for
+the wheel, its metadata and what the installer reads back on the device. They
+agree for every final release and diverge for every candidate, so nothing about
+`v2.3.0` exercised the disagreement.
 
-These tests execute the step exactly as it ships, extracted from the workflow
-by parsing the YAML rather than by pattern-matching the file.
+`v2.4.0-rc.1` and `v2.4.0-rc.2` were spent finding that out. Both cleared the
+protection preflight and the full test matrix; the first failed because the
+build compared the whole tag against the packaged version, the second because
+the wheel and the bundle were compared as strings. Each failure landed after the
+tag was immutable, so neither candidate could be rebuilt.
+
+These tests pin the invariant that would have caught both: one conversion
+authority, consulted at every site where the vocabularies meet, and consulted in
+preflight before a bundle or a signing credential exists.
 """
 
 from __future__ import annotations
 
-import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -24,123 +29,223 @@ from pathlib import Path
 import pytest
 import yaml
 
-_WORKFLOW = (
-    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "release.yml"
+from ori.security.release_bundles import ReleaseBundleError, distribution_version
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from check_release_identity import resolve_release_identity  # noqa: E402
+
+_REPO = Path(__file__).resolve().parents[1]
+_WORKFLOW = _REPO / ".github" / "workflows" / "release.yml"
+_SCRIPT = _REPO / "scripts" / "check_release_identity.py"
+
+
+def _pyproject(tmp_path: Path, version: str) -> Path:
+    path = tmp_path / "pyproject.toml"
+    path.write_text(
+        f'[project]\nname = "ori-runtime"\nversion = "{version}"\n', encoding="utf-8"
+    )
+    return path
+
+
+def _workflow() -> dict:
+    return yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
+
+
+# ── The conversion authority ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("runtime_version", "expected"),
+    [
+        ("2.4.0", "2.4.0"),
+        ("2.4.0-rc.3", "2.4.0rc3"),
+        ("2.4.0-rc.10", "2.4.0rc10"),
+        ("10.0.0-rc.1", "10.0.0rc1"),
+    ],
 )
+def test_canonical_identities_map_to_their_pep440_spelling(
+    runtime_version: str, expected: str
+) -> None:
+    assert distribution_version(runtime_version) == expected
 
 
-def _identity_script() -> str:
-    """The `run:` body of the build job's identity step, as it ships."""
-    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    for job in workflow["jobs"].values():
-        for step in job.get("steps") or []:
-            if step.get("id") == "identity":
-                return str(step["run"])
-    raise AssertionError("no step with id 'identity' in release.yml")
+@pytest.mark.parametrize(
+    "runtime_version",
+    [
+        "2.4.0-rc3",  # the same candidate under a second spelling
+        "2.4.0rc3",  # the PEP 440 spelling is not a release identity
+        "2.4.0-beta.1",  # only rc is canonical
+        "2.4.0-RC.3",
+        "2.4.0-rc.0",
+        "2.4.0-rc.03",
+        "02.4.0",
+        "2.4.0-rc.3+build",
+        "v2.4.0",
+        "2.4.0-rc.1-rc.2",
+        "",
+    ],
+)
+def test_ambiguous_or_malformed_identities_are_refused(runtime_version: str) -> None:
+    """One build must have one spelling.
+
+    Accepting `2.4.0-rc3` alongside `2.4.0-rc.3` would let one candidate be
+    published under two artifact names, each with its own signature.
+    """
+    with pytest.raises(ReleaseBundleError):
+        distribution_version(runtime_version)
 
 
-def _run_identity(tmp_path: Path, tag: str, declared: str):
-    """Run the step against *declared* in pyproject with *tag* as the ref."""
-    (tmp_path / "pyproject.toml").write_text(
-        f'[project]\nname = "ori-runtime"\nversion = "{declared}"\n', encoding="utf-8"
-    )
-    output = tmp_path / "github_output"
-    output.touch()
-    # The step reads the tagged commit's timestamp, so it needs a repository.
-    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
-    subprocess.run(["git", "add", "-A"], cwd=tmp_path, check=True)
-    subprocess.run(
-        ["git", "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "t"],
-        cwd=tmp_path,
-        check=True,
-    )
-    # The step calls `python`, which the CI runner provides via setup-python.
-    # A shim supplies the same name here without altering the shipped script.
-    shim_dir = tmp_path / "bin"
-    shim_dir.mkdir()
-    shim = shim_dir / "python"
-    shim.write_text(f'#!/bin/sh\nexec "{sys.executable}" "$@"\n', encoding="utf-8")
-    shim.chmod(0o755)
+# ── Tag against packaged version ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("tag", "declared"),
+    [("v2.4.0", "2.4.0"), ("v2.4.0-rc.3", "2.4.0rc3"), ("v3.0.0-rc.1", "3.0.0rc1")],
+)
+def test_a_tag_matching_its_packaged_version_resolves(
+    tmp_path: Path, tag: str, declared: str
+) -> None:
+    assert resolve_release_identity(tag, _pyproject(tmp_path, declared)) == tag[1:]
+
+
+@pytest.mark.parametrize(
+    ("tag", "declared", "reason"),
+    [
+        ("v2.4.0-rc.3", "2.4.0", "the candidate would carry the final wheel"),
+        ("v2.4.0", "2.4.0rc3", "the final would carry a candidate wheel"),
+        ("v2.4.0-rc.3", "2.4.0rc2", "a candidate must not build another candidate"),
+        ("v2.5.0", "2.4.0", "an unrelated release"),
+        ("v2.4.1", "2.4.0", "an unrelated patch"),
+    ],
+)
+def test_a_tag_naming_a_different_build_is_refused(
+    tmp_path: Path, tag: str, declared: str, reason: str
+) -> None:
+    with pytest.raises(ValueError, match="version"):
+        resolve_release_identity(tag, _pyproject(tmp_path, declared))
+    assert reason
+
+
+def test_a_non_canonical_tag_is_refused_before_the_version_is_read(
+    tmp_path: Path,
+) -> None:
+    """The trigger is a glob, so it admits tags this authority must reject."""
+    with pytest.raises(ValueError, match="canonical release identity"):
+        resolve_release_identity("v2.4.0-rc3", _pyproject(tmp_path, "2.4.0rc3"))
+
+
+def test_a_tag_without_its_v_prefix_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="does not start with"):
+        resolve_release_identity("2.4.0", _pyproject(tmp_path, "2.4.0"))
+
+
+# ── The shipped script, as the workflow invokes it ────────────────────────────
+
+
+def test_the_script_emits_the_version_the_bundle_is_built_with(tmp_path: Path) -> None:
+    """The build step appends this to GITHUB_OUTPUT verbatim.
+
+    A stray line on stdout becomes a step output, so the contract is the whole
+    stream, not a substring of it.
+    """
+    _pyproject(tmp_path, "2.4.0rc3")
 
     completed = subprocess.run(
-        ["bash", "-c", _identity_script()],
+        [sys.executable, str(_SCRIPT), "--tag", "v2.4.0-rc.3"],
         cwd=tmp_path,
         capture_output=True,
         text=True,
-        env={
-            "PATH": f"{shim_dir}:{os.environ.get('PATH', '')}",
-            "GITHUB_REF_NAME": tag,
-            "GITHUB_OUTPUT": str(output),
-            "HOME": str(tmp_path),
-        },
     )
-    return completed, output.read_text(encoding="utf-8")
-
-
-pytestmark = pytest.mark.skipif(
-    shutil.which("bash") is None or shutil.which("git") is None,
-    reason="bash and git are required to execute the workflow step",
-)
-
-
-@pytest.mark.parametrize(
-    "tag",
-    ["v2.4.0", "v2.4.0-rc.1", "v2.4.0-rc.2", "v2.4.0-beta.1"],
-    ids=["final", "rc1", "rc2", "beta"],
-)
-def test_identity_accepts_every_tag_shape_the_trigger_allows(tmp_path, tag):
-    """A candidate for 2.4.0 must build against a pyproject declaring 2.4.0.
-
-    The workflow trigger accepts these tags; rejecting them here made the two
-    disagree, so a tag could be published and then never built.
-    """
-    completed, output = _run_identity(tmp_path, tag, "2.4.0")
 
     assert completed.returncode == 0, completed.stderr
-    assert f"version={tag[1:]}" in output
+    assert completed.stdout == "version=2.4.0-rc.3\n"
 
 
-@pytest.mark.parametrize(
-    "tag", ["v2.5.0", "v2.4.1", "v2.4.1-rc.1"], ids=["minor", "patch", "patch_rc"]
-)
-def test_identity_rejects_a_tag_for_a_different_release(tmp_path, tag):
-    """Loosening the comparison must not let an unrelated version through."""
-    completed, _ = _run_identity(tmp_path, tag, "2.4.0")
+def test_the_script_fails_without_emitting_a_version(tmp_path: Path) -> None:
+    """A refused tag must leave GITHUB_OUTPUT empty, not partially written."""
+    _pyproject(tmp_path, "2.4.0")
+
+    completed = subprocess.run(
+        [sys.executable, str(_SCRIPT), "--tag", "v2.4.0-rc.3"],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
 
     assert completed.returncode == 1
-    assert "does not match pyproject version" in completed.stderr
+    assert completed.stdout == ""
+    assert "2.4.0rc3" in completed.stderr
 
 
-def test_bundle_version_keeps_the_prerelease_suffix(tmp_path):
-    """The emitted version names the bundle, so a candidate must stay distinct.
+def test_the_repository_tag_and_packaged_version_agree() -> None:
+    """The checked-in version must be releasable under some canonical tag.
 
-    Comparing on the release portion must not also *strip* the suffix: an rc
-    bundle named `ori-runtime-2.4.0-...` would be indistinguishable from the
-    final artifact.
+    A packaged version no tag can name is a release that cannot be cut.
     """
-    _, output = _run_identity(tmp_path, "v2.4.0-rc.1", "2.4.0")
-
-    assert "version=2.4.0-rc.1" in output
-    assert "version=2.4.0\n" not in output
-
-
-def test_trigger_and_identity_agree_on_prerelease_tags():
-    """Pin the relationship, not just the behaviour.
-
-    If the trigger stops accepting pre-release tags, this check becomes dead
-    weight; if it accepts a shape the identity step rejects, candidates break
-    after the tag is already immutable.
-    """
-    workflow = yaml.safe_load(_WORKFLOW.read_text(encoding="utf-8"))
-    # `on` parses as the boolean True in YAML 1.1.
-    triggers = workflow.get("on") or workflow.get(True)
-    tag_patterns = triggers["push"]["tags"]
-
-    assert any("-" in pattern for pattern in tag_patterns), (
-        "the trigger no longer accepts pre-release tags; the identity step's "
-        "suffix handling should be revisited together with it"
+    declared = (_REPO / "pyproject.toml").read_text(encoding="utf-8")
+    version = next(
+        line.split("=", 1)[1].strip().strip('"')
+        for line in declared.splitlines()
+        if line.startswith("version = ")
     )
-    assert "base=" in _identity_script(), (
-        "the identity step no longer separates the release portion from a "
-        "pre-release suffix, but the trigger still accepts pre-release tags"
+    candidates = [version, version.replace("rc", "-rc.")]
+    assert any(
+        distribution_version(candidate) == version
+        for candidate in candidates
+        if _is_canonical(candidate)
+    ), f"packaged version {version!r} is not reachable from any canonical tag"
+
+
+def _is_canonical(runtime_version: str) -> bool:
+    try:
+        distribution_version(runtime_version)
+    except ReleaseBundleError:
+        return False
+    return True
+
+
+# ── The workflow must consult the authority, and consult it early ─────────────
+
+
+def test_preflight_refuses_a_bad_tag_before_any_bundle_or_credential() -> None:
+    """Both spent candidates failed in the build job, after the tag was fixed.
+
+    Preflight runs before any bundle exists and before the signing environment
+    issues a credential, so it is the only place where refusing a tag still
+    leaves something recoverable.
+    """
+    preflight = _workflow()["jobs"]["preflight"]
+    steps = [step.get("run", "") for step in preflight["steps"]]
+
+    assert any("check_release_identity.py" in step for step in steps), (
+        "preflight does not verify that the tag and the packaged version agree"
+    )
+
+
+def test_the_build_takes_its_version_from_the_same_authority() -> None:
+    """Re-deriving the version in shell is how the two checks disagreed."""
+    jobs = _workflow()["jobs"]
+    build = next(job for name, job in jobs.items() if name.startswith("build"))
+    identity = next(step for step in build["steps"] if step.get("id") == "identity")
+
+    assert "check_release_identity.py" in identity["run"]
+    assert "%%-" not in identity["run"], (
+        "the build step still truncates the tag in shell instead of resolving "
+        "it through the release-identity authority"
+    )
+
+
+def test_the_trigger_admits_tags_only_the_authority_can_refuse() -> None:
+    """The glob cannot express the canonical form, so the authority must exist.
+
+    If the trigger were ever narrowed to final releases only, the pre-release
+    handling here would be dead weight and should be revisited with it.
+    """
+    triggers = _workflow().get("on") or _workflow().get(True)
+    patterns = triggers["push"]["tags"]
+
+    assert any("-" in pattern for pattern in patterns), (
+        "the trigger no longer accepts pre-release tags; the release-identity "
+        "authority should be revisited together with it"
     )


### PR DESCRIPTION
## What does this PR do?

`v2.4.0-rc.1` and `v2.4.0-rc.2` are published tags that produced nothing. This PR fixes the cause of both, and the reason a third would also have failed.

The pipeline carries **two version vocabularies**:

- **SemVer** — the git tag, the signature envelope, the bundle manifest, the artifact name
- **PEP 440** — the wheel, its metadata, and what the installer reads back on the device

They agree for every final release and diverge for every candidate, so nothing before `v2.4.0-rc.1` exercised the difference. Three sites compared across that boundary as strings:

| Site | First candidate to reach it | Where it fails |
|---|---|---|
| workflow identity step | `v2.4.0-rc.1` | build job |
| [build_release_bundle.py](scripts/build_release_bundle.py) | `v2.4.0-rc.2` | build job |
| [linux.py:1467](ori/installer/linux.py#L1467) | would have been `rc.3` | **on the device, after signature verification passed** |

That third one is why loosening the earlier checks was the wrong repair: it would have moved the failure from CI onto the hardware we are trying to validate, at the point where the operator has no fallback.

## One authority

`distribution_version()` in [release_bundles.py](ori/security/release_bundles.py) is the single conversion between the two spellings, and the release identity now admits exactly **one** form of each version:

```
2.4.0-rc.3  ->  2.4.0rc3          2.4.0  ->  2.4.0
2.4.0-rc3   ->  refused           2.4.0-beta.1 -> refused
2.4.0rc3    ->  refused           2.4.0-rc.03  -> refused
```

`2.4.0-rc3` is refused rather than accepted as a synonym. Admitting both would let one build be published under two artifact names, each with its own signature. The builder, the installer and the workflow all resolve through this function instead of normalising separately — separate normalisation is what let the three sites disagree in the first place.

A candidate now identifies itself consistently:

| | `v2.4.0-rc.3` | `v2.4.0` |
|---|---|---|
| Git tag | `v2.4.0-rc.3` | `v2.4.0` |
| Packaged version | `2.4.0rc3` | `2.4.0` |
| Wheel metadata | `2.4.0rc3` | `2.4.0` |
| Bundle / artifact | `2.4.0-rc.3` | `2.4.0` |

## Checked before the tag is spent

Both failures landed in the **build** job, after the tag was immutable — and a tag-triggered run resolves the workflow at its own ref, so fixing `main` cannot rescue a tag already pushed.

The check now runs in **preflight**, before a bundle exists and before the signing environment issues a credential. That is the last point where refusing a tag still leaves something recoverable. The build job repeats it rather than trusting it, and takes the version it builds with from the same authority instead of re-reading the ref in shell.

Preflight now installs the package, after the protections it exists to prove — so no code from the tagged commit runs before those protections are confirmed. This keeps `test_every_job_invoking_an_ori_importing_script_installs_the_package` satisfied as written; that guard caught this and was not weakened.

## Verification

Every fix was mutation-checked — reverted individually, confirming a test fails:

| Mutation | Result |
|---|---|
| authority: drop the SemVer→PEP 440 mapping | 8 failed |
| authority: admit `-rc3` as well | 4 failed |
| authority: skip identity validation | 12 failed |
| builder: compare raw SemVer | 1 failed |
| builder: drop the check entirely | 2 failed |
| installer: compare raw SemVer | 1 failed |
| workflow: drop the preflight gate | 1 failed |
| workflow: re-derive the version in shell | 1 failed |

Full suite: **3178 passed, 6 skipped**. Workflow supply-chain guard, capability-matrix guard, boundary typecheck and pre-commit all clean.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant

`_VERSION_RE` in `ori/security/release_bundles.py` is tightened, which narrows what the signed-bundle identity format accepts. No published artifact is affected: every release to date is a final version, and both candidates published nothing.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — release identity and packaging only. No runtime capability changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Action tier declarations are unchanged
- [x] No Tier C approval path is bypassed
- [x] No Tier D path routes through an LLM

`ori/security/release_bundles.py` and `ori/installer/linux.py` are release and install paths; neither participates in tier dispatch.

## Related issue

Unblocks the `v2.4.0` candidate for #273. Both spent tags are retained and recorded in `docs/releases/v2.4.0.md` as failed attempts; the next candidate is `v2.4.0-rc.3`.

## Testing notes

The spent tags are deliberately named in the code comments, the release notes and the test docstrings. The disagreement they exposed is invisible in a passing final release, so the reason each check exists needs to survive next to it.