### PR TITLE
fix(installer): report the code-integrity property each scope can actually hold

### DIFF
--- a/docs/linux-install.md
+++ b/docs/linux-install.md
@@ -33,6 +33,12 @@ interpreter version:
 Both production tuples use the interpreter their distribution ships, so no
 manual Python installation is required.
 
+Where the distribution's `python3` is some other version, the installer looks
+for a supported one rather than refusing the host: it tries `python3.12`,
+`python3.11`, then `python3`, and uses the first that reports 3.11 or 3.12. A
+workstation whose default is 3.10 installs normally as long as one of those is
+present. If none is, the installer says so and names what to install.
+
 **Raspberry Pi OS Bullseye is not supported.** It ships OpenSSL 1.1.1, which
 cannot perform the required verification — the installer reports
 `crypto_unavailable` rather than pretending otherwise.
@@ -212,10 +218,29 @@ Everything after the bootstrap is already covered by the KMS signature.
 | Starts at boot | Only if lingering is enabled | Yes |
 
 System scope defaults to the service user `ori-runtime`; override with
-`--service-user`. That account must already exist. Under system scope the
-installed code stays root-owned and read-only to the service: the runtime can
-read its config and create its health socket, but cannot modify the code it
-executes.
+`--service-user`. **That account must already exist** — the installer does not
+create system accounts on your behalf. Create it first:
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin ori-runtime
+```
+
+The installer checks for it immediately after you choose the scope, before it
+asks anything or writes anything, so a missing account costs you a message
+rather than an install.
+
+Under system scope the installed code stays root-owned and read-only to the
+service: the runtime can read its config and create its health socket, but
+cannot modify the code it executes. `ori doctor` proves this with a mandatory
+`permissions.code` check.
+
+**User scope cannot offer that property, and does not pretend to.** The release
+and the runtime share one Unix owner, so the account running the code can
+always restore write access to it — read-only permission bits would describe
+the current state, not a boundary. `ori doctor` therefore reports
+`permissions.code` as a warning under user scope. The installation is complete
+and usable; what it lacks is privilege separation, which only system scope
+provides.
 
 Choose **system** for devices in the field. Choose **user** for a workstation
 or a trial where you do not want a root-owned install.

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -35,8 +35,26 @@ installed — nothing was ever built, signed, or published from either.
 |---|---|---|
 | `v2.4.0-rc.1` | protection preflight, full test matrix | the build compared the whole tag against the packaged version, so no pre-release tag could ever match |
 | `v2.4.0-rc.2` | protection preflight, full test matrix | the wheel version and the bundle version were compared as strings, and a candidate spells them differently |
+| `v2.4.0-rc.3` | signed, published, exercised on hardware | neither scope could complete an install: system scope checked for its service account too late, and user scope was refused for a property it cannot have |
 
-Both failures share a cause. The release pipeline carries two version
+`v2.4.0-rc.3` is the first candidate that built, signed, and published. Its
+assets remain available and are not replaced. It failed on hardware, which is
+what it was published to do.
+
+Two defects surfaced there. A system-scope install stopped with
+`service_start_failed: system service user does not exist` — a precondition
+that had been checked only after the operator answered every identity prompt
+and the installer had built a virtual environment. A user-scope install then
+stopped with `post_install_health_failed: permissions.code`, because v2.4.0
+introduced a mandatory code-immutability check without the privilege separation
+that makes it satisfiable: under user scope the release and the runtime share
+one Unix owner. Sealing the tree read-only would have quieted the check without
+creating the boundary, since an owner can always restore write access to its
+own files. The check is now mandatory for system scope, where root-owned code
+and an unprivileged service account make it real, and an explicit warning under
+user scope, where it cannot be.
+
+The first two failures share a different cause. The release pipeline carries two version
 vocabularies — SemVer for the git tag, the signature envelope, the bundle
 manifest and the artifact name; PEP 440 for the wheel, its metadata and the
 version the installer reads back on the device. They agree for every final

--- a/ori/doctor.py
+++ b/ori/doctor.py
@@ -771,7 +771,19 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
     If supplementary groups could not be enumerated, an unseen group might
     carry write access to the release, and the check fails rather than
     presenting an unverified claim as a pass.
+
+    The property is only reachable under privilege separation. System scope has
+    it: the code is root-owned and the service runs as an unprivileged account
+    that can neither write it nor change its mode. User scope cannot, because
+    the release and the runtime share one Unix owner — an owner may always
+    ``chmod`` its own tree, so a compromised runtime can restore write access to
+    the code it is about to execute. Mode bits there describe the current state,
+    not a boundary, and reporting them as immutability would be a false
+    assurance. User scope is reported honestly as a warning instead.
     """
+    if identity.scope != "system":
+        return _user_scope_code_advisory(identity, service)
+
     remedy = (
         f"Make the release read-only to the service: "
         f"chown -R root:root {identity.active_release} && "
@@ -818,6 +830,34 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
         mandatory=True,
         remedy=remedy,
         details={"offending_path": violation.split(" ", 1)[0]},
+    )
+
+
+def _user_scope_code_advisory(
+    identity: InstallIdentity, service: ServiceIdentity
+) -> DoctorCheck:
+    """State plainly that user scope cannot offer code immutability.
+
+    This is a property of the deployment model, not a defect in the install, so
+    it is never blocking: a user-scope installation that reports this warning is
+    a complete and usable installation. Sealing the tree read-only would silence
+    the warning without creating the boundary — the owner can restore write at
+    any time — which is why no such sealing is attempted.
+    """
+    return DoctorCheck(
+        name="permissions.code",
+        status=WARN,
+        message=(
+            f"User-scope code is owned by the runtime account ({service.name}) "
+            "and cannot be made immutable from that account. Use system scope "
+            "for a production deployment with root-owned verified code."
+        ),
+        mandatory=False,
+        remedy=(
+            "Reinstall with --scope system to run the runtime as a dedicated "
+            "unprivileged account that cannot modify the verified release."
+        ),
+        details={"release": str(identity.active_release), "scope": identity.scope},
     )
 
 

--- a/ori/installer/cli.py
+++ b/ori/installer/cli.py
@@ -30,6 +30,7 @@ from ori.installer.linux import (
     SystemdServiceProfile,
     collect_installer_config,
     install_composed_release,
+    require_service_account,
     uninstall_runtime,
 )
 from ori.security.release_bundles import (
@@ -132,6 +133,12 @@ def _install(args: argparse.Namespace) -> dict[str, object]:
     # repeat rather than having a privilege boundary crossed on their behalf.
     scope_prompt.require_privilege(scope, sys.argv)
     profile = _profile(scope, args.service_user)
+    # A precondition of the scope just chosen, resolved before the operator is
+    # asked anything and before the host is touched. Deliberately not part of
+    # `prerequisites.ensure`: that abstraction offers to install OS packages,
+    # and creating a service account is not something this installer does on an
+    # operator's behalf.
+    require_service_account(profile)
     layout, unit_path, env_file = _paths(
         scope,
         root=args.root,

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -1158,6 +1158,31 @@ def render_systemd_unit(
     return rendered
 
 
+def require_service_account(profile: SystemdServiceProfile) -> None:
+    """Fail before the install touches anything when the account is missing.
+
+    The account is a precondition of system scope, not a step of it. Resolving
+    it costs a name lookup, and the installation that needs it takes minutes:
+    it builds a virtual environment from 44 wheels, having first prompted the
+    operator for device identity. Discovering the absence afterwards spends all
+    of that, rolls it back, and asks the operator to answer the same questions
+    again — so this is called immediately after the scope is known and before
+    anything is prompted, created, or built.
+    """
+    if profile.scope != "system" or profile.service_user is None:
+        return
+    try:
+        pwd.getpwnam(profile.service_user)
+    except KeyError as exc:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"system service user does not exist: {profile.service_user}. "
+            f"Create the unprivileged account first: sudo useradd --system "
+            f"--no-create-home --shell /usr/sbin/nologin {profile.service_user} "
+            f"— or install with --scope user for a workstation or trial.",
+        ) from exc
+
+
 def apply_system_service_permissions(
     layout: InstallLayout,
     profile: SystemdServiceProfile,
@@ -1800,9 +1825,56 @@ def install_release(
 ) -> InstallResult:
     """Prepare, activate, and health-gate one already-authenticated release."""
     destination = layout.release(version)
-    _ensure_private_directory(layout.root)
-    _ensure_private_directory(layout.releases)
-    _ensure_private_directory(layout.data)
+    # Ordered outermost first, so cleanup can unwind it in reverse.
+    scaffolding = [
+        directory
+        for directory in (layout.root, layout.releases, layout.data)
+        if _ensure_private_directory(directory)
+    ]
+    try:
+        return _install_release(
+            layout=layout,
+            version=version,
+            destination=destination,
+            prepare=prepare,
+            validate=validate,
+            restart_service=restart_service,
+            stop_service=stop_service,
+            check_health=check_health,
+            allow_downgrade=allow_downgrade,
+            service_profile=service_profile,
+            prepare_activation=prepare_activation,
+            rollback_activation=rollback_activation,
+            commit_activation=commit_activation,
+            allowed_data_sockets=allowed_data_sockets,
+        )
+    except Exception:
+        # A failed install leaves the host as it found it, as far as it still
+        # can. `_install_release` already removes the release tree it created;
+        # this takes the empty scaffolding with it, so a first install that
+        # fails does not leave an install root behind suggesting Ori is there.
+        _remove_created_scaffolding(scaffolding)
+        raise
+
+
+def _install_release(
+    *,
+    layout: InstallLayout,
+    version: str,
+    destination: Path,
+    prepare: Callable[[Path], None],
+    validate: Callable[[Path], None],
+    restart_service: Callable[[], None],
+    stop_service: Callable[[], None],
+    check_health: Callable[[Path], None],
+    allow_downgrade: bool,
+    service_profile: SystemdServiceProfile | None,
+    prepare_activation: Callable[[Path], None] | None,
+    rollback_activation: Callable[[], None] | None,
+    commit_activation: Callable[[Path], None] | None,
+    allowed_data_sockets: Sequence[Path],
+) -> InstallResult:
+    """Install into an install root whose directories already exist."""
     previous = _active_release(layout)
     previous_version = previous.name if previous is not None else None
     same_version = previous == destination and destination.is_dir()
@@ -1979,7 +2051,7 @@ def _assert_managed_path(layout: InstallLayout, path: Path) -> None:
         ) from exc
 
 
-def _ensure_private_directory(path: Path) -> None:
+def _ensure_private_directory(path: Path) -> bool:
     if path.is_symlink():
         raise LinuxInstallError(
             "unsafe_install_root", f"{path.name} must not be a symlink"
@@ -1997,6 +2069,28 @@ def _ensure_private_directory(path: Path) -> None:
         raise LinuxInstallError("unsafe_install_root", f"{path.name} is group-writable")
     if mode & 0o007:
         path.chmod(0o700)
+    return created
+
+
+def _remove_created_scaffolding(directories: Sequence[Path]) -> None:
+    """Undo the empty directory tree this invocation brought into being.
+
+    Only directories this run created are considered, and only while they are
+    still empty, so a pre-existing install root — or one still holding an
+    operator's data or an earlier release — is never removed by a failure. They
+    are unwound in reverse, because the parent cannot go until the child has.
+
+    Best-effort by construction: this runs while an installation failure is
+    already propagating, and a directory that cannot be removed is untidy, not
+    unsafe. Raising here would replace the operator's real diagnosis with a
+    cleanup error.
+    """
+    for directory in reversed(list(directories)):
+        try:
+            directory.rmdir()
+        except OSError:
+            # Not empty, not present, or not permitted — all fine to leave.
+            break
 
 
 def _version_key(

--- a/ori/installer/scope_prompt.py
+++ b/ori/installer/scope_prompt.py
@@ -35,6 +35,8 @@ _PROMPT = """
      Runs as your login user.
      Stops after your last session unless lingering is enabled.
      Does not start at boot without lingering.
+
+Type 1 or 2. Press Enter to accept 1 (system).
 """
 
 _CHOICES = {"1": "system", "2": "user", "system": "system", "user": "user"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0rc3"
+version = "2.4.0rc4"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -4,6 +4,27 @@ if [ -z "${BASH_VERSION:-}" ]; then
   echo "unsupported_target: install-linux.sh must be run with bash; use curl ... | bash -s -- ..." >&2
   exit 2
 fi
+# Find an interpreter this installer can actually use. Bundles are published
+# for 3.11 and 3.12 only, and `python3` is whatever the distribution chose: on
+# Pop!_OS it is 3.10 while a perfectly good python3.12 sits alongside it. Using
+# `python3` alone reports the host as unsupported when it is not.
+#
+# Each candidate is asked its own version rather than trusted for its name. A
+# `python3.12` on PATH may be a wrapper, a shim, or a broken symlink, and the
+# name proves nothing about what running it produces.
+ori_python=""
+for ori_candidate in python3.12 python3.11 python3; do
+  command -v "${ori_candidate}" >/dev/null 2>&1 || continue
+  if "${ori_candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] in ((3, 11), (3, 12)) else 1)' >/dev/null 2>&1; then
+    ori_python="${ori_candidate}"
+    break
+  fi
+done
+if [ -z "${ori_python}" ]; then
+  echo "unsupported_target: no supported Python found on PATH. Ori requires Python 3.11 or 3.12; install one (for example 'sudo apt install python3.12') and run this again." >&2
+  exit 2
+fi
+
 # Dispatch on execution mode, not on filename. BASH_SOURCE[0] is the script
 # path when a file is executed and unset when bash reads the program from
 # stdin, so it distinguishes the two without consulting $0 — which is merely
@@ -11,7 +32,7 @@ fi
 # in the working directory.
 ori_source="${BASH_SOURCE[0]-}"
 if [ -n "${ori_source}" ] && [ -f "${ori_source}" ] && [ -r "${ori_source}" ]; then
-  exec python3 "${ori_source}" "$@"
+  exec "${ori_python}" "${ori_source}" "$@"
 fi
 # No file to run, so the program must arrive on stdin. If stdin is a terminal
 # there is nothing to read, and exiting quietly would look like success.
@@ -19,7 +40,7 @@ if [ -t 0 ]; then
   echo "unsupported_target: no installer source found; run the downloaded file, or pipe it with 'curl -fsSL ... | bash -s -- ...'" >&2
   exit 2
 fi
-exec python3 - "$@"
+exec "${ori_python}" - "$@"
 ":"""
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -242,6 +242,24 @@ def test_inactive_service_is_a_blocking_failure(tmp_path: Path) -> None:
 
 
 def _checks(root: Path) -> dict[str, doctor.DoctorCheck]:
+    """Permission checks under system scope, where code immutability is claimed.
+
+    The service account is this test's own user, so the release tree is owned by
+    the very account the runtime would run as. That is the adversarial shape the
+    check exists to catch: under system scope a release the service can write is
+    a finding, whoever that service happens to be.
+    """
+    return {
+        c.name: c
+        for c in doctor.check_permissions(
+            _identity(
+                root, scope="system", service_user=pwd.getpwuid(os.getuid()).pw_name
+            )
+        )
+    }
+
+
+def _user_scope_checks(root: Path) -> dict[str, doctor.DoctorCheck]:
     return {c.name: c for c in doctor.check_permissions(_identity(root, scope="user"))}
 
 
@@ -329,6 +347,69 @@ def test_a_sealed_release_passes(tmp_path: Path, not_root: None) -> None:
         assert _checks(tmp_path)["permissions.code"].status == terminal.PASS
     finally:
         _unseal(tmp_path)
+
+
+# --- user scope cannot claim code immutability ----------------------------
+
+
+def test_user_scope_reports_an_advisory_rather_than_a_failure(
+    tmp_path: Path, not_root: None
+) -> None:
+    """A user-scope install is complete; it just cannot offer immutability.
+
+    The release and the runtime share one Unix owner, so the account that runs
+    the code can always restore write access to it. Failing here would reject a
+    working workstation install for a property its deployment model never had.
+    """
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+
+    code = _user_scope_checks(tmp_path)["permissions.code"]
+
+    assert code.status == terminal.WARN
+    assert code.mandatory is False
+    assert "cannot be made immutable" in code.message
+    assert "system scope" in code.message
+
+
+def test_user_scope_advisory_is_not_silenced_by_read_only_modes(
+    tmp_path: Path, not_root: None
+) -> None:
+    """Sealing the tree must not buy a passing claim.
+
+    Mode bits describe the current state, not a boundary: the owner may chmod
+    them back at any moment, so a compromised runtime can restore write access
+    to the code it is about to execute. Reporting PASS because the bits look
+    right at this instant would be a false assurance — which is exactly why the
+    installer does not seal user-scope trees to make this check quiet.
+    """
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+    _sealed(tmp_path)
+    try:
+        code = _user_scope_checks(tmp_path)["permissions.code"]
+
+        assert code.status == terminal.WARN
+        assert code.mandatory is False
+    finally:
+        _unseal(tmp_path)
+
+
+def test_system_scope_still_fails_on_a_release_the_service_can_write(
+    tmp_path: Path, not_root: None
+) -> None:
+    """The scope split must not weaken the scope that can enforce it."""
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+
+    code = _checks(tmp_path)["permissions.code"]
+
+    assert code.status == terminal.FAIL
+    assert code.mandatory is True
+    assert "not immutable" in code.message
 
 
 def test_an_uninspectable_directory_fails_closed(

--- a/tests/test_installer_activation.py
+++ b/tests/test_installer_activation.py
@@ -737,3 +737,104 @@ def test_a_real_doctor_run_satisfies_the_activation_boundary(
     activation._assert_complete(report)
     activation._assert_status_agrees(0, report)
     activation.assert_usable(report)
+
+
+# --- the real doctor, judged by the real gate ------------------------------
+#
+# Everything above stubs doctor's output to test how activation handles it.
+# That is why v2.4.0-rc.3 shipped a user-scope install that could never
+# succeed: the real doctor and the real gate had never been run against each
+# other. These tests join them, with no synthetic check dictionaries between.
+
+
+def _installed_layout(root: Path, scope: str) -> tuple[Path, object]:
+    """Build the directory shape the installer produces, at its real modes."""
+    from ori import doctor
+
+    release = root / "releases" / "2.4.0-rc.4"
+    (release / "venv" / "bin").mkdir(parents=True)
+    (release / "venv" / "bin" / "python").write_text("#!/bin/sh\n")
+    (release / "venv" / "bin" / "python").chmod(0o755)
+    (release / "ori").mkdir()
+    (release / "ori" / "runtime.py").write_text("# code\n")
+    data = root / "data"
+    data.mkdir()
+    (data / "ori.yaml").write_text("device: {}\n")
+    # _ensure_private_directory's mode, which is what an install really leaves.
+    for directory in (root, root / "releases", release, data):
+        directory.chmod(0o700)
+
+    identity = doctor.InstallIdentity(
+        scope=scope,
+        version="2.4.0-rc.4",
+        install_root=root,
+        active_release=release,
+        config_path=data / "ori.yaml",
+        data_path=data,
+        health_socket=data / "health.sock",
+        unit_path=root / "ori-runtime.service",
+        service_user=(
+            __import__("pwd").getpwuid(os.getuid()).pw_name
+            if scope == "system"
+            else None
+        ),
+    )
+    return release, identity
+
+
+def _as_reported(checks: list[object]) -> list[dict[str, object]]:
+    """Render real DoctorCheck objects the way doctor's JSON report does."""
+    return [
+        {
+            "name": c.name,
+            "status": c.status,
+            "message": c.message,
+            "mandatory": c.mandatory,
+        }
+        for c in checks
+    ]
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="mode-based denial is invisible to root")
+def test_a_real_user_scope_install_passes_the_real_gate(tmp_path: Path) -> None:
+    """A user-scope installation must complete, carrying the advisory.
+
+    This is the case that failed on hardware in v2.4.0-rc.3: the release is
+    owned by the account that runs it, and the mandatory code-immutability
+    check rejected the install for a property user scope cannot provide.
+    """
+    from ori import doctor
+
+    root = tmp_path / "ori"
+    root.mkdir()
+    _release, identity = _installed_layout(root, "user")
+
+    reported = _as_reported(doctor.check_permissions(identity))
+    code = next(c for c in reported if c["name"] == "permissions.code")
+
+    assert code["status"] == "WARN"
+    assert code["mandatory"] is False
+    assert activation.blocking(reported) == []
+    # The gate the installer actually calls inside its transaction.
+    activation.assert_usable(reported)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="mode-based denial is invisible to root")
+def test_a_real_system_scope_install_is_blocked_when_code_is_writable(
+    tmp_path: Path,
+) -> None:
+    """The scope that can enforce immutability must still enforce it."""
+    from ori import doctor
+
+    root = tmp_path / "ori"
+    root.mkdir()
+    _release, identity = _installed_layout(root, "system")
+
+    reported = _as_reported(doctor.check_permissions(identity))
+    code = next(c for c in reported if c["name"] == "permissions.code")
+
+    assert code["status"] == "FAIL"
+    assert code["mandatory"] is True
+    assert activation.blocking(reported) != []
+    with pytest.raises(LinuxInstallError, match="post_install_health_failed"):
+        activation.assert_usable(reported)

--- a/tests/test_installer_scope.py
+++ b/tests/test_installer_scope.py
@@ -102,6 +102,23 @@ def test_prompt_states_both_consequences(tty: None) -> None:
     assert "ori-runtime" in shown
 
 
+def test_prompt_says_how_to_answer_and_what_enter_does(tty: None) -> None:
+    """`Choose [1]: ` alone reads as a value already filled in.
+
+    An operator on hardware took the bracketed 1 for a pre-selection and sat
+    waiting at a prompt that was waiting for them. The default is real — Enter
+    accepts system — but the operator has to be told that it is theirs to send.
+    """
+    written: list[str] = []
+    scope_prompt.choose_scope(
+        supplied=None, unattended=False, prompt=_Prompt("1"), write=written.append
+    )
+    shown = "\n".join(written)
+
+    assert "Type 1 or 2" in shown
+    assert "Press Enter to accept 1 (system)" in shown
+
+
 def test_invalid_answer_reprompts_then_gives_up(tty: None) -> None:
     prompt = _Prompt("maybe", "3", "yes")
     with pytest.raises(LinuxInstallError) as excinfo:

--- a/tests/test_linux_bootstrap.py
+++ b/tests/test_linux_bootstrap.py
@@ -7,6 +7,7 @@ import base64
 import hashlib
 import json
 import runpy
+import shutil
 import subprocess
 import tarfile
 from pathlib import Path
@@ -448,3 +449,89 @@ def test_unexpected_faults_are_not_blamed_on_the_archive() -> None:
 
     assert "bootstrap_failed: installer failed unexpectedly" in source
     assert "unsafe_bundle_archive: installer failed unexpectedly" not in source
+
+
+# --- interpreter discovery -------------------------------------------------
+
+
+def _selected_interpreter(tmp_path: Path, entries: dict[str, str | None]) -> str:
+    """Run the real preamble and report which interpreter it chose."""
+    binaries = tmp_path / "bin"
+    binaries.mkdir(exist_ok=True)
+    for name, version in entries.items():
+        script = binaries / name
+        if version is None:
+            script.write_text("#!/bin/sh\nexit 127\n", encoding="utf-8")
+        else:
+            # Reports the requested version to the probe, and its own name when
+            # finally exec'd with the installer program.
+            script.write_text(
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                f"  *version_info*) exit {0 if version in ('3.11', '3.12') else 1} ;;\n"
+                f'  *) echo "{name}" ;;\n'
+                "esac\n",
+                encoding="utf-8",
+            )
+        script.chmod(0o755)
+
+    # bash by absolute path: PATH is reserved for the interpreters under test,
+    # so a real python3 on the system PATH cannot be the one selected.
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to execute the bootstrap preamble")
+    result = subprocess.run(
+        [bash, "-c", _preamble(), "installer"],
+        capture_output=True,
+        text=True,
+        env={"PATH": str(binaries)},
+        cwd=tmp_path,
+    )
+    return result.stdout.strip() or f"ERROR:{result.stderr.strip()}"
+
+
+def _preamble() -> str:
+    """The bash half of the polyglot, up to where it hands off to Python."""
+    source = Path("scripts/install-linux.sh").read_text(encoding="utf-8")
+    # The bash section ends at the closing polyglot marker; everything after it
+    # is the Python program, which bash never parses.
+    return source.split('":"""', 1)[0].replace('""":"', "", 1)
+
+
+def test_a_supported_interpreter_is_preferred_over_the_default_python3(
+    tmp_path: Path,
+) -> None:
+    """`python3` being 3.10 must not condemn a host that also has 3.12.
+
+    This is what Pop!_OS looks like: python3 is 3.10, python3.12 is installed
+    alongside it, and every published bundle targets 3.11 or 3.12.
+    """
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.10", "python3.12": "3.12"})
+
+    assert chosen == "python3.12"
+
+
+def test_the_stock_interpreter_is_used_when_it_is_supported(tmp_path: Path) -> None:
+    """Raspberry Pi OS Bookworm ships 3.11 as python3 and has no python3.12."""
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.11"})
+
+    assert chosen == "python3"
+
+
+def test_a_named_interpreter_that_cannot_run_is_skipped(tmp_path: Path) -> None:
+    """Existing on PATH is not evidence: a shim or dangling symlink proves nothing."""
+    chosen = _selected_interpreter(
+        tmp_path, {"python3.12": None, "python3.11": "3.11", "python3": "3.10"}
+    )
+
+    assert chosen == "python3.11"
+
+
+def test_a_host_with_no_supported_interpreter_is_told_what_to_install(
+    tmp_path: Path,
+) -> None:
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.10"})
+
+    assert chosen.startswith("ERROR:")
+    assert "unsupported_target" in chosen
+    assert "3.11 or 3.12" in chosen

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -648,7 +648,11 @@ def test_failed_post_move_validation_removes_unusable_release(tmp_path: Path) ->
         )
 
     assert not layout.release("2.3.0").exists()
-    assert list(layout.releases.iterdir()) == []
+    # This invocation created the install root, and the failure left it empty,
+    # so nothing of it remains — an operator whose first install failed has no
+    # directory tree suggesting Ori is installed.
+    assert not layout.releases.exists()
+    assert not layout.root.exists()
     assert not layout.current.exists()
 
 
@@ -1919,7 +1923,8 @@ def test_failed_shebang_repair_leaves_no_orphan_release(
         _install(layout, "2.3.1")
 
     assert not layout.release("2.3.1").exists()
-    assert list(layout.releases.iterdir()) == []
+    assert not layout.releases.exists()
+    assert not layout.root.exists()
     assert not layout.current.exists()
 
 

--- a/tests/test_linux_installer_cli.py
+++ b/tests/test_linux_installer_cli.py
@@ -299,6 +299,62 @@ def test_user_scope_rejects_service_user_before_verification(
     assert "--service-user is valid only for system scope" in capsys.readouterr().err
 
 
+def test_missing_service_account_is_refused_before_anything_is_touched(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The account is a precondition, so it is checked while nothing is spent.
+
+    In v2.4.0-rc.3 this was discovered after the operator had answered every
+    identity prompt and the installer had built a virtual environment from 44
+    wheels — minutes of work, then rolled back, then asked again. Verification,
+    prompting, and the filesystem must all still be untouched when it fails.
+    """
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        cli,
+        "load_release_key_registry",
+        lambda _path: pytest.fail("verification must not begin"),
+    )
+    monkeypatch.setattr("ori.installer.linux.pwd.getpwnam", _no_such_account)
+    root = tmp_path / "ori"
+    args = [
+        "install",
+        "--bundle",
+        str(tmp_path / "bundle.tar.gz"),
+        "--signature",
+        str(tmp_path / "bundle.tar.gz.sig"),
+        "--root",
+        str(root),
+        "--scope",
+        "system",
+        "--unattended",
+        "--device-id",
+        "ori-01",
+        "--name",
+        "Office",
+        "--location",
+        "Lagos",
+    ]
+
+    with pytest.raises(SystemExit) as error:
+        cli.main(args)
+
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert "system service user does not exist" in message
+    # The remedy an operator needs, not just the diagnosis.
+    assert "useradd" in message
+    assert "--scope user" in message
+    assert not root.exists()
+
+
+def _no_such_account(name: str) -> None:
+    """Stand in for a host where the service account was never created."""
+    raise KeyError(name)
+
+
 def test_uninstall_disables_unit_before_removing_release(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:


### PR DESCRIPTION
## What does this PR do?

`v2.4.0-rc.3` was installed on real hardware and failed in both scopes. This is the complete corrected set — deliberately one PR, so rc.4 is not followed by rc.5 for defects already known.

### The blocker: a mandatory check for a property user scope cannot have

v2.4.0 introduced `permissions.code`, proving the service cannot rewrite the code it executes, and applied it to both scopes. **Only system scope can hold that property** — code is root-owned, and the service runs as an unprivileged account that can neither write it nor change its mode. Under user scope the release and the runtime share one Unix owner, so **every user-scope install of v2.4.0 failed its own diagnostics and rolled back.**

Reproduced against the real check:

```
AS-BUILT -> FAIL: The verified release is not immutable to <user>
SEALED   -> PASS: <user> cannot modify the verified release
```

**Sealing was rejected as the fix.** It makes the check quiet without making it true: an owner may `chmod` its own files, so a compromised runtime can restore write access to the code it is about to execute. The bits describe the current state, not a boundary, and `PASS` on them is a false assurance. Sealing also breaks removal — verified, not assumed:

```
rmtree on sealed tree: FAILED -> PermissionError: [Errno 13] .../venv/bin
```

A read-only directory cannot have its entries unlinked, so sealing would convert today's clean `post_install_health_failed` into `rollback_failed` — the error that actually leaves debris.

`permissions.code` is now **mandatory for system scope** and an **explicit warning under user scope**. A user-scope install is complete and usable; what it lacks is privilege separation, and it says so.

### The second hardware failure: a precondition checked too late

A missing service account surfaced as `service_start_failed` *after* the operator answered every identity prompt and the installer built a venv from 44 wheels. It is now resolved immediately after the scope is known — before anything is prompted, created, or built — and the message carries the fix:

```
system service user does not exist: ori-runtime. Create the unprivileged
account first: sudo useradd --system --no-create-home --shell
/usr/sbin/nologin ori-runtime — or install with --scope user for a
workstation or trial.
```

Kept out of `prerequisites.ensure` on purpose: that abstraction offers to install OS packages, and creating a service account is not something this installer does on an operator's behalf.

### Also fixed

| | |
|---|---|
| **Interpreter discovery** | Probes `python3.12` → `python3.11` → `python3`, asking each for its version rather than trusting its name — a name on PATH may be a shim or dangling symlink. A 3.10 default no longer condemns a host with 3.12 installed. |
| **Scope prompt** | `Choose [1]: ` read as a pre-filled value. Enter always accepted the default; the prompt now says `Type 1 or 2. Press Enter to accept 1 (system).` |
| **Scaffolding** | Directories this invocation created are unwound in reverse while still empty. A pre-existing root, or one holding data or an earlier release, is never removed by a failure. |

**Resumable installs were declined.** Retry starts a fresh transaction; partial state is never inferred to be trustworthy. The cost that motivated the request — rebuilding the venv — is removed by failing before it is built.

## Why it shipped: the doctor was always stubbed

Every test touching post-install diagnostics fed `activation` synthetic check dictionaries. The real doctor and the real gate had never been run against each other, so a scope that could never pass shipped. Now:

- real `check_permissions` against a real installed tree, through the real `assert_usable`, for **both** scopes
- user scope: WARN, non-blocking, install completes
- user scope **sealed**: still WARN — no false immutability claim is available by chmod
- system scope with a service-writable release: FAIL, blocking, install refused

## Verification

Eight mutations, each reverted individually:

| Mutation | Result |
|---|---|
| doctor: user scope back to FAIL | 3 failed |
| doctor: advisory claims PASS | 2 failed |
| doctor: scopes swapped | 16 failed |
| installer: no scaffolding cleanup | 2 failed |
| installer: cleanup deletes non-empty dirs | 1 failed |
| bootstrap: only `python3` | 2 failed |
| bootstrap: trust the name | 2 failed |
| prompt: drop the instruction | 1 failed |
| cli: remove the early account check | 1 failed |

**Full suite: 3189 passed, 6 skipped.** Ruff, workflow guard, boundary typecheck, pre-commit all clean.

**Run on Linux, not just macOS** — `python:3.12-slim`, as a non-root user: **289 passed** across the installer, bootstrap, activation, scope, doctor, and CLI suites. (Three tests fail only under the container's `umask 002`, where they pre-create a group-writable install root that a pre-existing guard correctly refuses; under the standard `umask 022` all pass. Pre-existing fixture sensitivity, not part of this change.)

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant

`permissions.code` is a security check. It is **not weakened where it is enforceable**: system scope still fails closed, including on unresolved supplementary groups. What changed is that it no longer asserts a guarantee under a scope that cannot provide one.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — installer and diagnostics only. No runtime capability changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Action tier declarations are unchanged
- [x] No Tier C approval path is bypassed
- [x] No Tier D path routes through an LLM

`ori/doctor.py` and `ori/installer/` are diagnostic and install paths; neither participates in tier dispatch.

## Related issue

Unblocks #273. `v2.4.0-rc.3` assets stay published and are not replaced; `docs/releases/v2.4.0.md` records it as the third failed attempt, with what it reached and why it failed. Next candidate is `v2.4.0-rc.4`; packaged version is `2.4.0rc4`.

## Testing notes

expect a user-scope install to now **succeed with a warning** stating that user-scope code cannot be made immutable and that system scope is the production choice. That warning is the correct result, not a partial failure.