### PR TITLE
fix(installer): make each scope hold the code-integrity property it claims

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1788,3 +1788,48 @@ Non-goals:
   remains for the specs arc to build on.
 - This does not weaken first-party hooks. Packaged skills still import
   normally; they are reviewed and released with the runtime.
+
+## 2026-08-17 — The System Service Account Is A Constant, Not A Setting
+
+**Status:** Accepted
+
+The runtime's system service account is always `ori-runtime`. The installer
+creates it when absent, and `--service-user` accepts that one name.
+
+A configurable account name has to be carried by the unit file, the permission
+checks, the diagnostics, the documentation and every support answer. Each of
+those is a place the value can disagree with the others, and the failure that
+follows — a unit whose `User=` names an account the permission check never
+examined — appears at service start, not at install. `postgres` and `docker` are
+not per-host choices for the same reason: a fixed identity is what lets every
+one of those refer to the same thing without passing a variable between them.
+
+The installer now creates the account rather than requiring it to exist. This
+is consistent with what a distribution package does in its postinst, and with
+`prerequisites.ensure`, which already changes the host with consent. The earlier
+position — that creating an account was not something the installer does on an
+operator's behalf — was asserted, never decided, and it made an operator
+hand-perform the step the installer is best placed to get right. Consent is
+asked interactively and assumed under `--unattended`, which has already chosen a
+system install. Declining stops the installation; it never means proceeding
+without the account, which would produce a service that cannot start.
+
+An existing account is adopted exactly as found — no group, home, or shell is
+modified, because those may have been set deliberately. Uninstall leaves it in
+place: files outside the install root may belong to it, and a freed uid can be
+reused by a later account.
+
+**`--service-user` is narrowed, not removed.** It shipped in v2.3.0, and the
+compatibility contract recorded on 2026-08-14 holds that explicit installer
+flags and their meanings are stable across v2 minor releases. Removing it would
+break that promise, and would answer a script that passes it with an
+unrecognised-argument error rather than an explanation. It therefore remains,
+accepts `ori-runtime`, and refuses any other value with a stable
+`service_start_failed` naming the reason. An invocation that omitted the flag or
+passed the documented default is unaffected; the only invocation that changes is
+one naming a different account, which is the capability being withdrawn.
+
+This narrowing is within the middle category of that contract — an unsafe
+implicit default becoming an error — because the account the runtime runs as is
+privilege-relevant, and a name that only the unit file knew about was never
+verified against the identity the permission checks examined.

--- a/docs/linux-install.md
+++ b/docs/linux-install.md
@@ -33,6 +33,12 @@ interpreter version:
 Both production tuples use the interpreter their distribution ships, so no
 manual Python installation is required.
 
+Where the distribution's `python3` is some other version, the installer looks
+for a supported one rather than refusing the host: it tries `python3.12`,
+`python3.11`, then `python3`, and uses the first that reports 3.11 or 3.12. A
+workstation whose default is 3.10 installs normally as long as one of those is
+present. If none is, the installer says so and names what to install.
+
 **Raspberry Pi OS Bullseye is not supported.** It ships OpenSSL 1.1.1, which
 cannot perform the required verification — the installer reports
 `crypto_unavailable` rather than pretending otherwise.
@@ -113,7 +119,9 @@ curl -fsSL \
 
 You are asked, in order: the installation scope, a device ID, a device name, a
 location, and an optional operator contact. Then the values are read back and
-you confirm before anything is written to the host.
+you confirm. Nothing durable has been written to the host at that point — the
+bundle has been verified, but packages, the service account, the install root
+and the environment all follow your confirmation.
 
 Piped installs reopen `/dev/tty` for those prompts; if no terminal is available
 the install fails rather than silently choosing defaults. Prompts and progress
@@ -134,6 +142,7 @@ Installation scope:
      Stops after your last session unless lingering is enabled.
      Does not start at boot without lingering.
 
+Type 1 or 2. Press Enter to accept 1 (system).
 Choose [1]:
 ```
 
@@ -211,11 +220,44 @@ Everything after the bootstrap is already covered by the KMS signature.
 | Requires root | No — and refuses to run as root | Yes |
 | Starts at boot | Only if lingering is enabled | Yes |
 
-System scope defaults to the service user `ori-runtime`; override with
-`--service-user`. That account must already exist. Under system scope the
-installed code stays root-owned and read-only to the service: the runtime can
-read its config and create its health socket, but cannot modify the code it
-executes.
+System scope runs the runtime as **`ori-runtime`**, an unprivileged account with
+no home directory and no login shell. The name is fixed and is not
+configurable — like `postgres` or `docker`, it is the same on every host, so the
+unit file, the permission checks, the documentation and any support answer all
+refer to the same identity.
+
+The installer creates the account if it does not exist. That happens after the
+bundle signature is verified and after you confirm the device values — an
+unsigned bundle must not be able to leave an account behind — and before any
+package is installed or the environment is built. You are asked first;
+declining stops the installation and prints the command, since a system service
+whose account is missing cannot start. Under `--unattended` it is created
+without asking, because automation that selected system scope has already
+chosen a system install.
+
+An account that already exists is used exactly as found — its group, home, and
+shell are never modified, since they may have been set deliberately. Uninstall
+leaves the account in place: files outside the install root may belong to it,
+and a freed uid can be reused by a later account.
+
+If you prefer to create it yourself beforehand:
+
+```bash
+sudo useradd --system --no-create-home --shell /usr/sbin/nologin ori-runtime
+```
+
+Under system scope the installed code stays root-owned and read-only to the
+service: the runtime can read its config and create its health socket, but
+cannot modify the code it executes. `ori doctor` proves this with a mandatory
+`permissions.code` check.
+
+**User scope cannot offer that property, and does not pretend to.** The release
+and the runtime share one Unix owner, so the account running the code can
+always restore write access to it — read-only permission bits would describe
+the current state, not a boundary. `ori doctor` therefore reports
+`permissions.code` as a warning under user scope. The installation is complete
+and usable; what it lacks is privilege separation, which only system scope
+provides.
 
 Choose **system** for devices in the field. Choose **user** for a workstation
 or a trial where you do not want a root-owned install.

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -35,8 +35,29 @@ installed — nothing was ever built, signed, or published from either.
 |---|---|---|
 | `v2.4.0-rc.1` | protection preflight, full test matrix | the build compared the whole tag against the packaged version, so no pre-release tag could ever match |
 | `v2.4.0-rc.2` | protection preflight, full test matrix | the wheel version and the bundle version were compared as strings, and a candidate spells them differently |
+| `v2.4.0-rc.3` | signed, published, exercised on hardware | neither scope could complete an install: system scope checked for its service account too late, and user scope was refused for a property it cannot have |
 
-Both failures share a cause. The release pipeline carries two version
+`v2.4.0-rc.3` is the first candidate that built, signed, and published. Its
+assets remain available and are not replaced. It failed on hardware, which is
+what it was published to do.
+
+Two defects surfaced there. A system-scope install stopped with
+`service_start_failed: system service user does not exist` — a precondition
+that had been checked only after the operator answered every identity prompt
+and the installer had built a virtual environment. The installer now creates
+that account itself, as a distribution package does — after the bundle is
+verified and the values confirmed, and before any package is installed or the
+environment is built. A user-scope install then
+stopped with `post_install_health_failed: permissions.code`, because v2.4.0
+introduced a mandatory code-immutability check without the privilege separation
+that makes it satisfiable: under user scope the release and the runtime share
+one Unix owner. Sealing the tree read-only would have quieted the check without
+creating the boundary, since an owner can always restore write access to its
+own files. The check is now mandatory for system scope, where root-owned code
+and an unprivileged service account make it real, and an explicit warning under
+user scope, where it cannot be.
+
+The first two failures share a different cause. The release pipeline carries two version
 vocabularies — SemVer for the git tag, the signature envelope, the bundle
 manifest and the artifact name; PEP 440 for the wheel, its metadata and the
 version the installer reads back on the device. They agree for every final
@@ -373,7 +394,7 @@ the package will not load.
 
 ## Migration
 
-Two changes require action if you script the installer.
+Three changes require action if you script the installer.
 
 **Pass `--scope` explicitly.** `install` and `uninstall` no longer default to
 `user` scope:
@@ -395,8 +416,21 @@ in `DECISIONS.md` (2026-08-14): an ambiguous omitted argument may become
 required, and default human presentation may change where machine consumers
 have an explicit `--json` contract.
 
-What this release does **not** do is rename or remove an explicit flag, or
-change what an existing flag means.
+**Drop `--service-user`, or pass `ori-runtime`.** The system service account is
+now a constant, and the installer creates it when it does not exist:
+
+```bash
+ori-install-linux install --scope system --bundle ... --signature ...
+```
+
+The flag is retained and still accepts `ori-runtime`, so an invocation that
+omitted it or passed the documented default is unaffected. Naming a different
+account is refused with `service_start_failed`. A configurable account name had
+to be carried by the unit file, the permission checks, the diagnostics and the
+documentation, any of which could disagree about who the runtime is — see
+`DECISIONS.md` (2026-08-17).
+
+What this release does **not** do is rename or remove an explicit flag.
 
 Machine-facing output does change here, and this is the release that changes
 it. `--json` is new for `install`, and its document is richer than the summary

--- a/ori/cli.py
+++ b/ori/cli.py
@@ -274,7 +274,7 @@ def _add_install(commands: argparse._SubParsersAction[argparse.ArgumentParser]) 
     )
     parser.add_argument(
         "--service-user",
-        help="account the system service runs as (system scope; must exist)",
+        help="retained for compatibility; the system account is always ori-runtime",
     )
     parser.add_argument(
         "--root", help="install under this root instead of the default for the scope"

--- a/ori/doctor.py
+++ b/ori/doctor.py
@@ -771,7 +771,35 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
     If supplementary groups could not be enumerated, an unseen group might
     carry write access to the release, and the check fails rather than
     presenting an unverified claim as a pass.
+
+    The property is only reachable under privilege separation. System scope has
+    it: the code is root-owned and the service runs as an unprivileged account
+    that can neither write it nor change its mode. User scope cannot, because
+    the release and the runtime share one Unix owner — an owner may always
+    ``chmod`` its own tree, so a compromised runtime can restore write access to
+    the code it is about to execute. Mode bits there describe the current state,
+    not a boundary, and reporting them as immutability would be a false
+    assurance. User scope is reported honestly as a warning instead.
     """
+    if identity.scope == "user":
+        return _user_scope_code_advisory(identity, service)
+    if identity.scope != "system":
+        # An unrecognised scope is not a third deployment model to be given the
+        # benefit of the doubt. `!= "system"` would have handed one the user
+        # scope's advisory and turned a mandatory check into a passing warning.
+        return DoctorCheck(
+            name="permissions.code",
+            status=FAIL,
+            message=(
+                f"Installation scope {identity.scope!r} is unrecognised, so "
+                "whether the service can rewrite its own code cannot be "
+                "established."
+            ),
+            mandatory=True,
+            remedy="Reinstall with --scope system or --scope user.",
+            details={"scope": identity.scope},
+        )
+
     remedy = (
         f"Make the release read-only to the service: "
         f"chown -R root:root {identity.active_release} && "
@@ -818,6 +846,34 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
         mandatory=True,
         remedy=remedy,
         details={"offending_path": violation.split(" ", 1)[0]},
+    )
+
+
+def _user_scope_code_advisory(
+    identity: InstallIdentity, service: ServiceIdentity
+) -> DoctorCheck:
+    """State plainly that user scope cannot offer code immutability.
+
+    This is a property of the deployment model, not a defect in the install, so
+    it is never blocking: a user-scope installation that reports this warning is
+    a complete and usable installation. Sealing the tree read-only would silence
+    the warning without creating the boundary — the owner can restore write at
+    any time — which is why no such sealing is attempted.
+    """
+    return DoctorCheck(
+        name="permissions.code",
+        status=WARN,
+        message=(
+            f"User-scope code is owned by the runtime account ({service.name}) "
+            "and cannot be made immutable from that account. Use system scope "
+            "for a production deployment with root-owned verified code."
+        ),
+        mandatory=False,
+        remedy=(
+            "Reinstall with --scope system to run the runtime as a dedicated "
+            "unprivileged account that cannot modify the verified release."
+        ),
+        details={"release": str(identity.active_release), "scope": identity.scope},
     )
 
 

--- a/ori/installer/cli.py
+++ b/ori/installer/cli.py
@@ -23,12 +23,14 @@ from ori.installer import (
     scope_prompt,
 )
 from ori.installer.linux import (
+    SERVICE_USER,
     InstallerInputOptions,
     InstallLayout,
     LinuxInstallError,
     SystemdServiceManager,
     SystemdServiceProfile,
     collect_installer_config,
+    ensure_service_account,
     install_composed_release,
     uninstall_runtime,
 )
@@ -62,14 +64,28 @@ def detected_release_target() -> str:
     return f"linux-{normalized_architecture}-python{python_version}"
 
 
-def _profile(scope: str, service_user: str | None) -> SystemdServiceProfile:
+def _profile(scope: str, service_user: str | None = None) -> SystemdServiceProfile:
+    """Resolve the service profile, accepting only the canonical account name.
+
+    `--service-user` shipped in v2.3.0 and is kept rather than removed, because
+    an explicit flag an operator already wrote is what the installer's
+    compatibility promise protects. What it no longer does is name a different
+    account: the runtime's system identity is fixed, so the flag now accepts the
+    one value it always defaulted to and refuses the rest with a reason.
+    """
     if scope == "user":
         if service_user is not None:
             raise LinuxInstallError(
                 "service_start_failed", "--service-user is valid only for system scope"
             )
         return SystemdServiceProfile.user()
-    return SystemdServiceProfile.system(service_user or "ori-runtime")
+    if service_user is not None and service_user != SERVICE_USER:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"the system service account is always {SERVICE_USER} and cannot be "
+            f"renamed; drop --service-user, or pass --service-user {SERVICE_USER}",
+        )
+    return SystemdServiceProfile.system()
 
 
 def _paths(
@@ -168,6 +184,16 @@ def _install(args: argparse.Namespace) -> dict[str, object]:
     # Confirmed. Now the host may be changed — and only now, with the bundle
     # already proven authentic, so an unsigned or tampered bundle can never
     # reach a package prompt.
+    #
+    # The account goes first among those changes. It is the one an operator is
+    # most likely to decline, and declining it ends the installation: asking
+    # afterwards would mean OS packages had already been installed for a run
+    # that was never going to finish. Deliberately not part of
+    # `prerequisites.ensure`, which offers packages — an account is a different
+    # kind of change and asks for itself.
+    ensure_service_account(
+        profile, unattended=args.unattended, prompt=prompt, write=write
+    )
     prerequisites.ensure(unattended=args.unattended, prompt=prompt, write=write)
 
     service_manager = SystemdServiceManager(
@@ -323,8 +349,8 @@ def _add_scope_arguments(parser: argparse.ArgumentParser) -> None:
     # No default: scope decides whether the runtime survives a reboot and
     # whether it can rewrite its own code, so it is never chosen silently.
     parser.add_argument("--scope", choices=("user", "system"), default=None)
-    parser.add_argument("--root", type=Path)
     parser.add_argument("--service-user")
+    parser.add_argument("--root", type=Path)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -599,6 +599,15 @@ def _unsafe_unit_value(value: str) -> bool:
     )
 
 
+# The system service runs as one account, under one name, everywhere. `postgres`
+# and `docker` are not per-host choices, and neither is this: a fixed name is
+# what lets documentation, unit files, permission checks, support answers and an
+# operator's own muscle memory all refer to the same thing. A configurable name
+# buys nothing an operator wants and costs a variable that every one of those
+# has to carry.
+SERVICE_USER = "ori-runtime"
+
+
 @dataclass(frozen=True)
 class SystemdServiceProfile:
     """Explicit systemd scope and unprivileged runtime identity."""
@@ -617,13 +626,13 @@ class SystemdServiceProfile:
             raise LinuxInstallError(
                 "service_start_failed", "service profile is inconsistent"
             )
-        if not re.fullmatch(r"[a-z_][a-z0-9_-]{0,31}", self.service_user):
+        # Not a format check: the name is a constant, so anything else reaching
+        # here is a caller inventing an identity the rest of the system does not
+        # know about.
+        if self.service_user != SERVICE_USER:
             raise LinuxInstallError(
-                "service_start_failed", "system service user is invalid"
-            )
-        if self.service_user == "root":
-            raise LinuxInstallError(
-                "service_start_failed", "Runtime service user must be unprivileged"
+                "service_start_failed",
+                f"the system service account is always {SERVICE_USER}",
             )
 
     @classmethod
@@ -631,8 +640,8 @@ class SystemdServiceProfile:
         return cls(scope="user", service_user=None)
 
     @classmethod
-    def system(cls, service_user: str) -> SystemdServiceProfile:
-        return cls(scope="system", service_user=service_user)
+    def system(cls) -> SystemdServiceProfile:
+        return cls(scope="system", service_user=SERVICE_USER)
 
 
 @dataclass(frozen=True)
@@ -1156,6 +1165,268 @@ def render_systemd_unit(
             "service_start_failed", "service template has unresolved markers"
         )
     return rendered
+
+
+def ensure_service_account(
+    profile: SystemdServiceProfile,
+    *,
+    unattended: bool = False,
+    prompt: Callable[[str], str] = input,
+    write: Callable[[str], None] = print,
+    runner: Callable[[Sequence[str]], subprocess.CompletedProcess[str]] | None = None,
+) -> bool:
+    """Resolve the system service account, creating it when it is absent.
+
+    Returns whether this call created it.
+
+    A distribution package creates the account its service runs as; requiring an
+    operator to run `useradd` by hand asks them to perform the one step the
+    installer is best placed to get right, and to get it wrong in ways nobody
+    sees until the service starts. So this creates it — with a fixed name, a
+    fixed shape, and no login.
+
+    An account that already exists is used exactly as found. It may have been
+    given a home, a group, or an ACL deliberately, and adopting an existing
+    identity is not licence to reshape it.
+    """
+    if profile.scope != "system" or profile.service_user is None:
+        return False
+    if _account_is_usable(profile.service_user):
+        return False
+
+    manual = (
+        f"sudo useradd --system --no-create-home --shell {_nologin_shell()} "
+        f"{profile.service_user}"
+    )
+    if os.geteuid() != 0:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"creating the {profile.service_user} account requires root. "
+            f"Re-run with sudo, create it manually ({manual}), or install with "
+            "--scope user for a workstation or trial.",
+        )
+
+    useradd = _trusted_useradd()
+    if useradd is None:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"the {profile.service_user} account does not exist and useradd is "
+            f"not available to create it. Create it manually: {manual}",
+        )
+
+    if not unattended and not _confirmed_account_creation(
+        profile.service_user, prompt=prompt, write=write
+    ):
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"the {profile.service_user} account is required for a system "
+            f"install. Create it manually ({manual}), or install with "
+            "--scope user for a workstation or trial.",
+        )
+
+    command = [
+        useradd,
+        "--system",
+        "--no-create-home",
+        "--shell",
+        _nologin_shell(),
+        profile.service_user,
+    ]
+    run = runner or _run_account_command
+    try:
+        result = run(command)
+    except subprocess.TimeoutExpired as exc:
+        # `TimeoutExpired` is a SubprocessError, not an OSError, so it would
+        # otherwise travel past this handler and past `main`, which maps only
+        # the installer's own error types. A useradd waiting on a lock the
+        # installer cannot see would reach the operator as a traceback with no
+        # remedy in it.
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"creating the {profile.service_user} account timed out after "
+            f"{_ACCOUNT_COMMAND_TIMEOUT_SECONDS:g}s. Another process may hold "
+            f"the account database lock. Create it manually: {manual}",
+        ) from exc
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"could not create the {profile.service_user} account: {exc}. "
+            f"Create it manually: {manual}",
+        ) from exc
+    # A zero exit is the tool's opinion; the account is the fact. Proceeding on
+    # the former would defer the failure to the point where the service starts.
+    if result.returncode != 0 or not _account_is_usable(profile.service_user):
+        detail = (result.stderr or result.stdout or "").strip().splitlines()
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"could not create the {profile.service_user} account"
+            + (f" ({detail[-1]})" if detail else "")
+            + f". Create it manually: {manual}",
+        )
+    write(f"Created system service account {profile.service_user}.")
+    return True
+
+
+def _account_is_usable(name: str) -> bool:
+    """Whether *name* resolves to an account the runtime may run as.
+
+    Resolving is not enough. An account carrying uid 0 — whether aliased there
+    deliberately or created by a host tool that reuses the id — would run the
+    service as root, which is the single thing system scope exists to prevent.
+    Doctor rejects uid 0, but it runs after the unit has been installed and
+    started, so a name-only check hands the service root first and objects
+    afterwards.
+    """
+    try:
+        account = pwd.getpwnam(name)
+    except KeyError:
+        return False
+    if account.pw_uid == 0:
+        raise LinuxInstallError(
+            "service_start_failed",
+            f"the {name} account exists but has uid 0. The runtime must not run "
+            "as root under system scope. Remove or rename that account, or "
+            "install with --scope user for a workstation or trial.",
+        )
+    return True
+
+
+def _nologin_shell() -> str:
+    """The shell that denies login, wherever this distribution keeps it."""
+    for candidate in ("/usr/sbin/nologin", "/sbin/nologin", "/bin/false"):
+        if Path(candidate).exists():
+            return candidate
+    return "/bin/false"
+
+
+def _confirmed_account_creation(
+    name: str,
+    *,
+    prompt: Callable[[str], str],
+    write: Callable[[str], None],
+) -> bool:
+    """Ask before adding an account to the host, as package installs do.
+
+    Declining is a complete answer: the installation stops and the operator is
+    given the command. It never means "continue without the account", which
+    would produce a service that cannot start.
+    """
+    write(
+        f"\nA system install runs the runtime as {name}, an unprivileged "
+        f"account with no home directory and no login shell.\n"
+        f"That account does not exist yet and will be created.\n"
+        f"It is left in place if you later uninstall, because files elsewhere "
+        f"may belong to it.\n"
+    )
+    for _attempt in range(3):
+        try:
+            answer = prompt(f"Create the {name} account? [Y/n]: ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            return False
+        if answer in {"", "y", "yes"}:
+            return True
+        if answer in {"n", "no"}:
+            return False
+        write("  Answer y or n.")
+    return False
+
+
+# Fixed, in preference order. `PATH` is not consulted: this runs as root, and a
+# `PATH` carrying a writable directory ahead of the system ones would choose
+# what the installer executes with full privilege. An operator whose useradd
+# lives somewhere else can create the account by hand — the message says how.
+_USERADD_LOCATIONS: tuple[str, ...] = (
+    "/usr/sbin/useradd",
+    "/sbin/useradd",
+    "/usr/local/sbin/useradd",
+)
+
+
+def _trusted_useradd() -> str | None:
+    """Return a useradd only root could have placed there, or None.
+
+    Three things have to hold, and the inode is only one of them. A perfectly
+    owned, perfectly permissioned binary is still substitutable if any
+    directory on the way to it can be written by somebody else: replacing a
+    file needs write permission on its parent, not on the file. So every
+    component from the root down is checked, on the literal path and on the
+    path after symlinks are resolved, before the executable itself is judged.
+    """
+    for candidate in _USERADD_LOCATIONS:
+        try:
+            resolved = os.path.realpath(candidate)
+        except OSError:
+            continue
+        # The name as written, so a writable directory cannot redirect it, and
+        # the name after resolution, so a symlink cannot land somewhere its own
+        # parents are open. Neither implies the other.
+        if not _only_root_can_change(Path(candidate)):
+            continue
+        if resolved != candidate and not _only_root_can_change(Path(resolved)):
+            continue
+        try:
+            info = os.stat(resolved)
+        except OSError:
+            continue
+        if not stat.S_ISREG(info.st_mode):
+            continue
+        if info.st_uid != 0:
+            continue
+        # Writable by anyone but its owner is writable by somebody who is not
+        # root, which is the whole of the concern.
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            continue
+        if not os.access(resolved, os.X_OK):
+            continue
+        return resolved
+    return None
+
+
+def _only_root_can_change(path: Path) -> bool:
+    """Whether every directory leading to *path* is under root's control alone.
+
+    Walked from the filesystem root downwards. A single group- or
+    world-writable ancestor, or one owned by another account, is enough for an
+    unprivileged user to swap what the final name refers to by renaming or
+    unlinking within it — which is why the executable's own mode is not the
+    question being asked here.
+    """
+    for directory in reversed(path.parents):
+        try:
+            info = os.lstat(directory)
+        except OSError:
+            return False
+        if info.st_uid != 0:
+            return False
+        if stat.S_ISLNK(info.st_mode):
+            # A root-owned symlink inside a root-controlled directory is safe:
+            # repointing it needs write on the directory holding it, which the
+            # step before this one has already established. Its own mode is not
+            # evidence either way — Linux reports every symlink as 0777, so
+            # testing it for group-writability rejects `/sbin` on any system
+            # where `/sbin` is the usual link into `/usr/sbin`. Where it lands
+            # is checked separately.
+            continue
+        if not stat.S_ISDIR(info.st_mode):
+            return False
+        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+            return False
+    return True
+
+
+_ACCOUNT_COMMAND_TIMEOUT_SECONDS = 30.0
+
+
+def _run_account_command(
+    command: Sequence[str],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=_ACCOUNT_COMMAND_TIMEOUT_SECONDS,
+    )
 
 
 def apply_system_service_permissions(
@@ -1800,9 +2071,59 @@ def install_release(
 ) -> InstallResult:
     """Prepare, activate, and health-gate one already-authenticated release."""
     destination = layout.release(version)
-    _ensure_private_directory(layout.root)
-    _ensure_private_directory(layout.releases)
-    _ensure_private_directory(layout.data)
+    # Built inside the try, one directory at a time. A comprehension binds its
+    # result only after the last element, so a root that exists while `data` is
+    # a symlink would create `releases/`, raise, and leave it behind with no
+    # record that this run had made it.
+    scaffolding: list[Path] = []
+    try:
+        for directory in (layout.root, layout.releases, layout.data):
+            # Ordered outermost first, so cleanup can unwind it in reverse.
+            if _ensure_private_directory(directory):
+                scaffolding.append(directory)
+        return _install_release(
+            layout=layout,
+            version=version,
+            destination=destination,
+            prepare=prepare,
+            validate=validate,
+            restart_service=restart_service,
+            stop_service=stop_service,
+            check_health=check_health,
+            allow_downgrade=allow_downgrade,
+            service_profile=service_profile,
+            prepare_activation=prepare_activation,
+            rollback_activation=rollback_activation,
+            commit_activation=commit_activation,
+            allowed_data_sockets=allowed_data_sockets,
+        )
+    except Exception:
+        # A failed install leaves the host as it found it, as far as it still
+        # can. `_install_release` already removes the release tree it created;
+        # this takes the empty scaffolding with it, so a first install that
+        # fails does not leave an install root behind suggesting Ori is there.
+        _remove_created_scaffolding(scaffolding)
+        raise
+
+
+def _install_release(
+    *,
+    layout: InstallLayout,
+    version: str,
+    destination: Path,
+    prepare: Callable[[Path], None],
+    validate: Callable[[Path], None],
+    restart_service: Callable[[], None],
+    stop_service: Callable[[], None],
+    check_health: Callable[[Path], None],
+    allow_downgrade: bool,
+    service_profile: SystemdServiceProfile | None,
+    prepare_activation: Callable[[Path], None] | None,
+    rollback_activation: Callable[[], None] | None,
+    commit_activation: Callable[[Path], None] | None,
+    allowed_data_sockets: Sequence[Path],
+) -> InstallResult:
+    """Install into an install root whose directories already exist."""
     previous = _active_release(layout)
     previous_version = previous.name if previous is not None else None
     same_version = previous == destination and destination.is_dir()
@@ -1979,7 +2300,7 @@ def _assert_managed_path(layout: InstallLayout, path: Path) -> None:
         ) from exc
 
 
-def _ensure_private_directory(path: Path) -> None:
+def _ensure_private_directory(path: Path) -> bool:
     if path.is_symlink():
         raise LinuxInstallError(
             "unsafe_install_root", f"{path.name} must not be a symlink"
@@ -1997,6 +2318,32 @@ def _ensure_private_directory(path: Path) -> None:
         raise LinuxInstallError("unsafe_install_root", f"{path.name} is group-writable")
     if mode & 0o007:
         path.chmod(0o700)
+    return created
+
+
+def _remove_created_scaffolding(directories: Sequence[Path]) -> None:
+    """Undo the empty directory tree this invocation brought into being.
+
+    Only directories this run created are considered, and only while they are
+    still empty, so a pre-existing install root — or one still holding an
+    operator's data or an earlier release — is never removed by a failure. They
+    are unwound in reverse, because the parent cannot go until the child has.
+
+    Best-effort by construction: this runs while an installation failure is
+    already propagating, and a directory that cannot be removed is untidy, not
+    unsafe. Raising here would replace the operator's real diagnosis with a
+    cleanup error.
+    """
+    for directory in reversed(list(directories)):
+        try:
+            directory.rmdir()
+        except OSError:
+            # Not empty, not present, or not permitted — all fine to leave, and
+            # none of them says anything about the next one. Stopping here would
+            # strand an empty `releases/` simply because `data/` held a config
+            # the operator should keep. A parent still holding a survivor fails
+            # on its own attempt, which is the correct reason to leave it.
+            continue
 
 
 def _version_key(

--- a/ori/installer/scope_prompt.py
+++ b/ori/installer/scope_prompt.py
@@ -35,6 +35,8 @@ _PROMPT = """
      Runs as your login user.
      Stops after your last session unless lingering is enabled.
      Does not start at boot without lingering.
+
+Type 1 or 2. Press Enter to accept 1 (system).
 """
 
 _CHOICES = {"1": "system", "2": "user", "system": "system", "user": "user"}

--- a/ori/installer/upgrade.py
+++ b/ori/installer/upgrade.py
@@ -145,12 +145,12 @@ def _run_installer(
     # and silently dropped here would be a flag that appears to work.
     for option, flag in (
         ("--scope", "scope"),
+        ("--service-user", "service_user"),
         ("--device-id", "device_id"),
         ("--name", "name"),
         ("--location", "location"),
         ("--deployment-type", "deployment_type"),
         ("--operator-contact", "operator_contact"),
-        ("--service-user", "service_user"),
         ("--root", "root"),
     ):
         value = getattr(args, flag, None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0rc3"
+version = "2.4.0rc4"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -4,6 +4,27 @@ if [ -z "${BASH_VERSION:-}" ]; then
   echo "unsupported_target: install-linux.sh must be run with bash; use curl ... | bash -s -- ..." >&2
   exit 2
 fi
+# Find an interpreter this installer can actually use. Bundles are published
+# for 3.11 and 3.12 only, and `python3` is whatever the distribution chose: on
+# Pop!_OS it is 3.10 while a perfectly good python3.12 sits alongside it. Using
+# `python3` alone reports the host as unsupported when it is not.
+#
+# Each candidate is asked its own version rather than trusted for its name. A
+# `python3.12` on PATH may be a wrapper, a shim, or a broken symlink, and the
+# name proves nothing about what running it produces.
+ori_python=""
+for ori_candidate in python3.12 python3.11 python3; do
+  command -v "${ori_candidate}" >/dev/null 2>&1 || continue
+  if "${ori_candidate}" -c 'import sys; raise SystemExit(0 if sys.version_info[:2] in ((3, 11), (3, 12)) else 1)' >/dev/null 2>&1; then
+    ori_python="${ori_candidate}"
+    break
+  fi
+done
+if [ -z "${ori_python}" ]; then
+  echo "unsupported_target: no supported Python found on PATH. Ori requires Python 3.11 or 3.12; install one (for example 'sudo apt install python3.12') and run this again." >&2
+  exit 2
+fi
+
 # Dispatch on execution mode, not on filename. BASH_SOURCE[0] is the script
 # path when a file is executed and unset when bash reads the program from
 # stdin, so it distinguishes the two without consulting $0 — which is merely
@@ -11,7 +32,7 @@ fi
 # in the working directory.
 ori_source="${BASH_SOURCE[0]-}"
 if [ -n "${ori_source}" ] && [ -f "${ori_source}" ] && [ -r "${ori_source}" ]; then
-  exec python3 "${ori_source}" "$@"
+  exec "${ori_python}" "${ori_source}" "$@"
 fi
 # No file to run, so the program must arrive on stdin. If stdin is a terminal
 # there is nothing to read, and exiting quietly would look like success.
@@ -19,7 +40,7 @@ if [ -t 0 ]; then
   echo "unsupported_target: no installer source found; run the downloaded file, or pipe it with 'curl -fsSL ... | bash -s -- ...'" >&2
   exit 2
 fi
-exec python3 - "$@"
+exec "${ori_python}" - "$@"
 ":"""
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -242,6 +242,24 @@ def test_inactive_service_is_a_blocking_failure(tmp_path: Path) -> None:
 
 
 def _checks(root: Path) -> dict[str, doctor.DoctorCheck]:
+    """Permission checks under system scope, where code immutability is claimed.
+
+    The service account is this test's own user, so the release tree is owned by
+    the very account the runtime would run as. That is the adversarial shape the
+    check exists to catch: under system scope a release the service can write is
+    a finding, whoever that service happens to be.
+    """
+    return {
+        c.name: c
+        for c in doctor.check_permissions(
+            _identity(
+                root, scope="system", service_user=pwd.getpwuid(os.getuid()).pw_name
+            )
+        )
+    }
+
+
+def _user_scope_checks(root: Path) -> dict[str, doctor.DoctorCheck]:
     return {c.name: c for c in doctor.check_permissions(_identity(root, scope="user"))}
 
 
@@ -329,6 +347,89 @@ def test_a_sealed_release_passes(tmp_path: Path, not_root: None) -> None:
         assert _checks(tmp_path)["permissions.code"].status == terminal.PASS
     finally:
         _unseal(tmp_path)
+
+
+# --- user scope cannot claim code immutability ----------------------------
+
+
+def test_user_scope_reports_an_advisory_rather_than_a_failure(
+    tmp_path: Path, not_root: None
+) -> None:
+    """A user-scope install is complete; it just cannot offer immutability.
+
+    The release and the runtime share one Unix owner, so the account that runs
+    the code can always restore write access to it. Failing here would reject a
+    working workstation install for a property its deployment model never had.
+    """
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+
+    code = _user_scope_checks(tmp_path)["permissions.code"]
+
+    assert code.status == terminal.WARN
+    assert code.mandatory is False
+    assert "cannot be made immutable" in code.message
+    assert "system scope" in code.message
+
+
+def test_user_scope_advisory_is_not_silenced_by_read_only_modes(
+    tmp_path: Path, not_root: None
+) -> None:
+    """Sealing the tree must not buy a passing claim.
+
+    Mode bits describe the current state, not a boundary: the owner may chmod
+    them back at any moment, so a compromised runtime can restore write access
+    to the code it is about to execute. Reporting PASS because the bits look
+    right at this instant would be a false assurance — which is exactly why the
+    installer does not seal user-scope trees to make this check quiet.
+    """
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+    _sealed(tmp_path)
+    try:
+        code = _user_scope_checks(tmp_path)["permissions.code"]
+
+        assert code.status == terminal.WARN
+        assert code.mandatory is False
+    finally:
+        _unseal(tmp_path)
+
+
+@pytest.mark.parametrize("scope", ["systemx", "SYSTEM", "", "root"])
+def test_an_unrecognised_scope_is_refused_rather_than_treated_as_user(
+    tmp_path: Path, not_root: None, scope: str
+) -> None:
+    """An unknown scope is not a third deployment model to be trusted.
+
+    Testing `scope != "system"` would hand anything unrecognised the user
+    scope's advisory, turning a mandatory security check into a passing warning
+    for any value that is merely misspelled.
+    """
+    _layout(tmp_path)
+    identity = _identity(tmp_path, scope=scope, service_user=None)
+
+    code = {c.name: c for c in doctor.check_permissions(identity)}["permissions.code"]
+
+    assert code.status == terminal.FAIL
+    assert code.mandatory is True
+    assert "unrecognised" in code.message
+
+
+def test_system_scope_still_fails_on_a_release_the_service_can_write(
+    tmp_path: Path, not_root: None
+) -> None:
+    """The scope split must not weaken the scope that can enforce it."""
+    _layout(tmp_path)
+    (_release(tmp_path) / "ori").mkdir()
+    (_release(tmp_path) / "ori" / "runtime.py").write_text("# code\n")
+
+    code = _checks(tmp_path)["permissions.code"]
+
+    assert code.status == terminal.FAIL
+    assert code.mandatory is True
+    assert "not immutable" in code.message
 
 
 def test_an_uninspectable_directory_fails_closed(

--- a/tests/test_installer_activation.py
+++ b/tests/test_installer_activation.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import pwd
 import subprocess
 from pathlib import Path
 
@@ -737,3 +738,133 @@ def test_a_real_doctor_run_satisfies_the_activation_boundary(
     activation._assert_complete(report)
     activation._assert_status_agrees(0, report)
     activation.assert_usable(report)
+
+
+# --- the real doctor, judged by the real gate ------------------------------
+#
+# Everything above stubs doctor's output to test how activation handles it.
+# That is why v2.4.0-rc.3 shipped a user-scope install that could never
+# succeed: the real doctor and the real gate had never been run against each
+# other. These tests join them, with no synthetic check dictionaries between.
+
+
+def _install_release_for_real(root: Path, diagnose_as: str) -> tuple[Path, object]:
+    """Let the installer create the release, then describe what it produced.
+
+    The tree is not assembled by hand here. `install_release` creates the
+    install root, stages the release, moves it into place and sets `current`,
+    so the modes under diagnosis are the ones the installer really leaves — the
+    seam that shipped a user-scope install nobody could complete.
+    """
+    from ori import doctor
+    from ori.installer.linux import (
+        InstallLayout,
+        SystemdServiceProfile,
+        install_release,
+    )
+
+    def prepare(staging: Path) -> None:
+        binaries = staging / "venv" / "bin"
+        binaries.mkdir(parents=True)
+        interpreter = binaries / "python"
+        interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+        interpreter.chmod(0o755)
+        (staging / "ori").mkdir()
+        (staging / "ori" / "runtime.py").write_text("# code\n", encoding="utf-8")
+
+    layout = InstallLayout.resolve(root)
+    version = "2.4.0-rc.4"
+    install_release(
+        layout=layout,
+        version=version,
+        prepare=prepare,
+        validate=lambda _path: None,
+        restart_service=lambda: None,
+        stop_service=lambda: None,
+        check_health=lambda _path: None,
+        # Always installed under user scope: applying system permissions needs
+        # root, which this suite does not have and must not require. What the
+        # installer produces here — the modes, the staging move, `current` — is
+        # the same tree either way; only the identity diagnosing it differs.
+        service_profile=SystemdServiceProfile.user(),
+    )
+    release = layout.release(version)
+    (layout.data / "ori.yaml").write_text("device: {}\n", encoding="utf-8")
+
+    identity = doctor.InstallIdentity(
+        scope=diagnose_as,
+        version=version,
+        install_root=layout.root,
+        active_release=release,
+        config_path=layout.data / "ori.yaml",
+        data_path=layout.data,
+        health_socket=layout.data / "health.sock",
+        unit_path=layout.root / "ori-runtime.service",
+        service_user=(
+            pwd.getpwuid(os.getuid()).pw_name if diagnose_as == "system" else None
+        ),
+    )
+    return release, identity
+
+
+def _as_reported(checks: list[object]) -> list[dict[str, object]]:
+    """Render real DoctorCheck objects the way doctor's JSON report does."""
+    return [
+        {
+            "name": c.name,
+            "status": c.status,
+            "message": c.message,
+            "mandatory": c.mandatory,
+        }
+        for c in checks
+    ]
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="mode-based denial is invisible to root")
+def test_a_real_user_scope_install_passes_the_real_gate(tmp_path: Path) -> None:
+    """A user-scope installation must complete, carrying the advisory.
+
+    This is the case that failed on hardware in v2.4.0-rc.3: the release is
+    owned by the account that runs it, and the mandatory code-immutability
+    check rejected the install for a property user scope cannot provide.
+    """
+    from ori import doctor
+
+    root = tmp_path / "ori"
+    root.mkdir()
+    _release, identity = _install_release_for_real(root, "user")
+
+    reported = _as_reported(doctor.check_permissions(identity))
+    code = next(c for c in reported if c["name"] == "permissions.code")
+
+    assert code["status"] == "WARN"
+    assert code["mandatory"] is False
+    assert activation.blocking(reported) == []
+    # The gate the installer actually calls inside its transaction.
+    activation.assert_usable(reported)
+
+
+@pytest.mark.skipif(os.geteuid() == 0, reason="mode-based denial is invisible to root")
+def test_a_real_system_scope_install_is_blocked_when_code_is_writable(
+    tmp_path: Path,
+) -> None:
+    """The scope that can enforce immutability must still enforce it.
+
+    The tree is one the installer really produced; the identity diagnosing it
+    is a system one whose service account owns that tree. That is precisely the
+    condition the check exists to catch, and it must survive the scope split.
+    """
+    from ori import doctor
+
+    root = tmp_path / "ori"
+    root.mkdir()
+    _release, identity = _install_release_for_real(root, "system")
+
+    reported = _as_reported(doctor.check_permissions(identity))
+    code = next(c for c in reported if c["name"] == "permissions.code")
+
+    assert code["status"] == "FAIL"
+    assert code["mandatory"] is True
+    assert activation.blocking(reported) != []
+    with pytest.raises(LinuxInstallError, match="post_install_health_failed"):
+        activation.assert_usable(reported)

--- a/tests/test_installer_scope.py
+++ b/tests/test_installer_scope.py
@@ -102,6 +102,23 @@ def test_prompt_states_both_consequences(tty: None) -> None:
     assert "ori-runtime" in shown
 
 
+def test_prompt_says_how_to_answer_and_what_enter_does(tty: None) -> None:
+    """`Choose [1]: ` alone reads as a value already filled in.
+
+    An operator on hardware took the bracketed 1 for a pre-selection and sat
+    waiting at a prompt that was waiting for them. The default is real — Enter
+    accepts system — but the operator has to be told that it is theirs to send.
+    """
+    written: list[str] = []
+    scope_prompt.choose_scope(
+        supplied=None, unattended=False, prompt=_Prompt("1"), write=written.append
+    )
+    shown = "\n".join(written)
+
+    assert "Type 1 or 2" in shown
+    assert "Press Enter to accept 1 (system)" in shown
+
+
 def test_invalid_answer_reprompts_then_gives_up(tty: None) -> None:
     prompt = _Prompt("maybe", "3", "yes")
     with pytest.raises(LinuxInstallError) as excinfo:

--- a/tests/test_linux_bootstrap.py
+++ b/tests/test_linux_bootstrap.py
@@ -7,6 +7,7 @@ import base64
 import hashlib
 import json
 import runpy
+import shutil
 import subprocess
 import tarfile
 from pathlib import Path
@@ -448,3 +449,89 @@ def test_unexpected_faults_are_not_blamed_on_the_archive() -> None:
 
     assert "bootstrap_failed: installer failed unexpectedly" in source
     assert "unsafe_bundle_archive: installer failed unexpectedly" not in source
+
+
+# --- interpreter discovery -------------------------------------------------
+
+
+def _selected_interpreter(tmp_path: Path, entries: dict[str, str | None]) -> str:
+    """Run the real preamble and report which interpreter it chose."""
+    binaries = tmp_path / "bin"
+    binaries.mkdir(exist_ok=True)
+    for name, version in entries.items():
+        script = binaries / name
+        if version is None:
+            script.write_text("#!/bin/sh\nexit 127\n", encoding="utf-8")
+        else:
+            # Reports the requested version to the probe, and its own name when
+            # finally exec'd with the installer program.
+            script.write_text(
+                "#!/bin/sh\n"
+                'case "$*" in\n'
+                f"  *version_info*) exit {0 if version in ('3.11', '3.12') else 1} ;;\n"
+                f'  *) echo "{name}" ;;\n'
+                "esac\n",
+                encoding="utf-8",
+            )
+        script.chmod(0o755)
+
+    # bash by absolute path: PATH is reserved for the interpreters under test,
+    # so a real python3 on the system PATH cannot be the one selected.
+    bash = shutil.which("bash")
+    if bash is None:
+        pytest.skip("bash is required to execute the bootstrap preamble")
+    result = subprocess.run(
+        [bash, "-c", _preamble(), "installer"],
+        capture_output=True,
+        text=True,
+        env={"PATH": str(binaries)},
+        cwd=tmp_path,
+    )
+    return result.stdout.strip() or f"ERROR:{result.stderr.strip()}"
+
+
+def _preamble() -> str:
+    """The bash half of the polyglot, up to where it hands off to Python."""
+    source = Path("scripts/install-linux.sh").read_text(encoding="utf-8")
+    # The bash section ends at the closing polyglot marker; everything after it
+    # is the Python program, which bash never parses.
+    return source.split('":"""', 1)[0].replace('""":"', "", 1)
+
+
+def test_a_supported_interpreter_is_preferred_over_the_default_python3(
+    tmp_path: Path,
+) -> None:
+    """`python3` being 3.10 must not condemn a host that also has 3.12.
+
+    This is what Pop!_OS looks like: python3 is 3.10, python3.12 is installed
+    alongside it, and every published bundle targets 3.11 or 3.12.
+    """
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.10", "python3.12": "3.12"})
+
+    assert chosen == "python3.12"
+
+
+def test_the_stock_interpreter_is_used_when_it_is_supported(tmp_path: Path) -> None:
+    """Raspberry Pi OS Bookworm ships 3.11 as python3 and has no python3.12."""
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.11"})
+
+    assert chosen == "python3"
+
+
+def test_a_named_interpreter_that_cannot_run_is_skipped(tmp_path: Path) -> None:
+    """Existing on PATH is not evidence: a shim or dangling symlink proves nothing."""
+    chosen = _selected_interpreter(
+        tmp_path, {"python3.12": None, "python3.11": "3.11", "python3": "3.10"}
+    )
+
+    assert chosen == "python3.11"
+
+
+def test_a_host_with_no_supported_interpreter_is_told_what_to_install(
+    tmp_path: Path,
+) -> None:
+    chosen = _selected_interpreter(tmp_path, {"python3": "3.10"})
+
+    assert chosen.startswith("ERROR:")
+    assert "unsupported_target" in chosen
+    assert "3.11 or 3.12" in chosen

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -6,6 +6,7 @@ import os
 import pwd
 import shutil
 import socket
+import stat
 import subprocess
 import sys
 import tempfile
@@ -14,10 +15,12 @@ import tomllib
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 import yaml
 
+from ori.installer import linux as installer_linux
 from ori.installer.linux import (
     BootPersistence,
     InstallerConfigInput,
@@ -28,6 +31,7 @@ from ori.installer.linux import (
     SystemdServiceManager,
     SystemdServiceProfile,
     apply_system_service_permissions,
+    ensure_service_account,
     install_composed_release,
     install_release,
     provision_runtime_config,
@@ -584,7 +588,7 @@ def test_composed_reinstall_integrates_config_dac_and_live_health_socket(
             "layout": layout,
             "bundle": bundle,
             "values": InstallerConfigInput("ori-01", "Office", "Lagos"),
-            "service_profile": SystemdServiceProfile.system("ori"),
+            "service_profile": SystemdServiceProfile.system(),
             "service_manager": Manager(),
             "unit_template": _service_template(),
             "env_file": layout.data / "runtime.env",
@@ -648,7 +652,11 @@ def test_failed_post_move_validation_removes_unusable_release(tmp_path: Path) ->
         )
 
     assert not layout.release("2.3.0").exists()
-    assert list(layout.releases.iterdir()) == []
+    # This invocation created the install root, and the failure left it empty,
+    # so nothing of it remains — an operator whose first install failed has no
+    # directory tree suggesting Ori is installed.
+    assert not layout.releases.exists()
+    assert not layout.root.exists()
     assert not layout.current.exists()
 
 
@@ -673,7 +681,7 @@ def test_systemd_manager_separates_user_and_system_commands(tmp_path: Path) -> N
         effective_uid=1001,
     )
     system = SystemdServiceManager(
-        profile=SystemdServiceProfile.system("ori"),
+        profile=SystemdServiceProfile.system(),
         unit_path=(tmp_path / "system" / "ori-runtime.service").resolve(),
         runner=system_runner,
         effective_uid=0,
@@ -850,8 +858,8 @@ def test_systemd_manager_disables_before_removing_unit(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     ("manager_profile", "rendered_profile"),
     [
-        (SystemdServiceProfile.system("ori"), SystemdServiceProfile.user()),
-        (SystemdServiceProfile.user(), SystemdServiceProfile.system("ori")),
+        (SystemdServiceProfile.system(), SystemdServiceProfile.user()),
+        (SystemdServiceProfile.user(), SystemdServiceProfile.system()),
     ],
 )
 def test_systemd_manager_rejects_rendered_profile_mismatch(
@@ -899,7 +907,7 @@ def test_system_boot_persistence_queries_real_enablement(tmp_path: Path) -> None
         return subprocess.CompletedProcess(command, returncode, stdout, "")
 
     manager = SystemdServiceManager(
-        profile=SystemdServiceProfile.system("ori"),
+        profile=SystemdServiceProfile.system(),
         unit_path=(tmp_path / "units" / "ori-runtime.service").resolve(),
         runner=runner,
         effective_uid=0,
@@ -943,7 +951,7 @@ def test_systemd_manager_rejects_root_user_scope_and_command_failures(
             profile=SystemdServiceProfile.user(), unit_path=unit, effective_uid=0
         )
     manager = SystemdServiceManager(
-        profile=SystemdServiceProfile.system("ori"),
+        profile=SystemdServiceProfile.system(),
         unit_path=unit,
         effective_uid=0,
         runner=lambda command: subprocess.CompletedProcess(command, 1, "", "failed"),
@@ -1315,7 +1323,7 @@ def test_system_systemd_unit_uses_unprivileged_user_and_system_target(
 ) -> None:
     rendered = render_systemd_unit(
         _service_template(),
-        profile=SystemdServiceProfile.system("ori-runtime"),
+        profile=SystemdServiceProfile.system(),
         root=(tmp_path / "root").resolve(),
         data_dir=(tmp_path / "data").resolve(),
         config_path=(tmp_path / "data" / "config.yaml").resolve(),
@@ -1326,10 +1334,19 @@ def test_system_systemd_unit_uses_unprivileged_user_and_system_target(
     assert "@ORI_" not in rendered
 
 
-@pytest.mark.parametrize("service_user", ["root", "0", "Bad User", "ori;root"])
-def test_system_systemd_profile_rejects_unsafe_identity(service_user: str) -> None:
+@pytest.mark.parametrize(
+    "service_user", ["root", "0", "Bad User", "ori;root", "ori", "postgres"]
+)
+def test_system_systemd_profile_refuses_any_other_identity(service_user: str) -> None:
+    """The account name is a constant, so no other value may reach a unit file.
+
+    A configurable name would have to be carried by the unit file, the
+    permission checks, the documentation and every support answer, and each
+    could disagree. `root` and `ori;root` are refused for the obvious reasons;
+    `ori` and `postgres` are refused for the same one as any other name.
+    """
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
-        SystemdServiceProfile.system(service_user)
+        SystemdServiceProfile(scope="system", service_user=service_user)
 
 
 @pytest.mark.parametrize(
@@ -1419,7 +1436,7 @@ def test_system_permissions_keep_code_root_owned_and_data_service_owned(
         ),
     )
 
-    apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+    apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
     assert ownership[layout.root] == (0, 1002)
     assert ownership[regular] == (0, 1002)
@@ -1438,7 +1455,7 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
     layout.data.mkdir()
     monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 501)
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
     monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
     monkeypatch.setattr(
@@ -1448,7 +1465,7 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
     (layout.data / "escape").symlink_to(tmp_path / "outside")
     with pytest.raises(LinuxInstallError, match="unsafe_install_root"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
     assert layout.root.stat().st_mode & 0o777 == 0o755
 
 
@@ -1477,14 +1494,14 @@ def test_system_permissions_allow_only_configured_runtime_socket(
             with pytest.raises(LinuxInstallError, match="special files are forbidden"):
                 apply_system_service_permissions(
                     layout,
-                    SystemdServiceProfile.system("ori"),
+                    SystemdServiceProfile.system(),
                     allowed_data_sockets=(health_path,),
                 )
             unexpected_socket.close()
             unexpected_path.unlink()
             apply_system_service_permissions(
                 layout,
-                SystemdServiceProfile.system("ori"),
+                SystemdServiceProfile.system(),
                 allowed_data_sockets=(health_path,),
             )
             assert health_path.exists()
@@ -1528,7 +1545,7 @@ def test_system_upgrade_preserves_access_and_reapplies_permissions(
         restart_service=lambda: None,
         stop_service=lambda: None,
         check_health=lambda _path: None,
-        service_profile=SystemdServiceProfile.system("ori"),
+        service_profile=SystemdServiceProfile.system(),
     )
     assert observed_modes == [(0o750, 0o750)]
 
@@ -1555,7 +1572,7 @@ def test_permission_failure_is_stable_and_restores_current_owner(
         lambda *_args: (_ for _ in ()).throw(NotImplementedError("old glibc")),
     )
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
     assert ownership_calls == [(0, 1002), (original.st_uid, original.st_gid)]
 
 
@@ -1581,7 +1598,7 @@ def test_system_permissions_accept_internal_venv_directory_symlink(
     )
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
 
-    apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+    apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
     assert (release / "lib64").resolve() == library
     assert (binary / "python").resolve() == interpreter
@@ -1607,7 +1624,7 @@ def test_system_permissions_reject_escaping_release_symlinks(
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
 
     with pytest.raises(LinuxInstallError, match="unsafe_install_root"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
     (release / "lib64").unlink()
     external_python = tmp_path / "python"
@@ -1619,7 +1636,7 @@ def test_system_permissions_reject_escaping_release_symlinks(
     with pytest.raises(
         LinuxInstallError, match="external release symlink target is not trusted"
     ):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system("ori"))
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
 
 def test_permission_failure_removes_new_release_before_activation(
@@ -1641,7 +1658,7 @@ def test_permission_failure_removes_new_release_before_activation(
             restart_service=lambda: None,
             stop_service=lambda: None,
             check_health=lambda _path: None,
-            service_profile=SystemdServiceProfile.system("ori"),
+            service_profile=SystemdServiceProfile.system(),
         )
     assert not layout.release("2.3.0").exists()
     assert not layout.current.exists()
@@ -1717,7 +1734,7 @@ def test_system_config_is_owned_by_service_identity_without_ordering_dependency(
         config_path=config_path,
         release_python=Path(sys.executable),
         health_socket_path=config_path.parent / "health.sock",
-        service_profile=SystemdServiceProfile.system("ori"),
+        service_profile=SystemdServiceProfile.system(),
     )
 
     assert ownership == [(991, 992)]
@@ -1919,7 +1936,8 @@ def test_failed_shebang_repair_leaves_no_orphan_release(
         _install(layout, "2.3.1")
 
     assert not layout.release("2.3.1").exists()
-    assert list(layout.releases.iterdir()) == []
+    assert not layout.releases.exists()
+    assert not layout.root.exists()
     assert not layout.current.exists()
 
 
@@ -2089,3 +2107,536 @@ def test_long_path_sh_wrapper_form_is_rebound(tmp_path: Path) -> None:
     # Not executed here: the stand-in interpreter is a /bin/sh symlink, so the
     # re-exec would recurse. Real execution of this form is covered by the six
     # packaged commands in the wheel-installed test.
+
+
+# --- the system service account -------------------------------------------
+
+
+def _absent_account(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda name: (_ for _ in ()).throw(KeyError(name)),
+    )
+
+
+def test_account_creation_requires_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    _absent_account(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+    with pytest.raises(LinuxInstallError, match="requires root") as error:
+        ensure_service_account(SystemdServiceProfile.system(), unattended=True)
+
+    # The operator gets the command, not just the diagnosis.
+    assert "useradd" in error.value.detail
+    assert "--scope user" in error.value.detail
+
+
+def test_account_creation_without_useradd_names_the_manual_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _absent_account(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr("ori.installer.linux._trusted_useradd", lambda: None)
+
+    with pytest.raises(LinuxInstallError, match="useradd is not available") as error:
+        ensure_service_account(SystemdServiceProfile.system(), unattended=True)
+
+    assert "sudo useradd --system --no-create-home" in error.value.detail
+
+
+def test_declining_account_creation_stops_the_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """ "No" means do not change my system — never "continue without it".
+
+    Proceeding would produce a unit whose User= does not exist, which fails at
+    service start rather than here, where the remedy is still in front of you.
+    """
+    _absent_account(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux._trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("must not create an account after a refusal"),
+    )
+
+    with pytest.raises(LinuxInstallError, match="is required for a system") as error:
+        ensure_service_account(
+            SystemdServiceProfile.system(),
+            unattended=False,
+            prompt=lambda _p: "n",
+            write=lambda _s: None,
+        )
+
+    assert "sudo useradd" in error.value.detail
+
+
+def test_account_creation_is_confirmed_against_the_account_not_the_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A zero exit is the tool's opinion; the account is the fact.
+
+    Believing the exit code defers the failure to service start, by which point
+    the installation looks complete.
+    """
+    _absent_account(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux._trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda command: subprocess.CompletedProcess(list(command), 0, "", ""),
+    )
+
+    with pytest.raises(LinuxInstallError, match="could not create"):
+        ensure_service_account(SystemdServiceProfile.system(), unattended=True)
+
+
+def test_user_scope_never_touches_system_accounts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("user scope must not create an account"),
+    )
+
+    assert (
+        ensure_service_account(SystemdServiceProfile.user(), unattended=True) is False
+    )
+
+
+def test_an_existing_account_is_adopted_without_being_touched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Adopting an identity is not licence to reshape it.
+
+    Every precondition for creating one is satisfied here — root, useradd
+    present, unattended — so the only thing standing between this call and a
+    `useradd` invocation is the account already existing.
+    """
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda name: SimpleNamespace(pw_name=name, pw_uid=4242, pw_gid=4242),
+    )
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux._trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("an existing account must not be modified"),
+    )
+
+    created = ensure_service_account(
+        SystemdServiceProfile.system(),
+        unattended=True,
+        write=lambda _s: None,
+    )
+
+    assert created is False
+
+
+def test_cleanup_removes_every_empty_directory_it_created(tmp_path: Path) -> None:
+    """One surviving directory must not strand its empty siblings.
+
+    A failure that leaves an operator's config in `data/` should still take the
+    empty `releases/` with it; the root then stays because it genuinely still
+    holds something.
+    """
+    root = tmp_path / "ori"
+    releases, data = root / "releases", root / "data"
+    for directory in (root, releases, data):
+        directory.mkdir()
+    (data / "ori.yaml").write_text("device: {}\n", encoding="utf-8")
+
+    installer_linux._remove_created_scaffolding([root, releases, data])
+
+    assert not releases.exists()
+    assert data.exists(), "operator data must never be removed by cleanup"
+    assert root.exists(), "a root still holding data must stay"
+
+
+def test_an_existing_account_with_uid_zero_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An `ori-runtime` that resolves to root defeats the point of system scope.
+
+    Doctor rejects uid 0, but only once the unit is installed and started — by
+    which time the service has already run as root. Name resolution alone is
+    not evidence that an account is unprivileged.
+    """
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda name: SimpleNamespace(pw_name=name, pw_uid=0, pw_gid=0),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("nothing may be built on a root-owned identity"),
+    )
+
+    with pytest.raises(LinuxInstallError, match="uid 0") as error:
+        ensure_service_account(SystemdServiceProfile.system(), unattended=True)
+
+    assert "--scope user" in error.value.detail
+
+
+def test_a_created_account_is_verified_to_be_unprivileged(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The check after creation must prove the same property as the one before.
+
+    A host tool that hands back uid 0 satisfies "the name now resolves" while
+    producing exactly the account system scope exists to avoid.
+    """
+    state = {"created": False}
+
+    def getpwnam(name: str) -> object:
+        if not state["created"]:
+            raise KeyError(name)
+        return SimpleNamespace(pw_name=name, pw_uid=0, pw_gid=0)
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr("ori.installer.linux.pwd.getpwnam", getpwnam)
+    monkeypatch.setattr(
+        "ori.installer.linux._trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+
+    def useradd(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        state["created"] = True
+        return subprocess.CompletedProcess(list(command), 0, "", "")
+
+    monkeypatch.setattr("ori.installer.linux._run_account_command", useradd)
+
+    with pytest.raises(LinuxInstallError, match="uid 0"):
+        ensure_service_account(
+            SystemdServiceProfile.system(), unattended=True, write=lambda _s: None
+        )
+
+
+def test_useradd_is_never_taken_from_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """This runs as root, so `PATH` must not decide what is executed.
+
+    A writable directory ahead of the system ones on root's `PATH` would
+    otherwise choose the binary, and the installer would run it with full
+    privilege.
+    """
+    attacker = tmp_path / "bin"
+    attacker.mkdir()
+    planted = attacker / "useradd"
+    planted.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    planted.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{attacker}:/usr/sbin:/sbin")
+
+    resolved = installer_linux._trusted_useradd()
+
+    assert resolved != str(planted)
+    assert resolved is None or resolved in installer_linux._USERADD_LOCATIONS
+
+
+@pytest.mark.parametrize(
+    ("uid", "mode", "trusted", "why"),
+    [
+        (0, 0o755, True, "root-owned and writable only by root"),
+        (0, 0o775, False, "group-writable, so not only root could have put it there"),
+        (0, 0o757, False, "world-writable"),
+        (1000, 0o755, False, "owned by somebody other than root"),
+        (1000, 0o700, False, "unwritable by others, but still not root's"),
+    ],
+)
+def test_a_useradd_is_trusted_only_when_root_alone_could_have_placed_it(
+    monkeypatch: pytest.MonkeyPatch, uid: int, mode: int, trusted: bool, why: str
+) -> None:
+    """Each condition is isolated, so one guard cannot cover for the other.
+
+    A root-owned but group-writable binary and a well-permissioned one owned by
+    somebody else are both substitutions; a test that only supplies files
+    failing on both counts passes whichever guard is removed.
+    """
+    candidate = "/usr/sbin/useradd"
+    monkeypatch.setattr(
+        installer_linux, "_USERADD_LOCATIONS", (candidate,), raising=True
+    )
+    monkeypatch.setattr(
+        installer_linux.os,
+        "stat",
+        lambda path, **_kwargs: SimpleNamespace(
+            st_mode=stat.S_IFREG | mode, st_uid=uid
+        ),
+    )
+    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
+
+    resolved = installer_linux._trusted_useradd()
+
+    assert (resolved == candidate) is trusted, why
+
+
+_ROOT_DIR = (stat.S_IFDIR | 0o755, 0)
+_SAFE_BINARY = (stat.S_IFREG | 0o755, 0)
+
+
+def _fake_filesystem(
+    monkeypatch: pytest.MonkeyPatch,
+    entries: dict[str, tuple[int, int]],
+    *,
+    realpath: dict[str, str] | None = None,
+) -> None:
+    """Install a synthetic tree so each ancestor's mode can be stated exactly.
+
+    Real directories cannot be used: the cases that matter are root-owned ones,
+    and creating those needs root, which the suite must not require.
+    """
+
+    def lookup(path: object, **_kwargs: object) -> SimpleNamespace:
+        key = str(path)
+        if key not in entries:
+            raise FileNotFoundError(key)
+        mode, uid = entries[key]
+        return SimpleNamespace(st_mode=mode, st_uid=uid)
+
+    monkeypatch.setattr(installer_linux.os, "lstat", lookup)
+    monkeypatch.setattr(installer_linux.os, "stat", lookup)
+    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        installer_linux.os.path,
+        "realpath",
+        lambda path: (realpath or {}).get(str(path), str(path)),
+    )
+    monkeypatch.setattr(
+        installer_linux, "_USERADD_LOCATIONS", ("/usr/sbin/useradd",), raising=True
+    )
+
+
+def test_a_useradd_under_root_controlled_directories_is_trusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The safe case, so the unsafe ones below are not passing by accident."""
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": _SAFE_BINARY,
+        },
+    )
+
+    assert installer_linux._trusted_useradd() == "/usr/sbin/useradd"
+
+
+@pytest.mark.parametrize(
+    ("parent", "why"),
+    [
+        ((stat.S_IFDIR | 0o775, 0), "group-writable parent"),
+        ((stat.S_IFDIR | 0o777, 0), "world-writable parent"),
+        ((stat.S_IFDIR | 0o755, 1000), "parent owned by another account"),
+    ],
+)
+def test_a_useradd_beneath_an_unsafe_parent_is_not_trusted(
+    monkeypatch: pytest.MonkeyPatch, parent: tuple[int, int], why: str
+) -> None:
+    """Replacing a file needs write on its directory, not on the file.
+
+    The executable here is impeccable — regular, root-owned, 0755. Judging it
+    alone would call an account that can rename it out from under the installer
+    trustworthy.
+    """
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": parent,
+            "/usr/sbin/useradd": _SAFE_BINARY,
+        },
+    )
+
+    assert installer_linux._trusted_useradd() is None, why
+
+
+def test_an_unsafe_grandparent_is_caught_as_well(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Control has to hold the whole way down, not just at the last step."""
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": (stat.S_IFDIR | 0o777, 0),
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": _SAFE_BINARY,
+        },
+    )
+
+    assert installer_linux._trusted_useradd() is None
+
+
+def test_a_root_owned_symlink_component_does_not_disqualify_a_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`/sbin` is a link into `/usr/sbin` on any usr-merged distribution.
+
+    Linux reports every symlink as 0777, so testing a link component for
+    group-writability refuses the ordinary layout of the hosts this installer
+    targets. What protects the link is the directory holding it, which the walk
+    has already checked.
+    """
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/sbin": (stat.S_IFLNK | 0o777, 0),
+            "/sbin/useradd": _SAFE_BINARY,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": _SAFE_BINARY,
+        },
+    )
+    monkeypatch.setattr(
+        installer_linux, "_USERADD_LOCATIONS", ("/sbin/useradd",), raising=True
+    )
+
+    assert installer_linux._trusted_useradd() == "/sbin/useradd"
+
+
+def test_a_symlink_component_owned_by_another_account_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Ownership still counts, even where the mode bits do not."""
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/sbin": (stat.S_IFLNK | 0o777, 1000),
+            "/sbin/useradd": _SAFE_BINARY,
+        },
+    )
+    monkeypatch.setattr(
+        installer_linux, "_USERADD_LOCATIONS", ("/sbin/useradd",), raising=True
+    )
+
+    assert installer_linux._trusted_useradd() is None
+
+
+def test_a_symlink_landing_under_an_unsafe_directory_is_not_trusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A safe name may still resolve somewhere anyone can rewrite.
+
+    Every component of the written path is root-controlled here; the target's
+    directory is not, so where it lands has to be checked too.
+    """
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": (stat.S_IFLNK | 0o777, 0),
+            "/opt": (stat.S_IFDIR | 0o777, 0),
+            "/opt/useradd": _SAFE_BINARY,
+        },
+        realpath={"/usr/sbin/useradd": "/opt/useradd"},
+    )
+
+    assert installer_linux._trusted_useradd() is None
+
+
+def test_a_useradd_that_is_not_a_regular_file_is_not_trusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A directory or device in that position is not a binary to execute."""
+    monkeypatch.setattr(
+        installer_linux, "_USERADD_LOCATIONS", ("/usr/sbin/useradd",), raising=True
+    )
+    monkeypatch.setattr(
+        installer_linux.os,
+        "stat",
+        lambda path, **_kwargs: SimpleNamespace(st_mode=stat.S_IFDIR | 0o755, st_uid=0),
+    )
+    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
+
+    assert installer_linux._trusted_useradd() is None
+
+
+def test_a_hung_useradd_reports_a_stable_code_without_a_traceback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`TimeoutExpired` is a SubprocessError, not an OSError.
+
+    Left uncaught it travels past `main`, which maps only the installer's own
+    error types, and reaches the operator as a traceback carrying no remedy.
+    """
+    _absent_account(monkeypatch)
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        installer_linux, "_trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+
+    def hangs(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(list(command), 30)
+
+    with pytest.raises(LinuxInstallError) as error:
+        ensure_service_account(
+            SystemdServiceProfile.system(), unattended=True, runner=hangs
+        )
+
+    assert error.value.code == "service_start_failed"
+    assert "timed out" in error.value.detail
+    assert "sudo useradd" in error.value.detail
+
+
+def test_a_partially_created_scaffolding_is_still_cleaned_up(
+    tmp_path: Path,
+) -> None:
+    """Cleanup must know about directories made before the failing one.
+
+    A pre-existing root with an unsafe `data` creates `releases/` and then
+    raises. Recording the created directories only after the last one would
+    leave that `releases/` behind with nothing aware it had been made.
+    """
+    root = tmp_path / "ori"
+    root.mkdir(mode=0o700)
+    (tmp_path / "elsewhere").mkdir()
+    (root / "data").symlink_to(tmp_path / "elsewhere")
+    layout = InstallLayout.resolve(root)
+
+    with pytest.raises(LinuxInstallError, match="symlink"):
+        install_release(
+            layout=layout,
+            version="2.4.0-rc.4",
+            prepare=lambda _p: None,
+            validate=lambda _p: None,
+            restart_service=lambda: None,
+            stop_service=lambda: None,
+            check_health=lambda _p: None,
+        )
+
+    assert not (root / "releases").exists()
+    assert root.exists(), "a root this run did not create must never be removed"
+
+
+def test_uninstall_leaves_the_service_account_in_place(tmp_path: Path) -> None:
+    """Files outside the install root may belong to it, and uids get reused.
+
+    Asserted by running the uninstall rather than by reading it: a check that
+    the source does not contain "userdel" passes just as happily when the
+    removal moves behind a helper with another name.
+    """
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    (layout.releases / "2.4.0-rc.4").mkdir()
+    layout.data.mkdir(parents=True, exist_ok=True)
+    account_commands: list[Sequence[str]] = []
+
+    with mock.patch.object(
+        installer_linux, "_run_account_command", side_effect=account_commands.append
+    ):
+        uninstall_runtime(layout=layout, stop_service=lambda: None)
+
+    assert account_commands == []
+    assert not layout.releases.exists()

--- a/tests/test_linux_installer_cli.py
+++ b/tests/test_linux_installer_cli.py
@@ -12,6 +12,7 @@ import os
 import subprocess
 import sys
 import textwrap
+from collections.abc import Sequence
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -280,23 +281,187 @@ def test_workspace_failure_maps_to_stable_archive_error(
     )
 
 
-def test_user_scope_rejects_service_user_before_verification(
+def test_a_different_service_account_name_is_refused(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    """One name, everywhere — it is not a per-host choice.
+
+    A configurable account would have to be carried by the unit file, the
+    permission checks and the documentation, any of which could then disagree
+    with the others about who the runtime is.
+    """
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
     monkeypatch.setattr(
         cli,
         "load_release_key_registry",
         lambda _path: pytest.fail("verification must not begin"),
     )
-    args = [*_install_args(tmp_path), "--service-user", "ori-runtime"]
+    args = [*_system_install_args(tmp_path), "--service-user", "somebody-else"]
 
     with pytest.raises(SystemExit) as error:
         cli.main(args)
 
     assert error.value.code == 2
-    assert "--service-user is valid only for system scope" in capsys.readouterr().err
+    message = capsys.readouterr().err
+    assert "always ori-runtime" in message
+    assert "cannot be renamed" in message
+
+
+def test_the_canonical_service_account_name_is_still_accepted() -> None:
+    """A script that already passes the documented default keeps working.
+
+    The flag shipped in v2.3.0, and what the installer's compatibility promise
+    protects is the meaning of a flag an operator already wrote. Omitting it and
+    passing the canonical name resolve to the same profile.
+    """
+    explicit = cli._profile("system", "ori-runtime")
+    omitted = cli._profile("system", None)
+
+    assert explicit == omitted
+    assert explicit.service_user == "ori-runtime"
+
+
+def test_a_service_user_on_user_scope_is_refused() -> None:
+    """User units have no `User=`, so naming an account there means something
+    the installation cannot honour — silently ignoring it would produce a user
+    install the operator believes runs as somebody else."""
+    with pytest.raises(LinuxInstallError, match="only for system scope"):
+        cli._profile("user", "ori-runtime")
+
+
+def test_a_renamed_service_account_is_refused_at_the_profile() -> None:
+    with pytest.raises(LinuxInstallError, match="cannot be renamed"):
+        cli._profile("system", "somebody-else")
+
+
+@pytest.mark.skipif(
+    Path("/etc").resolve() != Path("/etc"),
+    reason="system scope resolves /etc, which is not canonical on this host",
+)
+def test_the_account_is_created_after_verification_and_before_the_build(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Creating an account is a durable host change, so it waits its turn.
+
+    An unsigned or tampered bundle must not be able to leave an account behind,
+    and confirmation promises that nothing has been changed yet — so creation
+    follows verification and the operator's agreement. It precedes the packages,
+    the bundle being opened and the environment being built, so a host that
+    cannot provide the account is not discovered after minutes of work, and a
+    declined account has not already cost an OS package install.
+    """
+    calls: list[str] = []
+    accounts = {"exists": False}
+
+    def getpwnam(name: str) -> object:
+        if accounts["exists"]:
+            return SimpleNamespace(pw_name=name, pw_uid=4242, pw_gid=4242)
+        raise KeyError(name)
+
+    def useradd(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        calls.append("account")
+        accounts["exists"] = True
+        return subprocess.CompletedProcess(list(command), 0, "", "")
+
+    def verify(**_kwargs: object) -> object:
+        calls.append("verify")
+        return SimpleNamespace(runtime_version="2.4.0-rc.4")
+
+    original_collect = cli.collect_installer_config
+
+    def collect(options: object, **channel: object) -> object:
+        calls.append("collect")
+        return original_collect(options, **channel)  # type: ignore[arg-type]
+
+    def extract(_verified: object, *, destination: Path) -> object:
+        calls.append("extract")
+        raise LinuxInstallError("offline_install_failed", "stop before building")
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        cli, "detected_release_target", lambda: "linux-x86_64-python3.12"
+    )
+    monkeypatch.setattr(cli, "load_release_key_registry", lambda _p: {"k": object()})
+    monkeypatch.setattr(cli, "verify_release_bundle", verify)
+    monkeypatch.setattr(cli, "collect_installer_config", collect)
+    monkeypatch.setattr(cli, "extract_verified_bundle", extract)
+    monkeypatch.setattr("ori.installer.linux.pwd.getpwnam", getpwnam)
+    monkeypatch.setattr(
+        "ori.installer.linux._trusted_useradd", lambda: "/usr/sbin/useradd"
+    )
+    monkeypatch.setattr("ori.installer.linux._run_account_command", useradd)
+    monkeypatch.setattr(
+        cli.prerequisites,
+        "ensure",
+        lambda **_kwargs: calls.append("prerequisites") or [],
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(_system_install_args(tmp_path))
+
+    # The account precedes the packages: it is the change an operator is most
+    # likely to decline, and declining it ends the run. Asking afterwards would
+    # mean packages had been installed for an installation that never finished.
+    assert calls == ["verify", "collect", "account", "prerequisites", "extract"]
+
+
+@pytest.mark.skipif(
+    Path("/etc").resolve() != Path("/etc"),
+    reason="system scope resolves /etc, which is not canonical on this host",
+)
+def test_an_unsigned_bundle_leaves_no_account_behind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected bundle must not mutate the host.
+
+    System scope, because that is the only scope with an account to create: a
+    user-scope run would pass this trivially without ever reaching the code
+    under test.
+    """
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda name: (_ for _ in ()).throw(KeyError(name)),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("an unverified bundle must not create an account"),
+    )
+    monkeypatch.setattr(
+        cli,
+        "verify_release_bundle",
+        lambda **_k: (_ for _ in ()).throw(
+            ReleaseBundleError("untrusted_release_key", "not signed by a known key")
+        ),
+    )
+
+    with pytest.raises(SystemExit):
+        cli.main(_system_install_args(tmp_path))
+
+
+def _system_install_args(tmp_path: Path) -> list[str]:
+    return [
+        "install",
+        "--bundle",
+        str(tmp_path / "bundle.tar.gz"),
+        "--signature",
+        str(tmp_path / "bundle.tar.gz.sig"),
+        "--root",
+        str(tmp_path / "ori"),
+        "--scope",
+        "system",
+        "--unattended",
+        "--device-id",
+        "ori-01",
+        "--name",
+        "Office",
+        "--location",
+        "Lagos",
+    ]
 
 
 def test_uninstall_disables_unit_before_removing_release(

--- a/tests/test_ori_cli.py
+++ b/tests/test_ori_cli.py
@@ -1134,6 +1134,8 @@ def test_every_exposed_option_is_forwarded(tmp_path: Path) -> None:
         ("--location", "Lagos"),
         ("--deployment-type", "server"),
         ("--operator-contact", "ops@example.com"),
+        # Still exposed and still forwarded; dropping it here would let the two
+        # sides drift apart unnoticed.
         ("--service-user", "ori-runtime"),
         ("--root", "/opt/ori"),
     ):


### PR DESCRIPTION
## What does this PR do?

v2.4.0 introduced a mandatory `permissions.code` check proving the service cannot rewrite the code it executes, and applied it to both scopes. **Only system scope can hold that property** — the code is root-owned and the service runs as an unprivileged account that can neither write it nor change its mode. Under user scope the release and the runtime share one Unix owner, so **every user-scope install of v2.4.0 failed its own post-install diagnostics and rolled back.**

### Sealing the tree was rejected as the fix

It makes the check quiet without making it true: an owner may `chmod` its own files, so a compromised runtime can restore write access to the code it is about to execute. The bits describe the current state, not a boundary. Sealing also breaks removal — a read-only directory cannot have its entries unlinked — converting a clean `post_install_health_failed` into `rollback_failed`, the error that actually leaves debris.

`permissions.code` is now **mandatory for system scope** and an **explicit warning under user scope**: a complete, usable installation that lacks privilege separation and says so. An unrecognised scope is refused outright rather than given the benefit of the user-scope advisory.

## The service account

The name is a constant. A configurable one has to be carried by the unit file, the permission checks, the diagnostics and the documentation — each a place it can disagree with the others, and the resulting failure appears at service start rather than at install. `--service-user` is retained and accepts that one name, because an explicit flag an operator already wrote is what the installer's compatibility promise protects (`DECISIONS.md`, 2026-08-17).

The installer creates the account when absent, as a distribution package does:

| Property | Behaviour |
|---|---|
| Ordering | After bundle verification and operator confirmation — an unsigned bundle can never leave an account behind |
| | Before prerequisite packages — the account is the change most likely to be declined, and declining ends the run |
| | Before the virtual environment — a host that cannot provide it is not discovered after minutes of building |
| Existing account | Adopted exactly as found; group, home and shell never modified |
| uid 0 | Refused before anything is prepared or started, and re-proved after creation |
| Uninstall | Never removes it — files elsewhere may belong to it, and uids get reused |

### Resolving `useradd`

This runs as root, so `PATH` is never consulted. The binary comes from fixed system locations and must be a regular, executable, root-owned file that no one but root can write.

Its own permissions do not settle it: replacing a file needs write on its **directory**. Every ancestor is therefore checked too — on the **literal** path, so a writable directory cannot redirect the name, and on the **resolved** path, so a symlink cannot land somewhere its own parents are open. Neither implies the other.

A root-owned symlink component is judged on ownership rather than mode, which Linux always reports as `0777`, so the ordinary usr-merged `/sbin` → `/usr/sbin` layout stays supported.

A hung `useradd` maps to `service_start_failed` with the manual command. `TimeoutExpired` is a `SubprocessError`, not an `OSError`, and would otherwise travel past `main` and reach the operator as a traceback carrying no remedy.

## Also fixed

| | |
|---|---|
| **Interpreter discovery** | Probes `python3.12` → `python3.11` → `python3`, asking each for its version rather than trusting its name. A 3.10 default no longer condemns a host with 3.12 installed. |
| **Scope prompt** | `Choose [1]: ` read as a pre-filled value. Enter always accepted the default; the prompt now says `Type 1 or 2. Press Enter to accept 1 (system).` |
| **Scaffolding** | Directories are recorded as they are created and unwound in reverse while empty, so a partial failure cannot strand one, a surviving sibling cannot block the others, and a pre-existing root is never touched. |

Resumable installs were declined: a retry starts a fresh transaction rather than inferring that partial state is trustworthy. The cost that motivated the request — rebuilding the environment — is removed by failing before it is built.

## Why it shipped: the doctor was always stubbed

Every test touching post-install diagnostics fed `activation` synthetic check dictionaries, so the real doctor and the real gate had never been run against each other. Now the real permission diagnosis runs against a release **`install_release` itself created**, through the gate the installer itself calls, for both scopes — including that a sealed user-scope tree still warns, so no false immutability claim is available by `chmod`.

## Verification

| | |
|---|---|
| Full suite | 3222 passed, 8 skipped |
| Linux (`python:3.12-slim`), non-root, umask 022 | 412 passed |
| Real `useradd` on a usr-merged host | `/usr/sbin/useradd` trusted; `/sbin/useradd` ancestors valid |
| World-writable parent, real filesystem | refused |
| Symlink at a safe name into a world-writable directory | refused |
| ruff / pre-commit / supply-chain guard / boundary typecheck | clean |

Every behavioural guard was mutation-checked by reverting it individually and confirming a test fails — including each ancestor condition separately, so no guard covers for another.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant

`permissions.code` is a security check and is **not weakened where it is enforceable**: system scope still fails closed, including on unresolved supplementary groups. What changed is that it no longer asserts a guarantee under a scope that cannot provide one. Account creation runs as root and is constrained accordingly.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — installer and diagnostics only. No runtime capability changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] Action tier declarations are unchanged
- [x] No Tier C approval path is bypassed
- [x] No Tier D path routes through an LLM

`ori/doctor.py` and `ori/installer/` are diagnostic and install paths; neither participates in tier dispatch.

## Related issue

Unblocks #273. `v2.4.0-rc.3` assets stay published and are not replaced; `docs/releases/v2.4.0.md` records it as the third failed attempt with what it reached and why. Next candidate is `v2.4.0-rc.4`; packaged version is `2.4.0rc4`.

## Testing notes

A user-scope install now completes carrying a warning that user-scope code cannot be made immutable and that system scope is the production choice. That warning is the correct outcome, not a partial failure. A system-scope install creates `ori-runtime` after confirmation and before packages, and reports a stable failure code with the manual command if it cannot.