### PR TITLE
fix(installer): settle path trust and scope, and prove the release on a host

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,17 @@ jobs:
             --cov-report=xml \
             -m "not hardware"
 
+      # System scope is only meaningful as root: the execution guard returns
+      # immediately for any other account, so an unprivileged run of these
+      # would pass without exercising anything. They assert `geteuid() == 0`
+      # rather than skipping, so a missing privileged invocation fails here
+      # instead of quietly reporting green.
+      - name: System-scope installer checks (root, real venv)
+        run: |
+          sudo -H env ORI_REQUIRE_ROOT_TESTS=1 \
+            "$(which python)" -m pytest \
+            tests/test_installer_system_scope.py -q
+
       - name: Audit pinned Python dependencies
         run: |
           python -m pip_audit -r requirements/runtime.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,17 @@ jobs:
       - name: Run test suite
         run: pytest tests/ -q -m "not hardware"
 
+      # System scope is only meaningful as root: the execution guard returns
+      # immediately for any other account, so an unprivileged run of these
+      # would pass without exercising anything. They assert `geteuid() == 0`
+      # rather than skipping, so a missing privileged invocation fails here
+      # instead of quietly reporting green.
+      - name: System-scope installer checks (root, real venv)
+        run: |
+          sudo -H env ORI_REQUIRE_ROOT_TESTS=1 \
+            "$(which python)" -m pytest \
+            tests/test_installer_system_scope.py -q
+
       - name: Audit pinned Python dependencies
         run: |
           python -m pip_audit -r requirements/runtime.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,8 +211,15 @@ jobs:
       # build-wheelhouse.sh invokes scripts/build_release_bundle.py, which
       # imports ori. `python scripts/x.py` puts scripts/ on sys.path[0], not
       # the repository root, so the package must be importable here.
+      #
+      # The hash-locked set first, because the runtime wheel is built with
+      # `--no-build-isolation`: the build backend that produces the artifact we
+      # sign has to be the pinned one, not whichever setuptools the runner
+      # image happens to ship or pip would fetch at build time.
       - name: Install build dependencies
-        run: python -m pip install --no-deps -e .
+        run: |
+          python -m pip install --require-hashes -r requirements/dev.txt
+          python -m pip install --no-deps -e .
 
       - name: Resolve release identity
         id: identity

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,10 +34,14 @@ repos:
             import pathlib
             import sys
 
-            roots = {"ori", "tests", "skills", "scripts"}
+            # Shell carries the same licence as Python and was never checked,
+            # so four scripts drifted without it. `docs/releases/evidence`
+            # holds executable harnesses, not prose, and belongs here too.
+            roots = {"ori", "tests", "skills", "scripts", "docs"}
             missing = [
                 str(f)
-                for f in pathlib.Path(".").rglob("*.py")
+                for pattern in ("*.py", "*.sh")
+                for f in pathlib.Path(".").rglob(pattern)
                 if f.parts and f.parts[0] in roots
                 and "SPDX-License-Identifier: Apache-2.0" not in f.read_text()
             ]

--- a/docs/linux-install.md
+++ b/docs/linux-install.md
@@ -39,6 +39,15 @@ for a supported one rather than refusing the host: it tries `python3.12`,
 workstation whose default is 3.10 installs normally as long as one of those is
 present. If none is, the installer says so and names what to install.
 
+**System scope additionally requires that interpreter to be one only root can
+change.** The release's environment is built from it and links back to it, so a
+Python installed under pyenv, a home directory, or any other prefix an
+unprivileged account can write would produce a release whose executing code
+that account could replace. The installer checks this before it changes
+anything and stops with the package-manager command if it fails; a distribution
+Python (`sudo apt install python3.12`) satisfies it. User scope is unaffected —
+it never claims code the runtime cannot rewrite.
+
 **Raspberry Pi OS Bullseye is not supported.** It ships OpenSSL 1.1.1, which
 cannot perform the required verification — the installer reports
 `crypto_unavailable` rather than pretending otherwise.
@@ -436,6 +445,19 @@ Scope is never inferred from whether you used `sudo`. If both a user and a
 system installation exist, `ori doctor` refuses to guess and asks for
 `--scope`.
 
+An install root that cannot be read is not treated as one that is absent. A
+system installation leaves `/opt/ori` owned by root with the service account's
+group and mode 0750 — traversable by the runtime, not by an ordinary operator
+account — so inspecting it without privilege gives a permission error rather
+than an answer — including
+after a system install has rolled back and left the directory behind. When one
+installation is definitely present and the other cannot be read, the readable
+one is selected and named in the report; the unreadable one cannot be the
+installation this account is running. When nothing can be established either
+way, the command says so and asks for `--scope`, and reports the path it could
+not inspect. No diagnostic command ends in a traceback because of a filesystem
+permission.
+
 ---
 
 ## Boot persistence
@@ -557,7 +579,7 @@ stable and defined by `ori-specs/runtime-release-bundle/v1`.
 
 | Code | Meaning |
 | --- | --- |
-| `unsupported_target` | Not Linux, or an unsupported architecture or Python version |
+| `unsupported_target` | Not Linux, or an unsupported architecture or Python version, or — for `--scope system` — a supported Python whose installation path is not root-controlled |
 | `crypto_unavailable` | OpenSSL is missing or older than 3 — not a bad signature |
 | `untrusted_release_key` | The bundle names a key that is not the pinned release key |
 | `invalid_signature_envelope` | The detached signature is malformed |

--- a/docs/releases/evidence/build-local-artifact.sh
+++ b/docs/releases/evidence/build-local-artifact.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+#
+# Build and development-sign a release artifact from a named commit.
+#
+# The artifact this produces is behaviourally the one the release workflow would
+# build from the same commit, with the trust anchor substituted. It is not
+# byte-identical: the packaged key registry is part of the source, so replacing
+# it changes the wheel and the bundle as well as the signature. What it
+# reproduces is installation behaviour; what it cannot speak to is signing
+# custody or anything downstream of publication.
+#
+# The production trust root is never modified. The substitution happens inside
+# an extracted copy of the commit under a temporary directory, which is removed
+# when the run ends; the checkout and the installed runtime on this host are
+# untouched.
+#
+# Usage: build-local-artifact.sh <commit> <target> <release-version> [outdir]
+#   e.g. build-local-artifact.sh HEAD linux-x86_64-python3.12 2.4.0-rc.5
+#
+# Prints the values an evidence record has to carry: source commit, archive
+# digest, artifact digest, and the fingerprint of the key that signed it.
+set -euo pipefail
+
+COMMIT="${1:?usage: build-local-artifact.sh <commit> <target> <release-version> [outdir]}"
+TARGET="${2:?target tuple required, e.g. linux-x86_64-python3.12}"
+RELEASE_VERSION="${3:?release version required, e.g. 2.4.0-rc.5}"
+# Resolved before any `cd`. A relative path would otherwise be interpreted from
+# the extracted source inside the temporary tree, and the cleanup trap would
+# delete the artifact this run exists to produce.
+OUTDIR="${4:-$PWD/ori-local-artifact}"
+mkdir -p "$OUTDIR"
+OUTDIR="$(cd "$OUTDIR" && pwd)"
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+FULL_COMMIT="$(git -C "$REPO_ROOT" rev-parse "$COMMIT^{commit}")"
+
+digest_of() {
+    if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -d' ' -f1
+    else shasum -a 256 "$1" | cut -d' ' -f1; fi
+}
+
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/ori-build-XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+SOURCE="$WORKDIR/source"
+mkdir -p "$SOURCE"
+
+# From the commit, not the working tree: an artifact built from uncommitted
+# edits cannot be reproduced by anyone reading the record.
+ARCHIVE="$WORKDIR/source.tar"
+git -C "$REPO_ROOT" archive --format=tar --output="$ARCHIVE" "$FULL_COMMIT"
+ARCHIVE_SHA256="$(digest_of "$ARCHIVE")"
+tar -C "$SOURCE" -xf "$ARCHIVE"
+cd "$SOURCE"
+
+# --- the target tuple is a claim about this machine, so prove it ------------
+# `$TARGET` otherwise only labels the artifact: a 3.10 build on x86_64 would
+# happily be named python3.12-aarch64, and nothing downstream would notice
+# until the bundle failed on a device.
+TUPLE_ARCH="$(printf '%s' "$TARGET" | cut -d- -f2)"
+TUPLE_PYTHON="$(printf '%s' "$TARGET" | sed 's/.*python//')"
+case "$TARGET" in
+    linux-x86_64-python3.1[12]|linux-aarch64-python3.1[12]) ;;
+    *) echo "unsupported target tuple: $TARGET" >&2; exit 1 ;;
+esac
+
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+    x86_64|amd64) HOST_ARCH=x86_64 ;;
+    aarch64|arm64) HOST_ARCH=aarch64 ;;
+esac
+[ "$HOST_ARCH" = "$TUPLE_ARCH" ] \
+    || { echo "target says $TUPLE_ARCH, this machine is $HOST_ARCH" >&2; exit 1; }
+
+# The exact interpreter the tuple names, not the host default.
+BUILD_PYTHON="$(command -v "python$TUPLE_PYTHON" || true)"
+[ -n "$BUILD_PYTHON" ] \
+    || { echo "target needs python$TUPLE_PYTHON; not on PATH" >&2; exit 1; }
+BUILD_PYTHON_VERSION="$("$BUILD_PYTHON" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+[ "$BUILD_PYTHON_VERSION" = "$TUPLE_PYTHON" ] \
+    || { echo "python$TUPLE_PYTHON reports $BUILD_PYTHON_VERSION" >&2; exit 1; }
+
+# The version under test must be the version this commit declares. Run with
+# the interpreter the tuple names: the host default may be older than the
+# source supports, and failing there says nothing about the release.
+"$BUILD_PYTHON" - "$RELEASE_VERSION" <<'PYIDENT'
+import pathlib
+import sys
+import tomllib
+
+sys.path.insert(0, ".")
+from ori.security.release_bundles import ReleaseBundleError, distribution_version
+
+requested = sys.argv[1]
+declared = tomllib.loads(
+    pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
+)["project"]["version"]
+try:
+    expected = distribution_version(requested)
+except ReleaseBundleError as exc:
+    sys.exit(f"{requested} is not a canonical release identity: {exc.detail}")
+if expected != declared:
+    sys.exit(f"{requested} needs pyproject version {expected!r}, found {declared!r}")
+PYIDENT
+
+"$BUILD_PYTHON" -m venv "$WORKDIR/venv" >/dev/null
+# Hash-locked, from the same development requirements CI installs. Live PyPI
+# resolution would put unpinned code into the tooling that signs the artifact.
+"$WORKDIR/venv/bin/pip" install --quiet --require-hashes \
+    -r "$SOURCE/requirements/dev.txt" >/dev/null
+"$WORKDIR/venv/bin/pip" install --quiet --no-deps -e . >/dev/null
+PY="$WORKDIR/venv/bin/python"
+
+# --- ephemeral signing key, and the trust root that accepts it --------------
+KEY="$WORKDIR/dev-key.pem"
+"$PY" - "$KEY" "$SOURCE" <<'PYKEY'
+import base64
+import hashlib
+import json
+import pathlib
+import sys
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import (
+    Encoding,
+    NoEncryption,
+    PrivateFormat,
+    PublicFormat,
+)
+
+key_path, source = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+key = Ed25519PrivateKey.generate()  # ephemeral; never a release key
+key_path.write_bytes(
+    key.private_bytes(Encoding.PEM, PrivateFormat.PKCS8, NoEncryption())
+)
+public = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+encoded = base64.b64encode(public).decode()
+
+# Only in the extracted copy: the checkout's trust root is not touched.
+registry = source / "ori" / "installer" / "release-keys.json"
+document = json.loads(registry.read_text())
+for entry in document["keys"]:
+    entry["public_key_b64"] = encoded
+registry.write_text(json.dumps(document, indent=2, sort_keys=True) + "\n")
+print(f"sha256:{hashlib.sha256(public).hexdigest()}")
+PYKEY
+KEY_FINGERPRINT="$("$PY" -c "
+import base64, hashlib
+from cryptography.hazmat.primitives.serialization import load_pem_private_key, Encoding, PublicFormat
+key = load_pem_private_key(open('$KEY','rb').read(), password=None)
+raw = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+print('sha256:' + hashlib.sha256(raw).hexdigest())
+")"
+chmod 600 "$KEY"
+
+# --- build, then sign -------------------------------------------------------
+ORI_PYTHON="$PY" \
+ORI_WHEELHOUSE_OUT="$WORKDIR/wheelhouse" ORI_WHEELHOUSE_TARGET=generic \
+ORI_RELEASE_BUNDLE_VERSION="$RELEASE_VERSION" ORI_RELEASE_BUNDLE_TARGET="$TARGET" \
+ORI_RELEASE_BUNDLE_OUT="$WORKDIR/bundle" \
+SOURCE_DATE_EPOCH="$(git -C "$REPO_ROOT" show -s --format=%ct "$FULL_COMMIT")" \
+    bash scripts/build-wheelhouse.sh >"$WORKDIR/build.log" 2>&1 \
+    || { tail -20 "$WORKDIR/build.log" >&2; exit 1; }
+
+ARTIFACT_NAME="ori-runtime-$RELEASE_VERSION-$TARGET.tar.gz"
+ARTIFACT="$WORKDIR/bundle/$ARTIFACT_NAME"
+[ -f "$ARTIFACT" ] || { echo "bundle not produced: $ARTIFACT" >&2; exit 1; }
+
+"$PY" scripts/sign-release-bundle.py \
+    --artifact "$ARTIFACT" \
+    --runtime-version "$RELEASE_VERSION" --target "$TARGET" \
+    --key-id ori-runtime-release-2026-01 \
+    --key-registry "$SOURCE/ori/installer/release-keys.json" \
+    --private-key-file "$KEY" \
+    --output "$ARTIFACT.signature.json" >/dev/null
+
+cp "$ARTIFACT" "$ARTIFACT.signature.json" "$OUTDIR/"
+cp "$SOURCE/ori/installer/release-keys.json" "$OUTDIR/release-keys.dev.json"
+
+cat <<SUMMARY
+=== LOCAL ARTIFACT ===
+  source commit     $FULL_COMMIT
+  archive sha256    $ARCHIVE_SHA256
+  release version   $RELEASE_VERSION
+  target            $TARGET
+  build interpreter $BUILD_PYTHON ($BUILD_PYTHON_VERSION on $HOST_ARCH)
+  artifact          $OUTDIR/$ARTIFACT_NAME
+  artifact sha256   $(digest_of "$ARTIFACT")
+  signature         $OUTDIR/$ARTIFACT_NAME.signature.json
+  dev key           $KEY_FINGERPRINT  (ephemeral, discarded with this run)
+  reproduce with    git archive --format=tar $FULL_COMMIT | sha256sum
+
+  This artifact is development-signed. It proves nothing about KMS custody,
+  the production trust root, publication, or authenticated download.
+SUMMARY

--- a/docs/releases/evidence/harness-linux-functional.sh
+++ b/docs/releases/evidence/harness-linux-functional.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
 # trust-substituted pre-publication functional evidence harness.
 #
 # Every claim below is an assertion. A claim that cannot be proven fails the
@@ -15,13 +17,17 @@
 # enforcement, published asset completeness, or publication reverification.
 set -euo pipefail
 
-HARNESS_REVISION="7"
-TARGET="${1:?usage: harness-linux-functional.sh <target> <commit> <archive> <sha256> <distro>}"
+HARNESS_REVISION="8"
+TARGET="${1:?usage: harness-linux-functional.sh <target> <commit> <archive> <sha256> <distro> <release-version>}"
 EXPECTED_COMMIT="${2:?expected source commit required}"
 ARCHIVE="${3:?source archive required (git archive --format=tar)}"
 ARCHIVE_SHA256="${4:?expected archive sha256 required}"
 EXPECTED_DISTRO="${5:?expected distro required, e.g. debian:12}"
-VERSION="${ORI_EVIDENCE_VERSION:-2.3.1}"
+# The release identity under test, in the SemVer form the signed artifact uses
+# (2.4.0, or 2.4.0-rc.5). There is no default: a stale one proves the wrong
+# release while looking like a pass, and this harness is meant to serve every
+# release rather than be copied for each one.
+RELEASE_VERSION="${6:?release version required, e.g. 2.4.0-rc.5}"
 WORK=/work
 BLOCKED=0
 
@@ -105,9 +111,12 @@ actual_python="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.v
             "tuple says $tuple_python, interpreter is $actual_python"
 pass "python $(python3 -V 2>&1 | cut -d' ' -f2) matches the tuple"
 
-# Read in a subshell: /etc/os-release defines VERSION, which would otherwise
-# clobber this harness's VERSION and be built into the bundle as the runtime
-# version. (It did exactly that on the first revision 5 run.)
+# Read in a subshell. /etc/os-release defines VERSION, which this harness once
+# used for the release identity — the distro's version was built into a bundle
+# as the runtime version on the first revision 5 run. The variable is now
+# RELEASE_VERSION, so the collision cannot recur; the subshell stays because
+# sourcing a file into the current shell to read two fields is still a way to
+# inherit whatever else it sets.
 # shellcheck source=/dev/null
 actual_distro="$(. /etc/os-release && echo "${ID:-unknown}:${VERSION_ID:-unknown}")"
 # shellcheck source=/dev/null
@@ -118,12 +127,49 @@ pretty_name="$(. /etc/os-release && echo "${PRETTY_NAME:-unknown}")"
 pass "distribution $actual_distro ($pretty_name)"
 
 printf '  harness revision %s, target %s\n' "$HARNESS_REVISION" "$TARGET"
+printf '  release version %s\n' "$RELEASE_VERSION"
 
 apt-get update -qq >/dev/null 2>&1
 apt-get install -y -qq python3-pip python3-venv >/dev/null 2>&1
 mkdir -p "$WORK" && tar -C "$WORK" -xf "$ARCHIVE"
 cd "$WORK"
 python3 -m pip install --quiet --break-system-packages cryptography pyyaml >/dev/null 2>&1
+
+# --- the version under test must be the version this source declares -------
+# A harness that serves every release can be pointed at the wrong one, and the
+# artifact it produced would then carry a name the source never claimed. A tag
+# and a packaged version disagreeing is what spent two release candidates, so
+# it is proven here through the runtime's own conversion rather than a second
+# one written into this script.
+echo "=== RELEASE IDENTITY ==="
+set +e
+identity_check="$(PYTHONPATH="$WORK" python3 - "$RELEASE_VERSION" 2>&1 <<'PYIDENT'
+import pathlib
+import sys
+import tomllib
+
+from ori.security.release_bundles import ReleaseBundleError, distribution_version
+
+requested = sys.argv[1]
+declared = tomllib.loads(
+    pathlib.Path("pyproject.toml").read_text(encoding="utf-8")
+)["project"]["version"]
+try:
+    expected = distribution_version(requested)
+except ReleaseBundleError as exc:
+    sys.exit(f"{requested} is not a canonical release identity: {exc.detail}")
+if expected != declared:
+    sys.exit(
+        f"{requested} needs pyproject version {expected!r}, found {declared!r}"
+    )
+print(f"{requested} matches the packaged version {declared}")
+PYIDENT
+)"
+identity_status=$?
+set -e
+[ "$identity_status" -eq 0 ] \
+    || fail "release version matches the source under test" "$identity_check"
+pass "release identity: $identity_check"
 
 # --- substitute BOTH trust anchors, before building -----------------------
 echo "=== TRUST ANCHOR SUBSTITUTION (before build) ==="
@@ -157,13 +203,19 @@ bootstrap.write_text(text)
 print(f"  ephemeral key sha256:{digest}")
 PY
 chmod 600 /tmp/dev-key.pem
+# The hash-locked set before the wheel is built. `build-wheelhouse.sh` builds
+# the runtime wheel with `--no-build-isolation`, so whatever setuptools is
+# present is the one that produces the artifact: without this the distribution's
+# own setuptools would build a bundle this run then presents as evidence.
+python3 -m pip install --quiet --break-system-packages --require-hashes \
+    -r requirements/dev.txt >/dev/null 2>&1
 python3 -m pip install --quiet --break-system-packages --no-deps -e . >/dev/null 2>&1
 
 # --- determinism: build twice, compare bytes ------------------------------
 echo "=== BUILD ==="
 build_once() {
     ORI_WHEELHOUSE_OUT="$1/wh" ORI_WHEELHOUSE_TARGET=generic \
-    ORI_RELEASE_BUNDLE_VERSION="$VERSION" ORI_RELEASE_BUNDLE_TARGET="$TARGET" \
+    ORI_RELEASE_BUNDLE_VERSION="$RELEASE_VERSION" ORI_RELEASE_BUNDLE_TARGET="$TARGET" \
     ORI_RELEASE_BUNDLE_OUT="$1/bundle" SOURCE_DATE_EPOCH=1700000000 \
         bash scripts/build-wheelhouse.sh >"$1/build.log" 2>&1 \
         || { tail -5 "$1/build.log" >&2; return 1; }
@@ -174,8 +226,8 @@ pass "first bundle build"
 build_once /tmp/b2 || fail "second bundle build" "see build log"
 pass "second bundle build"
 
-ARTIFACT="/tmp/b1/bundle/ori-runtime-$VERSION-$TARGET.tar.gz"
-SECOND="/tmp/b2/bundle/ori-runtime-$VERSION-$TARGET.tar.gz"
+ARTIFACT="/tmp/b1/bundle/ori-runtime-$RELEASE_VERSION-$TARGET.tar.gz"
+SECOND="/tmp/b2/bundle/ori-runtime-$RELEASE_VERSION-$TARGET.tar.gz"
 h1="$(sha256sum "$ARTIFACT" | cut -d' ' -f1)"
 h2="$(sha256sum "$SECOND" | cut -d' ' -f1)"
 [ "$h1" = "$h2" ] || fail "build is deterministic" "sha256 differs: $h1 vs $h2"
@@ -193,7 +245,7 @@ pathlib.Path("/tmp/reg.json").write_text(json.dumps({
               "purpose": RELEASE_KEY_PURPOSE, "status": "active"}]}))
 PY
 python3 scripts/sign-release-bundle.py --artifact "$ARTIFACT" \
-    --runtime-version "$VERSION" --target "$TARGET" \
+    --runtime-version "$RELEASE_VERSION" --target "$TARGET" \
     --key-id ori-runtime-release-2026-01 --key-registry /tmp/reg.json \
     --private-key-file /tmp/dev-key.pem --output "$ARTIFACT.signature.json" \
     >/dev/null 2>&1 || fail "sign final artifact" "signing failed"
@@ -220,17 +272,17 @@ cp scripts/install-linux.sh /tmp/renamed-installer.sh
 chmod +x /tmp/orig.sh /tmp/renamed-installer.sh
 
 DISPATCH_CODE="artifact_integrity_mismatch"
-assert_exit "dispatch: original name exits 2" 2 /tmp/orig.sh --version "$VERSION"
+assert_exit "dispatch: original name exits 2" 2 /tmp/orig.sh --version "$RELEASE_VERSION"
 assert_contains "dispatch: original name stable code" "$DISPATCH_CODE" "$LAST_OUTPUT"
-assert_exit "dispatch: renamed copy exits 2" 2 /tmp/renamed-installer.sh --version "$VERSION"
+assert_exit "dispatch: renamed copy exits 2" 2 /tmp/renamed-installer.sh --version "$RELEASE_VERSION"
 assert_contains "dispatch: renamed copy stable code" "$DISPATCH_CODE" "$LAST_OUTPUT"
-assert_exit "dispatch: absolute path exits 2" 2 bash /tmp/orig.sh --version "$VERSION"
+assert_exit "dispatch: absolute path exits 2" 2 bash /tmp/orig.sh --version "$RELEASE_VERSION"
 assert_contains "dispatch: absolute path stable code" "$DISPATCH_CODE" "$LAST_OUTPUT"
 assert_exit "dispatch: relative path exits 2" 2 \
-    bash -c "cd /tmp && ./orig.sh --version $VERSION"
+    bash -c "cd /tmp && ./orig.sh --version $RELEASE_VERSION"
 assert_contains "dispatch: relative path stable code" "$DISPATCH_CODE" "$LAST_OUTPUT"
 assert_exit "dispatch: piped exits 2" 2 \
-    bash -c "cat /tmp/orig.sh | bash -s -- --version $VERSION"
+    bash -c "cat /tmp/orig.sh | bash -s -- --version $RELEASE_VERSION"
 assert_contains "dispatch: piped stable code" "$DISPATCH_CODE" "$LAST_OUTPUT"
 assert_exit "dispatch: piped without arguments exits 2" 2 \
     bash -c "cat /tmp/orig.sh | bash"
@@ -252,7 +304,7 @@ after_tamper="$(sha256sum "$ARTIFACT" | cut -d' ' -f1)"
     || fail "artifact was actually modified" "sha256 unchanged: $after_tamper"
 pass "artifact was actually modified"
 assert_exit "tampered artifact rejected (exit 2)" 2 \
-    bash /tmp/boot.py --version "$VERSION" -- "${INSTALL_ARGS[@]}"
+    bash /tmp/boot.py --version "$RELEASE_VERSION" -- "${INSTALL_ARGS[@]}"
 assert_contains "tampered artifact code" "artifact_integrity_mismatch" "$LAST_OUTPUT"
 cp /tmp/pristine.tar.gz "$ARTIFACT"
 
@@ -265,7 +317,7 @@ d["signature"] = "A" * len(d["signature"])
 p.write_text(json.dumps(d))
 PY
 assert_exit "malformed envelope rejected (exit 2)" 2 \
-    bash /tmp/boot.py --version "$VERSION" -- "${INSTALL_ARGS[@]}"
+    bash /tmp/boot.py --version "$RELEASE_VERSION" -- "${INSTALL_ARGS[@]}"
 assert_contains "malformed envelope code" "invalid_signature_envelope" "$LAST_OUTPUT"
 cp /tmp/pristine.sig "$ARTIFACT.signature.json"
 
@@ -280,7 +332,7 @@ d["signature"] = "ed25519:" + base64.b64encode(bytes(raw)).decode()
 p.write_text(json.dumps(d))
 PY
 assert_exit "incorrect signature rejected (exit 2)" 2 \
-    bash /tmp/boot.py --version "$VERSION" -- "${INSTALL_ARGS[@]}"
+    bash /tmp/boot.py --version "$RELEASE_VERSION" -- "${INSTALL_ARGS[@]}"
 assert_contains "incorrect signature code" "signature_verification_failed" "$LAST_OUTPUT"
 cp /tmp/pristine.sig "$ARTIFACT.signature.json"
 
@@ -291,7 +343,7 @@ chmod -R a+rX /tmp/b1/bundle /tmp/boot.py
 HOME_DIR=/home/oriop
 
 set +e
-su oriop -c "bash /tmp/boot.py --version $VERSION -- ${INSTALL_ARGS[*]}" \
+su oriop -c "bash /tmp/boot.py --version $RELEASE_VERSION -- ${INSTALL_ARGS[*]}" \
     >/tmp/install.log 2>&1
 install_status=$?
 set -e
@@ -318,7 +370,7 @@ if [ "$install_status" -eq 0 ] && [ -d "$HOME_DIR/.local/ori/current" ]; then
     grep -q "VIRTUAL_ENV=" "$BIN/activate" || fail "activation script rebound" "no VIRTUAL_ENV"
     pass "activation script rebound"
 
-    su oriop -c "bash /tmp/boot.py --version $VERSION -- ${INSTALL_ARGS[*]}" \
+    su oriop -c "bash /tmp/boot.py --version $RELEASE_VERSION -- ${INSTALL_ARGS[*]}" \
         >/tmp/reinstall.log 2>&1 || fail "same-version reinstall" "non-zero exit"
     pass "same-version reinstall"
 

--- a/docs/releases/evidence/harness-systemd-host.sh
+++ b/docs/releases/evidence/harness-systemd-host.sh
@@ -1,0 +1,441 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+#
+# Pre-publication system-scope evidence, on a real systemd host.
+#
+# The container harness marks installation and every downstream service claim
+# BLOCKED, because a container has no systemd session bus. Those are exactly
+# the claims release candidates have failed on hardware, so they are proven
+# here instead: on the machine, as root, against an artifact built and
+# development-signed from a named commit.
+#
+# Every claim is an assertion. A claim that cannot be proven fails the run; a
+# claim the environment blocks is recorded as BLOCKED and changes the exit
+# status, so partial coverage can never read as full coverage.
+#
+# Exit status:
+#   0  every required claim proven
+#   1  a required claim failed
+#   3  claims remain BLOCKED by the environment (partial coverage)
+#
+# The full procedure — prerequisites, how to capture each phase's exit status,
+# what to record, and how to reset the host — is in systemd-host-runbook.md
+# beside this file. Reboot cannot be spanned by one process, so the run has
+# phases:
+#
+#   sudo ./harness-systemd-host.sh install <bundle> <sig> <registry> <sha256> <version>
+#   # reboot the host
+#   sudo ./harness-systemd-host.sh persist <version>
+#   sudo ./harness-systemd-host.sh rollback <bundle> <sig> <registry> <sha256> <version>
+#   sudo ./harness-systemd-host.sh uninstall
+#
+# The artifact is verified before anything from it is extracted or executed.
+# Installing first and letting the newly installed code check its own source
+# would invert the trust boundary: this runs as root, so the digest and the
+# signature are checked with tooling that predates the artifact — coreutils and
+# openssl — against a registry and digest supplied by the caller.
+#
+# This proves nothing about KMS custody, the production trust root, GitHub
+# publication, authenticated download, published asset completeness, or
+# post-publication reverification. Those belong to the protected release
+# workflow and are proven only by a real tag.
+set -euo pipefail
+
+HARNESS_REVISION="12"
+PHASE="${1:?usage: harness-systemd-host.sh <install|persist|rollback|uninstall> ...}"
+BLOCKED=0
+UNIT="ori-runtime.service"
+SYSTEM_ROOT="/opt/ori"
+
+# Deterministic, so the resulting config and diagnosis can be asserted rather
+# than merely produced.
+EVIDENCE_DEVICE_ID="ori-rc-evidence"
+EVIDENCE_NAME="Ori Release Candidate Evidence"
+EVIDENCE_LOCATION="Pre-publication test host"
+# Root-owned, and outside the install root so the installer's own uninstall
+# cannot remove it mid-run. The harness clears it in its uninstall phase.
+STATE_FILE="/var/lib/ori-evidence-state"
+
+pass()    { printf '  %-56s PASS\n' "$1"; }
+blocked() { printf '  %-56s BLOCKED (%s)\n' "$1" "$2"; BLOCKED=1; }
+fail()    { printf '  %-56s FAIL: %s\n' "$1" "$2" >&2; exit 1; }
+
+require_root() {
+    [ "$(id -u)" -eq 0 ] || fail "running as root" "re-run with sudo"
+}
+
+# systemd must be the init system, not merely installed: `systemctl` exists in
+# images that cannot run a unit, and a BLOCKED run there would look like a pass
+# to anyone reading only the exit status.
+require_systemd() {
+    [ -d /run/systemd/system ] \
+        || fail "systemd is the init system" "/run/systemd/system is absent"
+    command -v systemctl >/dev/null 2>&1 || fail "systemctl is available" "not on PATH"
+}
+
+# Root-owned and private. A predictable path under /tmp is writable by every
+# account on the host, so a root process writing there can be aimed elsewhere
+# through a symlink planted in advance.
+make_workspace() {
+    WORKSPACE="$(mktemp -d "$SYSTEM_ROOT-evidence-XXXXXX")"
+    chmod 700 "$WORKSPACE"
+}
+
+record_host() {
+    # shellcheck source=/dev/null
+    local pretty; pretty="$(. /etc/os-release && echo "${PRETTY_NAME:-unknown}")"
+    printf '=== HOST ===\n'
+    printf '  harness revision  %s (phase %s)\n' "$HARNESS_REVISION" "$PHASE"
+    printf '  distribution      %s\n' "$pretty"
+    printf '  kernel            %s\n' "$(uname -sr)"
+    printf '  architecture      %s\n' "$(uname -m)"
+    printf '  systemd           %s\n' "$(systemctl --version | head -1)"
+    printf '  python3           %s (%s)\n' \
+        "$(python3 -V 2>&1 | cut -d' ' -f2)" "$(command -v python3)"
+    printf '  base interpreter  %s\n' \
+        "$(python3 -c 'import sys; print(sys._base_executable)')"
+}
+
+assert_exit() {
+    local label="$1" expected="$2"; shift 2
+    local output status
+    set +e; output="$("$@" 2>&1)"; status=$?; set -e
+    [ "$status" -eq "$expected" ] \
+        || fail "$label" "expected exit $expected, got $status: $(head -1 <<<"$output")"
+    LAST_OUTPUT="$output"
+    pass "$label"
+}
+
+assert_contains() {
+    case "$3" in
+        *"$2"*) pass "$1" ;;
+        *) fail "$1" "expected '$2' in: $(head -3 <<<"$3")" ;;
+    esac
+}
+
+finish() {
+    if [ "$BLOCKED" -eq 1 ]; then
+        printf '\n  partial coverage: claims BLOCKED by this environment\n'
+        exit 3
+    fi
+    printf '\n  every required claim proven for phase %s\n' "$PHASE"
+}
+
+# --- verification and binding live in Python ---------------------------------
+#
+# Five review rounds found the same defect in five shell variables: a value
+# checked in one place and used in another. `scripts/evidence_host.py` makes
+# each of them a function argument — the target parsed from the signed
+# envelope, the interpreter selected and validated in one act, the digest and
+# signature checked with tooling that predates the artifact, the install record
+# written atomically and bound to its version. Shell keeps `sudo`, systemctl,
+# and phase dispatch.
+EVIDENCE_PY="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)/scripts/evidence_host.py"
+[ -f "$EVIDENCE_PY" ] || fail "the evidence module is present" "$EVIDENCE_PY"
+
+evidence() {
+    python3 "$EVIDENCE_PY" "$@"
+}
+
+verify_artifact() {
+    local bundle="$1" signature="$2" registry="$3" expected_sha="$4" version="$5"
+    local output
+    if ! output="$(evidence verify --bundle "$bundle" --signature "$signature" \
+            --registry "$registry" --sha256 "$expected_sha" --version "$version" \
+            --workspace "$WORKSPACE/verify" 2>&1)"; then
+        fail "the artifact verifies before extraction" "$output"
+    fi
+    pass "verified before extraction: $output"
+}
+
+select_tooling_interpreter() {
+    local signature="$1" output
+    if ! output="$(evidence select-python --signature "$signature" 2>&1)"; then
+        fail "an interpreter matching the artifact's target" "$output"
+    fi
+    TOOLING_PYTHON="$output"
+    pass "tooling interpreter $TOOLING_PYTHON matches the artifact target"
+}
+
+# The bundle's own hash-locked wheelhouse, in the order the bootstrap uses:
+# pinned dependencies with hashes enforced, then the one runtime wheel.
+install_release_tooling() {
+    local extracted="$1" destination="$2"
+    "${TOOLING_PYTHON:?select_tooling_interpreter must run first}" \
+        -m venv "$destination" >/dev/null
+    "$destination/bin/pip" install --quiet --no-index --require-hashes \
+        --find-links "$extracted/wheelhouse" \
+        -r "$extracted/wheelhouse/requirements.txt" >/dev/null
+    local wheel
+    wheel="$(find "$extracted/wheelhouse" -maxdepth 1 -name 'ori_runtime-*.whl' | head -1)"
+    [ -n "$wheel" ] || fail "the wheelhouse holds a runtime wheel" "none found"
+    "$destination/bin/pip" install --quiet --no-index --no-deps "$wheel" >/dev/null
+}
+
+# --- install ------------------------------------------------------------------
+
+phase_install() {
+    local bundle="${2:?bundle path required}"
+    local signature="${3:?signature path required}"
+    local registry="${4:?development key registry required}"
+    local expected_sha="${5:?expected artifact sha256 required}"
+    local version="${6:?release version required}"
+    require_root; require_systemd; record_host; make_workspace
+    trap 'rm -rf "$WORKSPACE"' EXIT
+
+    echo "=== VERIFY (before extraction) ==="
+    verify_artifact "$bundle" "$signature" "$registry" "$expected_sha" "$version"
+
+    select_tooling_interpreter "$signature"
+
+    echo "=== CLEAN STATE ==="
+    [ ! -e "$SYSTEM_ROOT" ] \
+        || fail "no prior system installation" "$SYSTEM_ROOT exists; uninstall first"
+    if systemctl list-unit-files "$UNIT" 2>/dev/null | grep -q "$UNIT"; then
+        fail "no prior unit" "$UNIT is already known to systemd"
+    fi
+    [ ! -e /usr/local/bin/ori ] \
+        || fail "no prior launcher" "/usr/local/bin/ori exists; uninstall first"
+    pass "no prior system installation"
+
+    echo "=== INSTALL (system scope) ==="
+    tar -C "$WORKSPACE" -xf "$bundle"
+    local extracted
+    extracted="$(find "$WORKSPACE" -maxdepth 1 -mindepth 1 -type d | head -1)"
+    install_release_tooling "$extracted" "$WORKSPACE/venv"
+
+    assert_exit "install completes" 0 \
+        "$WORKSPACE/venv/bin/ori-install-linux" install \
+            --scope system --unattended \
+            --bundle "$bundle" --signature "$signature" \
+            --expected-version "$version" \
+            --device-id "$EVIDENCE_DEVICE_ID" \
+            --name "$EVIDENCE_NAME" \
+            --location "$EVIDENCE_LOCATION" \
+            --json
+    local report="$LAST_OUTPUT"
+    assert_contains "install reports healthy" '"status": "healthy"' "$report"
+    assert_contains "install reports system scope" '"scope": "system"' "$report"
+    assert_contains "install reports the requested version" "\"version\": \"$version\"" "$report"
+    assert_contains "install reports the evidence device" \
+        "\"device_id\": \"$EVIDENCE_DEVICE_ID\"" "$report"
+
+    echo "=== LAUNCHER ==="
+    # A launcher conflict is deliberately non-fatal, so an installation can
+    # report healthy having installed no `ori` command at all. Diagnosing
+    # through the absolute venv path would never notice.
+    assert_contains "launcher was installed" '"launcher_installed": true' "$report"
+    local launcher="/usr/local/bin/ori"
+    [ -x "$launcher" ] || fail "launcher is executable" "$launcher"
+    assert_contains "install reports the expected launcher path" \
+        "\"launcher_path\": \"$launcher\"" "$report"
+    assert_exit "doctor runs through the launcher" 0 \
+        "$launcher" doctor --scope system --json
+    assert_contains "the launcher diagnosed this installation" \
+        "\"device_id\": \"$EVIDENCE_DEVICE_ID\"" "$LAST_OUTPUT"
+
+    echo "=== CONFIG ==="
+    local config="$SYSTEM_ROOT/data/ori.yaml"
+    [ -f "$config" ] || fail "config was written" "$config is absent"
+    assert_contains "config carries the evidence device id" \
+        "$EVIDENCE_DEVICE_ID" "$(cat "$config")"
+    assert_contains "config carries the evidence location" \
+        "$EVIDENCE_LOCATION" "$(cat "$config")"
+
+    echo "=== SERVICE ==="
+    assert_exit "unit is active" 0 systemctl is-active --quiet "$UNIT"
+    assert_exit "unit is enabled for boot" 0 systemctl is-enabled --quiet "$UNIT"
+    assert_contains "unit runs as ori-runtime" "User=ori-runtime" "$(systemctl cat "$UNIT")"
+
+    echo "=== HEALTH SOCKET ==="
+    local socket="$SYSTEM_ROOT/data/health.sock"
+    [ -S "$socket" ] || fail "health socket exists" "not a socket: $socket"
+    pass "health socket exists"
+
+    echo "=== INSTALLED DOCTOR ==="
+    assert_exit "installed doctor reports no blocking failure" 0 \
+        "$SYSTEM_ROOT/current/venv/bin/ori" doctor --scope system --json
+    local diagnosis="$LAST_OUTPUT"
+    assert_contains "doctor diagnosed this installation" '"scope": "system"' "$diagnosis"
+    assert_contains "doctor reports the requested version" \
+        "\"version\": \"$version\"" "$diagnosis"
+    assert_contains "doctor reports the evidence device" \
+        "\"device_id\": \"$EVIDENCE_DEVICE_ID\"" "$diagnosis"
+
+    # The defect that rolled back every rc.4 system install: an ordinary venv
+    # interpreter refused because a symlink's mode reads as world-writable.
+    case "$diagnosis" in
+        *'"name": "permissions.code"'*'"status": "FAIL"'*)
+            fail "code integrity passes on a real venv" "permissions.code reported FAIL" ;;
+        *'"name": "permissions.code"'*) pass "code integrity passes on a real venv" ;;
+        *) fail "code integrity was assessed" "permissions.code absent from the report" ;;
+    esac
+
+    # Last, and only now. Written earlier, a record of this boot would survive
+    # any assertion above failing, and the persistence phase would later treat
+    # a failed installation as its provenance.
+    evidence record --path "$STATE_FILE" --version "$version" >/dev/null \
+        || fail "the installation was recorded" "could not write $STATE_FILE"
+    pass "install boot recorded, after every install assertion passed"
+    finish
+}
+
+# --- persist (after a reboot) --------------------------------------------------
+
+phase_persist() {
+    local version="${2:?release version required}"
+    require_root; require_systemd; record_host
+
+    echo "=== REBOOT PERSISTENCE ==="
+    local record
+    if ! record="$(evidence require-reboot --path "$STATE_FILE" \
+            --version "$version" 2>&1)"; then
+        fail "the host rebooted since this release was installed" "$record"
+    fi
+    pass "the host rebooted since this release was installed ($record)"
+
+    assert_exit "unit is active after reboot" 0 systemctl is-active --quiet "$UNIT"
+    assert_exit "unit is still enabled" 0 systemctl is-enabled --quiet "$UNIT"
+    assert_exit "doctor is healthy after reboot" 0 \
+        "$SYSTEM_ROOT/current/venv/bin/ori" doctor --scope system --json
+    assert_contains "doctor still reports the release under test" \
+        "\"version\": \"$version\"" "$LAST_OUTPUT"
+    finish
+}
+
+# --- rollback on a failure that reaches activation ----------------------------
+
+phase_rollback() {
+    local bundle="${2:-}" signature="${3:-}" registry="${4:-}"
+    local expected_sha="${5:-}" version="${6:-}"
+    require_root; require_systemd; record_host
+
+    echo "=== ROLLBACK ==="
+    local previous; previous="$(readlink -f "$SYSTEM_ROOT/current" 2>/dev/null || echo none)"
+    [ "$previous" != "none" ] || fail "an installation to roll back from" "no active release"
+    printf '  active release before  %s\n' "$previous"
+
+    # Rollback needs a failure *after* activation. A tampered or mis-signed
+    # artifact cannot produce one: verification refuses it before anything is
+    # installed, and treating that refusal as rollback would prove nothing while
+    # reporting PASS. This phase therefore needs an artifact that installs and
+    # then fails its own post-install diagnosis.
+    if [ -z "$bundle" ] || [ ! -f "$bundle" ] || [ -z "$version" ]; then
+        blocked "rollback restores the previous release" \
+                "no post-activation-failing artifact supplied"
+        printf '  supply one as: rollback <bundle> <sig> <registry> <sha256> <version>\n'
+        finish
+        return
+    fi
+
+    make_workspace
+    trap 'rm -rf "$WORKSPACE"' EXIT
+    verify_artifact "$bundle" "$signature" "$registry" "$expected_sha" "$version"
+    select_tooling_interpreter "$signature"
+    tar -C "$WORKSPACE" -xf "$bundle"
+    local extracted
+    extracted="$(find "$WORKSPACE" -maxdepth 1 -mindepth 1 -type d | head -1)"
+    install_release_tooling "$extracted" "$WORKSPACE/venv"
+
+    set +e
+    "$WORKSPACE/venv/bin/ori-install-linux" install \
+        --scope system --unattended \
+        --bundle "$bundle" --signature "$signature" \
+        --expected-version "$version" \
+        --device-id "$EVIDENCE_DEVICE_ID" --name "$EVIDENCE_NAME" \
+        --location "$EVIDENCE_LOCATION" --json >"$WORKSPACE/rollback.json" 2>&1
+    local status=$?
+    set -e
+    local output; output="$(cat "$WORKSPACE/rollback.json")"
+
+    # The exact stable code, not "some nonzero exit": an argument error, a
+    # signature rejection or a target mismatch all exit nonzero without ever
+    # activating anything, and would otherwise be recorded as a rollback.
+    assert_contains "the candidate failed after activation" \
+        "post_install_health_failed" "$output"
+    [ "$status" -ne 0 ] || fail "the failing artifact actually failed" "install reported success"
+
+    local after; after="$(readlink -f "$SYSTEM_ROOT/current")"
+    printf '  active release after   %s\n' "$after"
+    [ "$after" = "$previous" ] \
+        || fail "rollback restored the previous release" \
+                "active moved from $previous to $after"
+    pass "rollback restored the previous release"
+
+    [ ! -e "$SYSTEM_ROOT/releases/$version" ] \
+        || fail "the failed candidate was removed" \
+                "$SYSTEM_ROOT/releases/$version remains"
+    pass "the failed candidate was removed"
+
+    assert_exit "service still active after rollback" 0 systemctl is-active --quiet "$UNIT"
+    assert_exit "doctor still healthy after rollback" 0 \
+        "$SYSTEM_ROOT/current/venv/bin/ori" doctor --scope system --json
+    finish
+}
+
+# --- uninstall -----------------------------------------------------------------
+
+phase_uninstall() {
+    require_root; require_systemd; record_host
+    echo "=== UNINSTALL ==="
+    # The installer removes its own tree, including data, because the evidence
+    # installation exists only for this run. Retention under the default flag is
+    # the installer's behaviour and is covered by the unit suite; asserting it
+    # here would mean deleting the retained data afterwards by hand.
+    assert_exit "uninstall completes" 0 \
+        "$SYSTEM_ROOT/current/venv/bin/ori-install-linux" \
+            uninstall --scope system --remove-data
+    if systemctl list-unit-files "$UNIT" 2>/dev/null | grep -q "$UNIT"; then
+        fail "unit removed" "$UNIT is still known to systemd"
+    fi
+    pass "unit removed"
+
+    # Every managed path, by name. `rmdir` below is the proof that nothing else
+    # was left, but it cannot say which of these survived.
+    local leftover
+    for leftover in current releases data; do
+        [ ! -e "$SYSTEM_ROOT/$leftover" ] \
+            || fail "uninstall removed $leftover" "$SYSTEM_ROOT/$leftover remains"
+    done
+    pass "no release, data or active symlink remains"
+
+    # Deliberate: files elsewhere may belong to it, and a freed uid can be
+    # reused by a later account.
+    if getent passwd ori-runtime >/dev/null; then
+        pass "service account retained, as designed"
+    else
+        blocked "service account retained" "ori-runtime absent"
+    fi
+
+    rm -f "$STATE_FILE"
+    pass "evidence state removed ($STATE_FILE)"
+
+    # Non-recursive, and never forced. `rmdir` removes a directory only when it
+    # is already empty, so it cannot delete anything the installer chose to
+    # keep, cannot descend into a real deployment, and refuses outright on a
+    # symlink. What is left behind is reported rather than destroyed — a
+    # recursive removal here would be authorised by nothing stronger than this
+    # harness having been pointed at the host.
+    if rmdir "$SYSTEM_ROOT" 2>/dev/null; then
+        pass "install root removed; a further run starts clean"
+    else
+        blocked "install root removed" \
+                "$SYSTEM_ROOT is not empty: $(ls -A "$SYSTEM_ROOT" 2>/dev/null | tr '\n' ' ')"
+    fi
+
+    # The account is retained by design and does not block a further run:
+    # installation reuses an existing usable account and creates one only when
+    # it is absent.
+    printf '\n  retained on this host: the ori-runtime service account\n'
+    printf '  remove it deliberately if you want it gone: userdel ori-runtime\n'
+    finish
+}
+
+case "$PHASE" in
+    install)   phase_install "$@" ;;
+    persist)   phase_persist "$@" ;;
+    rollback)  phase_rollback "$@" ;;
+    uninstall) phase_uninstall "$@" ;;
+    *) fail "known phase" "unknown phase '$PHASE'" ;;
+esac

--- a/docs/releases/evidence/run-evidence.sh
+++ b/docs/releases/evidence/run-evidence.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
 # Host-side driver for the trust-substituted functional evidence harness.
 #
 # Takes ONE commit and derives everything else from it: the archive, its
@@ -9,14 +11,17 @@
 # A reviewer reproduces the recorded digest with:
 #     git archive --format=tar <commit> | sha256sum
 #
-# Usage: run-evidence.sh <commit> <target> <image> <distro>
+# Usage: run-evidence.sh <commit> <target> <image> <distro> <release-version>
 # Exit:  0 all claims proven · 1 a claim failed · 3 partial (BLOCKED claims)
 set -euo pipefail
 
-COMMIT="${1:?usage: run-evidence.sh <commit> <target> <image> <distro>}"
+COMMIT="${1:?usage: run-evidence.sh <commit> <target> <image> <distro> <release-version>}"
 TARGET="${2:?target tuple required, e.g. linux-aarch64-python3.11}"
 IMAGE="${3:?container image required}"
 DISTRO="${4:?expected distro required, e.g. debian:12}"
+# In the SemVer form the signed artifact uses. The harness proves it agrees
+# with the packaged version in the commit above, so the two cannot drift.
+RELEASE_VERSION="${5:?release version required, e.g. 2.4.0-rc.5}"
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 HARNESS="$REPO_ROOT/docs/releases/evidence/harness-linux-functional.sh"
@@ -61,6 +66,7 @@ cat <<SUMMARY
 === EVIDENCE RUN ===
   commit          $FULL_COMMIT
   archive sha256  $DIGEST
+  release         $RELEASE_VERSION
   target          $TARGET
   image           $IMAGE
   image id        $IMAGE_ID
@@ -79,7 +85,7 @@ docker run --rm \
     -v "$REPO_ROOT/docs/releases/evidence":/evidence:ro \
     "$IMAGE_ID" \
     bash /evidence/harness-linux-functional.sh \
-        "$TARGET" "$FULL_COMMIT" /src.tar "$DIGEST" "$DISTRO"
+        "$TARGET" "$FULL_COMMIT" /src.tar "$DIGEST" "$DISTRO" "$RELEASE_VERSION"
 STATUS=$?
 set -e
 

--- a/docs/releases/evidence/systemd-host-runbook.md
+++ b/docs/releases/evidence/systemd-host-runbook.md
@@ -1,0 +1,215 @@
+# Systemd-host pre-publication evidence — runbook
+
+The container harness marks installation and every downstream service claim
+BLOCKED, because a container has no systemd session bus. Those are exactly the
+claims release candidates have failed on hardware. This runbook proves them on
+a real machine, against an artifact built and development-signed from a named
+commit.
+
+It is version-agnostic: set the variables in step 0 and every command below is
+copy-pasteable verbatim. Nothing here names a release.
+
+## What a passing run establishes
+
+| Phase | Claim |
+| --- | --- |
+| `install` | The artifact verifies before extraction; a system-scope install completes, reports healthy, writes its config, installs a working launcher, enables and starts the unit under `ori-runtime`, opens its health socket, and diagnoses clean — including `permissions.code` on a real venv |
+| `persist` | The unit is still active and enabled after a genuine reboot, and the runtime still reports the release under test |
+| `rollback` | A candidate that fails *after* activation restores the previous release and removes itself, leaving the service healthy |
+| `uninstall` | The unit and every managed path are removed, the service account is retained, and the empty install root is taken away with `rmdir` so the host can run again |
+
+## What it does not establish
+
+KMS signing custody, the production trust root, GitHub publication,
+authenticated download, published asset completeness, and post-publication
+reverification. Those belong to the protected release workflow and are proven
+only by a real tag. The artifact here is development-signed with an ephemeral
+key that is discarded when the build finishes.
+
+The build is not byte-identical to the workflow's. The packaged key registry is
+part of the source, so substituting it changes the wheel and the bundle as well
+as the signature. What is reproduced is installation behaviour.
+
+## Prerequisites
+
+- systemd is the init system — `test -d /run/systemd/system`
+- **No existing Ori installation.** `/opt/ori` absent, no `ori-runtime.service`
+  known to systemd, no `/usr/local/bin/ori`. The harness refuses otherwise
+  rather than install over one.
+- The interpreter the target names, on `PATH` (`python3.11` or `python3.12`),
+  plus a `python3` of 3.9 or newer for the harness itself
+- `git`, `tar`, `openssl`, and `sudo`
+- A clean checkout of the commit under test — the builder archives from the
+  commit, not the working tree, so uncommitted edits are not included
+- The ability to reboot the host
+
+## 0. Set the run's identity
+
+```bash
+set -o pipefail                     # see the note below — this is not optional
+cd /path/to/ori                     # the checkout under test
+COMMIT=$(git rev-parse HEAD)        # must be the exact merged commit
+VERSION=<the version this commit declares>   # e.g. 2.4.0-rc.5
+TARGET=linux-$(uname -m)-python3.12          # or python3.11
+OUT=$HOME/ori-evidence
+mkdir -p "$OUT"
+```
+
+Every command below pipes into `tee` so the run is logged. **Without
+`pipefail`, `$?` after such a pipe is `tee`'s status and is always 0** — it
+would report success for a failed phase and hide partial coverage entirely.
+With it, `$?` is the harness's own status, including the 3 that means BLOCKED.
+
+Each block below sets it again rather than relying on this one. The reboot ends
+the shell that ran the install, and a fresh shell pasting a later block would
+otherwise read every phase as a pass. `${PIPESTATUS[0]}` is a bash-only
+alternative; it silently expands to nothing under zsh, so this runbook does not
+use it.
+
+`VERSION` is checked against `pyproject.toml` through the same normalisation the
+release workflow uses; a mismatch stops the build before anything is signed.
+
+## 1. Build and development-sign the artifact
+
+```bash
+set -o pipefail
+./docs/releases/evidence/build-local-artifact.sh \
+    "$COMMIT" "$TARGET" "$VERSION" "$OUT" 2>&1 | tee "$OUT/build.log"
+echo "build exit $?"
+```
+
+Record the summary block it prints — source commit, archive digest, artifact
+digest, and the ephemeral key fingerprint.
+
+Then derive the arguments the harness needs:
+
+```bash
+BUNDLE="$OUT/ori-runtime-$VERSION-$TARGET.tar.gz"
+SIG="$BUNDLE.signature.json"
+KEYS="$OUT/release-keys.dev.json"
+SHA=$(sha256sum "$BUNDLE" | cut -d' ' -f1)
+```
+
+## 2. Install
+
+```bash
+set -o pipefail
+sudo ./docs/releases/evidence/harness-systemd-host.sh \
+    install "$BUNDLE" "$SIG" "$KEYS" "$SHA" "$VERSION" 2>&1 \
+    | tee "$OUT/install.log"
+echo "install exit $?"
+```
+
+Do not proceed unless this is **0**. The boot is recorded only after every
+install assertion has passed, so a failed install cannot later be presented as
+the provenance of a persistence claim.
+
+## 3. Reboot, then prove persistence
+
+```bash
+sudo reboot
+```
+
+After the host comes back:
+
+```bash
+set -o pipefail
+cd /path/to/ori
+sudo ./docs/releases/evidence/harness-systemd-host.sh persist "$VERSION" 2>&1 \
+    | tee "$OUT/persist.log"
+echo "persist exit $?"
+```
+
+The phase compares the current boot id against the one recorded at install.
+Uptime is not accepted: installing shortly after an ordinary boot and checking
+immediately satisfies any uptime bound while nothing has restarted.
+
+## 4. Rollback
+
+Rollback needs a candidate that installs and *then* fails its own post-install
+diagnosis. A tampered or mis-signed artifact cannot produce one — verification
+refuses it before anything is installed, and recording that refusal as a
+rollback would prove nothing while printing PASS.
+
+Without such an artifact the phase records BLOCKED and the run exits **3**:
+
+```bash
+set -o pipefail
+sudo ./docs/releases/evidence/harness-systemd-host.sh rollback 2>&1 \
+    | tee "$OUT/rollback.log"
+echo "rollback exit $?"
+```
+
+To prove it instead, build a second artifact from a scratch commit that makes a
+mandatory health check fail, and pass it the same way as step 2:
+
+```bash
+sudo ./docs/releases/evidence/harness-systemd-host.sh \
+    rollback "$FAILING_BUNDLE" "$FAILING_SIG" "$KEYS" "$FAILING_SHA" "$FAILING_VERSION"
+```
+
+The phase requires the exact `post_install_health_failed` code. "Some nonzero
+exit" is satisfied by an argument error or a signature rejection, neither of
+which ever activates anything — indistinguishable from a successful rollback
+unless the code is checked.
+
+## 5. Uninstall
+
+```bash
+set -o pipefail
+sudo ./docs/releases/evidence/harness-systemd-host.sh uninstall 2>&1 \
+    | tee "$OUT/uninstall.log"
+echo "uninstall exit $?"
+```
+
+This uninstalls with `--remove-data`, because the evidence installation exists
+only for this run. The installer removes its own tree; the phase then checks
+that `current`, `releases` and `data` are all gone and finishes with a
+non-recursive `rmdir /opt/ori`.
+
+Nothing here removes anything recursively. `rmdir` deletes a directory only
+when it is already empty, so it cannot descend into a real deployment, cannot
+delete anything the installer chose to keep, and refuses outright on a symlink.
+If the install root is not empty, the phase reports what remains and records
+BLOCKED rather than forcing it.
+
+Retention under the default flag is the installer's own behaviour and is
+covered by the unit suite — asserting it here would mean deleting the retained
+data by hand afterwards.
+
+The `ori-runtime` account is retained deliberately: files elsewhere may belong
+to it, and a freed uid can be reused by a later account. It does not block a
+further run — installation adopts an existing usable account as found. Remove
+it only if you want it gone:
+
+```bash
+sudo userdel ori-runtime
+```
+
+## Exit status
+
+| Status | Meaning |
+| --- | --- |
+| 0 | Every required claim proven |
+| 1 | A required claim failed — the run is not evidence |
+| 3 | Claims remain BLOCKED by the environment; partial coverage |
+
+A run that exits 3 must be reported as partial. Reading only "it finished" turns
+untested claims into apparent passes.
+
+## Recording the run
+
+Write one record per run at `docs/releases/evidence/<version>-systemd-host.md`,
+following the layout of the container-run records already in this directory. It
+must carry:
+
+- source commit and source-archive SHA-256, with the command to reproduce it
+- artifact SHA-256 and the ephemeral key fingerprint
+- harness revision (printed in each phase's `=== HOST ===` block)
+- host identity: distribution, kernel, architecture, systemd version, and both
+  the `python3` and base interpreter paths
+- the exit status of every phase, and the attached logs
+- the limitations above, restated — evidence that overstates itself is worse
+  than none
+
+The harness prints the host block itself, so paste it rather than retyping it.

--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -36,6 +36,7 @@ installed — nothing was ever built, signed, or published from either.
 | `v2.4.0-rc.1` | protection preflight, full test matrix | the build compared the whole tag against the packaged version, so no pre-release tag could ever match |
 | `v2.4.0-rc.2` | protection preflight, full test matrix | the wheel version and the bundle version were compared as strings, and a candidate spells them differently |
 | `v2.4.0-rc.3` | signed, published, exercised on hardware | neither scope could complete an install: system scope checked for its service account too late, and user scope was refused for a property it cannot have |
+| `v2.4.0-rc.4` | signed, published, installed on hardware | user scope installed and ran; system scope rolled back because the interpreter's ordinary symlink was misread as writable, and bare `ori doctor` raised on an install root it could not read |
 
 `v2.4.0-rc.3` is the first candidate that built, signed, and published. Its
 assets remain available and are not replaced. It failed on hardware, which is
@@ -56,6 +57,38 @@ creating the boundary, since an owner can always restore write access to its
 own files. The check is now mandatory for system scope, where root-owned code
 and an unprivileged service account make it real, and an explicit warning under
 user scope, where it cannot be.
+
+`v2.4.0-rc.4` installed. A user-scope installation completed, ran, and reported
+`13 pass · 3 warn · 0 fail`, including the advisory that user-scope code cannot
+be made immutable from the account that runs it. Two defects remained.
+
+A system-scope installation rolled back at post-install diagnostics. The
+release was correct — root-owned, unwritable by anyone else — but the execution
+guard read the mode of `venv/bin/python` and refused it. Linux reports every
+symlink as 0777 whatever it points at, and a virtual environment's interpreter
+is always a symlink, so a correct installation was refused by a check reading
+permission bits that grant nothing. Replacing a symlink requires write access to
+the directory holding it, which is the thing that has to be verified.
+
+That rule now has one definition rather than several. A single path-trust
+primitive walks every component from the root, checks ownership everywhere and
+write permission only where it means something, follows symlinks one hop at a
+time while validating each destination in full, and bounds resolution so a
+cyclic or absurdly long link tree ends the check instead of the process. The
+root-execution guard, the release's external-symlink admission and the
+installer's `useradd` resolution all use it, so the boundaries cannot disagree
+about the same path. Trust is the test, not containment: an interpreter that
+resolves to `/usr/bin/python3.12` is normal and allowed, provided root alone
+controls every step of the way there.
+
+The second defect was in scope detection. `ori doctor` with no `--scope`
+inspects both install roots, and a system root left behind by a rolled-back
+installation is unreadable to an ordinary account — so the command the installer
+itself recommends ended in a traceback. Detection now distinguishes "absent"
+from "could not be read": a definitively present installation is selected when
+the other root is unreadable, and when nothing can be established the operator
+is told to pass `--scope` explicitly. Both command entry points also refuse to
+let any inspection failure escape as a traceback.
 
 The first two failures share a different cause. The release pipeline carries two version
 vocabularies — SemVer for the git tag, the signature envelope, the bundle

--- a/ori/cli.py
+++ b/ori/cli.py
@@ -348,6 +348,7 @@ def _resolve(args: argparse.Namespace) -> tuple[Any, str] | int:
     """Resolve the installation, turning every lookup failure into an exit code."""
     from ori.installer.paths import (
         AmbiguousScopeError,
+        IndeterminateScopeError,
         UnmanagedReleaseError,
         resolve_identity,
     )
@@ -357,11 +358,26 @@ def _resolve(args: argparse.Namespace) -> tuple[Any, str] | int:
     except AmbiguousScopeError as exc:
         print(f"ori: {exc}", file=sys.stderr)
         return EXIT_UNUSABLE
+    except IndeterminateScopeError as exc:
+        print(f"ori: {exc}", file=sys.stderr)
+        return EXIT_UNUSABLE
     except UnmanagedReleaseError as exc:
         print(f"ori: unusable installation: {exc}", file=sys.stderr)
         return EXIT_UNUSABLE
     except FileNotFoundError as exc:
         print(f"ori: no installation found: {exc}", file=sys.stderr)
+        return EXIT_UNUSABLE
+    except OSError as exc:
+        # A backstop, not the mechanism: detection classifies what it cannot
+        # read. Anything that still reaches here is an inspection failure this
+        # code did not anticipate, and a diagnostic command must report it
+        # rather than end in a traceback.
+        print(
+            f"ori: could not inspect the installation ({exc.filename or exc}): "
+            f"{exc.strerror or exc}. Pass --scope user or --scope system "
+            "explicitly.",
+            file=sys.stderr,
+        )
         return EXIT_UNUSABLE
 
 

--- a/ori/doctor.py
+++ b/ori/doctor.py
@@ -121,12 +121,12 @@ def assert_execution_allowed(identity: InstallIdentity) -> None:
     # alongside a root that points into a user's home. What actually makes
     # execution safe is that no unprivileged account can alter the interpreter
     # or anything leading to it, so that is what gets verified.
-    untrusted = _first_untrusted_component(interpreter_path(identity))
-    if untrusted is not None:
+    failure = _interpreter_trust_failure(interpreter_path(identity))
+    if failure is not None:
         raise UnsafeExecutionError(
-            f"refusing to execute as root: {untrusted} is not owned by root or "
-            "is writable by another account, so its contents are not trusted "
-            "with privilege. Inspect this installation as the user who owns it."
+            f"refusing to execute as root: {failure}, so its contents are not "
+            "trusted with privilege. Inspect this installation as the user who "
+            "owns it."
         )
 
 
@@ -135,23 +135,21 @@ def interpreter_path(identity: InstallIdentity) -> Path:
     return identity.active_release / "venv" / "bin" / "python"
 
 
-def _first_untrusted_component(path: Path) -> Path | None:
-    """Return the first component root should not trust, walking downwards.
+def _interpreter_trust_failure(path: Path) -> str | None:
+    """Describe why root must not execute *path*, or None if it may.
 
-    A missing component ends the walk successfully: if every existing ancestor
-    is root-owned and unwritable by others, no unprivileged account can create
-    what is missing, so nothing there can be planted.
+    The interpreter is normally a symlink chain ending outside the
+    installation — `python` to `python3` to the packaged binary — so the
+    question is whether root alone controls every step of it, not whether it
+    stays within the release. A symlink's own mode answers nothing: Linux
+    reports every one as 0777, and reading that as write permission refuses
+    every virtual environment ever built.
     """
-    for candidate in [*reversed(path.parents), path]:
-        try:
-            info = candidate.lstat()
-        except FileNotFoundError:
-            return None
-        except OSError:
-            return candidate
-        if info.st_uid != 0 or info.st_mode & 0o022:
-            return candidate
-    return None
+    from ori.installer.trusted_paths import (  # local import: installer is optional
+        trust_failure,
+    )
+
+    return trust_failure(path, require_executable=True)
 
 
 def _run(
@@ -1146,6 +1144,7 @@ def run(
     """
     from ori.installer.paths import (  # local import: optional dep
         AmbiguousScopeError,
+        IndeterminateScopeError,
         UnmanagedReleaseError,
         resolve_identity,
     )
@@ -1155,11 +1154,25 @@ def run(
     except AmbiguousScopeError as exc:
         print(f"ambiguous installation: {exc}", file=sys.stderr)
         return 2
+    except IndeterminateScopeError as exc:
+        print(f"indeterminate installation: {exc}", file=sys.stderr)
+        return 2
     except UnmanagedReleaseError as exc:
         print(f"unusable installation: {exc}", file=sys.stderr)
         return 2
     except FileNotFoundError as exc:
         print(f"no Ori installation found: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        # A backstop, not the mechanism. Doctor is the command an operator runs
+        # when something is already wrong; ending in a traceback makes it one
+        # more thing that is wrong.
+        print(
+            f"could not inspect the installation ({exc.filename or exc}): "
+            f"{exc.strerror or exc}. Pass --scope user or --scope system "
+            "explicitly.",
+            file=sys.stderr,
+        )
         return 2
 
     try:

--- a/ori/installer/cli.py
+++ b/ori/installer/cli.py
@@ -32,6 +32,7 @@ from ori.installer.linux import (
     collect_installer_config,
     ensure_service_account,
     install_composed_release,
+    require_trusted_base_interpreter,
     uninstall_runtime,
 )
 from ori.security.release_bundles import (
@@ -148,6 +149,11 @@ def _install(args: argparse.Namespace) -> dict[str, object]:
     # repeat rather than having a privilege boundary crossed on their behalf.
     scope_prompt.require_privilege(scope, sys.argv)
     profile = _profile(scope, args.service_user)
+    # Read-only, so it costs nothing and can be answered before the operator is
+    # asked anything: a system install whose interpreter is not root-controlled
+    # cannot succeed, and finding that out after building an environment is the
+    # expensive way to learn it.
+    require_trusted_base_interpreter(profile)
     layout, unit_path, env_file = _paths(
         scope,
         root=args.root,

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -22,6 +22,7 @@ from typing import Callable, Literal, Sequence
 import yaml
 
 from ori.installer import identity
+from ori.installer.trusted_paths import trust_failure
 from ori.security.release_bundles import ExtractedReleaseBundle, distribution_version
 
 _VERSION_RE = re.compile(
@@ -1167,6 +1168,41 @@ def render_systemd_unit(
     return rendered
 
 
+def require_trusted_base_interpreter(profile: SystemdServiceProfile) -> None:
+    """Refuse a system install built on an interpreter root does not control.
+
+    The release's virtual environment is created from whichever interpreter the
+    bootstrap selected, and `bin/python` in that environment links back to it.
+    So an interpreter under a user-writable prefix — pyenv, a home directory,
+    `/usr/local` owned by an admin account — produces a release whose executing
+    code an unprivileged account can replace. Diagnostics catch that, but only
+    after the bundle has been unpacked, the environment built, the service
+    account created and the unit started, and the whole installation then rolls
+    back for a condition that was knowable in microseconds.
+
+    Read-only, so it runs before anything is prompted, created, or built. User
+    scope is unaffected: it never claims code the runtime cannot rewrite.
+    """
+    if profile.scope != "system":
+        return
+    # In a virtual environment `sys.executable` is the environment's own stub;
+    # `_base_executable` is the interpreter a new environment would actually be
+    # built from, which is the one whose provenance matters here.
+    base = getattr(sys, "_base_executable", None) or sys.executable
+    failure = trust_failure(base, require_executable=True)
+    if failure is None:
+        return
+    raise LinuxInstallError(
+        "unsupported_target",
+        f"a system install needs an interpreter only root can change, but "
+        f"{failure}. The release environment is built from it, so its "
+        f"code would be replaceable by whoever controls that path. Install "
+        f"Python from the distribution — for example 'sudo apt install "
+        f"python3.12' — and run this again with that interpreter, or install "
+        f"with --scope user for a workstation or trial.",
+    )
+
+
 def ensure_service_account(
     profile: SystemdServiceProfile,
     *,
@@ -1345,73 +1381,15 @@ _USERADD_LOCATIONS: tuple[str, ...] = (
 def _trusted_useradd() -> str | None:
     """Return a useradd only root could have placed there, or None.
 
-    Three things have to hold, and the inode is only one of them. A perfectly
-    owned, perfectly permissioned binary is still substitutable if any
-    directory on the way to it can be written by somebody else: replacing a
-    file needs write permission on its parent, not on the file. So every
-    component from the root down is checked, on the literal path and on the
-    path after symlinks are resolved, before the executable itself is judged.
+    `PATH` is never consulted: this runs as root, and a `PATH` carrying a
+    writable directory ahead of the system ones would choose what the installer
+    executes with full privilege. Each fixed location is then judged by the same
+    path-trust primitive the rest of the installer uses.
     """
     for candidate in _USERADD_LOCATIONS:
-        try:
-            resolved = os.path.realpath(candidate)
-        except OSError:
-            continue
-        # The name as written, so a writable directory cannot redirect it, and
-        # the name after resolution, so a symlink cannot land somewhere its own
-        # parents are open. Neither implies the other.
-        if not _only_root_can_change(Path(candidate)):
-            continue
-        if resolved != candidate and not _only_root_can_change(Path(resolved)):
-            continue
-        try:
-            info = os.stat(resolved)
-        except OSError:
-            continue
-        if not stat.S_ISREG(info.st_mode):
-            continue
-        if info.st_uid != 0:
-            continue
-        # Writable by anyone but its owner is writable by somebody who is not
-        # root, which is the whole of the concern.
-        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
-            continue
-        if not os.access(resolved, os.X_OK):
-            continue
-        return resolved
+        if trust_failure(candidate, require_executable=True) is None:
+            return candidate
     return None
-
-
-def _only_root_can_change(path: Path) -> bool:
-    """Whether every directory leading to *path* is under root's control alone.
-
-    Walked from the filesystem root downwards. A single group- or
-    world-writable ancestor, or one owned by another account, is enough for an
-    unprivileged user to swap what the final name refers to by renaming or
-    unlinking within it — which is why the executable's own mode is not the
-    question being asked here.
-    """
-    for directory in reversed(path.parents):
-        try:
-            info = os.lstat(directory)
-        except OSError:
-            return False
-        if info.st_uid != 0:
-            return False
-        if stat.S_ISLNK(info.st_mode):
-            # A root-owned symlink inside a root-controlled directory is safe:
-            # repointing it needs write on the directory holding it, which the
-            # step before this one has already established. Its own mode is not
-            # evidence either way — Linux reports every symlink as 0777, so
-            # testing it for group-writability rejects `/sbin` on any system
-            # where `/sbin` is the usual link into `/usr/sbin`. Where it lands
-            # is checked separately.
-            continue
-        if not stat.S_ISDIR(info.st_mode):
-            return False
-        if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
-            return False
-    return True
 
 
 _ACCOUNT_COMMAND_TIMEOUT_SECONDS = 30.0
@@ -1601,21 +1579,16 @@ def _validate_release_symlink(
         raise LinuxInstallError(
             "unsafe_install_root", "release directory symlink escapes its release"
         )
-    try:
-        target_stat = path.resolve(strict=True).stat()
-    except (OSError, RuntimeError) as exc:
+    # An external target's own mode is not the whole question: replacing a file
+    # needs write permission on the directory holding it, so everything leading
+    # to it is verified as well, through the same primitive the root-execution
+    # guard uses. The two boundaries answering differently is how a release can
+    # admit a link that diagnostics then refuse.
+    failure = trust_failure(path, require_executable=True)
+    if failure is not None:
         raise LinuxInstallError(
-            "unsafe_install_root", "release file symlink target is unavailable"
-        ) from exc
-    target_mode = stat.S_IMODE(target_stat.st_mode)
-    if (
-        not stat.S_ISREG(target_stat.st_mode)
-        or target_stat.st_uid != 0
-        or target_mode & 0o022
-        or not target_mode & 0o111
-    ):
-        raise LinuxInstallError(
-            "unsafe_install_root", "external release symlink target is not trusted"
+            "unsafe_install_root",
+            f"external release symlink target is not trusted: {failure}",
         )
 
 

--- a/ori/installer/paths.py
+++ b/ori/installer/paths.py
@@ -10,6 +10,7 @@ it finds, so every command can state the scope and paths it is acting on.
 
 from __future__ import annotations
 
+from enum import Enum
 from pathlib import Path
 
 import yaml
@@ -51,6 +52,34 @@ class UnmanagedReleaseError(Exception):
     """``current`` does not point at a release this installer manages."""
 
 
+class IndeterminateScopeError(Exception):
+    """An install root could not be inspected, so scope cannot be settled."""
+
+
+class _Presence(Enum):
+    """What inspecting an install root established.
+
+    `INACCESSIBLE` is deliberately not folded into `ABSENT`. A root that cannot
+    be read is not a root that is not there, and treating the two alike would
+    let a permission problem silently choose a scope — or, as shipped, let the
+    exception escape as a traceback out of a diagnostic command.
+    """
+
+    PRESENT = "present"
+    ABSENT = "absent"
+    INACCESSIBLE = "inaccessible"
+
+
+def _presence(root: Path) -> _Presence:
+    """Whether an installation is active at *root*, as far as we may look."""
+    try:
+        return _Presence.PRESENT if (root / "current").exists() else _Presence.ABSENT
+    except OSError:
+        # A system root left behind by an install this account cannot read is
+        # ordinary — `/opt/ori` is 0700 to root — and must not end the command.
+        return _Presence.INACCESSIBLE
+
+
 def detect_scope(root: Path | None = None) -> str:
     """Return the scope of the one managed installation present.
 
@@ -61,17 +90,32 @@ def detect_scope(root: Path | None = None) -> str:
     """
     if root is not None:
         return "system" if root == SYSTEM_ROOT else "user"
-    user_present = (user_root() / "current").exists()
-    system_present = (SYSTEM_ROOT / "current").exists()
-    if user_present and system_present:
+    user = _presence(user_root())
+    system = _presence(SYSTEM_ROOT)
+
+    if user is _Presence.PRESENT and system is _Presence.PRESENT:
         raise AmbiguousScopeError(
             f"installations exist at both {user_root()} and {SYSTEM_ROOT}; "
             "pass --scope user or --scope system"
         )
-    if user_present:
+    # One installation is definitely here and the other cannot be read. The
+    # unreadable one cannot be the one this account is running, so naming the
+    # readable one is the only answer that is both usable and true — and every
+    # report states the scope it settled on.
+    if user is _Presence.PRESENT:
         return "user"
-    if system_present:
+    if system is _Presence.PRESENT:
         return "system"
+    if _Presence.INACCESSIBLE in (user, system):
+        unreadable = " and ".join(
+            str(candidate)
+            for candidate, presence in ((user_root(), user), (SYSTEM_ROOT, system))
+            if presence is _Presence.INACCESSIBLE
+        )
+        raise IndeterminateScopeError(
+            f"could not inspect {unreadable}, and no other installation was "
+            "found; pass --scope user or --scope system explicitly"
+        )
     raise FileNotFoundError(f"no installation at {user_root()} or {SYSTEM_ROOT}")
 
 

--- a/ori/installer/trusted_paths.py
+++ b/ori/installer/trusted_paths.py
@@ -1,0 +1,168 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""One definition of a path only root can change.
+
+Several places need the same answer before they hand something privilege: the
+interpreter root is about to execute, an executable a release links out to, the
+`useradd` the installer runs as root. Each previously asked it in its own way,
+and the answers disagreed — most consequentially over symlinks, whose mode bits
+Linux reports as ``0777`` regardless of what they point at. Reading that as
+write permission classifies every virtual environment's ``bin/python`` as
+attacker-writable, which is how a correctly installed, root-owned release came
+to be refused by its own diagnostics.
+
+The rule stated once, here:
+
+- Ownership is checked on every component. Anything not owned by root is
+  untrusted, symlinks included.
+- Write permission is checked on directories and on the final file. It is never
+  checked on a symlink, because a symlink's mode grants nothing: replacing one
+  requires write permission on the directory holding it, which the walk has
+  already established.
+- Symlinks are followed one hop at a time, and every destination along the way
+  is validated in full — not only the path that resolution finally lands on.
+- Resolution is bounded and cycle-aware, so a malicious or broken link tree
+  ends the check instead of the process.
+
+Trust is the test, not containment. A virtual environment's interpreter
+normally resolves to ``/usr/bin/python3.12`` or ``/usr/local/bin/python3.12``,
+well outside the installation, and that is fine as long as root alone controls
+it. Requiring targets to stay inside the release would reject every venv ever
+built.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+# Deep enough for any legitimate interpreter chain — `python` to `python3` to
+# `python3.12` to the packaged binary is four — and shallow enough that a
+# hostile link tree ends quickly.
+MAX_SYMLINK_HOPS = 40
+
+_OTHER_WRITE = stat.S_IWGRP | stat.S_IWOTH
+
+
+def trust_failure(
+    path: str | os.PathLike[str],
+    *,
+    require_executable: bool = False,
+) -> str | None:
+    """Return why root cannot trust *path*, naming the component, or None.
+
+    With *require_executable*, the path must exist and end at a regular,
+    root-owned, root-writable-only executable. Without it, the path is judged
+    as far as it exists: a component that is missing beneath trusted ancestors
+    cannot be created by an unprivileged account, so nothing can be planted
+    there and the walk ends successfully.
+    """
+    failure = _walk(
+        Path(path),
+        require_executable=require_executable,
+        budget=[MAX_SYMLINK_HOPS],
+        seen=set(),
+    )
+    if failure is None:
+        return None
+    component, reason = failure
+    return f"{component} {reason}"
+
+
+def _walk(
+    path: Path,
+    *,
+    require_executable: bool,
+    budget: list[int],
+    seen: set[tuple[int, int]],
+) -> tuple[Path, str] | None:
+    for component in [*reversed(path.parents), path]:
+        final = component == path
+        try:
+            info = os.lstat(component)
+        except FileNotFoundError:
+            if require_executable:
+                # Something has to be run at the end of this path, and a gap
+                # anywhere along it means there is nothing to run.
+                return component, "does not exist"
+            # Beneath trusted ancestors, only root could create what is
+            # missing, so there is nothing here to distrust.
+            return None
+        except OSError as exc:
+            # Never "probably fine": an inode that cannot be inspected cannot
+            # be shown to be safe.
+            return component, f"could not be inspected ({exc.strerror or exc})"
+
+        if info.st_uid != 0:
+            return component, "is not owned by root"
+
+        if stat.S_ISLNK(info.st_mode):
+            failure = _follow(
+                component,
+                require_executable=require_executable and final,
+                budget=budget,
+                seen=seen,
+            )
+            if failure is not None:
+                return failure
+            if final:
+                return None
+            continue
+
+        if stat.S_ISDIR(info.st_mode):
+            if info.st_mode & _OTHER_WRITE:
+                return component, "is writable by another account"
+            if final and require_executable:
+                # A directory where the executable should be. Traversing into
+                # the next component is what makes a directory acceptable, and
+                # there is no next component here.
+                return component, "is not a regular file"
+            continue
+
+        if not final:
+            return component, "is not a directory"
+
+        if require_executable and not stat.S_ISREG(info.st_mode):
+            return component, "is not a regular file"
+        if info.st_mode & _OTHER_WRITE:
+            return component, "is writable by another account"
+        if require_executable and not info.st_mode & 0o111:
+            return component, "is not executable"
+        return None
+    return None
+
+
+def _follow(
+    link: Path,
+    *,
+    require_executable: bool,
+    budget: list[int],
+    seen: set[tuple[int, int]],
+) -> tuple[Path, str] | None:
+    """Validate one hop and everything the destination itself rests on."""
+    budget[0] -= 1
+    if budget[0] < 0:
+        return link, "resolves through too many symlinks"
+    try:
+        info = os.lstat(link)
+    except OSError as exc:
+        return link, f"could not be inspected ({exc.strerror or exc})"
+    identity = (info.st_dev, info.st_ino)
+    if identity in seen:
+        return link, "resolves through a symlink cycle"
+    seen.add(identity)
+
+    try:
+        target = os.readlink(link)
+    except OSError as exc:
+        return link, f"symlink could not be read ({exc.strerror or exc})"
+
+    destination = Path(os.path.normpath(os.path.join(link.parent, target)))
+    return _walk(
+        destination,
+        require_executable=require_executable,
+        budget=budget,
+        seen=seen,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,6 +191,13 @@ target-version = "py311"
 select = ["E", "F", "I", "N", "W"]
 ignore = ["E501"]
 
+# `tests/` imports a few helpers from `scripts/`, which is not a package and so
+# is not on the analyzer's path by default. Two test modules already did this
+# and reported an unresolved import in the editor; declaring the path once
+# fixes both rather than scattering per-file suppressions.
+[tool.pyright]
+extraPaths = ["scripts"]
+
 [tool.mypy]
 python_version = "3.11"
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0rc4"
+version = "2.4.0rc5"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/build-wheelhouse.sh
+++ b/scripts/build-wheelhouse.sh
@@ -191,8 +191,15 @@ fi
 
 # 2. Build the ori-runtime wheel itself
 echo "Building ${PACKAGE_NAME} wheel..."
+# --no-build-isolation: pyproject declares `setuptools>=68` and `wheel`, and
+# without this pip builds in a fresh environment it populates from PyPI at
+# build time. The wheel that gets signed would then be produced by tooling
+# outside the hash lock, which is the one place it matters most. The caller is
+# responsible for having the pinned build backend installed; every caller
+# installs requirements/dev.txt, which pins it.
 "${PYTHON}" -m pip wheel \
   --no-deps \
+  --no-build-isolation \
   --wheel-dir "${OUT}" \
   .
 

--- a/scripts/evidence_host.py
+++ b/scripts/evidence_host.py
@@ -1,0 +1,438 @@
+#!/usr/bin/env python3
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The bindings the host evidence harness kept getting wrong.
+
+Five review rounds found the same defect in five variables: a value checked in
+one place and used in another, with the two free to disagree. A target verified
+but not enforced. Tooling hash-locked but not used. An interpreter selected but
+not applied. A boot recorded but its version ignored. Each was a shell variable,
+and each was defended by a test that matched text rather than behaviour — which
+is how a comment containing a flag's name came to satisfy an assertion about
+the flag.
+
+Here they are function arguments. Selecting the interpreter and returning it is
+one act; a caller cannot verify one thing and use another without saying so.
+The tests exercise these functions rather than reading the script that calls
+them.
+
+Shell keeps what shell is for: `sudo`, `systemctl`, and dispatching phases.
+
+Only the standard library is used. This runs on an operator's machine before
+anything is installed, so it cannot depend on the package it is about to test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Sequence
+
+SUPPORTED_PYTHON = ("3.11", "3.12")
+SIGNATURE_DOMAIN = b"ori.runtime_release_bundle_signature.v1\0"
+_ED25519_SPKI_PREFIX = bytes.fromhex("302a300506032b6570032100")
+
+# `ori/security/release_bundles.py` refuses a key that is not purpose-bound, and
+# refuses a revoked one at verification. Checking less here would let this
+# report a signature verified for an artifact the installer then refuses —
+# a PASS recorded for a claim that is not true.
+RELEASE_KEY_PURPOSE = "runtime_release_bundle"
+TRUSTED_KEY_STATUS = frozenset({"active", "verify_only"})
+
+# uname reports these; the tuple names the left-hand form.
+_ARCH_ALIASES = {
+    "x86_64": "x86_64",
+    "amd64": "x86_64",
+    "aarch64": "aarch64",
+    "arm64": "aarch64",
+}
+
+
+class EvidenceError(Exception):
+    """A claim could not be established. The message is for an operator."""
+
+
+def _read_bytes(path: Path, description: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as exc:
+        raise EvidenceError(f"{description} is unreadable: {exc}") from exc
+
+
+def _required_field(mapping: dict[str, object], field: str, description: str) -> str:
+    """A registry is untrusted input; a missing field is an operator message."""
+    value = mapping.get(field)
+    if not isinstance(value, str) or not value:
+        raise EvidenceError(f"{description} declares no {field}")
+    return value
+
+
+def _decode_base64(value: str, description: str) -> bytes:
+    try:
+        return base64.b64decode(value, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise EvidenceError(f"{description} is not valid base64: {exc}") from exc
+
+
+def _run_openssl(arguments: Sequence[str]) -> subprocess.CompletedProcess[str]:
+    """Run openssl, reporting its absence as a prerequisite rather than a crash.
+
+    This is the tooling that predates the artifact, so a host without it cannot
+    verify at all — an operator needs to be told that, not shown a traceback
+    from deep inside subprocess.
+    """
+    try:
+        return subprocess.run(
+            ["openssl", *arguments], capture_output=True, text=True, check=False
+        )
+    except OSError as exc:
+        raise EvidenceError(f"openssl could not be run: {exc}") from exc
+
+
+def _read_json(path: Path, description: str) -> dict[str, object]:
+    """Read JSON as an operator error rather than a traceback.
+
+    A mistyped path and a truncated download are the two most likely things to
+    go wrong on the host, and the shell branches on the exit status: a
+    traceback is not a contract.
+    """
+    try:
+        document = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise EvidenceError(f"{description} is unreadable: {exc}") from exc
+    if not isinstance(document, dict):
+        raise EvidenceError(f"{description} is not a JSON object")
+    return document
+
+
+@dataclass(frozen=True)
+class Target:
+    """A release target tuple, parsed rather than pattern-matched in shell."""
+
+    architecture: str
+    python: str
+
+    @classmethod
+    def parse(cls, value: str) -> Target:
+        match = re.fullmatch(r"linux-(x86_64|aarch64)-python(3\.\d+)", value)
+        if match is None:
+            raise EvidenceError(f"unsupported target tuple: {value}")
+        architecture, python = match.group(1), match.group(2)
+        if python not in SUPPORTED_PYTHON:
+            raise EvidenceError(f"unsupported Python in target: {value}")
+        return cls(architecture=architecture, python=python)
+
+    def __str__(self) -> str:
+        return f"linux-{self.architecture}-python{self.python}"
+
+    def require_host_architecture(self, machine: str) -> None:
+        """Refuse a target this machine cannot honestly build or install."""
+        actual = _ARCH_ALIASES.get(machine, machine)
+        if actual != self.architecture:
+            raise EvidenceError(
+                f"target is for {self.architecture}, this host is {actual}"
+            )
+
+
+def interpreter_for(target: Target, *, which=shutil.which) -> Path:
+    """Return the interpreter *target* names, having asked it its own version.
+
+    A name on PATH is not evidence: `python3.12` may be a wrapper, a shim, or a
+    link to something else entirely. Selecting and validating happen together
+    so a caller cannot end up building with one and claiming another.
+    """
+    located = which(f"python{target.python}")
+    if located is None:
+        raise EvidenceError(f"target needs python{target.python}, which is not on PATH")
+    try:
+        reported = subprocess.run(
+            [
+                located,
+                "-c",
+                "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as exc:
+        # A name on PATH that is a directory, a broken symlink, or a file
+        # without an interpreter line. This is the check that catches it.
+        raise EvidenceError(f"{located} could not be run: {exc}") from exc
+    if reported.returncode != 0:
+        raise EvidenceError(f"{located} could not be run: {reported.stderr.strip()}")
+    version = reported.stdout.strip()
+    if version != target.python:
+        raise EvidenceError(f"{located} reports {version}, not {target.python}")
+    return Path(located)
+
+
+def envelope_target(signature: Path) -> Target:
+    """The target the artifact was signed for, from the envelope itself.
+
+    Taking it from anywhere else lets a 3.12 artifact be driven by a 3.10
+    installer, which refuses before installation is attempted — a failure about
+    the harness wearing the appearance of a failure about the release.
+    """
+    document = _read_json(signature, "signature envelope")
+    if "target" not in document:
+        raise EvidenceError("signature envelope declares no target")
+    return Target.parse(str(document["target"]))
+
+
+def verify_artifact(
+    *,
+    bundle: Path,
+    signature: Path,
+    registry: Path,
+    expected_sha256: str,
+    expected_version: str,
+    workspace: Path,
+) -> str:
+    """Verify digest and signature with tooling that predates the artifact.
+
+    Installing first and letting the newly installed code check its own source
+    inverts the trust boundary; this runs as root, so it uses openssl and
+    hashlib against a registry the caller supplies.
+    """
+    payload = _read_bytes(bundle, f"the artifact {bundle.name}")
+    actual = hashlib.sha256(payload).hexdigest()
+    if actual != expected_sha256:
+        raise EvidenceError(
+            f"artifact digest is {actual}, the record says {expected_sha256}"
+        )
+
+    envelope = _read_json(signature, "signature envelope")
+    required = {
+        "artifact",
+        "artifact_sha256",
+        "artifact_size",
+        "key_id",
+        "runtime_version",
+        "schema",
+        "signature",
+        "target",
+    }
+    missing = sorted(required - set(envelope))
+    if missing:
+        raise EvidenceError(f"signature envelope is missing {', '.join(missing)}")
+    if envelope["runtime_version"] != expected_version:
+        raise EvidenceError(
+            f"envelope names {envelope['runtime_version']}, expected {expected_version}"
+        )
+    if envelope["artifact"] != bundle.name:
+        raise EvidenceError(f"envelope names {envelope['artifact']}, got {bundle.name}")
+    if envelope["artifact_size"] != len(payload):
+        raise EvidenceError("artifact size does not match the envelope")
+    if envelope["artifact_sha256"] != f"sha256:{actual}":
+        raise EvidenceError("artifact digest does not match the envelope")
+
+    entries = _read_json(registry, "key registry").get("keys")
+    if not isinstance(entries, list):
+        raise EvidenceError("key registry declares no keys")
+    keys = {entry.get("key_id"): entry for entry in entries if isinstance(entry, dict)}
+    key = keys.get(envelope["key_id"])
+    if key is None:
+        raise EvidenceError(
+            f"envelope names key {envelope['key_id']}, absent from the registry"
+        )
+    if key.get("purpose") != RELEASE_KEY_PURPOSE:
+        raise EvidenceError(f"key {envelope['key_id']} is not a release-bundle key")
+    if key.get("status") not in TRUSTED_KEY_STATUS:
+        raise EvidenceError(
+            f"key {envelope['key_id']} has status {key.get('status')!r}, not trusted"
+        )
+
+    scheme, _, encoded = str(envelope["signature"]).partition(":")
+    if scheme != "ed25519":
+        raise EvidenceError(f"unsupported signature scheme: {scheme}")
+
+    unsigned = {k: v for k, v in envelope.items() if k != "signature"}
+    message = (
+        SIGNATURE_DOMAIN
+        + json.dumps(
+            unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+    )
+
+    public_key = _decode_base64(
+        _required_field(key, "public_key_b64", f"key {envelope['key_id']}"),
+        f"public key for {envelope['key_id']}",
+    )
+    signature_bytes = _decode_base64(encoded, "signature")
+
+    public = workspace / "public.der"
+    try:
+        workspace.mkdir(parents=True, exist_ok=True)
+        public.write_bytes(_ED25519_SPKI_PREFIX + public_key)
+        (workspace / "message.bin").write_bytes(message)
+        (workspace / "signature.bin").write_bytes(signature_bytes)
+    except OSError as exc:
+        raise EvidenceError(f"verification workspace is unusable: {exc}") from exc
+
+    result = _run_openssl(
+        [
+            "pkeyutl",
+            "-verify",
+            "-pubin",
+            "-inkey",
+            str(public),
+            "-keyform",
+            "DER",
+            "-rawin",
+            "-in",
+            str(workspace / "message.bin"),
+            "-sigfile",
+            str(workspace / "signature.bin"),
+        ]
+    )
+    if result.returncode != 0:
+        raise EvidenceError(
+            f"signature did not verify: {result.stdout.strip()} {result.stderr.strip()}"
+        )
+    return f"{bundle.name} verified against {envelope['key_id']}"
+
+
+@dataclass(frozen=True)
+class InstallRecord:
+    """What an install phase proved, for a later phase to rely on."""
+
+    boot_id: str
+    version: str
+
+    def render(self) -> str:
+        return f"boot_id={self.boot_id}\nversion={self.version}\n"
+
+    @classmethod
+    def parse(cls, text: str) -> InstallRecord:
+        fields = dict(line.split("=", 1) for line in text.splitlines() if "=" in line)
+        if "boot_id" not in fields or "version" not in fields:
+            raise EvidenceError("install record is incomplete")
+        return cls(boot_id=fields["boot_id"], version=fields["version"])
+
+
+def write_record(path: Path, record: InstallRecord) -> None:
+    """Write via a staged rename, so no reader sees a half-written record.
+
+    The record's own mode is what keeps it private. Its directory is not this
+    function's to reassign: the real path is `/var/lib/ori-evidence-state`, and
+    tightening `/var/lib` on an operator's host would break every account on
+    the machine to protect one file that is already 0600.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle, staged = tempfile.mkstemp(dir=path.parent, prefix=".record-")
+    try:
+        with os.fdopen(handle, "w", encoding="utf-8") as stream:
+            stream.write(record.render())
+        os.chmod(staged, 0o600)
+        os.replace(staged, path)
+    except BaseException:
+        Path(staged).unlink(missing_ok=True)
+        raise
+
+
+def require_reboot_since(
+    record_path: Path, *, expected_version: str, current_boot: str | None = None
+) -> InstallRecord:
+    """Establish that this host rebooted since *that* installation.
+
+    Uptime cannot: installing shortly after an ordinary boot and running the
+    next phase immediately satisfies any bound while nothing has restarted. And
+    a record left by an earlier candidate would otherwise let this vouch for
+    whichever release happens to be active now.
+    """
+    try:
+        record = InstallRecord.parse(record_path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise EvidenceError(f"no install record at {record_path}: {exc}") from exc
+    if record.version != expected_version:
+        raise EvidenceError(
+            f"the record is for {record.version}, asked about {expected_version}"
+        )
+    if current_boot is None:
+        current_boot = current_boot_id()
+    if not current_boot:
+        raise EvidenceError("the current boot id is empty; cannot establish a reboot")
+    if record.boot_id == current_boot:
+        raise EvidenceError(
+            f"still boot {current_boot}; reboot before running this phase"
+        )
+    return record
+
+
+def current_boot_id(path: Path = Path("/proc/sys/kernel/random/boot_id")) -> str:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        raise EvidenceError(f"boot id is unavailable: {exc}") from exc
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    choose = sub.add_parser("select-python", help="resolve the artifact's interpreter")
+    choose.add_argument("--signature", type=Path, required=True)
+
+    check = sub.add_parser("verify", help="verify digest and signature")
+    check.add_argument("--bundle", type=Path, required=True)
+    check.add_argument("--signature", type=Path, required=True)
+    check.add_argument("--registry", type=Path, required=True)
+    check.add_argument("--sha256", required=True)
+    check.add_argument("--version", required=True)
+    check.add_argument("--workspace", type=Path, required=True)
+
+    record = sub.add_parser("record", help="record a passing installation")
+    record.add_argument("--path", type=Path, required=True)
+    record.add_argument("--version", required=True)
+
+    persisted = sub.add_parser("require-reboot", help="require a later boot")
+    persisted.add_argument("--path", type=Path, required=True)
+    persisted.add_argument("--version", required=True)
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "select-python":
+            target = envelope_target(args.signature)
+            target.require_host_architecture(os.uname().machine)
+            print(interpreter_for(target))
+        elif args.command == "verify":
+            print(
+                verify_artifact(
+                    bundle=args.bundle,
+                    signature=args.signature,
+                    registry=args.registry,
+                    expected_sha256=args.sha256,
+                    expected_version=args.version,
+                    workspace=args.workspace,
+                )
+            )
+        elif args.command == "record":
+            write_record(
+                args.path,
+                InstallRecord(boot_id=current_boot_id(), version=args.version),
+            )
+            print(f"recorded {args.version}")
+        elif args.command == "require-reboot":
+            found = require_reboot_since(args.path, expected_version=args.version)
+            print(f"rebooted since {found.boot_id}")
+    except EvidenceError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# This file is a bash/Python polyglot: bash runs the preamble below, selects an
+# interpreter, and `exec`s it before reaching any Python. `bash -n` parses the
+# whole file at once and therefore reports a syntax error on the first
+# Python-only construct — that is expected, and is not a defect to repair by
+# restructuring this preamble. What must hold is that bash never falls through
+# into the Python: every path here ends in `exec` or `exit`, which
+# `test_the_preamble_always_hands_off_before_python_begins` pins. Both dispatch
+# modes are exercised by `test_shell_polyglot_help_runs_without_importing_runtime`.
 """:"
 if [ -z "${BASH_VERSION:-}" ]; then
   echo "unsupported_target: install-linux.sh must be run with bash; use curl ... | bash -s -- ..." >&2

--- a/scripts/run-workflow-guard.sh
+++ b/scripts/run-workflow-guard.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
 # Launch the supply-chain guard with an interpreter that has the repository's
 # hash-installed dependencies.
 #

--- a/scripts/smoke-runtime-local.sh
+++ b/scripts/smoke-runtime-local.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -9,13 +9,16 @@ import json
 import os
 import pwd
 import socket
+import stat
 import subprocess
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Sequence
 
 import pytest
 
 from ori import doctor
+from ori.installer import trusted_paths
 from ori.utils import terminal
 
 
@@ -82,14 +85,30 @@ def test_run_doctor_refuses_before_spawning_anything(
     assert runner.calls == []
 
 
+# Which component of a temporary tree is untrusted first is the platform's
+# choice, not the installer's: pytest builds under `/tmp` on Linux, which is
+# mode 1777, and under a user-owned `/var/folders/...` on macOS. Both are
+# genuine refusals, so the assertion is that root declined and said which
+# component and why — not which of the two reasons this host happened to reach.
+_TRUST_REASONS = ("is not owned by root", "is writable by another account")
+
+
+def _refusal_is_explained(message: str) -> bool:
+    return "refusing to execute as root" in message and any(
+        reason in message for reason in _TRUST_REASONS
+    )
+
+
 def test_a_system_label_on_a_user_owned_root_is_refused(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """`--scope system --root /home/alice/...` must not launder a user install."""
     monkeypatch.setattr(os, "geteuid", lambda: 0)
+
     with pytest.raises(doctor.UnsafeExecutionError) as excinfo:
         doctor.assert_execution_allowed(_identity(tmp_path, scope="system"))
-    assert "not owned by root" in str(excinfo.value)
+
+    assert _refusal_is_explained(str(excinfo.value)), excinfo.value
 
 
 def test_run_doctor_refuses_a_laundered_root_before_spawning_anything(
@@ -120,34 +139,53 @@ def test_an_explicit_root_is_still_refused_execution_as_root(
 
 def test_a_root_owned_chain_is_trusted() -> None:
     """The real system layout: root-owned, not writable by group or other."""
-    assert doctor._first_untrusted_component(Path("/usr/bin/env")) is None
+    assert doctor._interpreter_trust_failure(Path("/usr/bin/env")) is None
 
 
-def test_a_user_owned_component_is_named(tmp_path: Path, not_root: None) -> None:
-    """The temp tree is user-owned somewhere above tmp_path; that must be caught."""
-    untrusted = doctor._first_untrusted_component(tmp_path / "x" / "y")
-    assert untrusted is not None
-    assert untrusted == tmp_path or untrusted in tmp_path.parents
+def test_an_untrusted_component_is_named(tmp_path: Path, not_root: None) -> None:
+    """A temporary tree is untrusted somewhere above; that must be caught.
+
+    The component named is whichever fails first — user-owned on one platform,
+    world-writable on another — and either answer identifies a path root cannot
+    rely on.
+    """
+    failure = doctor._interpreter_trust_failure(tmp_path / "x" / "y")
+
+    assert failure is not None
+    assert any(reason in failure for reason in _TRUST_REASONS), failure
 
 
 def test_a_group_writable_component_is_untrusted(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Root ownership alone is not enough if another account can write it."""
+    monkeypatch.setattr(
+        trusted_paths.os,
+        "lstat",
+        lambda path: SimpleNamespace(st_uid=0, st_mode=stat.S_IFDIR | 0o775),
+    )
 
-    class _Stat:
-        st_uid = 0
-        st_mode = 0o40775  # root-owned, group-writable
+    failure = doctor._interpreter_trust_failure(tmp_path)
 
-    monkeypatch.setattr(Path, "lstat", lambda self: _Stat())
-    assert doctor._first_untrusted_component(tmp_path) is not None
+    assert failure is not None
+    assert "is writable by another account" in failure
 
 
 def test_a_missing_component_below_a_trusted_chain_is_accepted() -> None:
-    """Nothing unprivileged can create it, so there is nothing to plant."""
-    assert (
-        doctor._first_untrusted_component(Path("/usr/absent/venv/bin/python")) is None
-    )
+    """Nothing unprivileged can create it, so there is nothing to plant.
+
+    The execution guard asks only whether anything untrusted lies on the path;
+    whether the interpreter exists is the caller's concern.
+    """
+    assert trusted_paths.trust_failure("/usr/absent/venv/bin/python") is None
+
+
+def test_an_interpreter_that_does_not_exist_is_refused() -> None:
+    """Executing it is the question here, and a missing file cannot be run."""
+    failure = doctor._interpreter_trust_failure(Path("/usr/absent/venv/bin/python"))
+
+    assert failure is not None
+    assert "does not exist" in failure
 
 
 def test_user_scope_as_its_owner_is_allowed(

--- a/tests/test_evidence_harness.py
+++ b/tests/test_evidence_harness.py
@@ -223,7 +223,7 @@ def test_the_digest_helper_is_defined_before_use() -> None:
 def test_the_harness_revision_is_current() -> None:
     """A run is evidence for one revision; bump it whenever bytes change."""
     source = HARNESS.read_text(encoding="utf-8")
-    assert 'HARNESS_REVISION="7"' in source
+    assert 'HARNESS_REVISION="8"' in source
 
 
 def test_the_driver_runs_the_resolved_image_not_the_tag() -> None:
@@ -247,3 +247,620 @@ def test_it_declares_what_it_cannot_prove(source: str) -> None:
     header = source[: source.index("set -euo pipefail")]
     for absent in ("KMS", "redirect", "reverification"):
         assert absent in header, f"header must disclaim {absent}"
+
+
+# --- the systemd-host harness and the artifact builder -----------------------
+#
+# These run as root on an operator's machine. Nothing here executes them; each
+# claim is a property of the text that would run, chosen because getting it
+# wrong produces a PASS for something never tested.
+
+HOST_HARNESS = Path("docs/releases/evidence/harness-systemd-host.sh")
+ARTIFACT_BUILDER = Path("docs/releases/evidence/build-local-artifact.sh")
+RUNBOOK = Path("docs/releases/evidence/systemd-host-runbook.md")
+
+
+def _host_harness() -> str:
+    return HOST_HARNESS.read_text(encoding="utf-8")
+
+
+def _phase(name: str) -> str:
+    """One phase's body, so a claim cannot be satisfied by another phase.
+
+    Matching anywhere in the file lets `--device-id` in the rollback phase
+    vouch for an install phase that omits it.
+    """
+    source = _host_harness()
+    start = source.index(f"phase_{name}() {{")
+    remainder = source[start + 1 :]
+    following = [
+        remainder.index(f"phase_{other}() {{")
+        for other in ("install", "persist", "rollback", "uninstall")
+        if f"phase_{other}() {{" in remainder
+    ]
+    return remainder[: min(following)] if following else remainder
+
+
+def test_the_install_phase_supplies_the_identity_unattended_mode_requires() -> None:
+    """`--unattended` without identity is rejected before anything installs.
+
+    A phase that omits them cannot reach activation at all, so every claim
+    after it would describe an installation that never happened.
+    """
+    install = _phase("install")
+
+    for option in ("--device-id", "--name", "--location"):
+        assert option in install, f"install phase omits {option}"
+
+
+def test_the_install_phase_asserts_the_identity_it_supplied() -> None:
+    """Producing a config is not evidence that it holds the right values."""
+    source = _host_harness()
+
+    assert "config carries the evidence device id" in source
+    assert "doctor reports the evidence device" in source
+
+
+def test_every_install_asserts_the_release_under_test() -> None:
+    """Each phase must bind its claims to the requested version.
+
+    Reboot persistence for some other active release is not persistence for
+    this candidate.
+    """
+    assert "install reports the requested version" in _phase("install")
+    persist = _phase("persist")
+    # The record is version-bound inside `evidence_host.require_reboot_since`,
+    # which is tested there. What remains a property of the shell is that it
+    # passes the version at all: omit it and the phase would vouch for
+    # whichever release the host happens to be running.
+    assert '--version "$version"' in persist, (
+        "persistence does not bind its claim to the release under test"
+    )
+    assert "doctor still reports the release under test" in persist
+
+
+def test_rollback_requires_the_exact_stable_failure_code() -> None:
+    """ "Some nonzero exit" is satisfied by never activating anything.
+
+    An argument error, a signature rejection or a target mismatch all exit
+    nonzero without installing, and `current` would not have moved — which is
+    indistinguishable from a successful rollback unless the code is checked.
+    """
+    source = _host_harness()
+
+    assert "post_install_health_failed" in source
+    assert "the failed candidate was removed" in source
+
+
+def test_rollback_passes_the_expected_version() -> None:
+    """Without it the candidate can be refused for the wrong reason."""
+    source = _host_harness()
+    rollback = source[
+        source.index("phase_rollback()") : source.index("phase_uninstall()")
+    ]
+
+    assert "--expected-version" in rollback
+
+
+def test_the_artifact_is_verified_before_it_is_extracted_or_executed() -> None:
+    """Otherwise the artifact's own code is what vouches for the artifact.
+
+    This harness runs as root: digest and signature are checked with tooling
+    that predates the bundle, before `tar` or `pip` touch it.
+    """
+    # The call site inside each phase, not the function definition, which
+    # necessarily precedes everything and therefore proves nothing.
+    for name in ("install", "rollback"):
+        body = _phase(name)
+        if "tar -C" not in body:
+            continue
+        assert "verify_artifact " in body, f"{name} extracts without verifying"
+        assert body.index("verify_artifact ") < body.index("tar -C"), (
+            f"{name} extracts before it verifies"
+        )
+    # The digest and signature checks themselves live in `evidence_host.py`,
+    # against tooling that predates the artifact; they are exercised there
+    # with real Ed25519 material rather than asserted as text here.
+    assert "openssl" in Path("scripts/evidence_host.py").read_text(encoding="utf-8")
+
+
+def test_the_release_tooling_is_installed_with_hashes_enforced() -> None:
+    """The bootstrap's sequence: hash-locked dependencies, then the one wheel."""
+    source = _host_harness()
+
+    assert "--require-hashes" in source
+    assert "--no-deps" in source
+
+
+def test_the_harness_writes_only_to_a_private_root_owned_workspace() -> None:
+    """A predictable /tmp path is writable by every account on the host.
+
+    A root process writing there can be aimed elsewhere by a symlink planted
+    in advance.
+    """
+    source = _host_harness()
+
+    assert "mktemp -d" in source
+    assert "chmod 700" in source
+    assert "/tmp/rollback" not in source
+
+
+def test_the_builder_does_not_claim_byte_identity_with_production() -> None:
+    """It substitutes the packaged registry, so the bytes genuinely differ."""
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+
+    # Matched on the word alone: the sentence wraps across comment lines, and
+    # an assertion on the wrapped phrasing would fail on reflow rather than on
+    # the claim it is meant to police.
+    assert "byte-for-byte" not in source
+    assert "byte-identical" in source
+
+
+def test_the_builder_resolves_its_output_directory_before_changing_directory() -> None:
+    """A relative outdir would land inside the tree the cleanup trap removes."""
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+    resolve = source.index('OUTDIR="$(cd "$OUTDIR" && pwd)"')
+    change = source.index('cd "$SOURCE"')
+
+    assert resolve < change
+
+
+def test_both_new_scripts_state_what_they_do_not_prove() -> None:
+    """Evidence that overstates itself is worse than none."""
+    for path in (HOST_HARNESS, ARTIFACT_BUILDER):
+        source = path.read_text(encoding="utf-8")
+        assert "KMS" in source, f"{path} does not disclaim signing custody"
+        assert "publication" in source, f"{path} does not disclaim publication"
+
+
+def test_the_builder_enforces_the_target_tuple_it_labels() -> None:
+    """A tuple is a claim about this machine, not a filename.
+
+    Building with the host default interpreter while naming the artifact for
+    another version produces a bundle that fails only once it reaches a device.
+    """
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+
+    # The comparison, not the mention: `uname -m` survives having its result
+    # compared against nothing.
+    assert '[ "$HOST_ARCH" = "$TUPLE_ARCH" ]' in source, (
+        "the builder never compares the architecture it claims"
+    )
+    assert 'BUILD_PYTHON="$(command -v "python$TUPLE_PYTHON"' in source
+    assert '[ "$BUILD_PYTHON_VERSION" = "$TUPLE_PYTHON" ]' in source, (
+        "the selected interpreter is never asked its own version"
+    )
+
+
+def test_the_builder_builds_with_the_interpreter_it_verified() -> None:
+    """`build-wheelhouse.sh` defaults to ambient python3 without ORI_PYTHON.
+
+    Verifying one interpreter and building with another leaves the tuple as
+    decoration.
+    """
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+
+    # The venv the hashes were enforced into, not the bare system interpreter:
+    # `pip download` and `pip wheel` run from ORI_PYTHON, so pointing it at
+    # $BUILD_PYTHON leaves ambient packages in control of the build.
+    assert 'ORI_PYTHON="$PY"' in source
+    assert 'ORI_PYTHON="$BUILD_PYTHON"' not in source
+    assert 'venv "$WORKDIR/venv"' in source
+    assert '"$BUILD_PYTHON" -m venv' in source
+
+
+def test_the_builder_installs_hash_locked_tooling() -> None:
+    """Live resolution puts unpinned code into what signs the artifact."""
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+
+    assert "--require-hashes" in source
+    assert "requirements/dev.txt" in source
+    assert "pip install --quiet cryptography" not in source
+
+
+def test_persistence_requires_a_different_boot_not_a_low_uptime() -> None:
+    """Installing just after a boot and running the phase at once passes any
+    uptime bound while nothing has restarted.
+
+    Comparing the boot ids is `require_reboot_since`, tested against both
+    outcomes in `test_evidence_host.py`. The shell must reach it, and must not
+    substitute a weaker signal of its own.
+    """
+    install = _phase("install")
+    persist = _phase("persist")
+
+    assert "evidence record" in install, "the install phase records no boot"
+    assert "evidence require-reboot" in persist, "persistence checks no boot"
+    assert "/proc/uptime" not in persist, "uptime is not evidence of a reboot"
+
+
+def test_the_install_phase_proves_the_launcher_works() -> None:
+    """A launcher conflict is non-fatal, so an install can report healthy with
+    no `ori` command at all — invisible to a doctor run by absolute path."""
+    install = _phase("install")
+
+    assert '"launcher_installed": true' in install
+    assert "doctor runs through the launcher" in install
+    assert '"$launcher" doctor' in install
+
+
+def test_the_clean_state_check_rejects_a_pre_existing_launcher() -> None:
+    """An `ori` already on PATH would be the thing the run then exercises."""
+    install = _phase("install")
+
+    # The guard itself: the path and the label both survive the condition
+    # being replaced with one that is always true.
+    assert "[ ! -e /usr/local/bin/ori ]" in install, (
+        "the clean-state phase does not reject a pre-existing launcher"
+    )
+
+
+def test_the_builder_checks_the_version_with_the_tuple_interpreter() -> None:
+    """The host default may be older than the source supports.
+
+    Reading pyproject with a 3.10 default fails on `tomllib` before the 3.12 the
+    tuple asked for is ever discovered — a failure about the machine dressed as
+    a failure about the release.
+    """
+    source = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+    discovery = source.index('BUILD_PYTHON="$(command -v')
+    check = source.index('- "$RELEASE_VERSION"')
+
+    assert discovery < check, "the version check runs before interpreter discovery"
+    assert '"$BUILD_PYTHON" - "$RELEASE_VERSION"' in source, (
+        "the version check does not use the tuple's interpreter"
+    )
+
+
+def test_the_host_harness_derives_its_interpreter_from_the_signed_target() -> None:
+    """A correctly built 3.12 artifact driven by a 3.10 installer is refused
+    with `unsupported_target` before installation is ever attempted.
+
+    Reading the target, matching the host architecture and asking the
+    interpreter its own version are `evidence_host.py`, tested there against a
+    fake interpreter that lies. The shell must derive the interpreter from the
+    signature rather than name one itself.
+    """
+    install = _phase("install")
+
+    assert "select_tooling_interpreter" in install
+    assert 'select-python --signature "$signature"' in _host_harness(), (
+        "the interpreter is not derived from the signed envelope"
+    )
+
+
+def test_the_host_harness_builds_tooling_with_that_interpreter() -> None:
+    """Selecting an interpreter and then using another leaves it decorative."""
+    source = _host_harness()
+
+    assert "python3 -m venv" not in source, "the host default still builds tooling"
+    assert '"${TOOLING_PYTHON:?' in source
+
+
+def test_the_install_phase_records_its_boot_only_after_every_assertion() -> None:
+    """A record written early survives the assertions after it failing.
+
+    The persistence phase would then treat a failed installation as its
+    provenance — the run it vouches for never having completed.
+    """
+    install = _phase("install")
+    record = install.index("evidence record")
+
+    for label in (
+        "launcher was installed",
+        "config carries the evidence device id",
+        "unit is enabled for boot",
+        "health socket exists",
+        "installed doctor reports no blocking failure",
+    ):
+        assert label in install, f"install no longer asserts {label!r}"
+        assert install.index(label) < record, (
+            f"the boot record is written before {label!r} is asserted"
+        )
+
+
+def test_the_host_harness_revision_is_current() -> None:
+    """A run is evidence for one revision; bump it whenever bytes change.
+
+    The container harness carries this pin already. Without the same one here,
+    a record naming revision 6 could describe any of several scripts.
+    """
+    assert 'HARNESS_REVISION="12"' in _host_harness()
+
+
+def _uninstall_commands() -> str:
+    """Lines the uninstall phase executes, without its closing report.
+
+    `userdel` appears there as guidance; matching the whole phase would confuse
+    printing an instruction with carrying it out.
+    """
+    return "\n".join(
+        line
+        for line in _phase("uninstall").splitlines()
+        if not line.lstrip().startswith(("printf", "#"))
+    )
+
+
+def test_the_uninstall_phase_removes_nothing_recursively() -> None:
+    """As root, `rm -rf` on a system path needs stronger authority than a grep.
+
+    An earlier revision authorised it when the evidence device id appeared
+    anywhere in the YAML — a string that can occur in any field, including a
+    real deployment's. `rmdir` needs no such judgement: it removes a directory
+    only when the directory is already empty.
+    """
+    executed = _uninstall_commands()
+
+    assert "rm -rf" not in executed, "the phase removes a tree recursively"
+    assert "rm -r " not in executed
+    assert 'grep -q "$EVIDENCE_DEVICE_ID"' not in executed, (
+        "a string match is not proof the harness owns this installation"
+    )
+    assert 'rmdir "$SYSTEM_ROOT"' in executed
+
+
+def test_the_installer_empties_the_root_before_rmdir_takes_it() -> None:
+    """`rmdir` refuses a non-empty directory, so its success is the proof.
+
+    It cannot say *which* path survived, so each managed path is named. The
+    installer does the deleting; the harness only takes away what is left.
+    """
+    executed = _uninstall_commands()
+    removal = executed.index('rmdir "$SYSTEM_ROOT"')
+
+    assert "--remove-data" in executed, "data would survive and block a re-run"
+    named = re.search(r"for leftover in ([\w ]+); do", executed)
+    assert named, "the managed paths are never enumerated"
+    assert set(named.group(1).split()) == {"current", "releases", "data"}, (
+        f"the phase checks {named.group(1)!r}, not every managed path"
+    )
+    assert '[ ! -e "$SYSTEM_ROOT/$leftover" ]' in executed, "presence is not checked"
+    assert executed.index("for leftover in") < removal
+
+
+def test_a_non_empty_install_root_is_reported_not_forced() -> None:
+    """Something the installer kept is a finding, not something to destroy."""
+    uninstall = _phase("uninstall")
+
+    # BLOCKED, so partial coverage changes the exit status rather than the
+    # phase quietly deciding on its own to force the removal through.
+    assert 'blocked "install root removed"' in uninstall
+    assert "rmdir -p" not in uninstall, "rmdir -p would climb out of the root"
+
+
+def test_the_harness_leaves_the_host_able_to_run_again() -> None:
+    """A retained install root makes the next install refuse the clean-state
+    check, which is exactly the protection that must not be weakened."""
+    executed = _uninstall_commands()
+
+    assert 'rm -f "$STATE_FILE"' in executed
+    # The account is reused as found by `ensure_service_account`, so it does
+    # not block a further run and is not the harness's to delete.
+    assert "userdel" not in executed, "the uninstall phase deletes the account itself"
+
+
+def test_the_host_harness_delegates_binding_rather_than_reimplementing_it() -> None:
+    """Shell keeps sudo, systemctl and phase dispatch.
+
+    Every check the module owns is exercised in `test_evidence_host.py` against
+    real Ed25519 material and a lying interpreter. A shell copy alongside it
+    would be the untested one.
+    """
+    source = _host_harness()
+    # Command lines only. The header explains the trust model and names the
+    # tooling by design; matching the whole file would fail on the explanation
+    # rather than on a duplicated check.
+    commands = "\n".join(
+        line for line in source.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    assert "evidence_host.py" in commands
+    for reimplemented in ("sha256sum", "openssl", "/proc/sys/kernel/random/boot_id"):
+        assert reimplemented not in commands, (
+            f"{reimplemented} is checked in shell as well as in the module"
+        )
+
+
+def test_the_signed_wheel_is_built_with_the_pinned_backend() -> None:
+    """`pyproject` declares `setuptools>=68`, so without this pip builds in an
+    environment it populates from PyPI at build time — and the code being
+    signed is produced by tooling outside the hash lock."""
+    source = Path("scripts/build-wheelhouse.sh").read_text(encoding="utf-8")
+    # The runtime wheel specifically. `pip wheel` is invoked three times here,
+    # and the dependency builds already carried the flag — slicing from the
+    # first occurrence validates an unrelated command and passes whatever the
+    # runtime wheel does.
+    marker = "Build the ori-runtime wheel itself"
+    block = source[source.index(marker) :].split("\n\n")[0]
+    # Command lines only. The comment beside the flag explains why it is there
+    # and contains the flag's name, so matching the whole block is satisfied by
+    # the explanation surviving its own removal.
+    command = "\n".join(
+        line for line in block.splitlines() if not line.lstrip().startswith("#")
+    )
+
+    assert "-m pip wheel" in command, "the runtime wheel build moved"
+    assert "--no-build-isolation" in command, (
+        "the signed wheel is built with live-resolved build tooling"
+    )
+
+
+def _invokes_build_wheelhouse(text: str) -> bool:
+    """A line that runs it, not one that mentions it.
+
+    `install-pi.sh` and the docs print the command as a hint; treating those as
+    callers would demand a build backend from scripts that never build.
+    """
+    return any(
+        "build-wheelhouse.sh" in line
+        and not line.lstrip().startswith(("#", "echo"))
+        and "echo " not in line
+        for line in text.splitlines()
+    )
+
+
+def test_every_caller_that_builds_the_wheel_installs_the_pinned_backend() -> None:
+    """`--no-build-isolation` uses whatever is already installed.
+
+    The flag lives on the shared script, so every caller inherits the
+    requirement. Checking only the workflow missed the container harness, which
+    built evidence bundles with the distribution's own setuptools.
+    """
+    import yaml
+
+    callers: dict[str, str] = {}
+    workflow = yaml.safe_load(
+        Path(".github/workflows/release.yml").read_text(encoding="utf-8")
+    )
+    for name, job in workflow["jobs"].items():
+        commands = "\n".join(
+            str(step.get("run", "")) for step in job.get("steps") or []
+        )
+        if _invokes_build_wheelhouse(commands):
+            callers[f"job {name!r}"] = commands
+    for script in sorted(Path("docs/releases/evidence").glob("*.sh")) + sorted(
+        Path("scripts").glob("*.sh")
+    ):
+        text = script.read_text(encoding="utf-8")
+        if _invokes_build_wheelhouse(text):
+            callers[str(script)] = text
+
+    assert len(callers) >= 3, (
+        f"expected the workflow and both harnesses: {sorted(callers)}"
+    )
+    for name, text in callers.items():
+        assert "--require-hashes" in text and "requirements/dev.txt" in text, (
+            f"{name} builds the signed wheel without the pinned build backend"
+        )
+
+
+def test_the_pinned_build_backend_is_actually_pinned() -> None:
+    """`--no-build-isolation` is only as good as the lock behind it.
+
+    setuptools and wheel are in `dev.txt` transitively, by way of pip-tools.
+    A future compile that drops those edges would remove the pin and break the
+    release build at signing time — the furthest possible point from the cause.
+    """
+    locked = Path("requirements/dev.txt").read_text(encoding="utf-8")
+
+    for package in ("setuptools", "wheel"):
+        assert re.search(rf"^{package}==", locked, re.M), (
+            f"requirements/dev.txt no longer pins {package}, which "
+            "--no-build-isolation requires; declare it in dev.in"
+        )
+
+
+# --- the runbook, bound to the scripts it describes ---------------------------
+#
+# A runbook drifts the way the shell variables did. These bind each instruction
+# to the thing it instructs: a wrong command here costs an operator a reboot
+# cycle on a machine that has to be reset by hand before it can be retried.
+
+
+def _runbook() -> str:
+    return RUNBOOK.read_text(encoding="utf-8")
+
+
+def test_the_runbook_names_only_phases_the_harness_dispatches() -> None:
+    dispatched = set(re.findall(r"^\s{4}(\w+)\)\s+phase_", _host_harness(), re.M))
+    instructed = set(
+        re.findall(r"harness-systemd-host\.sh \\?\s*\n?\s*(\w+)", _runbook())
+    )
+
+    assert instructed, "the runbook invokes the harness nowhere"
+    assert instructed <= dispatched, (
+        f"the runbook invokes phases the harness does not dispatch: "
+        f"{sorted(instructed - dispatched)}"
+    )
+
+
+def test_the_runbook_passes_install_arguments_in_the_harness_order() -> None:
+    """The harness reads them positionally; a swap installs the wrong thing."""
+    runbook = _runbook()
+
+    assert 'install "$BUNDLE" "$SIG" "$KEYS" "$SHA" "$VERSION"' in runbook
+    for phase in ("install", "rollback"):
+        body = _phase(phase)
+        for position, name in enumerate(
+            ("bundle", "signature", "registry", "expected_sha", "version"), start=2
+        ):
+            assert f'{name}="${{{position}' in body, (
+                f"{phase} no longer reads {name} from position {position}"
+            )
+
+
+def test_the_runbook_derives_the_filenames_the_builder_writes() -> None:
+    """Derived by hand, so a rename in the builder silently breaks the run."""
+    builder = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+    runbook = _runbook()
+
+    produced = re.search(r'ARTIFACT_NAME="([^"]+)"', builder).group(1)
+    assert produced.replace("$RELEASE_VERSION", "$VERSION") in runbook, (
+        f"the runbook does not derive the artifact name the builder writes: {produced}"
+    )
+    registry = re.search(r'"\$OUTDIR/(release-keys[^"]*)"', builder).group(1)
+    assert registry in runbook, "the runbook names a registry the builder never writes"
+
+
+def test_the_runbook_calls_the_builder_with_its_declared_argument_order() -> None:
+    builder = ARTIFACT_BUILDER.read_text(encoding="utf-8")
+
+    assert "build-local-artifact.sh <commit> <target> <release-version>" in builder
+    assert '"$COMMIT" "$TARGET" "$VERSION" "$OUT"' in _runbook()
+
+
+def test_every_runbook_block_that_pipes_sets_pipefail_itself() -> None:
+    """The reboot ends the shell that ran the install.
+
+    A fresh shell pasting a later block inherits no options, and `$?` after a
+    pipe is `tee`'s status — always 0. Relying on an option set in an earlier
+    block reports every post-reboot phase as a pass. `PIPESTATUS` is the
+    bash-only alternative and expands to nothing under zsh, failing the same
+    way silently.
+    """
+    blocks = re.findall(r"```bash\n(.*?)```", _runbook(), re.S)
+    piping = [block for block in blocks if "| tee" in block]
+
+    assert len(piping) >= 4, f"expected a block per phase, found {len(piping)}"
+    for block in piping:
+        assert "set -o pipefail" in block, (
+            f"this block reports tee's status, not the harness's:\n{block}"
+        )
+        assert "${PIPESTATUS" not in block, "PIPESTATUS is empty under zsh"
+
+
+def test_the_runbook_states_the_exit_status_that_means_partial_coverage() -> None:
+    """Reading only "it finished" turns untested claims into apparent passes."""
+    runbook = _runbook()
+
+    assert "| 3 |" in runbook, "the runbook does not explain exit 3"
+    assert "BLOCKED" in runbook
+
+
+def test_the_runbook_repeats_what_the_run_cannot_prove() -> None:
+    runbook = _runbook()
+
+    for absent in ("KMS", "publication", "byte-identical"):
+        assert absent in runbook, f"the runbook does not disclaim {absent}"
+
+
+def test_the_host_scripts_stay_executable() -> None:
+    """The runbook invokes both as `./script`, and git records the mode.
+
+    A lost execute bit turns every documented command into "permission
+    denied" on the operator's machine, after they have already built an
+    artifact and are about to install as root.
+    """
+    for script in (HOST_HARNESS, ARTIFACT_BUILDER):
+        assert script.is_file(), f"{script} is missing"
+        assert script.stat().st_mode & 0o111, f"{script} is not executable"
+
+
+def test_the_host_scripts_are_valid_shell() -> None:
+    """`bash -n` is a whole-file parse, which these are: unlike the polyglot
+    bootstrap, nothing here hands off to another interpreter."""
+    for script in (HOST_HARNESS, ARTIFACT_BUILDER):
+        completed = subprocess.run(
+            ["bash", "-n", str(script)], capture_output=True, text=True, check=False
+        )
+        assert completed.returncode == 0, f"{script}: {completed.stderr}"

--- a/tests/test_evidence_host.py
+++ b/tests/test_evidence_host.py
@@ -1,0 +1,667 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The host evidence bindings, exercised rather than read.
+
+Five review rounds found the same defect in five shell variables — a value
+checked in one place and used in another — and each was defended by a test that
+matched text. One of those assertions was satisfied by a comment containing the
+name of the flag it was meant to police, which survived the flag's removal.
+
+These call the functions. A binding that drifts fails here because the
+behaviour changes, not because a string moved.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+from evidence_host import (  # noqa: E402
+    EvidenceError,
+    InstallRecord,
+    Target,
+    envelope_target,
+    interpreter_for,
+    require_reboot_since,
+    verify_artifact,
+    write_record,
+)
+
+# --- the target tuple ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "architecture", "python"),
+    [
+        ("linux-x86_64-python3.12", "x86_64", "3.12"),
+        ("linux-aarch64-python3.11", "aarch64", "3.11"),
+    ],
+)
+def test_a_supported_tuple_parses(value: str, architecture: str, python: str) -> None:
+    target = Target.parse(value)
+
+    assert target.architecture == architecture
+    assert target.python == python
+    assert str(target) == value
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "linux-x86_64-python3.10",  # unsupported interpreter
+        "linux-riscv64-python3.12",  # unsupported architecture
+        "darwin-x86_64-python3.12",
+        "linux-x86_64",
+        "",
+    ],
+)
+def test_an_unsupported_tuple_is_refused(value: str) -> None:
+    with pytest.raises(EvidenceError):
+        Target.parse(value)
+
+
+@pytest.mark.parametrize("machine", ["x86_64", "amd64"])
+def test_a_matching_architecture_is_accepted(machine: str) -> None:
+    Target.parse("linux-x86_64-python3.12").require_host_architecture(machine)
+
+
+@pytest.mark.parametrize("machine", ["aarch64", "arm64", "riscv64"])
+def test_a_mismatched_architecture_is_refused(machine: str) -> None:
+    """A tuple is a claim about this machine, not a filename."""
+    with pytest.raises(EvidenceError, match="this host is"):
+        Target.parse("linux-x86_64-python3.12").require_host_architecture(machine)
+
+
+# --- selecting the interpreter ------------------------------------------------
+
+
+def _fake_interpreter(directory: Path, name: str, reports: str) -> Path:
+    path = directory / name
+    path.write_text(
+        f'#!/bin/sh\nif [ "$1" = "-c" ]; then echo {reports}; fi\n',
+        encoding="utf-8",
+    )
+    path.chmod(0o755)
+    return path
+
+
+def test_the_selected_interpreter_is_asked_its_own_version(tmp_path: Path) -> None:
+    """A name on PATH is not evidence: it may be a wrapper or a shim."""
+    honest = _fake_interpreter(tmp_path, "python3.12", "3.12")
+
+    chosen = interpreter_for(
+        Target.parse("linux-x86_64-python3.12"), which=lambda _name: str(honest)
+    )
+
+    assert chosen == honest
+
+
+def test_an_interpreter_that_reports_another_version_is_refused(tmp_path: Path) -> None:
+    """The exact case a 3.10 host produces when 3.12 is only named."""
+    liar = _fake_interpreter(tmp_path, "python3.12", "3.10")
+
+    with pytest.raises(EvidenceError, match="reports 3.10"):
+        interpreter_for(
+            Target.parse("linux-x86_64-python3.12"), which=lambda _name: str(liar)
+        )
+
+
+def test_a_missing_interpreter_is_refused() -> None:
+    with pytest.raises(EvidenceError, match="not on PATH"):
+        interpreter_for(
+            Target.parse("linux-x86_64-python3.12"), which=lambda _name: None
+        )
+
+
+# --- the target comes from the signed envelope --------------------------------
+
+
+def _envelope(path: Path, **overrides: object) -> Path:
+    document = {
+        "artifact": "ori-runtime-2.4.0-rc.5-linux-x86_64-python3.12.tar.gz",
+        "artifact_sha256": "sha256:" + "0" * 64,
+        "artifact_size": 1,
+        "key_id": "ori-runtime-release-2026-01",
+        "runtime_version": "2.4.0-rc.5",
+        "schema": "ori.runtime_release_bundle_signature.v1",
+        "signature": "ed25519:",
+        "target": "linux-x86_64-python3.12",
+    }
+    document.update(overrides)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+def test_the_target_is_read_from_the_envelope(tmp_path: Path) -> None:
+    """Taking it from anywhere else lets a 3.12 artifact be driven by 3.10."""
+    signature = _envelope(tmp_path / "sig.json")
+
+    assert str(envelope_target(signature)) == "linux-x86_64-python3.12"
+
+
+def test_an_envelope_without_a_target_is_refused(tmp_path: Path) -> None:
+    path = tmp_path / "sig.json"
+    path.write_text(json.dumps({"runtime_version": "2.4.0-rc.5"}), encoding="utf-8")
+
+    with pytest.raises(EvidenceError, match="declares no target"):
+        envelope_target(path)
+
+
+# --- verification, before anything is extracted -------------------------------
+
+
+def _signed(tmp_path: Path, payload: bytes = b"bundle") -> dict[str, Path]:
+    """A real Ed25519-signed artifact, so verification is genuinely exercised."""
+    cryptography = pytest.importorskip("cryptography")
+    del cryptography
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+    bundle = tmp_path / "ori-runtime-2.4.0-rc.5-linux-x86_64-python3.12.tar.gz"
+    bundle.write_bytes(payload)
+
+    key = Ed25519PrivateKey.generate()
+    public = key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    registry = tmp_path / "keys.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema": "ori.runtime_release_keys.v1",
+                "keys": [
+                    {
+                        "key_id": "ori-runtime-release-2026-01",
+                        "public_key_b64": base64.b64encode(public).decode(),
+                        "purpose": "runtime_release_bundle",
+                        "status": "active",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    unsigned = {
+        "artifact": bundle.name,
+        "artifact_sha256": "sha256:" + hashlib.sha256(payload).hexdigest(),
+        "artifact_size": len(payload),
+        "key_id": "ori-runtime-release-2026-01",
+        "runtime_version": "2.4.0-rc.5",
+        "schema": "ori.runtime_release_bundle_signature.v1",
+        "target": "linux-x86_64-python3.12",
+    }
+    message = (
+        b"ori.runtime_release_bundle_signature.v1\0"
+        + json.dumps(
+            unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+        ).encode()
+    )
+    envelope = dict(unsigned)
+    envelope["signature"] = "ed25519:" + base64.b64encode(key.sign(message)).decode()
+    signature = tmp_path / "sig.json"
+    signature.write_text(json.dumps(envelope), encoding="utf-8")
+    return {"bundle": bundle, "signature": signature, "registry": registry}
+
+
+def _openssl_available() -> bool:
+    try:
+        return (
+            subprocess.run(
+                ["openssl", "version"], capture_output=True, check=False
+            ).returncode
+            == 0
+        )
+    except OSError:
+        return False
+
+
+requires_openssl = pytest.mark.skipif(
+    not _openssl_available(), reason="openssl is required to verify Ed25519"
+)
+
+
+@requires_openssl
+def test_a_correctly_signed_artifact_verifies(tmp_path: Path) -> None:
+    paths = _signed(tmp_path)
+
+    message = verify_artifact(
+        bundle=paths["bundle"],
+        signature=paths["signature"],
+        registry=paths["registry"],
+        expected_sha256=hashlib.sha256(b"bundle").hexdigest(),
+        expected_version="2.4.0-rc.5",
+        workspace=tmp_path / "work",
+    )
+
+    assert "verified" in message
+
+
+@requires_openssl
+def test_a_tampered_artifact_is_refused(tmp_path: Path) -> None:
+    paths = _signed(tmp_path)
+    # Same length as the original, so the digest check is what refuses it
+    # rather than the size check firing first.
+    paths["bundle"].write_bytes(b"tamper")
+
+    with pytest.raises(EvidenceError, match="digest"):
+        verify_artifact(
+            bundle=paths["bundle"],
+            signature=paths["signature"],
+            registry=paths["registry"],
+            expected_sha256=hashlib.sha256(b"tamper").hexdigest(),
+            expected_version="2.4.0-rc.5",
+            workspace=tmp_path / "work",
+        )
+
+
+@requires_openssl
+def test_an_artifact_signed_by_another_key_is_refused(tmp_path: Path) -> None:
+    """The registry is the trust anchor; a valid signature by a stranger fails."""
+    paths = _signed(tmp_path)
+    elsewhere = tmp_path / "other"
+    elsewhere.mkdir()
+    other = _signed(elsewhere)
+    paths["signature"].write_text(
+        other["signature"].read_text(encoding="utf-8"), encoding="utf-8"
+    )
+
+    # The reason, not merely a refusal: every other field is identical, so a
+    # bare `raises` would also pass if the signature check were removed and
+    # some earlier field check happened to fire.
+    with pytest.raises(EvidenceError, match="did not verify"):
+        verify_artifact(
+            bundle=paths["bundle"],
+            signature=paths["signature"],
+            registry=paths["registry"],
+            expected_sha256=hashlib.sha256(b"bundle").hexdigest(),
+            expected_version="2.4.0-rc.5",
+            workspace=tmp_path / "work",
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "expected"),
+    [
+        ("status", "revoked", "not trusted"),
+        ("purpose", "something_else", "not a release-bundle key"),
+    ],
+)
+@requires_openssl
+def test_a_key_production_would_refuse_is_refused_here(
+    tmp_path: Path, field: str, value: str, expected: str
+) -> None:
+    """`release_bundles.py` refuses both, and this runs before it.
+
+    Verifying more loosely than the installer would record a PASS for an
+    artifact the installer then refuses with `untrusted_release_key`.
+    """
+    paths = _signed(tmp_path)
+    registry = json.loads(paths["registry"].read_text(encoding="utf-8"))
+    registry["keys"][0][field] = value
+    paths["registry"].write_text(json.dumps(registry), encoding="utf-8")
+
+    with pytest.raises(EvidenceError, match=expected):
+        verify_artifact(
+            bundle=paths["bundle"],
+            signature=paths["signature"],
+            registry=paths["registry"],
+            expected_sha256=hashlib.sha256(b"bundle").hexdigest(),
+            expected_version="2.4.0-rc.5",
+            workspace=tmp_path / "work",
+        )
+
+
+def test_a_digest_that_disagrees_with_the_record_is_refused(tmp_path: Path) -> None:
+    """Checked before the signature: the record is what the operator was given."""
+    paths = _signed(tmp_path)
+
+    with pytest.raises(EvidenceError, match="the record says"):
+        verify_artifact(
+            bundle=paths["bundle"],
+            signature=paths["signature"],
+            registry=paths["registry"],
+            expected_sha256="0" * 64,
+            expected_version="2.4.0-rc.5",
+            workspace=tmp_path / "work",
+        )
+
+
+def test_an_envelope_for_another_version_is_refused(tmp_path: Path) -> None:
+    paths = _signed(tmp_path)
+
+    with pytest.raises(EvidenceError, match="expected 2.4.0-rc.4"):
+        verify_artifact(
+            bundle=paths["bundle"],
+            signature=paths["signature"],
+            registry=paths["registry"],
+            expected_sha256=hashlib.sha256(b"bundle").hexdigest(),
+            expected_version="2.4.0-rc.4",
+            workspace=tmp_path / "work",
+        )
+
+
+# --- the install record -------------------------------------------------------
+
+
+def test_a_record_round_trips(tmp_path: Path) -> None:
+    path = tmp_path / "state"
+    write_record(path, InstallRecord(boot_id="boot-a", version="2.4.0-rc.5"))
+
+    assert InstallRecord.parse(path.read_text(encoding="utf-8")) == InstallRecord(
+        boot_id="boot-a", version="2.4.0-rc.5"
+    )
+
+
+def test_a_record_is_private_to_root(tmp_path: Path) -> None:
+    path = tmp_path / "nested" / "state"
+    write_record(path, InstallRecord(boot_id="boot-a", version="2.4.0-rc.5"))
+
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+    assert not list(path.parent.glob(".record-*")), "a staging file was left behind"
+
+
+def test_a_failed_write_leaves_the_previous_record_intact(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """What atomicity means here, asserted by interrupting a write.
+
+    Asserting the mode and the absence of a staging file does not test this: a
+    plain in-place `write_text` satisfies both, and truncates the destination
+    the moment it fails.
+    """
+    import evidence_host
+
+    path = tmp_path / "state"
+    write_record(path, InstallRecord(boot_id="boot-a", version="2.4.0-rc.5"))
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise OSError("interrupted")
+
+    monkeypatch.setattr(evidence_host.os, "replace", refuse)
+    with pytest.raises(OSError):
+        write_record(path, InstallRecord(boot_id="boot-b", version="2.4.0-rc.6"))
+
+    survivor = InstallRecord.parse(path.read_text(encoding="utf-8"))
+    assert survivor == InstallRecord(boot_id="boot-a", version="2.4.0-rc.5")
+    assert not list(path.parent.glob(".record-*")), "a staging file was left behind"
+
+
+def test_writing_a_record_does_not_reassign_its_directory(tmp_path: Path) -> None:
+    """The real path is /var/lib/ori-evidence-state, and this runs as root.
+
+    Tightening the parent to 0700 there would make /var/lib unreadable to every
+    non-root account on the operator's host — breaking the machine to protect a
+    file that is already 0600.
+    """
+    parent = tmp_path / "lib"
+    parent.mkdir()
+    parent.chmod(0o755)
+
+    write_record(parent / "ori-evidence-state", InstallRecord(boot_id="b", version="v"))
+
+    assert oct(parent.stat().st_mode & 0o777) == "0o755"
+
+
+def test_persistence_requires_a_different_boot(tmp_path: Path) -> None:
+    """Installing just after a boot and checking at once restarts nothing."""
+    path = tmp_path / "state"
+    write_record(path, InstallRecord(boot_id="boot-a", version="2.4.0-rc.5"))
+
+    with pytest.raises(EvidenceError, match="reboot before"):
+        require_reboot_since(path, expected_version="2.4.0-rc.5", current_boot="boot-a")
+
+    found = require_reboot_since(
+        path, expected_version="2.4.0-rc.5", current_boot="boot-b"
+    )
+    assert found.boot_id == "boot-a"
+
+
+def test_persistence_refuses_a_record_for_another_release(tmp_path: Path) -> None:
+    """A stale record plus a later reboot would vouch for whatever is active."""
+    path = tmp_path / "state"
+    write_record(path, InstallRecord(boot_id="boot-a", version="2.4.0-rc.4"))
+
+    with pytest.raises(EvidenceError, match="asked about 2.4.0-rc.5"):
+        require_reboot_since(path, expected_version="2.4.0-rc.5", current_boot="boot-b")
+
+
+def test_persistence_refuses_a_missing_record(tmp_path: Path) -> None:
+    with pytest.raises(EvidenceError, match="no install record"):
+        require_reboot_since(
+            tmp_path / "absent", expected_version="2.4.0-rc.5", current_boot="boot-b"
+        )
+
+
+# --- the command line the shell calls -----------------------------------------
+
+
+def _run(*arguments: str, **kwargs: object) -> subprocess.CompletedProcess[str]:
+    module = Path(__file__).resolve().parents[1] / "scripts" / "evidence_host.py"
+    return subprocess.run(
+        [sys.executable, str(module), *arguments],
+        capture_output=True,
+        text=True,
+        check=False,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
+def test_the_cli_reports_failures_as_a_message_and_an_exit_code(tmp_path: Path) -> None:
+    """The shell branches on the status; a traceback is not a contract."""
+    result = _run(
+        "require-reboot", "--path", str(tmp_path / "absent"), "--version", "2.4.0-rc.5"
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "no install record" in result.stderr
+
+
+def test_no_operator_mistake_reaches_the_shell_as_a_traceback(tmp_path: Path) -> None:
+    """A mistyped path and a truncated download are the likely host mistakes.
+
+    The contract was asserted on one path and violated on the rest: a malformed
+    envelope and an absent bundle both raised through `main`.
+    """
+    malformed = tmp_path / "bad.json"
+    malformed.write_text("not json", encoding="utf-8")
+    present = tmp_path / "bundle.tar.gz"
+    present.write_bytes(b"x")
+    registry = tmp_path / "keys.json"
+    registry.write_text(json.dumps({"keys": []}), encoding="utf-8")
+    digest = hashlib.sha256(b"x").hexdigest()
+
+    invocations = {
+        "malformed envelope, selecting an interpreter": (
+            "select-python",
+            "--signature",
+            str(malformed),
+        ),
+        "malformed envelope, verifying": (
+            "verify",
+            "--bundle",
+            str(present),
+            "--signature",
+            str(malformed),
+            "--registry",
+            str(registry),
+            "--sha256",
+            digest,
+            "--version",
+            "2.4.0-rc.5",
+            "--workspace",
+            str(tmp_path / "w"),
+        ),
+        "absent artifact": (
+            "verify",
+            "--bundle",
+            str(tmp_path / "absent.tar.gz"),
+            "--signature",
+            str(malformed),
+            "--registry",
+            str(registry),
+            "--sha256",
+            digest,
+            "--version",
+            "2.4.0-rc.5",
+            "--workspace",
+            str(tmp_path / "w"),
+        ),
+    }
+    for description, arguments in invocations.items():
+        result = _run(*arguments)
+
+        assert result.returncode == 1, f"{description}: exit {result.returncode}"
+        assert "Traceback" not in result.stderr, f"{description} raised"
+        assert result.stderr.strip(), f"{description} explained nothing"
+
+
+def _corrupt(tmp_path: Path, **edits: object) -> dict[str, Path]:
+    """A correctly signed set, then one field broken."""
+    paths = _signed(tmp_path)
+    for target, (field, value) in edits.items():  # type: ignore[misc]
+        document = json.loads(paths[target].read_text(encoding="utf-8"))
+        if target == "registry":
+            if value is None:
+                del document["keys"][0][field]
+            else:
+                document["keys"][0][field] = value
+        else:
+            document[field] = value
+        paths[target].write_text(json.dumps(document), encoding="utf-8")
+    return paths
+
+
+@requires_openssl
+@pytest.mark.parametrize(
+    ("description", "edits", "expected"),
+    [
+        (
+            "a key entry with no public key",
+            {"registry": ("public_key_b64", None)},
+            "declares no public_key_b64",
+        ),
+        (
+            "a public key that is not base64",
+            {"registry": ("public_key_b64", "not!b64")},
+            "not valid base64",
+        ),
+        (
+            "a signature that is not base64",
+            {"signature": ("signature", "ed25519:@@@")},
+            "not valid base64",
+        ),
+    ],
+)
+def test_malformed_cryptographic_input_is_an_operator_message(
+    tmp_path: Path, description: str, edits: dict[str, object], expected: str
+) -> None:
+    """Indexing a registry field and strict base64 both raise on bad input.
+
+    `KeyError` and `binascii.Error` are not `EvidenceError`, so they escaped
+    `main` as tracebacks. The earlier no-traceback test covered malformed JSON
+    and absent files, which is a different failure entirely.
+    """
+    paths = _corrupt(tmp_path, **edits)
+
+    result = _run(
+        "verify",
+        "--bundle",
+        str(paths["bundle"]),
+        "--signature",
+        str(paths["signature"]),
+        "--registry",
+        str(paths["registry"]),
+        "--sha256",
+        hashlib.sha256(b"bundle").hexdigest(),
+        "--version",
+        "2.4.0-rc.5",
+        "--workspace",
+        str(tmp_path / "work"),
+    )
+
+    assert result.returncode == 1, description
+    assert "Traceback" not in result.stderr, f"{description} raised"
+    assert expected in result.stderr, f"{description}: {result.stderr.strip()}"
+
+
+@requires_openssl
+def test_an_unusable_workspace_is_an_operator_message(tmp_path: Path) -> None:
+    """The workspace is a caller-supplied path; a file where a directory is
+    expected raised `NotADirectoryError` out of `main`."""
+    paths = _signed(tmp_path)
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory", encoding="utf-8")
+
+    result = _run(
+        "verify",
+        "--bundle",
+        str(paths["bundle"]),
+        "--signature",
+        str(paths["signature"]),
+        "--registry",
+        str(paths["registry"]),
+        "--sha256",
+        hashlib.sha256(b"bundle").hexdigest(),
+        "--version",
+        "2.4.0-rc.5",
+        "--workspace",
+        str(blocker / "work"),
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "workspace is unusable" in result.stderr
+
+
+def test_a_host_without_openssl_is_told_so(tmp_path: Path) -> None:
+    """openssl is the tooling that predates the artifact. A host without it
+    cannot verify at all, and needs to be told that rather than shown a
+    traceback from inside subprocess."""
+    paths = _signed(tmp_path)
+
+    result = _run(
+        "verify",
+        "--bundle",
+        str(paths["bundle"]),
+        "--signature",
+        str(paths["signature"]),
+        "--registry",
+        str(paths["registry"]),
+        "--sha256",
+        hashlib.sha256(b"bundle").hexdigest(),
+        "--version",
+        "2.4.0-rc.5",
+        "--workspace",
+        str(tmp_path / "work"),
+        env={**os.environ, "PATH": str(tmp_path / "no-tools")},
+    )
+
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+    assert "openssl could not be run" in result.stderr
+
+
+def test_the_cli_records_and_then_requires_a_reboot(tmp_path: Path) -> None:
+    """End to end, through the same entry point the harness uses."""
+    if not Path("/proc/sys/kernel/random/boot_id").exists():
+        pytest.skip("boot id is a Linux interface")
+    path = tmp_path / "state"
+
+    assert (
+        _run("record", "--path", str(path), "--version", "2.4.0-rc.5").returncode == 0
+    )
+    same_boot = _run("require-reboot", "--path", str(path), "--version", "2.4.0-rc.5")
+
+    assert same_boot.returncode == 1
+    assert "reboot before" in same_boot.stderr
+    assert os.stat(path).st_mode & 0o777 == 0o600

--- a/tests/test_installer_scope.py
+++ b/tests/test_installer_scope.py
@@ -235,6 +235,156 @@ def test_no_installation_is_reported_as_such(
         paths.detect_scope()
 
 
+# --- an install root that cannot be read is not an install root that is absent
+
+
+def _unreadable(monkeypatch: pytest.MonkeyPatch, *roots: Path) -> None:
+    """Make `(root / "current").exists()` raise, as an unreadable 0700 root does.
+
+    Simulated rather than chmod'd, so the case is exercised as the user who
+    cannot read it even when the suite runs as root — which can read anything,
+    and would quietly turn this into no test at all.
+    """
+    blocked = {str(root) for root in roots}
+    original = Path.exists
+
+    def guarded(self: Path, **kwargs: object) -> bool:
+        if str(self.parent) in blocked:
+            raise PermissionError(13, "Permission denied", str(self))
+        return original(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "exists", guarded)
+
+
+def test_a_present_installation_wins_over_an_unreadable_one(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The unreadable root cannot be the one this account is running.
+
+    This is the shape a workstation ends up in after a system install fails and
+    rolls back: `/opt/ori` remains, unreadable, while the user installation is
+    the real one. Refusing to answer here would make the installer's own
+    next-step advice — run `ori doctor` — fail.
+    """
+    user_root = tmp_path / "home" / ".local" / "ori"
+    system_root = tmp_path / "opt" / "ori"
+    _make_install(user_root)
+    system_root.mkdir(parents=True)
+    monkeypatch.setattr(paths, "user_root", lambda: user_root)
+    monkeypatch.setattr(paths, "SYSTEM_ROOT", system_root)
+    _unreadable(monkeypatch, system_root)
+
+    assert paths.detect_scope() == "user"
+
+
+def test_a_present_system_installation_wins_over_an_unreadable_user_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    user_root = tmp_path / "home" / ".local" / "ori"
+    system_root = tmp_path / "opt" / "ori"
+    user_root.mkdir(parents=True)
+    _make_install(system_root)
+    monkeypatch.setattr(paths, "user_root", lambda: user_root)
+    monkeypatch.setattr(paths, "SYSTEM_ROOT", system_root)
+    _unreadable(monkeypatch, user_root)
+
+    assert paths.detect_scope() == "system"
+
+
+@pytest.mark.parametrize("unreadable", ["both", "system_only", "user_only"], ids=str)
+def test_nothing_readable_asks_for_an_explicit_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, unreadable: str
+) -> None:
+    """Inaccessible must not collapse into absent.
+
+    With nothing else found, the honest answer is that scope could not be
+    established — not a guess, and not a traceback.
+    """
+    user_root = tmp_path / "home" / ".local" / "ori"
+    system_root = tmp_path / "opt" / "ori"
+    user_root.mkdir(parents=True)
+    system_root.mkdir(parents=True)
+    monkeypatch.setattr(paths, "user_root", lambda: user_root)
+    monkeypatch.setattr(paths, "SYSTEM_ROOT", system_root)
+    blocked = {
+        "both": (user_root, system_root),
+        "system_only": (system_root,),
+        "user_only": (user_root,),
+    }[unreadable]
+    _unreadable(monkeypatch, *blocked)
+
+    with pytest.raises(paths.IndeterminateScopeError) as excinfo:
+        paths.detect_scope()
+
+    assert "--scope" in str(excinfo.value)
+
+
+def test_an_explicit_scope_never_inspects_the_other_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Naming the scope must not depend on a root the caller did not name."""
+    inspected: list[str] = []
+    original = Path.exists
+
+    def recording(self: Path, **kwargs: object) -> bool:
+        inspected.append(str(self))
+        return original(self, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(paths, "user_root", lambda: tmp_path / "user")
+    monkeypatch.setattr(paths, "SYSTEM_ROOT", tmp_path / "system")
+    monkeypatch.setattr(Path, "exists", recording)
+
+    assert paths.detect_scope(root=tmp_path / "user") == "user"
+    assert paths.detect_scope(root=tmp_path / "system") == "system"
+    assert inspected == []
+
+
+@pytest.mark.parametrize("command", ["doctor", "status"])
+def test_a_diagnostic_command_never_ends_in_a_traceback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    command: str,
+) -> None:
+    """Doctor is what an operator runs when something is already wrong.
+
+    A backstop independent of detection: whatever inspection failure reaches
+    here, it becomes an exit code and a sentence naming the path, never a
+    traceback out of the tool meant to explain the problem.
+    """
+    from ori import cli
+
+    def explode(**_kwargs: object) -> tuple[object, str]:
+        raise PermissionError(13, "Permission denied", "/opt/ori/current")
+
+    monkeypatch.setattr("ori.installer.paths.resolve_identity", explode)
+
+    exit_code = cli.main([command])
+
+    assert exit_code == 2
+    message = capsys.readouterr().err
+    assert "Traceback" not in message
+    assert "/opt/ori/current" in message
+    assert "--scope" in message
+
+
+def test_doctor_run_reports_an_inspection_failure_without_a_traceback(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from ori import doctor
+
+    def explode(**_kwargs: object) -> tuple[object, str]:
+        raise PermissionError(13, "Permission denied", "/opt/ori/current")
+
+    monkeypatch.setattr("ori.installer.paths.resolve_identity", explode)
+
+    assert doctor.run() == 2
+    message = capsys.readouterr().err
+    assert "Traceback" not in message
+    assert "/opt/ori/current" in message
+    assert "--scope" in message
+
+
 def test_resolve_identity_describes_the_active_release(tmp_path: Path) -> None:
     release = _make_install(tmp_path, version="2.3.1")
     identity, _ = paths.resolve_identity(scope="user", root=tmp_path)

--- a/tests/test_installer_system_scope.py
+++ b/tests/test_installer_system_scope.py
@@ -66,6 +66,11 @@ _STAND_IN_ACCOUNT = "daemon"
 
 _COUNTER = itertools.count()
 
+# `/opt` first, because that is where a real installation goes and the test is
+# most faithful there. The rest are ordinary root-owned system directories to
+# fall back on when a host leaves `/opt` open.
+_ROOT_CONTROLLED_PARENTS = ("/opt", "/var/lib", "/usr/local/lib", "/")
+
 # Candidates for the interpreter the installed environment is built from,
 # preferred order. `sys.executable` is deliberately not first: under
 # `actions/setup-python` it lives in the runner's tool cache, which is writable
@@ -109,15 +114,30 @@ def service_account(monkeypatch: pytest.MonkeyPatch) -> pwd.struct_passwd:
 
 @pytest.fixture
 def system_root() -> Iterator[Path]:
-    """An install root beneath a root-controlled directory, as `/opt/ori` is.
+    """An install root beneath a directory only root can change, as `/opt/ori` is.
 
     `tmp_path` cannot serve: pytest puts it under `/tmp`, which is mode 1777,
     and a world-writable ancestor is correctly untrusted. A failure there would
     say nothing about the installer.
+
+    `/opt` is where a real installation lives and is tried first, but it is not
+    root-exclusive everywhere — a CI runner image may leave it writable by the
+    build account, and the installer then refuses every path beneath it, which
+    is the correct answer for that host rather than a defect. So the parent is
+    established by asking, not assumed. Failing beats skipping if none can be
+    found: a host with no root-controlled directory cannot carry a system
+    installation at all, and silence would hide exactly that.
     """
-    parent = Path("/opt")
-    if not parent.is_dir():
-        pytest.skip("/opt is unavailable on this host")
+    for candidate in _ROOT_CONTROLLED_PARENTS:
+        parent = Path(candidate)
+        if parent.is_dir() and trust_failure(parent) is None:
+            break
+    else:
+        tried = ", ".join(
+            f"{c} ({trust_failure(Path(c)) or 'absent'})"
+            for c in _ROOT_CONTROLLED_PARENTS
+        )
+        pytest.fail(f"no root-controlled parent directory on this host: {tried}")
     root = parent / f"ori-systemscope-{os.getpid()}-{next(_COUNTER)}"
     try:
         yield root

--- a/tests/test_installer_system_scope.py
+++ b/tests/test_installer_system_scope.py
@@ -1,0 +1,407 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""A real system-scope installation, as root, against a real virtual environment.
+
+Two things here cannot be approximated. `venv/bin/python` is a symlink, and
+Linux reports every symlink's mode as 0777 whatever it points at, so a check
+that reads those bits as write permission classifies a correctly installed,
+root-owned release as attacker-writable — invisible to any test that stands a
+plain file in for the interpreter. And the permissions a system installation
+has are the ones `apply_system_service_permissions` produces; reproducing them
+with `chown` and `chmod` in the test only tests the reproduction.
+
+So the installation is driven through `install_release` with a system profile,
+letting the real permission pass run, and the resulting tree is judged by the
+real diagnostics and the real activation gate.
+
+Selection is by explicit opt-in rather than by privilege. An ordinary
+unprivileged `pytest tests/` skips this module; the dedicated step sets
+`ORI_REQUIRE_ROOT_TESTS=1`, and with that set the module asserts root instead
+of skipping, so an invocation that lost its `sudo` fails loudly rather than
+reporting green having run nothing:
+
+    sudo -H env ORI_REQUIRE_ROOT_TESTS=1 \\
+      "$(which python)" -m pytest tests/test_installer_system_scope.py -q
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import pwd
+import shutil
+import stat
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from ori import doctor
+from ori.installer import activation, trusted_paths
+from ori.installer.linux import InstallLayout, SystemdServiceProfile, install_release
+from ori.installer.trusted_paths import trust_failure
+
+_REQUIRED = os.environ.get("ORI_REQUIRE_ROOT_TESTS") == "1"
+
+pytestmark = [
+    pytest.mark.skipif(
+        not _REQUIRED,
+        reason="set ORI_REQUIRE_ROOT_TESTS=1 and run as root to select these",
+    ),
+    pytest.mark.skipif(
+        sys.platform != "linux",
+        reason="system scope, root ownership and 0777 symlink modes are Linux "
+        "behaviour",
+    ),
+]
+
+# An unprivileged account present on any Debian-derived host. The service
+# account is not created here — an existing identity is lent to the profile so
+# the real permission application runs against a real uid, gid and group list
+# without leaving a durable account behind on whatever machine ran the suite.
+_STAND_IN_ACCOUNT = "daemon"
+
+_COUNTER = itertools.count()
+
+# Candidates for the interpreter the installed environment is built from,
+# preferred order. `sys.executable` is deliberately not first: under
+# `actions/setup-python` it lives in the runner's tool cache, which is writable
+# by the runner account by design, so a venv built from it is exactly the
+# untrusted arrangement these tests exist to reject — a true failure that says
+# nothing about the installer. The running version is preferred so the
+# environment matches the interpreter under test.
+_BASE_INTERPRETER_CANDIDATES = (
+    f"/usr/bin/python{sys.version_info.major}.{sys.version_info.minor}",
+    f"/usr/local/bin/python{sys.version_info.major}.{sys.version_info.minor}",
+    "/usr/bin/python3.12",
+    "/usr/bin/python3.11",
+    "/usr/bin/python3",
+    "/usr/local/bin/python3",
+    sys.executable,
+)
+
+
+def test_this_module_is_running_as_root() -> None:
+    """Fail rather than skip, so a lost `sudo` cannot look like a pass."""
+    assert os.geteuid() == 0, (
+        "ORI_REQUIRE_ROOT_TESTS=1 selects these tests, so they must be running "
+        "as root; invoke them with sudo -H env ORI_REQUIRE_ROOT_TESTS=1 "
+        '"$(which python)" -m pytest tests/test_installer_system_scope.py'
+    )
+
+
+@pytest.fixture
+def service_account(monkeypatch: pytest.MonkeyPatch) -> pwd.struct_passwd:
+    """Resolve the runtime's service account to a real unprivileged one."""
+    record = pwd.getpwnam(_STAND_IN_ACCOUNT)
+    assert record.pw_uid != 0, "the stand-in service account must be unprivileged"
+    original = pwd.getpwnam
+
+    def resolve(name: str) -> pwd.struct_passwd:
+        return record if name == "ori-runtime" else original(name)
+
+    monkeypatch.setattr(pwd, "getpwnam", resolve)
+    return record
+
+
+@pytest.fixture
+def system_root() -> Iterator[Path]:
+    """An install root beneath a root-controlled directory, as `/opt/ori` is.
+
+    `tmp_path` cannot serve: pytest puts it under `/tmp`, which is mode 1777,
+    and a world-writable ancestor is correctly untrusted. A failure there would
+    say nothing about the installer.
+    """
+    parent = Path("/opt")
+    if not parent.is_dir():
+        pytest.skip("/opt is unavailable on this host")
+    root = parent / f"ori-systemscope-{os.getpid()}-{next(_COUNTER)}"
+    try:
+        yield root
+    finally:
+        subprocess.run(["chmod", "-R", "u+rwX", str(root)], check=False)
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def _trusted_base_interpreter() -> str:
+    """The first candidate root alone controls, or fail saying what was tried.
+
+    Skipping would be the wrong answer: a host with no root-controlled Python
+    cannot install system scope at all, so silence here would hide the very
+    condition the installer now refuses up front.
+    """
+    tried: list[str] = []
+    for candidate in _BASE_INTERPRETER_CANDIDATES:
+        if not Path(candidate).exists():
+            tried.append(f"{candidate}: absent")
+            continue
+        failure = trust_failure(candidate, require_executable=True)
+        if failure is not None:
+            tried.append(f"{candidate}: {failure}")
+            continue
+        # Trusted is not sufficient: Debian ships `ensurepip` in a separate
+        # package, so an interpreter can be perfectly root-controlled and still
+        # unable to build an environment. Asking it directly is cheaper than
+        # discovering it inside a fixture.
+        probe = subprocess.run(
+            [candidate, "-c", "import ensurepip, venv"],
+            capture_output=True,
+            check=False,
+        )
+        if probe.returncode != 0:
+            tried.append(f"{candidate}: cannot build a virtual environment")
+            continue
+        return candidate
+    raise AssertionError(
+        "no root-controlled interpreter to build the release environment "
+        "from; tried " + "; ".join(tried)
+    )
+
+
+def _install_system_scope(root: Path) -> tuple[InstallLayout, Path]:
+    """Install through the installer, with the real system permission pass."""
+    layout = InstallLayout.resolve(root)
+
+    def prepare(staging: Path) -> None:
+        subprocess.run(
+            [_trusted_base_interpreter(), "-m", "venv", str(staging / "venv")],
+            check=True,
+            capture_output=True,
+        )
+        (staging / "ori").mkdir()
+        (staging / "ori" / "runtime.py").write_text("# code\n", encoding="utf-8")
+
+    install_release(
+        layout=layout,
+        version="2.4.0-rc.5",
+        prepare=prepare,
+        validate=lambda _path: None,
+        restart_service=lambda: None,
+        stop_service=lambda: None,
+        check_health=lambda _path: None,
+        # The real thing: this is what runs `apply_system_service_permissions`.
+        service_profile=SystemdServiceProfile.system(),
+        allowed_data_sockets=(layout.data / "health.sock",),
+    )
+    (layout.data / "ori.yaml").write_text("device: {}\n", encoding="utf-8")
+    return layout, layout.release("2.4.0-rc.5")
+
+
+def _identity(layout: InstallLayout, release: Path) -> doctor.InstallIdentity:
+    return doctor.InstallIdentity(
+        scope="system",
+        version="2.4.0-rc.5",
+        install_root=layout.root,
+        active_release=release,
+        config_path=layout.data / "ori.yaml",
+        data_path=layout.data,
+        health_socket=layout.data / "health.sock",
+        unit_path=Path("/etc/systemd/system/ori-runtime.service"),
+        service_user="ori-runtime",
+    )
+
+
+@pytest.fixture
+def installation(
+    system_root: Path, service_account: pwd.struct_passwd
+) -> tuple[InstallLayout, Path, doctor.InstallIdentity]:
+    layout, release = _install_system_scope(system_root)
+    return layout, release, _identity(layout, release)
+
+
+def _reported(checks: list[doctor.DoctorCheck]) -> list[dict[str, object]]:
+    return [
+        {
+            "name": check.name,
+            "status": check.status,
+            "message": check.message,
+            "mandatory": check.mandatory,
+        }
+        for check in checks
+    ]
+
+
+def test_the_environment_is_built_from_a_root_controlled_interpreter() -> None:
+    """State the requirement these tests depend on, rather than assuming it.
+
+    A venv links back to the interpreter it was built from, so building one from
+    a runner's tool cache would produce a release that fails for a reason about
+    the CI host rather than about the installer.
+    """
+    chosen = _trusted_base_interpreter()
+
+    assert trust_failure(chosen, require_executable=True) is None
+
+
+# --- the premise -------------------------------------------------------------
+
+
+def test_the_interpreter_of_a_real_venv_is_a_symlink(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """If a future Python stops symlinking `bin/python`, say so here.
+
+    The checks below would keep passing while no longer exercising the case
+    that rolled back every system installation.
+    """
+    _layout, release, _identity_ = installation
+    info = (release / "venv" / "bin" / "python").lstat()
+
+    assert stat.S_ISLNK(info.st_mode)
+    assert stat.S_IMODE(info.st_mode) == 0o777
+
+
+# --- what the installer actually produces ------------------------------------
+
+
+def test_root_may_execute_a_release_the_installer_produced(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """The defect that rolled back every system installation."""
+    _layout, _release, identity = installation
+
+    doctor.assert_execution_allowed(identity)
+
+
+def test_every_mandatory_permission_check_passes(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """The whole report, not one check of it.
+
+    Asserting `permissions.code` alone would pass while the service could not
+    traverse the root or read its config — an installation that cannot run.
+    """
+    _layout, _release, identity = installation
+
+    checks = doctor.check_permissions(identity)
+    failures = [c for c in checks if c.mandatory and c.status != doctor.PASS]
+
+    assert "permissions.code" in {check.name for check in checks}
+    assert not failures, [f"{c.name}: {c.message}" for c in failures]
+
+
+def test_the_activation_gate_accepts_the_report(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """The gate the installer itself calls, on the real report."""
+    _layout, _release, identity = installation
+
+    reported = _reported(doctor.check_permissions(identity))
+
+    assert activation.blocking(reported) == []
+    activation.assert_usable(reported)
+
+
+def test_the_interpreter_target_may_live_outside_the_release(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """Containment is not the rule; trust is.
+
+    A venv interpreter resolves to the system Python, and requiring targets to
+    stay inside the release would reject every one.
+    """
+    _layout, release, _identity_ = installation
+    interpreter = release / "venv" / "bin" / "python"
+
+    assert not Path(os.path.realpath(interpreter)).is_relative_to(release)
+    assert trust_failure(interpreter, require_executable=True) is None
+
+
+# --- and the same integration must refuse a tree that stops deserving trust ---
+
+
+def test_an_interpreter_target_under_an_open_directory_is_refused(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+    system_root: Path,
+) -> None:
+    """A root-owned binary under a directory anyone can write is replaceable."""
+    _layout, release, identity = installation
+    open_directory = system_root.parent / f"{system_root.name}-open"
+    open_directory.mkdir()
+    try:
+        planted = open_directory / "python"
+        shutil.copy2(os.path.realpath(release / "venv" / "bin" / "python"), planted)
+        os.chown(planted, 0, 0)
+        planted.chmod(0o755)
+        open_directory.chmod(0o777)
+        interpreter = release / "venv" / "bin" / "python"
+        interpreter.unlink()
+        interpreter.symlink_to(planted)
+
+        with pytest.raises(doctor.UnsafeExecutionError) as error:
+            doctor.assert_execution_allowed(identity)
+
+        assert str(open_directory) in str(error.value)
+        assert "is writable by another account" in str(error.value)
+    finally:
+        shutil.rmtree(open_directory, ignore_errors=True)
+
+
+def test_a_writable_ancestor_of_the_interpreter_is_refused(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """Trust has to hold the whole way down, on a real installed tree."""
+    _layout, release, identity = installation
+    (release / "venv" / "bin").chmod(0o777)
+
+    with pytest.raises(doctor.UnsafeExecutionError) as error:
+        doctor.assert_execution_allowed(identity)
+
+    assert "is writable by another account" in str(error.value)
+
+
+def test_a_dangling_interpreter_is_refused_without_hanging(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+    system_root: Path,
+) -> None:
+    _layout, release, identity = installation
+    interpreter = release / "venv" / "bin" / "python"
+    interpreter.unlink()
+    interpreter.symlink_to(system_root / "absent" / "python")
+
+    with pytest.raises(doctor.UnsafeExecutionError):
+        doctor.assert_execution_allowed(identity)
+
+
+def test_a_cyclic_interpreter_is_refused_without_hanging(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """A link tree that never resolves must end the check, not the process."""
+    _layout, release, identity = installation
+    binaries = release / "venv" / "bin"
+    (binaries / "python").unlink()
+    (binaries / "python").symlink_to(binaries / "loop-a")
+    (binaries / "loop-a").symlink_to(binaries / "loop-b")
+    (binaries / "loop-b").symlink_to(binaries / "loop-a")
+
+    with pytest.raises(doctor.UnsafeExecutionError):
+        doctor.assert_execution_allowed(identity)
+
+
+def test_a_chain_longer_than_the_hop_budget_is_refused(
+    installation: tuple[InstallLayout, Path, doctor.InstallIdentity],
+) -> None:
+    """The budget, isolated from cycle detection.
+
+    A cycle is caught by having seen the inode before, so a loop proves nothing
+    about the hop limit. Only a long chain of distinct links reaches it.
+    """
+    _layout, release, identity = installation
+    binaries = release / "venv" / "bin"
+    (binaries / "python").unlink()
+    depth = trusted_paths.MAX_SYMLINK_HOPS + 5
+    for index in range(depth):
+        target = binaries / (f"hop-{index + 1}" if index + 1 < depth else "hop-end")
+        (binaries / f"hop-{index}").symlink_to(target)
+    (binaries / "hop-end").write_text("#!/bin/sh\n", encoding="utf-8")
+    (binaries / "hop-end").chmod(0o755)
+    (binaries / "python").symlink_to(binaries / "hop-0")
+    subprocess.run(["chown", "-h", "-R", "root:root", str(binaries)], check=True)
+
+    with pytest.raises(doctor.UnsafeExecutionError) as error:
+        doctor.assert_execution_allowed(identity)
+
+    assert "too many symlinks" in str(error.value)

--- a/tests/test_linux_bootstrap.py
+++ b/tests/test_linux_bootstrap.py
@@ -535,3 +535,32 @@ def test_a_host_with_no_supported_interpreter_is_told_what_to_install(
     assert chosen.startswith("ERROR:")
     assert "unsupported_target" in chosen
     assert "3.11 or 3.12" in chosen
+
+
+def test_the_preamble_always_hands_off_before_python_begins() -> None:
+    """Bash must never fall through into the Python half.
+
+    This file is a polyglot: bash parses incrementally and `exec`s an
+    interpreter before reaching Python-only syntax, which is why `bash -n` —
+    a whole-file parse — reports an error on it and cannot be used to validate
+    it. The property that actually matters is that the shell preamble has no
+    exit that reaches the Python: if it fell through, bash would try to run
+    a set literal and a class body as commands.
+    """
+    source = Path("scripts/install-linux.sh").read_text(encoding="utf-8")
+    terminator = '":"""'
+
+    assert source.count(terminator) == 1, "the polyglot terminator is not unique"
+    preamble = source[: source.index(terminator)]
+    handoff = [
+        line.strip()
+        for line in preamble.splitlines()
+        if line.strip() and not line.strip().startswith("#")
+    ]
+    assert handoff[-1].startswith("exec "), (
+        f"the preamble ends with {handoff[-1]!r}; without a final exec, bash "
+        "continues into the Python and parses it as shell"
+    )
+    # Every other way out is an explicit failure, so no path reaches Python.
+    for statement in ("exit 2", "exec "):
+        assert statement in preamble, f"the preamble never uses {statement!r}"

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -21,6 +21,7 @@ import pytest
 import yaml
 
 from ori.installer import linux as installer_linux
+from ori.installer import trusted_paths
 from ori.installer.linux import (
     BootPersistence,
     InstallerConfigInput,
@@ -2358,17 +2359,15 @@ def test_a_useradd_is_trusted_only_when_root_alone_could_have_placed_it(
     failing on both counts passes whichever guard is removed.
     """
     candidate = "/usr/sbin/useradd"
-    monkeypatch.setattr(
-        installer_linux, "_USERADD_LOCATIONS", (candidate,), raising=True
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            candidate: (stat.S_IFREG | mode, uid),
+        },
     )
-    monkeypatch.setattr(
-        installer_linux.os,
-        "stat",
-        lambda path, **_kwargs: SimpleNamespace(
-            st_mode=stat.S_IFREG | mode, st_uid=uid
-        ),
-    )
-    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
 
     resolved = installer_linux._trusted_useradd()
 
@@ -2383,9 +2382,9 @@ def _fake_filesystem(
     monkeypatch: pytest.MonkeyPatch,
     entries: dict[str, tuple[int, int]],
     *,
-    realpath: dict[str, str] | None = None,
+    links: dict[str, str] | None = None,
 ) -> None:
-    """Install a synthetic tree so each ancestor's mode can be stated exactly.
+    """Install a synthetic tree so each component's mode can be stated exactly.
 
     Real directories cannot be used: the cases that matter are root-owned ones,
     and creating those needs root, which the suite must not require.
@@ -2396,16 +2395,16 @@ def _fake_filesystem(
         if key not in entries:
             raise FileNotFoundError(key)
         mode, uid = entries[key]
-        return SimpleNamespace(st_mode=mode, st_uid=uid)
+        return SimpleNamespace(st_mode=mode, st_uid=uid, st_dev=1, st_ino=hash(key))
 
-    monkeypatch.setattr(installer_linux.os, "lstat", lookup)
-    monkeypatch.setattr(installer_linux.os, "stat", lookup)
-    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
-    monkeypatch.setattr(
-        installer_linux.os.path,
-        "realpath",
-        lambda path: (realpath or {}).get(str(path), str(path)),
-    )
+    def readlink(path: object) -> str:
+        key = str(path)
+        if (links or {}).get(key) is None:
+            raise OSError(22, "Invalid argument", key)
+        return (links or {})[key]
+
+    monkeypatch.setattr(trusted_paths.os, "lstat", lookup)
+    monkeypatch.setattr(trusted_paths.os, "readlink", readlink)
     monkeypatch.setattr(
         installer_linux, "_USERADD_LOCATIONS", ("/usr/sbin/useradd",), raising=True
     )
@@ -2478,29 +2477,20 @@ def test_an_unsafe_grandparent_is_caught_as_well(
 def test_a_root_owned_symlink_component_does_not_disqualify_a_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """`/sbin` is a link into `/usr/sbin` on any usr-merged distribution.
-
-    Linux reports every symlink as 0777, so testing a link component for
-    group-writability refuses the ordinary layout of the hosts this installer
-    targets. What protects the link is the directory holding it, which the walk
-    has already checked.
-    """
+    """A link's own mode grants nothing; Linux reports every one as 0777."""
     _fake_filesystem(
         monkeypatch,
         {
             "/": _ROOT_DIR,
-            "/sbin": (stat.S_IFLNK | 0o777, 0),
-            "/sbin/useradd": _SAFE_BINARY,
             "/usr": _ROOT_DIR,
             "/usr/sbin": _ROOT_DIR,
-            "/usr/sbin/useradd": _SAFE_BINARY,
+            "/usr/sbin/useradd": (stat.S_IFLNK | 0o777, 0),
+            "/usr/sbin/useradd.real": _SAFE_BINARY,
         },
-    )
-    monkeypatch.setattr(
-        installer_linux, "_USERADD_LOCATIONS", ("/sbin/useradd",), raising=True
+        links={"/usr/sbin/useradd": "/usr/sbin/useradd.real"},
     )
 
-    assert installer_linux._trusted_useradd() == "/sbin/useradd"
+    assert installer_linux._trusted_useradd() == "/usr/sbin/useradd"
 
 
 def test_a_symlink_component_owned_by_another_account_is_refused(
@@ -2511,12 +2501,12 @@ def test_a_symlink_component_owned_by_another_account_is_refused(
         monkeypatch,
         {
             "/": _ROOT_DIR,
-            "/sbin": (stat.S_IFLNK | 0o777, 1000),
-            "/sbin/useradd": _SAFE_BINARY,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": (stat.S_IFLNK | 0o777, 1000),
+            "/usr/sbin/useradd.real": _SAFE_BINARY,
         },
-    )
-    monkeypatch.setattr(
-        installer_linux, "_USERADD_LOCATIONS", ("/sbin/useradd",), raising=True
+        links={"/usr/sbin/useradd": "/usr/sbin/useradd.real"},
     )
 
     assert installer_linux._trusted_useradd() is None
@@ -2525,11 +2515,7 @@ def test_a_symlink_component_owned_by_another_account_is_refused(
 def test_a_symlink_landing_under_an_unsafe_directory_is_not_trusted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A safe name may still resolve somewhere anyone can rewrite.
-
-    Every component of the written path is root-controlled here; the target's
-    directory is not, so where it lands has to be checked too.
-    """
+    """A safe name may still resolve somewhere anyone can rewrite."""
     _fake_filesystem(
         monkeypatch,
         {
@@ -2540,7 +2526,7 @@ def test_a_symlink_landing_under_an_unsafe_directory_is_not_trusted(
             "/opt": (stat.S_IFDIR | 0o777, 0),
             "/opt/useradd": _SAFE_BINARY,
         },
-        realpath={"/usr/sbin/useradd": "/opt/useradd"},
+        links={"/usr/sbin/useradd": "/opt/useradd"},
     )
 
     assert installer_linux._trusted_useradd() is None
@@ -2550,15 +2536,31 @@ def test_a_useradd_that_is_not_a_regular_file_is_not_trusted(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A directory or device in that position is not a binary to execute."""
-    monkeypatch.setattr(
-        installer_linux, "_USERADD_LOCATIONS", ("/usr/sbin/useradd",), raising=True
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": (stat.S_IFDIR | 0o755, 0),
+        },
     )
-    monkeypatch.setattr(
-        installer_linux.os,
-        "stat",
-        lambda path, **_kwargs: SimpleNamespace(st_mode=stat.S_IFDIR | 0o755, st_uid=0),
+
+    assert installer_linux._trusted_useradd() is None
+
+
+def test_a_useradd_that_is_not_executable_is_not_trusted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fake_filesystem(
+        monkeypatch,
+        {
+            "/": _ROOT_DIR,
+            "/usr": _ROOT_DIR,
+            "/usr/sbin": _ROOT_DIR,
+            "/usr/sbin/useradd": (stat.S_IFREG | 0o644, 0),
+        },
     )
-    monkeypatch.setattr(installer_linux.os, "access", lambda *_a, **_k: True)
 
     assert installer_linux._trusted_useradd() is None
 

--- a/tests/test_linux_installer_cli.py
+++ b/tests/test_linux_installer_cli.py
@@ -281,6 +281,107 @@ def test_workspace_failure_maps_to_stable_archive_error(
     )
 
 
+@pytest.mark.skipif(
+    Path("/etc").resolve() != Path("/etc"),
+    reason="system scope resolves /etc, which is not canonical on this host",
+)
+def test_a_user_controlled_interpreter_is_refused_before_any_host_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A pyenv or home-directory Python cannot carry a system installation.
+
+    The release environment is built from it and links back to it, so its code
+    would be replaceable by whoever controls that prefix. Diagnostics would
+    catch it — after the bundle is unpacked, the environment built, the account
+    created and the unit started, and the whole thing then rolled back. It is
+    knowable in microseconds, so nothing may be spent before it is asked.
+    """
+    prefix = tmp_path / "pyenv" / "versions" / "3.12.3" / "bin"
+    prefix.mkdir(parents=True)
+    interpreter = prefix / "python3.12"
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    monkeypatch.setattr(sys, "_base_executable", str(interpreter), raising=False)
+    monkeypatch.setattr(
+        cli,
+        "load_release_key_registry",
+        lambda _path: pytest.fail("verification must not begin"),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._run_account_command",
+        lambda _c: pytest.fail("no account may be created"),
+    )
+
+    with pytest.raises(SystemExit) as error:
+        cli.main(_system_install_args(tmp_path))
+
+    assert error.value.code == 2
+    message = capsys.readouterr().err
+    assert "only root can change" in message
+    assert "apt install" in message
+    assert "--scope user" in message
+    assert not (tmp_path / "ori").exists()
+
+
+def test_a_root_controlled_interpreter_is_accepted_for_system_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The check must not refuse the ordinary case it exists to protect.
+
+    Under a user-scope profile this returns before inspecting anything, so a
+    user-scope call would keep passing even if every system interpreter were
+    refused. The profile is therefore system, and the path the primitive was
+    handed is recorded — accepting without looking is the failure this guards.
+    """
+    from ori.installer import linux as installer_linux
+    from ori.installer.linux import (
+        SystemdServiceProfile,
+        require_trusted_base_interpreter,
+    )
+
+    inspected: list[str] = []
+    real = installer_linux.trust_failure
+
+    def recording(path: object, **kwargs: object) -> object:
+        inspected.append(str(path))
+        return real(path, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(installer_linux, "trust_failure", recording)
+    # Root-owned, unwritable by others, and beneath root-controlled directories
+    # on every supported host.
+    monkeypatch.setattr(sys, "_base_executable", "/usr/bin/env", raising=False)
+
+    require_trusted_base_interpreter(SystemdServiceProfile.system())
+
+    assert inspected == ["/usr/bin/env"]
+
+
+def test_the_interpreter_refusal_uses_a_documented_failure_code(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Automation branches on the code, not on the sentence."""
+    from ori.installer.linux import (
+        LinuxInstallError,
+        SystemdServiceProfile,
+        require_trusted_base_interpreter,
+    )
+
+    interpreter = tmp_path / "bin" / "python3.12"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("#!/bin/sh\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    monkeypatch.setattr(sys, "_base_executable", str(interpreter), raising=False)
+
+    with pytest.raises(LinuxInstallError) as error:
+        require_trusted_base_interpreter(SystemdServiceProfile.system())
+
+    assert error.value.code == "unsupported_target"
+
+
 def test_a_different_service_account_name_is_refused(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_linux_installer_cli.py
+++ b/tests/test_linux_installer_cli.py
@@ -481,7 +481,19 @@ def test_the_account_is_created_after_verification_and_before_the_build(
         calls.append("extract")
         raise LinuxInstallError("offline_install_failed", "stop before building")
 
+    original_trust = cli.require_trusted_base_interpreter
+
+    def interpreter_trust(profile: object) -> None:
+        calls.append("interpreter")
+        original_trust(profile)  # type: ignore[arg-type]
+
     monkeypatch.setattr(os, "geteuid", lambda: 0)
+    # A root-owned interpreter, so the real check runs and passes. Left to the
+    # ambient one this reads whatever the host happens to provide: a CI runner
+    # builds on a tool cache that is writable by design, which aborts the run
+    # before `verify` and empties the very ordering under test.
+    monkeypatch.setattr(sys, "_base_executable", "/usr/bin/env", raising=False)
+    monkeypatch.setattr(cli, "require_trusted_base_interpreter", interpreter_trust)
     monkeypatch.setattr(
         cli, "detected_release_target", lambda: "linux-x86_64-python3.12"
     )
@@ -506,7 +518,17 @@ def test_the_account_is_created_after_verification_and_before_the_build(
     # The account precedes the packages: it is the change an operator is most
     # likely to decline, and declining it ends the run. Asking afterwards would
     # mean packages had been installed for an installation that never finished.
-    assert calls == ["verify", "collect", "account", "prerequisites", "extract"]
+    # The interpreter check is first because it is read-only and costs nothing,
+    # so a host that cannot carry the installation is turned away before the
+    # operator is asked anything.
+    assert calls == [
+        "interpreter",
+        "verify",
+        "collect",
+        "account",
+        "prerequisites",
+        "extract",
+    ]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## What does this PR do?

A system-scope installation could not complete on a real machine. The release was correct — root-owned and unwritable by anyone else — but the guard deciding whether root may execute it read the mode of `venv/bin/python`. Linux reports every symlink as 0777 whatever it points at, and a virtual environment's interpreter is always a symlink, so a correct installation was refused by a check reading permission bits that grant nothing. Replacing a symlink requires write access to the directory holding it, and that is the thing that has to be established.

The diagnostics an operator was then told to run failed too. `ori doctor` without `--scope` inspects both install roots, and a system root left behind by a rolled-back installation is unreadable to an ordinary account, so the recommended command ended in a traceback.

**One definition of a trusted path.** `trust_failure` walks every component from the filesystem root, checks ownership everywhere and write permission only where it means something, follows symlinks one hop at a time while validating each destination in full, and bounds resolution so a cyclic or absurdly long link tree ends the check rather than the process. The root-execution guard, the release's external-symlink admission — which previously judged a target's inode without looking at the directories leading to it — and the installer's `useradd` resolution all consult it, so those boundaries cannot disagree about one path. Trust is the test, not containment: an interpreter resolving to `/usr/bin/python3.12` is ordinary and permitted, provided root alone controls every step of the way there.

The same reasoning applies before an installation starts. A release's environment is built from whichever interpreter the bootstrap selected and links back to it, so a Python under pyenv or a home directory yields a release whose executing code an unprivileged account can replace. System scope now establishes that before anything is verified, prompted, created or built, and names the distribution package that fixes it.

**Scope is established, not guessed.** Detection distinguishes a root that is absent from one that cannot be read. A definitively present installation is selected when the other is unreadable, since an unreadable one cannot be the installation this account is running; when nothing can be established the operator is asked for `--scope` and told which path could not be inspected. Both command entry points refuse to let an inspection failure escape as a traceback.

**The signed wheel's build backend is pinned.** `pyproject` declares `setuptools>=68`, so the wheel entering a signed artifact was built by whichever backend pip resolved at build time — the one place in the pipeline where unpinned tooling matters most. The runtime wheel is now built with `--no-build-isolation`, which makes the caller responsible for the backend, and every caller that builds it installs the hash-locked development set first. That set pins setuptools and wheel only because pip-tools depends on them, so a compile dropping those edges would silently remove the pin; a check now fails at compile time rather than at signing time.

**Installation is provable on real hardware.** The container harness marks installation and every downstream service claim BLOCKED, because a container has no systemd session bus — and those are exactly the claims release candidates have failed on. A second harness runs on a real machine, as root, against an artifact built and development-signed from a named commit, in phases either side of a reboot. Version, target, interpreter selection, signature verification and the install record live in one Python module as function arguments rather than as shell variables checked in one place and used in another, and a version-agnostic runbook covers the procedure so a release does not need its own copy.

Nothing in that run removes anything recursively. The installer removes its own tree; the phase then names each managed path and takes the emptied root away with `rmdir`, which deletes only an already-empty directory and so cannot descend into a real deployment. A root left holding anything is reported and recorded as blocked rather than forced.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

Neither capability box applies, so both are left unchecked rather than ticked as satisfied. Capability behaviour is unchanged and no capability-impacting file is touched: the guard watches `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py` and `ori/config.py`, and this branch changes none of them. No matrix entry is owed and no bypass token is needed — the guard passes on its own.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

The Tier D box is left unchecked because no Tier D code path is added or altered. The installer and its diagnostics sit outside the action tier framework. No runtime dependency was added, and the evidence module is standard library only so it can run on a host before anything is installed.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no skill is added or modified.

## Related issue

Refs #273

## Testing notes

The privileged suite installs through the installer with a system profile and the real permission pass, against a real virtual environment, and judges the result with the real diagnostics and the real activation gate. Every previous test of this area stood a regular file in for the interpreter and approximated system permissions with `chown` and `chmod`, which is why a release that could never execute passed them. The suite is selected by an explicit opt-in rather than by privilege, and asserts `geteuid() == 0` rather than skipping without it, so an invocation that lost its `sudo` fails instead of reporting green having run nothing. Its environment is built from a root-controlled interpreter rather than the runner tool cache, which is writable by design and would fail for a reason about the host rather than the installer.

The evidence bindings are exercised as functions — against real Ed25519 material, a tampered artifact, a stranger's key, a key the installer itself would refuse, an unwritable workspace, a host without OpenSSL, and an interpreter that misreports its own version — rather than by matching text in the scripts that call them.

The host evidence run has not happened yet. Installation, reboot persistence and rollback on real hardware remain unproven until the harness is run from the merged commit. Nothing here speaks to KMS custody, the production trust root, publication, authenticated download or post-publication reverification, which are proven only by a real tag.
