### PR TITLE
chore(release): prepare v2.4.0-rc.6

### DIFF
--- a/docs/releases/v2.4.0.md
+++ b/docs/releases/v2.4.0.md
@@ -27,9 +27,9 @@ Raspberry Pi and it failed, that was the extraction defect below.
 
 ## Release candidates
 
-`v2.4.0-rc.1` and `v2.4.0-rc.2` are published tags that produced no artifacts.
-Both are retained. Neither was moved or deleted, and neither should be
-installed — nothing was ever built, signed, or published from either.
+`v2.4.0-rc.1`, `v2.4.0-rc.2` and `v2.4.0-rc.5` are published tags that produced
+no artifacts. All are retained. None was moved or deleted, and none should be
+installed — nothing was ever built, signed, or published from any of them.
 
 | Tag | Reached | Failed because |
 |---|---|---|
@@ -37,6 +37,7 @@ installed — nothing was ever built, signed, or published from either.
 | `v2.4.0-rc.2` | protection preflight, full test matrix | the wheel version and the bundle version were compared as strings, and a candidate spells them differently |
 | `v2.4.0-rc.3` | signed, published, exercised on hardware | neither scope could complete an install: system scope checked for its service account too late, and user scope was refused for a property it cannot have |
 | `v2.4.0-rc.4` | signed, published, installed on hardware | user scope installed and ran; system scope rolled back because the interpreter's ordinary symlink was misread as writable, and bare `ori doctor` raised on an install root it could not read |
+| `v2.4.0-rc.5` | protection preflight | the tag was annotated rather than signed, and a release tag must carry a verified signature; the preflight refused it before anything was built |
 
 `v2.4.0-rc.3` is the first candidate that built, signed, and published. Its
 assets remain available and are not replaced. It failed on hardware, which is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0rc5"
+version = "2.4.0rc6"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

`v2.4.0-rc.5` was tagged without a signature. `check_release_protections.py` requires a release tag to carry a verified one, so the preflight refused it and every downstream job was skipped — nothing was built, signed, or published from that tag. The `Protect immutable release tags` ruleset blocks deletion, update and non-fast-forward on `refs/tags/v*`, so the tag stays where it is and is recorded alongside the earlier candidates that produced no artifacts, rather than being moved or reused.

This bumps the packaged version to `2.4.0rc6` so the next candidate can be tagged. The preflight admits a tag only when its normalised form exactly matches what the package declares, which is why the version has to move with the tag rather than being reused.

The release notes gain a row for `v2.4.0-rc.5` in the existing candidate table, recording how far it reached and what stopped it, in the same form as `rc.1` through `rc.4`.

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

Release preparation: a version bump and the candidate record. None of the categories above applies.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

No `.py` file is added and no capability-impacting file is touched, so both capability boxes are left unchecked rather than ticked as satisfied. The guard watches `ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py` and `ori/config.py`; this change touches `pyproject.toml` and one release note.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable — no runtime file is modified.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no skill is added or modified.

## Related issue

Refs #273

## Testing notes

The full suite passes and the release identity checker resolves `v2.4.0-rc.6` against the bumped package version, which is the condition the preflight enforces before anything is built or signed.

Signing the tag is the step that failed last time and is not something this change can assert. It is verified at tag creation and again by the preflight.
