### PR TITLE
fix(runtime): stop reporting three things that are not true

### DIFF
--- a/ori/config.py
+++ b/ori/config.py
@@ -1111,6 +1111,20 @@ def _parse_gateway(data: Any) -> GatewayConfig:
 
     enabled = bool(data.get("enabled", False))
     broker_url = str(data.get("broker_url", ""))
+    if enabled and "${" in broker_url:
+        # `_expand_env_vars` deliberately leaves `${VAR}` literal when the
+        # variable is unset, and every other field carrying a secret or an
+        # endpoint checks for the leftover. This one did not, so an unset
+        # variable produced a URL the parser below accepts and no client can
+        # reach: the only symptom was a refusal from every connection, with
+        # nothing naming the cause. Report it here, where the variable can be
+        # named, rather than leaving an operator to infer it from a broker log.
+        unexpanded = re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", broker_url)
+        detail = f": {', '.join(unexpanded)}" if unexpanded else ""
+        raise ConfigValidationError(
+            "gateway.broker_url contains an unexpanded environment variable"
+            f"{detail}. Set it in the environment, or remove it from the URL."
+        )
     if enabled:
         # An enabled gateway with an unusable endpoint is invalid configuration,
         # not a runtime availability problem. Validated with the same parser the

--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -334,7 +334,10 @@ def cmd_approve(args: argparse.Namespace) -> int:
         )
     )
     print(f"{args.device_id} approved in the runtime registry")
-    print("Run `publish` to sign and publish the retained approval.")
+    print(
+        "Run `prepare-approval` to sign the approval bytes, then publish them "
+        "through the runtime gateway."
+    )
     return 0
 
 
@@ -397,7 +400,17 @@ async def _publish(
         await store.close()
 
 
-def cmd_publish(args: argparse.Namespace) -> int:
+def cmd_prepare_approval(args: argparse.Namespace) -> int:
+    """Sign from the approved row and emit the approval bytes.
+
+    This command does not publish and never has. `_publish` refuses a live
+    publisher on purpose: live publication runs inside the runtime's gateway,
+    because a CLI that is about to exit must not assert liveness supervision
+    over a device. What it did do was print `publish RETAINED on ...` to
+    stderr afterwards, which read as confirmation that a retained message had
+    reached the broker. On a security-critical step, an operator who believed
+    that would think a device had been provisioned when nothing had been sent.
+    """
     message = asyncio.run(
         _publish(
             args.db,
@@ -413,10 +426,24 @@ def cmd_publish(args: argparse.Namespace) -> int:
     else:
         sys.stdout.write(message.decode("utf-8") + "\n")
     print(
-        f"publish RETAINED on ori/fw/{args.device_id}/provision (QoS 1)",
+        "signed approval emitted for "
+        f"{args.device_id}; NOT published. Publish it through the runtime "
+        f"gateway on ori/fw/{args.device_id}/provision (retained, QoS 1), "
+        "or hand these bytes to your bench MQTT client.",
         file=sys.stderr,
     )
     return 0
+
+
+# The old name asserted an act this command does not perform. It stays as a
+# deprecated alias so existing provisioning scripts keep working, and warns.
+def cmd_publish(args: argparse.Namespace) -> int:
+    print(
+        "warning: `publish` is deprecated and never published; it emits signed "
+        "approval bytes. Use `prepare-approval`.",
+        file=sys.stderr,
+    )
+    return cmd_prepare_approval(args)
 
 
 async def _reinstate(db_path: str, device_id: str, actor: str, reason: str) -> None:
@@ -586,15 +613,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.set_defaults(func=cmd_approve)
 
-    p = sub.add_parser(
-        "publish", help="sign from the approved row and emit the approval"
-    )
-    p.add_argument("--db", required=True)
-    p.add_argument("--device-id", required=True)
-    p.add_argument("--provisioner-seed", required=True)
-    p.add_argument("--runtime-command-seed", required=True)
-    p.add_argument("--out")
-    p.set_defaults(func=cmd_publish)
+    for _name, _help, _fn in (
+        (
+            "prepare-approval",
+            "sign from the approved row and emit the approval bytes (does not publish)",
+            cmd_prepare_approval,
+        ),
+        ("publish", "deprecated alias for prepare-approval", cmd_publish),
+    ):
+        p = sub.add_parser(_name, help=_help)
+        p.add_argument("--db", required=True)
+        p.add_argument("--device-id", required=True)
+        p.add_argument("--provisioner-seed", required=True)
+        p.add_argument("--runtime-command-seed", required=True)
+        p.add_argument("--out")
+        p.set_defaults(func=_fn)
 
     p = sub.add_parser(
         "reinstate", help="return a revoked identity to service (anchor -> pending)"

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -4624,15 +4624,16 @@ def _warn_gateway_security_posture(config: Config) -> None:
 
     auth_enabled = bool(auth_cfg.get("enabled", False))
     tls_enabled = bool(tls_cfg.get("enabled", False))
-    is_loopback = any(
-        broker_url.startswith(p)
-        for p in (
-            "mqtt://127.",
-            "mqtt://localhost",
-            "mqtts://127.",
-            "mqtts://localhost",
-        )
-    )
+    # Parse the host out rather than prefix-matching the URL. Production
+    # posture requires broker credentials, so the very configuration this
+    # runtime asks for — `mqtt://user:pass@127.0.0.1:1883` — carries userinfo
+    # ahead of the host and matches no prefix. Classifying that as a public
+    # broker made the runtime log, at ERROR, that traffic was unauthenticated
+    # while it was in fact authenticated. A security channel that cries wolf
+    # is worse than a silent one: the operator either acts on a false alarm or
+    # learns to ignore it.
+    parsed = urlparse(broker_url if "://" in broker_url else f"mqtt://{broker_url}")
+    is_loopback = _is_loopback_host(parsed.hostname)
 
     if not auth_enabled:
         if not is_loopback:
@@ -4677,7 +4678,7 @@ def _warn_sms_webhook_security_posture(config: Config) -> None:
         return
 
     host = str(webhook_cfg.get("host", "127.0.0.1") or "").strip()
-    if _is_loopback_bind_host(host):
+    if _is_loopback_host(host):
         return
 
     signature_cfg = webhook_cfg.get("signature") or {}
@@ -4705,7 +4706,7 @@ def _warn_sms_webhook_security_posture(config: Config) -> None:
         )
 
 
-def _is_loopback_bind_host(host: str | None) -> bool:
+def _is_loopback_host(host: str | None) -> bool:
     value = str(host or "").strip().lower()
     if value in {"localhost", "::1"}:
         return True

--- a/tests/test_truthful_operator_output.py
+++ b/tests/test_truthful_operator_output.py
@@ -1,0 +1,207 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The runtime must not report a claim that is not true.
+
+Three defects shared that shape, and each cost a debugging cycle during
+firmware bring-up because the output was believed:
+
+1. A credentialed loopback broker was classified as public, so the runtime
+   logged, at ERROR, that MQTT traffic was unauthenticated while it was
+   authenticated. Production posture *requires* those credentials, so the
+   configuration the runtime asks for was the one that triggered the alarm.
+2. The provisioner printed `publish RETAINED on ...` after publishing
+   nothing, on a security-critical step.
+3. An unexpanded `${VAR}` in `gateway.broker_url` passed config load and
+   surfaced only as a connection refusal from every client, naming nothing.
+
+These tests assert the corrected behaviour rather than the wording, so a
+future rephrasing does not silently reopen any of them.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import yaml
+
+from ori.config import Config, ConfigValidationError
+from ori.runtime import _is_loopback_host, _warn_gateway_security_posture
+
+# --- 1. loopback classification -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("127.0.0.1", True),
+        ("127.1.2.3", True),
+        ("localhost", True),
+        ("::1", True),
+        ("192.168.1.10", False),
+        ("broker.example.com", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_loopback_host_classification(host, expected):
+    assert _is_loopback_host(host) is expected
+
+
+class _StubGateway:
+    def __init__(self, broker_url: str) -> None:
+        self.enabled = True
+        self.broker_url = broker_url
+        self.auth: dict = {"enabled": False}
+        self.tls: dict = {"enabled": False}
+
+
+class _StubConfig:
+    def __init__(self, broker_url: str) -> None:
+        self.gateway = _StubGateway(broker_url)
+
+
+@pytest.mark.parametrize(
+    "broker_url",
+    [
+        "mqtt://user:pass@127.0.0.1:1883",
+        "mqtts://ori-runtime:secret@localhost:8883",
+        "mqtt://127.0.0.1:1883",
+        "mqtt://[::1]:1883",
+    ],
+)
+def test_credentialed_loopback_broker_logs_no_security_error(broker_url, caplog):
+    """Credentials in the URL must not make a loopback broker read as public.
+
+    This is the regression: the old check prefix-matched the whole URL, and
+    `mqtt://user:pass@127.0.0.1:1883` carries userinfo ahead of the host, so
+    it matched no prefix and was reported as an unauthenticated public broker.
+    """
+    with caplog.at_level(logging.WARNING):
+        _warn_gateway_security_posture(_StubConfig(broker_url))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], f"false security ERROR for loopback broker: {errors}"
+
+
+def test_non_loopback_broker_without_auth_still_logs_error(caplog):
+    """The fix must not silence the alarm it exists to make accurate."""
+    with caplog.at_level(logging.WARNING):
+        _warn_gateway_security_posture(_StubConfig("mqtt://user:pass@10.0.0.5:1883"))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "a real public unauthenticated broker must still raise ERROR"
+
+
+# --- 2. unexpanded environment variables ----------------------------------
+
+
+def _minimal_config(tmp_path, broker_url: str) -> str:
+    document = {
+        "device": {"id": "test-device", "name": "Test", "location": "Lab"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {"enabled": True, "broker_url": broker_url},
+    }
+    path = tmp_path / "ori.yaml"
+    path.write_text(yaml.safe_dump(document))
+    return str(path)
+
+
+def test_unexpanded_broker_url_variable_is_refused_at_load(tmp_path, monkeypatch):
+    monkeypatch.delenv("ORI_TEST_BROKER_HOST", raising=False)
+    path = _minimal_config(tmp_path, "mqtt://${ORI_TEST_BROKER_HOST}:1883")
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        Config.load(path)
+
+    message = str(excinfo.value)
+    assert "unexpanded" in message.lower()
+    assert "ORI_TEST_BROKER_HOST" in message, "the missing variable must be named"
+
+
+def test_expanded_broker_url_loads(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORI_TEST_BROKER_HOST", "127.0.0.1")
+    path = _minimal_config(tmp_path, "mqtt://${ORI_TEST_BROKER_HOST}:1883")
+
+    config = Config.load(path)
+    assert config.gateway.broker_url == "mqtt://127.0.0.1:1883"
+
+
+def test_disabled_gateway_tolerates_unexpanded_variable(tmp_path, monkeypatch):
+    """A disabled gateway is not a configuration the runtime will act on."""
+    monkeypatch.delenv("ORI_TEST_BROKER_HOST", raising=False)
+    document = {
+        "device": {"id": "test-device", "name": "Test", "location": "Lab"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {"enabled": False, "broker_url": "mqtt://${ORI_TEST_BROKER_HOST}"},
+    }
+    path = tmp_path / "ori.yaml"
+    path.write_text(yaml.safe_dump(document))
+
+    Config.load(str(path))
+
+
+# --- 3. the provisioner claims no publication it did not perform ----------
+
+
+def _cli_help(argv: list[str]) -> str:
+    """Capture argparse help without importing internals the CLI does not export."""
+    import contextlib
+    import io
+
+    from ori.firmware_provisioner import main
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer), pytest.raises(SystemExit):
+        main(argv)
+    return buffer.getvalue()
+
+
+def test_provisioner_exposes_prepare_approval_and_deprecated_alias():
+    """The renamed command exists, and the old name keeps working.
+
+    Renaming alone would break provisioning scripts in the field, so the
+    misleading name stays as an alias that warns rather than disappearing.
+    """
+    help_text = _cli_help(["--help"])
+    assert "prepare-approval" in help_text
+    assert "publish" in help_text, "existing provisioning scripts must keep working"
+
+
+def test_top_level_help_does_not_claim_publication():
+    """Argparse wraps long help, so normalise whitespace before asserting."""
+    help_text = " ".join(_cli_help(["--help"]).split())
+    assert (
+        "prepare-approval sign from the approved row and emit the approval bytes (does not publish)"
+        in help_text
+    )
+
+
+def test_deprecated_alias_is_marked_deprecated():
+    help_text = " ".join(_cli_help(["--help"]).split())
+    assert "publish deprecated alias for prepare-approval" in help_text
+
+
+def test_no_command_help_claims_a_retained_publication():
+    """No subcommand may describe itself as publishing.
+
+    Live publication runs inside the runtime's gateway; this CLI signs and
+    exits, and must not imply a broker was reached.
+    """
+    help_text = " ".join(_cli_help(["--help"]).split()).lower()
+    assert "retained" not in help_text


### PR DESCRIPTION
## What does this PR do?

Fixes the three defects in #331. They share one invariant — the runtime must not report a claim that is not true — and each cost a debugging cycle during firmware bring-up, because the output was believed.

**A credentialed loopback broker was reported as public.** The posture check prefix-matched the whole broker URL against `mqtt://127.`, `mqtt://localhost` and friends. `mqtt://user:pass@127.0.0.1:1883` carries userinfo ahead of the host and matches none of them, so the runtime logged at ERROR that MQTT traffic was unauthenticated while it was authenticated. This matters more than a cosmetic log defect: production posture *requires* broker credentials, so the configuration the runtime asks for is exactly the one that triggers the false alarm, and an operator either acts on it or learns to ignore the channel. The adjacent TLS warning was wrong the same way. The host is now parsed out and classified by the existing helper, which also handles `::1` and every other loopback address the prefix test silently missed.

**The provisioner claimed a publication it never performed.** `publish` printed `publish RETAINED on ori/fw/<id>/provision (QoS 1)` to stderr after publishing nothing. The refusal of a live publisher is deliberate and stays — live publication runs inside the runtime's gateway, because a CLI about to exit must not assert liveness supervision over a device. The defect was the claim, on a security-critical step where believing it means thinking a device was provisioned when nothing was sent. The command is now `prepare-approval` and says it does not publish; `publish` remains as a deprecated alias that warns, so provisioning scripts in the field keep working. The `approve` command's closing hint carried the same false instruction and is corrected.

**An unexpanded `${VAR}` in `gateway.broker_url` passed config load.** `_expand_env_vars` deliberately leaves the literal when a variable is unset, and every other field carrying a secret or an endpoint checks for the leftover — eleven of them in `config.py`. This one did not, so an unset variable produced a URL no client could reach, and the only symptom was a refusal from every connection with nothing naming the cause. Now refused at load, with the missing variable named.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

The loopback fix is security-adjacent but does not change a safety invariant: it corrects which posture message is emitted, and the ERROR for a genuinely public unauthenticated broker still fires, with a test asserting it.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changed. Gateway posture reporting, provisioner CLI naming, and config validation are all corrections to what the runtime *says*, not to what it can do. The one behavioural change is that an invalid `broker_url` now fails at load instead of at every connection, which is the same capability failing earlier and more legibly.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `urlparse` and `re` were already imported in the files that use them; no dependency is added.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no bundled skill is modified.

## Related issue

Fixes #331.

## Testing notes

Full suite: 3335 passed, 22 skipped — 20 new tests in `tests/test_truthful_operator_output.py`. `mypy ori/` clean across 125 source files.

Both boundaries are mutation-checked rather than assumed. Reverting the loopback fix to the old prefix match fails three of the four credentialed cases, including `mqtt://[::1]:1883`, which the old implementation never handled. Removing the config guard fails the refusal test. A test that passes against the old code would have proved nothing.

The CLI tests drive the real `main()` help surface rather than an internal parser factory, so they assert what an operator actually sees.
