### PR TITLE
fix(runtime): share one strict loopback classifier and stop three false reports

### DIFF
--- a/ori/config.py
+++ b/ori/config.py
@@ -25,6 +25,7 @@ from ori.security.config_signatures import (
 from ori.security.remote_command_lockout import normalize_remote_command_lockout_config
 from ori.security.remote_commands import normalize_remote_command_sender
 from ori.utils.bool_utils import is_truthy
+from ori.utils.net_utils import is_loopback_host
 from ori.utils.path_utils import path_is_relative_to
 
 logger = logging.getLogger(__name__)
@@ -1111,6 +1112,20 @@ def _parse_gateway(data: Any) -> GatewayConfig:
 
     enabled = bool(data.get("enabled", False))
     broker_url = str(data.get("broker_url", ""))
+    if enabled and "${" in broker_url:
+        # `_expand_env_vars` deliberately leaves `${VAR}` literal when the
+        # variable is unset, and every other field carrying a secret or an
+        # endpoint checks for the leftover. This one did not, so an unset
+        # variable produced a URL the parser below accepts and no client can
+        # reach: the only symptom was a refusal from every connection, with
+        # nothing naming the cause. Report it here, where the variable can be
+        # named, rather than leaving an operator to infer it from a broker log.
+        unexpanded = re.findall(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}", broker_url)
+        detail = f": {', '.join(unexpanded)}" if unexpanded else ""
+        raise ConfigValidationError(
+            "gateway.broker_url contains an unexpanded environment variable"
+            f"{detail}. Set it in the environment, or remove it from the URL."
+        )
     if enabled:
         # An enabled gateway with an unusable endpoint is invalid configuration,
         # not a runtime availability problem. Validated with the same parser the
@@ -1184,7 +1199,7 @@ def _warn_gateway_network_posture(gateway: GatewayConfig) -> None:
     if not broker_url:
         return
     parsed = urlparse(broker_url if "://" in broker_url else f"mqtt://{broker_url}")
-    if parsed.hostname is None or _is_loopback_host(parsed.hostname):
+    if parsed.hostname is None or is_loopback_host(parsed.hostname):
         return
 
     missing: list[str] = []
@@ -1266,7 +1281,7 @@ def _parse_telemetry_export(data: Any) -> TelemetryExportConfig:
             raise ConfigValidationError(
                 "telemetry_export.endpoint must be an absolute http(s) URL."
             )
-        if parsed.scheme != "https" and not _is_loopback_host(parsed.hostname):
+        if parsed.scheme != "https" and not is_loopback_host(parsed.hostname):
             raise ConfigValidationError(
                 "telemetry_export.endpoint must use https:// unless it targets "
                 "localhost or 127.0.0.1."
@@ -1971,7 +1986,7 @@ def _validate_production_security_posture(
                 "production posture requires gateway.encryption.enabled: true "
                 "when gateway is enabled"
             )
-        non_loopback = not _is_loopback_host(parsed.hostname)
+        non_loopback = not is_loopback_host(parsed.hostname)
         if non_loopback:
             if scheme != "mqtts" and not is_truthy(gateway.tls.get("enabled", False)):
                 raise ConfigValidationError(
@@ -2013,7 +2028,7 @@ def _validate_production_security_posture(
     incoming = sms_cfg.get("incoming_webhook") or {}
     if isinstance(incoming, dict) and is_truthy(incoming.get("enabled", False)):
         host = str(incoming.get("host", "127.0.0.1") or "").strip()
-        if not _is_loopback_host(host):
+        if not is_loopback_host(host):
             allowed_source_cidrs = incoming.get("allowed_source_cidrs")
             if not _sms_webhook_source_cidrs_present(allowed_source_cidrs):
                 raise ConfigValidationError(
@@ -2050,11 +2065,6 @@ def _validate_production_security_posture(
         raise ConfigValidationError(
             "production posture requires a verified config_signature block"
         )
-
-
-def _is_loopback_host(host: str | None) -> bool:
-    value = str(host or "").strip().lower()
-    return value in {"localhost", "::1"} or value.startswith("127.")
 
 
 def _validate_state_store_encryption_posture(

--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -334,7 +334,10 @@ def cmd_approve(args: argparse.Namespace) -> int:
         )
     )
     print(f"{args.device_id} approved in the runtime registry")
-    print("Run `publish` to sign and publish the retained approval.")
+    print(
+        "Run `prepare-approval` to sign the approval bytes, then publish them "
+        "through the runtime gateway."
+    )
     return 0
 
 
@@ -397,7 +400,17 @@ async def _publish(
         await store.close()
 
 
-def cmd_publish(args: argparse.Namespace) -> int:
+def cmd_prepare_approval(args: argparse.Namespace) -> int:
+    """Sign from the approved row and emit the approval bytes.
+
+    This command does not publish and never has. `_publish` refuses a live
+    publisher on purpose: live publication runs inside the runtime's gateway,
+    because a CLI that is about to exit must not assert liveness supervision
+    over a device. What it did do was print `publish RETAINED on ...` to
+    stderr afterwards, which read as confirmation that a retained message had
+    reached the broker. On a security-critical step, an operator who believed
+    that would think a device had been provisioned when nothing had been sent.
+    """
     message = asyncio.run(
         _publish(
             args.db,
@@ -413,10 +426,24 @@ def cmd_publish(args: argparse.Namespace) -> int:
     else:
         sys.stdout.write(message.decode("utf-8") + "\n")
     print(
-        f"publish RETAINED on ori/fw/{args.device_id}/provision (QoS 1)",
+        "signed approval emitted for "
+        f"{args.device_id}; NOT published. Publish it through the runtime "
+        f"gateway on ori/fw/{args.device_id}/provision (retained, QoS 1), "
+        "or hand these bytes to your bench MQTT client.",
         file=sys.stderr,
     )
     return 0
+
+
+# The old name asserted an act this command does not perform. It stays as a
+# deprecated alias so existing provisioning scripts keep working, and warns.
+def cmd_publish(args: argparse.Namespace) -> int:
+    print(
+        "warning: `publish` is deprecated and never published; it emits signed "
+        "approval bytes. Use `prepare-approval`.",
+        file=sys.stderr,
+    )
+    return cmd_prepare_approval(args)
 
 
 async def _reinstate(db_path: str, device_id: str, actor: str, reason: str) -> None:
@@ -586,15 +613,21 @@ def main(argv: list[str] | None = None) -> int:
     )
     p.set_defaults(func=cmd_approve)
 
-    p = sub.add_parser(
-        "publish", help="sign from the approved row and emit the approval"
-    )
-    p.add_argument("--db", required=True)
-    p.add_argument("--device-id", required=True)
-    p.add_argument("--provisioner-seed", required=True)
-    p.add_argument("--runtime-command-seed", required=True)
-    p.add_argument("--out")
-    p.set_defaults(func=cmd_publish)
+    for _name, _help, _fn in (
+        (
+            "prepare-approval",
+            "sign from the approved row and emit the approval bytes (does not publish)",
+            cmd_prepare_approval,
+        ),
+        ("publish", "deprecated alias for prepare-approval", cmd_publish),
+    ):
+        p = sub.add_parser(_name, help=_help)
+        p.add_argument("--db", required=True)
+        p.add_argument("--device-id", required=True)
+        p.add_argument("--provisioner-seed", required=True)
+        p.add_argument("--runtime-command-seed", required=True)
+        p.add_argument("--out")
+        p.set_defaults(func=_fn)
 
     p = sub.add_parser(
         "reinstate", help="return a revoked identity to service (anchor -> pending)"

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -23,9 +23,8 @@ import os
 import signal
 import stat
 from collections.abc import Awaitable, Callable
-from ipaddress import ip_address
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 from urllib.parse import urlparse
 
 from ori.actions.alert_failover import AlertFailoverSender
@@ -146,6 +145,7 @@ from ori.skills.signing import verify_signed_payload
 from ori.state.store import StateStore
 from ori.telemetry.http_export import HttpTelemetryExporter
 from ori.utils.bool_utils import is_truthy
+from ori.utils.net_utils import is_loopback_host
 from ori.utils.path_utils import path_is_relative_to
 from ori.utils.time_utils import now_ms
 
@@ -3217,7 +3217,13 @@ class OriRuntime:
             else:
                 exact_sender = getattr(alert_sender, "send_exact", None)
                 if callable(exact_sender):
-                    delivered = await exact_sender(
+                    # `callable()` narrows to a callable returning `object`,
+                    # which is not awaitable. The cast names the contract a
+                    # duck-typed sender must satisfy; the guard is unchanged,
+                    # so a non-callable attribute still falls through to
+                    # `send()` rather than being invoked.
+                    send_exact = cast("Callable[..., Awaitable[bool]]", exact_sender)
+                    delivered = await send_exact(
                         message=message,
                         to_number=recipient,
                         channel=channel,
@@ -4624,15 +4630,16 @@ def _warn_gateway_security_posture(config: Config) -> None:
 
     auth_enabled = bool(auth_cfg.get("enabled", False))
     tls_enabled = bool(tls_cfg.get("enabled", False))
-    is_loopback = any(
-        broker_url.startswith(p)
-        for p in (
-            "mqtt://127.",
-            "mqtt://localhost",
-            "mqtts://127.",
-            "mqtts://localhost",
-        )
-    )
+    # Parse the host out rather than prefix-matching the URL. Production
+    # posture requires broker credentials, so the very configuration this
+    # runtime asks for — `mqtt://user:pass@127.0.0.1:1883` — carries userinfo
+    # ahead of the host and matches no prefix. Classifying that as a public
+    # broker made the runtime log, at ERROR, that traffic was unauthenticated
+    # while it was in fact authenticated. A security channel that cries wolf
+    # is worse than a silent one: the operator either acts on a false alarm or
+    # learns to ignore it.
+    parsed = urlparse(broker_url if "://" in broker_url else f"mqtt://{broker_url}")
+    is_loopback = is_loopback_host(parsed.hostname)
 
     if not auth_enabled:
         if not is_loopback:
@@ -4677,7 +4684,7 @@ def _warn_sms_webhook_security_posture(config: Config) -> None:
         return
 
     host = str(webhook_cfg.get("host", "127.0.0.1") or "").strip()
-    if _is_loopback_bind_host(host):
+    if is_loopback_host(host):
         return
 
     signature_cfg = webhook_cfg.get("signature") or {}
@@ -4703,16 +4710,6 @@ def _warn_sms_webhook_security_posture(config: Config) -> None:
             "Africa's Talking provider IP ranges or a trusted reverse proxy.",
             host,
         )
-
-
-def _is_loopback_bind_host(host: str | None) -> bool:
-    value = str(host or "").strip().lower()
-    if value in {"localhost", "::1"}:
-        return True
-    try:
-        return ip_address(value).is_loopback
-    except ValueError:
-        return False
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/ori/utils/net_utils.py
+++ b/ori/utils/net_utils.py
@@ -1,0 +1,51 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Network-address classification shared by config validation and the runtime.
+
+There were two implementations of "is this host loopback" and they disagreed.
+Configuration validation tested `value.startswith("127.")`, which is true of
+`127.attacker.example` — a perfectly registrable DNS name that resolves
+wherever its owner points it. Under production posture that string took the
+loopback branch and skipped every non-loopback requirement at once: TLS, the
+broker deployment check, `anonymous_access: disabled`, per-device ACLs,
+`require_credentials`, and the username/password check. The runtime's own
+diagnostics used `ip_address()` and classified the same host as public, so the
+two halves of the system disagreed about whether a deployment was hardened.
+
+One helper, used by both. A host is loopback only when it is the literal name
+`localhost` or an address the standard library resolves as loopback. No
+prefix matching: a name is not an address, and treating it as one is how the
+bypass above existed.
+"""
+
+from __future__ import annotations
+
+from ipaddress import ip_address
+
+# The one hostname treated as loopback without being an address. Matched
+# exactly, so `localhost.attacker.example` is not loopback.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost"})
+
+
+def is_loopback_host(host: str | None) -> bool:
+    """True when *host* is unambiguously loopback.
+
+    Accepts the host component of a parsed URL, not a whole URL: callers must
+    parse first, because userinfo (`user:pass@127.0.0.1`) precedes the host and
+    defeats any comparison against the raw string.
+    """
+    value = str(host or "").strip().lower()
+    if not value:
+        return False
+    if value in _LOOPBACK_HOSTNAMES:
+        return True
+    # Brackets survive some hand-built URLs even though urlparse strips them.
+    if value.startswith("[") and value.endswith("]"):
+        value = value[1:-1]
+    try:
+        return ip_address(value).is_loopback
+    except ValueError:
+        # Not an address. A hostname is never loopback on the strength of how
+        # it is spelled, however much it resembles one.
+        return False

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2184,9 +2184,9 @@ yarl==1.23.0 \
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==26.1.2 \
-    --hash=sha256:382ff9f685ee3bc25864f820aa50505825f10f5458ffff07e30a6d96e5715cab \
-    --hash=sha256:f49cd134c61cf2fd75e0ce2676db03e4054504a5a4986d00f8299ae632dc4605
+pip==26.2.1 \
+    --hash=sha256:71138adf1f4ca900cdb7d289c21b7494329f2332b6d85f0e1c42108c0384ed3e \
+    --hash=sha256:f6ad667e89a1fe78046c8f13232b247200f5258d7828f3f7883d660878e0813f
     # via
     #   pip-api
     #   pip-tools

--- a/tests/test_firmware_provisioner.py
+++ b/tests/test_firmware_provisioner.py
@@ -553,3 +553,107 @@ class TestBackfillDoesNotFireOnNewDevices:
         assert len(first) == len(second) == 1
         assert second[0]["actor"] == ""
         assert "migration" not in {t["actor"] for t in second}
+
+
+def _prepare_approval(bench, device_id="ori-fw-bench0001", command="prepare-approval"):
+    return main(
+        [
+            command,
+            "--db",
+            bench["db"],
+            "--device-id",
+            device_id,
+            "--provisioner-seed",
+            bench["auth_seed"],
+            "--runtime-command-seed",
+            bench["rt_seed"],
+        ]
+    )
+
+
+class TestTheCliClaimsNoPublicationItDoesNotPerform:
+    """This CLI signs an approval and exits. It never reaches a broker.
+
+    That refusal is deliberate: live publication runs inside the runtime's
+    gateway, because a tool about to exit must not assert liveness
+    supervision over a device. What the command used to do was print
+    `publish RETAINED on ori/fw/<id>/provision (QoS 1)` afterwards, which
+    reads as confirmation that a retained message was delivered. An
+    operator who believed it would think a device was provisioned when
+    nothing had been sent — on the step that grants a device its identity.
+
+    These tests exercise the commands rather than their help text, because
+    the help was never the thing that lied.
+    """
+
+    def test_prepare_approval_emits_the_signed_bytes(self, bench, capsys) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        _confirm(bench)
+        capsys.readouterr()  # discard fixture setup output
+        assert _prepare_approval(bench) == 0
+
+        message = json.loads(capsys.readouterr().out)
+        assert message["approval"]["device_id"] == "ori-fw-bench0001"
+        assert message["signature"].startswith("ed25519:")
+
+    def test_prepare_approval_says_it_did_not_publish(self, bench, capsys) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        _confirm(bench)
+        assert _prepare_approval(bench) == 0
+
+        err = capsys.readouterr().err
+        assert "NOT published" in err
+
+    def test_prepare_approval_never_claims_a_retained_publication(
+        self, bench, capsys
+    ) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        _confirm(bench)
+        assert _prepare_approval(bench) == 0
+
+        captured = capsys.readouterr()
+        combined = (captured.out + captured.err).lower()
+        assert "publish retained" not in combined
+        assert "qos 1)" not in combined.replace("(retained, qos 1)", "")
+
+    def test_deprecated_publish_alias_warns_and_still_works(
+        self, bench, capsys
+    ) -> None:
+        """Renaming alone would break provisioning scripts in the field."""
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        _confirm(bench)
+        capsys.readouterr()  # discard fixture setup output
+        assert _prepare_approval(bench, command="publish") == 0
+
+        captured = capsys.readouterr()
+        assert "deprecated" in captured.err
+        assert "prepare-approval" in captured.err
+        assert "NOT published" in captured.err
+        message = json.loads(captured.out)
+        assert message["approval"]["device_id"] == "ori-fw-bench0001"
+
+    def test_both_names_emit_identical_bytes(self, bench, capsys) -> None:
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+        _confirm(bench)
+        capsys.readouterr()  # discard fixture setup output
+
+        assert _prepare_approval(bench) == 0
+        renamed = capsys.readouterr().out
+        assert _prepare_approval(bench, command="publish") == 0
+        aliased = capsys.readouterr().out
+
+        assert json.loads(renamed) == json.loads(aliased)
+
+    def test_approve_does_not_tell_the_operator_to_publish(self, bench, capsys) -> None:
+        """The approve hint carried the same false instruction."""
+        assert _register(bench) == 0
+        assert _approve(bench) == 0
+
+        out = capsys.readouterr().out.lower()
+        assert "prepare-approval" in out
+        assert "publish the retained approval" not in out

--- a/tests/test_truthful_operator_output.py
+++ b/tests/test_truthful_operator_output.py
@@ -1,0 +1,244 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The runtime must not report a claim that is not true.
+
+Three defects shared that shape, and each cost a debugging cycle during
+firmware bring-up because the output was believed:
+
+1. A credentialed loopback broker was classified as public, so the runtime
+   logged, at ERROR, that MQTT traffic was unauthenticated while it was
+   authenticated. Production posture *requires* those credentials, so the
+   configuration the runtime asks for was the one that triggered the alarm.
+2. The provisioner printed `publish RETAINED on ...` after publishing
+   nothing, on a security-critical step.
+3. An unexpanded `${VAR}` in `gateway.broker_url` passed config load and
+   surfaced only as a connection refusal from every client, naming nothing.
+
+These tests assert the corrected behaviour rather than the wording, so a
+future rephrasing does not silently reopen any of them. Defect 2 is covered
+by command-level tests in tests/test_firmware_provisioner.py.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+import yaml
+
+from ori.config import Config, ConfigValidationError
+from ori.runtime import _warn_gateway_security_posture
+from ori.utils.net_utils import is_loopback_host
+
+# --- 1. loopback classification -------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "host,expected",
+    [
+        ("127.0.0.1", True),
+        ("127.1.2.3", True),
+        ("localhost", True),
+        ("::1", True),
+        ("192.168.1.10", False),
+        ("broker.example.com", False),
+        # Registrable DNS names that a prefix test called loopback. Under
+        # production posture that skipped TLS, the broker deployment check,
+        # anonymous_access, per-device ACLs, require_credentials, and the
+        # username/password requirement — all six, from one hostname.
+        ("127.attacker.example", False),
+        ("127.0.0.1.evil.com", False),
+        ("127.evil", False),
+        ("localhost.evil.com", False),
+        ("[::1]", True),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_loopback_host_classification(host, expected):
+    assert is_loopback_host(host) is expected
+
+
+class _StubGateway:
+    def __init__(self, broker_url: str) -> None:
+        self.enabled = True
+        self.broker_url = broker_url
+        self.auth: dict = {"enabled": False}
+        self.tls: dict = {"enabled": False}
+
+
+class _StubConfig:
+    def __init__(self, broker_url: str) -> None:
+        self.gateway = _StubGateway(broker_url)
+
+
+@pytest.mark.parametrize(
+    "broker_url",
+    [
+        "mqtt://user:pass@127.0.0.1:1883",
+        "mqtts://ori-runtime:secret@localhost:8883",
+        "mqtt://127.0.0.1:1883",
+        "mqtt://[::1]:1883",
+    ],
+)
+def test_credentialed_loopback_broker_logs_no_security_error(broker_url, caplog):
+    """Credentials in the URL must not make a loopback broker read as public.
+
+    This is the regression: the old check prefix-matched the whole URL, and
+    `mqtt://user:pass@127.0.0.1:1883` carries userinfo ahead of the host, so
+    it matched no prefix and was reported as an unauthenticated public broker.
+    """
+    with caplog.at_level(logging.WARNING):
+        _warn_gateway_security_posture(_StubConfig(broker_url))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors == [], f"false security ERROR for loopback broker: {errors}"
+
+
+def test_non_loopback_broker_without_auth_still_logs_error(caplog):
+    """The fix must not silence the alarm it exists to make accurate."""
+    with caplog.at_level(logging.WARNING):
+        _warn_gateway_security_posture(_StubConfig("mqtt://user:pass@10.0.0.5:1883"))
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, "a real public unauthenticated broker must still raise ERROR"
+
+
+# --- 2. unexpanded environment variables ----------------------------------
+
+
+def _minimal_config(tmp_path, broker_url: str) -> str:
+    document = {
+        "device": {"id": "test-device", "name": "Test", "location": "Lab"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {"enabled": True, "broker_url": broker_url},
+    }
+    path = tmp_path / "ori.yaml"
+    path.write_text(yaml.safe_dump(document))
+    return str(path)
+
+
+def test_unexpanded_broker_url_variable_is_refused_at_load(tmp_path, monkeypatch):
+    monkeypatch.delenv("ORI_TEST_BROKER_HOST", raising=False)
+    path = _minimal_config(tmp_path, "mqtt://${ORI_TEST_BROKER_HOST}:1883")
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        Config.load(path)
+
+    message = str(excinfo.value)
+    assert "unexpanded" in message.lower()
+    assert "ORI_TEST_BROKER_HOST" in message, "the missing variable must be named"
+
+
+def test_expanded_broker_url_loads(tmp_path, monkeypatch):
+    monkeypatch.setenv("ORI_TEST_BROKER_HOST", "127.0.0.1")
+    path = _minimal_config(tmp_path, "mqtt://${ORI_TEST_BROKER_HOST}:1883")
+
+    config = Config.load(path)
+    assert config.gateway.broker_url == "mqtt://127.0.0.1:1883"
+
+
+def test_disabled_gateway_tolerates_unexpanded_variable(tmp_path, monkeypatch):
+    """A disabled gateway is not a configuration the runtime will act on."""
+    monkeypatch.delenv("ORI_TEST_BROKER_HOST", raising=False)
+    document = {
+        "device": {"id": "test-device", "name": "Test", "location": "Lab"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {"enabled": False, "broker_url": "mqtt://${ORI_TEST_BROKER_HOST}"},
+    }
+    path = tmp_path / "ori.yaml"
+    path.write_text(yaml.safe_dump(document))
+
+    Config.load(str(path))
+
+
+# --- 3. the provisioner claims no publication it did not perform ----------
+
+
+# Command-level coverage for the provisioner lives in
+# tests/test_firmware_provisioner.py, next to the `bench` fixture that builds
+# a keyed registry. Help text was never the thing that lied, so asserting on
+# it here would have proved nothing about what the command prints.
+
+
+# --- 4. the bypass the split implementation allowed -----------------------
+
+
+@pytest.mark.parametrize(
+    "host,expect_hardening_demanded",
+    [
+        ("127.attacker.example", True),
+        ("127.0.0.1.evil.com", True),
+        ("localhost.evil.com", True),
+        ("127.0.0.1", False),
+        ("localhost", False),
+    ],
+)
+def test_hostname_resembling_loopback_still_demands_hardening(
+    tmp_path, caplog, host, expect_hardening_demanded
+):
+    """A registrable DNS name must not take the loopback branch.
+
+    Config validation used to test `value.startswith("127.")`, so
+    `127.attacker.example` was classified loopback and the entire non-loopback
+    hardening branch was skipped: TLS, the broker deployment check,
+    `anonymous_access: disabled`, per-device ACLs, `require_credentials`, and
+    the username/password requirement. The runtime's own diagnostics used
+    `ip_address()` and called the same host public, so the two halves of the
+    system disagreed about whether a deployment was hardened.
+
+    Asserted in development posture, where the same classification produces a
+    warning rather than a raise. Production posture reaches this branch only
+    after several earlier requirements pass, and building a config hardened
+    enough to get there would test those instead of this.
+    """
+    document = {
+        "device": {"id": "test-device", "name": "Test", "location": "Lab"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {"enabled": True, "broker_url": f"mqtt://{host}:1883"},
+    }
+    path = tmp_path / "ori.yaml"
+    path.write_text(yaml.safe_dump(document))
+
+    with caplog.at_level(logging.WARNING):
+        Config.load(str(path))
+
+    demanded = any(
+        "non-loopback gateway broker is missing hardening" in record.getMessage()
+        for record in caplog.records
+    )
+    assert demanded is expect_hardening_demanded
+
+
+def test_config_and_runtime_share_one_loopback_implementation():
+    """Two implementations disagreeing is the defect, not the strictness.
+
+    Import identity is the assertion because a copied-but-equivalent helper
+    would drift again, which is exactly what happened the first time.
+    """
+    from ori import config as config_module
+    from ori import runtime as runtime_module
+
+    assert config_module.is_loopback_host is runtime_module.is_loopback_host


### PR DESCRIPTION
## What does this PR do?

The runtime told operators four things that were not true, and one of them was a production-posture bypass. All four shared a root cause worth naming: a classification or a message that was written once, believed thereafter, and never checked against what the code actually did.

**Two implementations of "is this host loopback" disagreed, and the weaker one guarded production hardening.** Configuration validation tested `value.startswith("127.")`. That is true of `127.attacker.example` — a registrable DNS name that resolves wherever its owner points it. Under production posture that string took the loopback branch and skipped the entire non-loopback requirement set at once: gateway TLS, `broker_posture.deployment_check: required`, `anonymous_access: disabled`, `acl_policy: per_device_required`, `require_credentials: true`, and the username/password check. Six requirements, defeated by a hostname. The runtime's own diagnostics used `ip_address()` and classified the same host as public, so the two halves of the system disagreed about whether a deployment was hardened. There is now one strict classifier in `ori/utils/net_utils.py`, used by both paths, and a test asserts import identity rather than equivalent behaviour — a copied-but-equal helper is precisely how these drifted apart.

**A credentialed loopback broker was reported as an unauthenticated public one.** The gateway posture check prefix-matched the whole broker URL. `mqtt://user:pass@127.0.0.1:1883` carries userinfo ahead of the host and matched nothing, so the runtime logged at ERROR that MQTT traffic was unauthenticated while it was authenticated. Production posture *requires* those credentials, so the configuration the runtime asks for was the one that raised the false alarm. The host is now parsed before classification, which also fixes `mqtt://[::1]:1883`, never handled at all. The ERROR for a genuinely public unauthenticated broker still fires, and a test holds it there.

**The provisioner claimed a publication it never performed.** `publish` printed `publish RETAINED on ori/fw/<id>/provision (QoS 1)` to stderr after publishing nothing. The refusal of a live publisher is deliberate and unchanged — live publication runs inside the runtime's gateway, because a CLI about to exit must not assert liveness supervision over a device. The defect was the claim, on the step that grants a device its identity: an operator who believed it would think a device was provisioned when nothing had been sent. The command is now `prepare-approval` and states that it does not publish. `publish` remains as a deprecated alias that warns and emits byte-identical output, so provisioning scripts in the field keep working. The `approve` command's closing hint carried the same false instruction.

**An unexpanded `${VAR}` in `gateway.broker_url` passed config load.** `_expand_env_vars` deliberately leaves the literal when a variable is unset, and eleven other fields in `config.py` check for the leftover. This one did not, so an unset variable produced a URL no client could reach and the only symptom was a refusal from every connection, naming nothing. It is refused at load, with the missing variable named.

The branch also bumps `pip` to 26.2.1 in `requirements/dev.txt`. PYSEC-2026-3721 affects the pinned 26.1.2 and fails the dependency audit on every PR against `main`, so the bump is a prerequisite for this one to be mergeable rather than a change of its own. `requirements/runtime.txt` is unaffected and already audits clean.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

Marked `security` for the loopback classifier: a hostname could previously satisfy the loopback branch that gates every non-loopback broker hardening requirement under production posture.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changed. Gateway posture reporting, provisioner CLI naming, and config validation are corrections to what the runtime *says* and how it *classifies*, not to what it can do. Two behaviours do change and neither is a capability: a hostname resembling a loopback address no longer satisfies the loopback branch, and an invalid `broker_url` now fails at load instead of at every connection.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `urlparse`, `re` and `cast` were already available in the files that use them; the new `ori/utils/net_utils.py` imports only `ipaddress` from the standard library.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no bundled skill is modified.

## Related issue

Fixes #331.

## Testing notes

Full suite: 3348 passed, 22 skipped. `mypy ori/` clean across 126 source files, `scripts/typecheck-boundaries.sh` clean across 30. Both dependency audits report no known vulnerabilities.

Every fix is mutation-checked rather than assumed. Reverting the shared classifier to prefix matching fails five tests, including the two that assert a hostname resembling a loopback address still demands broker hardening. Reverting the URL parsing fails three of the four credentialed-loopback cases. Removing the config guard fails the refusal test. A test that passes against the old code proves nothing about the fix.

Provisioner coverage drives the real commands rather than their help text, which was never the thing that lied: the tests register, approve and confirm a device against a temporary keyed registry, then parse the signed envelope the command emits, assert it states it did not publish, and prove the deprecated alias produces byte-identical output.
