### PR TITLE
fix(installer): keep the identity an installation already carries

### DIFF
--- a/ori/installer/cli.py
+++ b/ori/installer/cli.py
@@ -17,6 +17,7 @@ from typing import Callable, NoReturn, Sequence
 
 from ori.installer import (
     activation,
+    identity,
     launcher,
     paths,
     prerequisites,
@@ -174,10 +175,19 @@ def _install(args: argparse.Namespace) -> dict[str, object]:
     # Identity is collected and confirmed first, because confirmation promises
     # that nothing has been changed yet. Installing packages before the
     # operator has agreed to proceed would make that promise false.
+    # An upgrade runs this same code against an existing root, so the identity
+    # question is only open when nothing is installed. Read it before asking:
+    # a device's identity keys its MQTT topics, the client ids its broker ACLs
+    # are written against, and every stored row indexed by it.
+    try:
+        installed_identity = identity.read_installed(layout)
+    except identity.InstalledConfigUnreadableError as exc:
+        raise LinuxInstallError("config_validation_failed", str(exc)) from exc
     values = collect_installer_config(
         InstallerInputOptions(
             unattended=args.unattended,
             device_id=args.device_id,
+            installed=installed_identity,
             name=args.name,
             location=args.location,
             deployment_type=args.deployment_type,

--- a/ori/installer/identity.py
+++ b/ori/installer/identity.py
@@ -20,6 +20,13 @@ import re
 import secrets
 import socket
 from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime
+    from ori.installer.linux import InstallLayout
 
 # Hostnames that stock images ship with. They identify the image, not the
 # device, so a fleet of them would collide on identity.
@@ -103,3 +110,153 @@ def suggest(
     device_id = f"{stem[: _MAX_LENGTH - len(suffix) - 1]}-{suffix}"
     display = raw.strip().split(".")[0] or device_id
     return SuggestedIdentity(device_id, display, True)
+
+
+@dataclass(frozen=True)
+class InstalledIdentity:
+    """The identity an existing installation already carries.
+
+    A device's identity is not a preference the installer may re-ask on every
+    run. It keys the runtime's MQTT topics, the client identifiers per-device
+    broker ACLs are written against, and the `(device_id, timestamp)` index on
+    every stored reasoning, action and Tier C decision row. Changing it while
+    the data directory survives leaves all of that stranded.
+    """
+
+    device_id: str
+    name: str
+    location: str
+
+
+class InstalledConfigUnreadableError(Exception):
+    """An installation exists but its identity could not be read.
+
+    Distinct from "no installation": a fresh install may derive an identity
+    from the host, whereas an upgrade that cannot read the identity it is
+    replacing must stop rather than invent one.
+    """
+
+
+def _exists(path: Path, description: str) -> bool:
+    """Whether *path* is there, distinguishing absent from uninspectable.
+
+    `Path.exists()` propagates PermissionError rather than answering False, so
+    a path inside a directory this process cannot read would otherwise raise
+    out of identity detection as an unhandled error.
+    """
+    try:
+        return path.exists() or path.is_symlink()
+    except OSError as exc:
+        raise InstalledConfigUnreadableError(
+            f"{description} at {path} could not be inspected, so whether this "
+            f"root is in use cannot be determined: {exc}"
+        ) from exc
+
+
+def _entries(directory: Path, description: str) -> list[str]:
+    """List *directory*, distinguishing absent from uninspectable.
+
+    A directory that cannot be read is not an empty one. Collapsing every
+    OSError into "no entries" would turn a permissions failure or an I/O
+    error into "unused root", which is the one answer that licenses deriving
+    a new identity — fail-open on exactly the question that must fail closed.
+    """
+    try:
+        return sorted(entry.name for entry in directory.iterdir())
+    except FileNotFoundError:
+        return []
+    except OSError as exc:
+        raise InstalledConfigUnreadableError(
+            f"{description} at {directory} could not be inspected, so whether "
+            f"this root is in use cannot be determined: {exc}"
+        ) from exc
+
+
+# Directories this installer creates as scaffolding. Their presence says
+# nothing; their contents do.
+_SCAFFOLDING = frozenset({"releases", "data", "current"})
+
+
+def _occupancy(layout: InstallLayout) -> list[str]:
+    """Every sign that the managed root is already in use.
+
+    Named rather than enumerated by filename: an earlier version listed four
+    known files in the data directory, so deleting `ori.yaml` while an
+    activated release remained made an occupied installation read as empty.
+    A device's identity is not recoverable from a release tree, which is
+    precisely why its absence there has to stop the run rather than license
+    a new one.
+    """
+    signs: list[str] = []
+    current = layout.current
+    if _exists(current, "the active release pointer"):
+        signs.append(f"an activated release at {current}")
+    releases = _entries(layout.releases, "the releases directory")
+    if releases:
+        signs.append(f"managed releases ({', '.join(releases)})")
+    data_entries = _entries(layout.data, "the data directory")
+    if data_entries:
+        signs.append(f"runtime state ({', '.join(data_entries)})")
+    # Anything the installer did not put here is still occupancy: an unused
+    # managed root is unused, not merely free of the artifacts this code
+    # happens to know the names of.
+    unexpected = [
+        name
+        for name in _entries(layout.root, "the install root")
+        if name not in _SCAFFOLDING
+    ]
+    if unexpected:
+        signs.append(f"unexpected entries ({', '.join(unexpected)})")
+    return signs
+
+
+def read_installed(layout: InstallLayout) -> InstalledIdentity | None:
+    """Return the identity carried by the installation at *layout*, if any.
+
+    Returns ``None`` only for a managed root that is genuinely unused, which
+    is the sole case that licenses deriving an identity from the host.
+    Re-running the installer over a root that holds anything is not a fresh
+    install, however it is invoked.
+
+    A configuration that cannot be parsed, one carrying no device id, and an
+    occupied root without a readable configuration all raise. Each would
+    otherwise let a run invent an identity for a device whose real one is
+    merely unreadable — and ``device.id`` is not a display name. It is part of
+    the durable identity namespace: evidence idempotency keys derive from it,
+    the signing anchor is registered against it, MQTT topics and client
+    identifiers embed it, broker ACLs are assigned by it, the firmware
+    registry relates to it, and stored rows are indexed by it.
+    """
+    config_path = layout.data / "ori.yaml"
+    if not _exists(config_path, "the runtime configuration"):
+        occupied = _occupancy(layout)
+        if occupied:
+            raise InstalledConfigUnreadableError(
+                f"{layout.root} already holds {', and '.join(occupied)}, but no "
+                "readable configuration, so the device it belongs to cannot be "
+                "identified. Deriving a new identity here would strand that "
+                "installation."
+            )
+        return None
+    try:
+        document = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, yaml.YAMLError) as exc:
+        raise InstalledConfigUnreadableError(
+            f"an installation exists at {config_path} but its configuration "
+            "could not be read"
+        ) from exc
+    device = document.get("device") if isinstance(document, dict) else None
+    if not isinstance(device, dict):
+        raise InstalledConfigUnreadableError(
+            f"an installation exists at {config_path} but declares no device section"
+        )
+    device_id = str(device.get("id", "") or "").strip()
+    if not device_id:
+        raise InstalledConfigUnreadableError(
+            f"an installation exists at {config_path} but declares no device id"
+        )
+    return InstalledIdentity(
+        device_id=device_id,
+        name=str(device.get("name", "") or "").strip(),
+        location=str(device.get("location", "") or "").strip(),
+    )

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -15,7 +15,7 @@ import subprocess
 import sys
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable, Literal, Sequence
 
@@ -131,6 +131,10 @@ class InstallerInputOptions:
     # Off by default so an unattended run is reproducible: a random suffix
     # would give the same automation a different device on every execution.
     generate_device_id: bool = False
+    # The identity already on disk, when this run is upgrading rather than
+    # installing. Present means the device has an identity the installer must
+    # keep; absent means nothing is installed and the host may supply one.
+    installed: identity.InstalledIdentity | None = None
 
 
 def collect_installer_config(
@@ -146,6 +150,42 @@ def collect_installer_config(
     values and prompts only for missing fields, retrying invalid prompt input a
     bounded number of times.
     """
+    installed = options.installed
+    if installed is not None:
+        # `device.id` is not a display name. Evidence idempotency keys derive
+        # from it, the signing anchor is registered against it, MQTT topics
+        # and client identifiers embed it, broker ACLs are assigned by it, and
+        # stored rows are indexed by it. An install or an upgrade may not
+        # change it, and no flag makes that safe: rewriting it while the state
+        # database survives would silently break the uniqueness that already
+        # signed evidence depends on. Adopting a new identity is a migration
+        # ceremony, not an installer option.
+        supplied = (options.device_id or "").strip()
+        if supplied and supplied != installed.device_id:
+            raise LinuxInstallError(
+                "config_validation_failed",
+                f"this installation is device {installed.device_id!r} and "
+                f"--device-id was given as {supplied!r}. An install cannot "
+                "change an established identity: evidence idempotency keys, "
+                "the signing anchor, MQTT topics, broker ACLs and stored rows "
+                "all derive from it. Omit --device-id to keep it.",
+            )
+        if options.generate_device_id:
+            raise LinuxInstallError(
+                "config_validation_failed",
+                f"this installation is device {installed.device_id!r}, so "
+                "--generate-device-id contradicts it. That flag derives a new "
+                "identity from the host and applies only to an empty root.",
+            )
+        options = replace(options, device_id=installed.device_id)
+        # Name and location are already recorded too. An upgrade that demanded
+        # them again would fail an unattended run that has no reason to carry
+        # them, and re-prompt an interactive one for answers already on disk.
+        if not (options.name or "").strip() and installed.name:
+            options = replace(options, name=installed.name)
+        if not (options.location or "").strip() and installed.location:
+            options = replace(options, location=installed.location)
+
     if options.unattended:
         device_id = options.device_id
         name = options.name
@@ -189,7 +229,10 @@ def collect_installer_config(
             ),
         )
 
-    suggestion = identity.suggest()
+    # A host-derived suggestion answers "what should this device be called",
+    # which is only an open question on an empty root. On an upgrade the
+    # answer is already on disk and is not the operator's to revise here.
+    suggestion = identity.suggest() if installed is None else None
     device_id = _collect_interactive_value(
         supplied=options.device_id,
         label="Device ID",
@@ -197,7 +240,11 @@ def collect_installer_config(
         prompt=prompt,
         write=write,
         hint=identity.DEVICE_ID_HINT,
-        default=suggestion.device_id if suggestion else None,
+        default=(
+            installed.device_id
+            if installed is not None
+            else (suggestion.device_id if suggestion else None)
+        ),
     )
     name = _collect_interactive_value(
         supplied=options.name,
@@ -205,7 +252,11 @@ def collect_installer_config(
         validate=lambda value: _validate_device_text("name", value),
         prompt=prompt,
         write=write,
-        default=suggestion.name if suggestion else None,
+        default=(
+            installed.name or None
+            if installed is not None
+            else (suggestion.name if suggestion else None)
+        ),
     )
     # Neither of these can be derived from the host, and a plausible-looking
     # guess is worse than a blank in a fleet report.
@@ -215,6 +266,7 @@ def collect_installer_config(
         validate=lambda value: _validate_device_text("location", value),
         prompt=prompt,
         write=write,
+        default=installed.location or None if installed is not None else None,
     )
     operator_contact = _collect_interactive_value(
         supplied=options.operator_contact,

--- a/tests/test_installer_identity_continuity.py
+++ b/tests/test_installer_identity_continuity.py
@@ -1,0 +1,309 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""An upgrade must not re-identify the device it is upgrading.
+
+Install and upgrade are the same code path: `ori install` authenticates the
+new bundle and runs *that bundle's* installer against the same root. That
+function only ever knew how to author an identity, so a run that did not
+repeat `--device-id` invented a new one.
+
+On a host whose name is distinctive the invented value happened to match, and
+the bug stayed hidden. On a stock image it does not: `raspberrypi` is in
+GENERIC_HOSTNAMES, so `suggest()` appends `secrets.token_hex`, and every run
+produces a different device. That is the default hostname of the hardware this
+runtime targets.
+
+The data directory survives the upgrade while the identity does not, which
+strands the runtime's `ori/{device_id}/...` topics, the client identifiers
+per-device broker ACLs are written against, and every stored reasoning, action
+and Tier C decision row indexed by `(device_id, timestamp)`.
+
+Identity continuity holds regardless of who authored the identity. A config
+generated and signed by a provisioning backend is preserved by the same rule
+that preserves a locally derived one, because the installer stops authoring
+identity on upgrade and starts reading it.
+"""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from ori.installer import identity
+from ori.installer.linux import (
+    InstallerInputOptions,
+    InstallLayout,
+    LinuxInstallError,
+    collect_installer_config,
+)
+
+
+def _layout(tmp_path) -> InstallLayout:
+    """A managed root with its directories present but nothing in them."""
+    layout = InstallLayout.resolve(tmp_path)
+    layout.releases.mkdir(parents=True, exist_ok=True)
+    layout.data.mkdir(parents=True, exist_ok=True)
+    return layout
+
+
+def _write_config(layout, device_id, name="Deployed", location="Ikeja"):
+    config = layout.data / "ori.yaml"
+    config.write_text(
+        yaml.safe_dump(
+            {"device": {"id": device_id, "name": name, "location": location}}
+        )
+    )
+    return config
+
+
+# --- reading an existing installation --------------------------------------
+
+
+def test_unused_root_reads_as_no_installation(tmp_path):
+    """Only a genuinely unused managed root may derive an identity."""
+    assert identity.read_installed(_layout(tmp_path)) is None
+
+
+def test_occupied_root_without_config_refuses_by_activated_release(tmp_path):
+    """An activated release with no config is an installation, not a fresh root.
+
+    A device's identity is not recoverable from a release tree, so deleting
+    the config must stop the run rather than license a new identity.
+    """
+    layout = _layout(tmp_path)
+    release = layout.releases / "2.4.0"
+    release.mkdir(parents=True)
+    layout.current.symlink_to(release)
+    with pytest.raises(identity.InstalledConfigUnreadableError) as excinfo:
+        identity.read_installed(layout)
+    assert "activated release" in str(excinfo.value)
+
+
+def test_occupied_root_without_config_refuses_by_managed_release(tmp_path):
+    """A staged release with no `current` pointer still occupies the root."""
+    layout = _layout(tmp_path)
+    (layout.releases / "2.4.0").mkdir(parents=True)
+    with pytest.raises(identity.InstalledConfigUnreadableError) as excinfo:
+        identity.read_installed(layout)
+    assert "managed releases" in str(excinfo.value)
+
+
+def test_unexpected_root_entry_refuses(tmp_path):
+    """An unused managed root is unused, not merely free of known artifacts."""
+    layout = _layout(tmp_path)
+    (layout.root / "leftover.db").write_bytes(b"")
+    with pytest.raises(identity.InstalledConfigUnreadableError) as excinfo:
+        identity.read_installed(layout)
+    assert "leftover.db" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("directory", ["data", "releases", "root"])
+def test_uninspectable_directory_fails_closed(tmp_path, directory):
+    """A directory that cannot be read is not an empty one.
+
+    Collapsing a permissions or I/O failure into "no entries" would answer
+    "is this root in use?" with the one value that licenses deriving a new
+    identity. That question must fail closed.
+    """
+    layout = _layout(tmp_path)
+    target = {
+        "data": layout.data,
+        "releases": layout.releases,
+        "root": layout.root,
+    }[directory]
+    original = target.stat().st_mode
+    target.chmod(0o000)
+    try:
+        with pytest.raises(identity.InstalledConfigUnreadableError) as excinfo:
+            identity.read_installed(layout)
+        assert "could not be inspected" in str(excinfo.value)
+    finally:
+        target.chmod(original)
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        "ori_state.db",
+        "ori_evidence.db",
+        "ori_evidence.key",
+        # Not a name this code knows. Occupancy is decided by the directory
+        # holding anything, so a state path configured away from its default,
+        # or an artifact added later, is covered without being enumerated.
+        "some-future-artifact.db",
+    ],
+)
+def test_occupied_root_without_config_refuses_by_any_data_entry(tmp_path, artifact):
+    layout = _layout(tmp_path)
+    (layout.data / artifact).write_bytes(b"")
+    with pytest.raises(identity.InstalledConfigUnreadableError) as excinfo:
+        identity.read_installed(layout)
+    assert artifact in str(excinfo.value)
+
+
+def test_existing_config_yields_its_identity(tmp_path):
+    layout = _layout(tmp_path)
+    _write_config(layout, "energy-monitor-ikeja-01")
+    installed = identity.read_installed(layout)
+    assert installed is not None
+    assert installed.device_id == "energy-monitor-ikeja-01"
+    assert installed.name == "Deployed"
+    assert installed.location == "Ikeja"
+
+
+@pytest.mark.parametrize(
+    "contents",
+    [
+        "device: [not, a, mapping]",
+        "device:\n  name: no id here\n",
+        "device:\n  id: '   '\n",
+        ": : not yaml : :",
+    ],
+)
+def test_unreadable_installation_refuses_rather_than_inventing(tmp_path, contents):
+    """A config that exists but cannot be read is not a fresh install.
+
+    Returning None here would let an upgrade invent an identity for a device
+    whose real one is merely unreadable — the exact failure this prevents.
+    """
+    layout = _layout(tmp_path)
+    (layout.data / "ori.yaml").write_text(contents)
+    with pytest.raises(identity.InstalledConfigUnreadableError):
+        identity.read_installed(layout)
+
+
+# --- collection preserves what is deployed ---------------------------------
+
+
+def _installed(device_id="energy-monitor-ikeja-01"):
+    return identity.InstalledIdentity(
+        device_id=device_id, name="Deployed", location="Ikeja"
+    )
+
+
+def test_unattended_upgrade_without_device_id_keeps_the_deployed_identity():
+    values = collect_installer_config(
+        InstallerInputOptions(
+            unattended=True,
+            location="Ikeja",
+            installed=_installed(),
+        )
+    )
+    assert values.device_id == "energy-monitor-ikeja-01"
+
+
+def test_generate_device_id_on_an_installation_is_refused_as_contradictory():
+    """That flag derives an identity from the host; the root already has one."""
+    with pytest.raises(LinuxInstallError) as excinfo:
+        collect_installer_config(
+            InstallerInputOptions(
+                unattended=True,
+                location="Ikeja",
+                generate_device_id=True,
+                installed=_installed(),
+            )
+        )
+    assert "--generate-device-id" in str(excinfo.value)
+
+
+def test_conflicting_device_id_is_refused():
+    """No install or upgrade input may mutate an established identity."""
+    with pytest.raises(LinuxInstallError) as excinfo:
+        collect_installer_config(
+            InstallerInputOptions(
+                unattended=True,
+                device_id="something-else",
+                name="N",
+                location="L",
+                installed=_installed(),
+            )
+        )
+    message = str(excinfo.value)
+    assert "energy-monitor-ikeja-01" in message
+    assert "evidence idempotency" in message
+
+
+def test_no_installer_option_can_mutate_an_established_identity():
+    """Asserted over the option surface rather than one flag at a time.
+
+    A future option that reached identity would otherwise pass every other
+    test in this file.
+    """
+    installed = _installed()
+    for overrides in (
+        {"device_id": "other-id"},
+        {"generate_device_id": True},
+        {"device_id": "other-id", "generate_device_id": True},
+    ):
+        with pytest.raises(LinuxInstallError):
+            collect_installer_config(
+                InstallerInputOptions(
+                    unattended=True,
+                    name="N",
+                    location="L",
+                    installed=installed,
+                    **overrides,
+                )
+            )
+
+    kept = collect_installer_config(
+        InstallerInputOptions(unattended=True, installed=installed)
+    )
+    assert kept.device_id == installed.device_id
+
+
+def test_fresh_install_still_derives_identity_from_the_host():
+    """Nothing installed means the question is genuinely open."""
+    values = collect_installer_config(
+        InstallerInputOptions(
+            unattended=True,
+            name="Fresh",
+            location="Lab",
+            generate_device_id=True,
+            installed=None,
+        )
+    )
+    assert values.device_id
+
+
+def test_generic_hostname_upgrade_does_not_drift():
+    """The case that made this demo-fatal.
+
+    `raspberrypi` is the default hostname of stock Raspberry Pi OS and is in
+    GENERIC_HOSTNAMES, so a host-derived suggestion carries a random suffix
+    and differs on every run. Two upgrades of the same installation must still
+    produce the same device.
+    """
+    assert identity.needs_suffix(identity.normalise("raspberrypi"))
+    first = identity.suggest("raspberrypi")
+    second = identity.suggest("raspberrypi")
+    assert first is not None and second is not None
+    assert first.device_id != second.device_id, "precondition: suggestion drifts"
+
+    installed = _installed("pi-ikeja-01")
+    runs = [
+        collect_installer_config(
+            InstallerInputOptions(
+                unattended=True, location="Ikeja", installed=installed
+            )
+        ).device_id
+        for _ in range(2)
+    ]
+    assert runs == ["pi-ikeja-01", "pi-ikeja-01"]
+
+
+def test_backend_authored_identity_is_preserved_the_same_way(tmp_path):
+    """Identity continuity does not depend on who authored the identity.
+
+    A configuration generated and signed by a provisioning backend is read
+    back by the same path as a locally derived one, so the rule survives the
+    move to backend-issued identity rather than being replaced by it.
+    """
+    layout = _layout(tmp_path)
+    _write_config(layout, "tenant-site-0042")
+    installed = identity.read_installed(layout)
+    values = collect_installer_config(
+        InstallerInputOptions(unattended=True, location="Site", installed=installed)
+    )
+    assert values.device_id == "tenant-site-0042"


### PR DESCRIPTION
## What does this PR do?

An install and an upgrade are the same code path: `ori install` authenticates the new bundle and runs *that bundle's* installer against the same root. That function only ever knew how to author a device identity, and it rewrites `ori.yaml` unconditionally on every run — the only guard on the existing file checks that it is a regular file rather than a symlink or directory, not that it already exists. So a run that did not repeat `--device-id` invented a new one.

On a host with a distinctive name the invented value happened to match and the defect stayed hidden. On a stock image it does not: `raspberrypi` is in `GENERIC_HOSTNAMES`, so the host-derived suggestion appends `secrets.token_hex` and every run produces a different device. That is the default hostname of the hardware this runtime targets.

The data directory survives an upgrade while the identity did not, which strands the runtime's `ori/{device_id}/...` topics, the client identifiers per-device broker ACLs are written against, and every stored reasoning, action and Tier C decision row indexed by `(device_id, timestamp)`.

**`device.id` cannot be changed by an install or an upgrade at all, and there is no flag that permits it.** It is part of the durable identity namespace, and the sharpest consequence is in the evidence chain: every attestation's `event_id` derives from `(device_id, action_log id)` and is UNIQUE in the chain schema, as the idempotency key of already-signed evidence. Rewriting the identity while the state database survives would mean the same `action_log id` deriving a different `event_id` — the lookup that prevents double-attestation on retry stops finding its entry — or colliding with genuine evidence from the device that previously held the name. Adopting a new identity is a migration ceremony, not an installer option.

So identity becomes a read rather than an author. The write was never going to be conditional; the surviving data directory is exactly what an upgrade preserves, and identity was the one thing in it the installer kept re-deriving.

**Classifying the root, and failing closed.** `read_installed` inspects the whole `InstallLayout` and returns nothing only for a managed root that is genuinely unused — the sole case that licenses deriving an identity from the host. Occupancy is established by the activated release pointer, any managed release, any entry in the data directory, and any unexpected entry directly under the root. It is deliberately not a list of known filenames: a state path configured away from its default, or an artifact added later, would otherwise slip through and make an occupied installation read as empty.

Three states, not two. A missing directory is empty. A readable empty directory is empty. **A directory that cannot be inspected is not empty** — collapsing a permissions or I/O failure into "no entries" would answer "is this root in use?" with the one value that licenses a new identity. The same rule covers existence checks, because `Path.exists()` propagates `PermissionError` rather than answering false, so a path inside an unreadable directory would otherwise raise out of identity detection entirely.

An unparseable configuration, one carrying no device section or no device id, and an occupied root without a readable configuration all refuse. Each would otherwise let a run invent an identity for a device whose real one is merely unreadable.

**Conflicting input is refused rather than reconciled.** A `--device-id` differing from the installed identity is an error naming what derives from it. `--generate-device-id` against an existing installation is refused as contradictory: it derives an identity from the host, and the host is not where this device's identity lives. Silently ignoring it would be its own small untruth. Name and location are preserved too, since an upgrade that demanded them again would fail an unattended run with no reason to carry them.

Identity continuity does not depend on who authored the identity. A configuration generated and signed by a provisioning backend is read back by the same path as a locally derived one, so the rule survives the move to backend-issued identity rather than being replaced by it.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

Marked `security` because the failure mode reaches signed evidence: re-identification while state survives breaks the uniqueness that already-attested actions depend on.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changed. One-command installation, its transaction, and its rollback behave as the matrix describes. What changes is which identity a run writes and when it refuses to proceed.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched; Tier D fires locally with no identity lookup. No dependency is added — `identity.py` gains `pathlib` and a `TYPE_CHECKING` import of `InstallLayout`, which avoids an import cycle at runtime.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no bundled skill is modified.

## Related issue

Fixes #329. Superseding an identity while preserving its history is #338, decommissioning one is #339, and both are blocked on the lifecycle contract in ori-specs.

## Testing notes

Full suite: 3371 passed, 22 skipped. `mypy ori/` clean across 126 source files, `scripts/typecheck-boundaries.sh` clean across 30.

Mutation-checked rather than assumed. Removing the preservation block fails five tests. Reverting occupancy to a list of known filenames fails the activated-release, managed-release and unknown-artifact cases. Restoring the swallowed `OSError` fails the inaccessible-directory case. A test that passes against the old code proves nothing about the fix.

The generic-hostname test asserts its own precondition before its claim: two `suggest("raspberrypi")` calls must produce different identities before it can mean anything that two upgrades produce the same one. Refusal coverage is written against the option surface rather than one flag at a time, so a future option that reached identity fails immediately instead of passing every other test in the file.
