### PR TITLE
feat(runtime): reconcile outstanding epoch confirmations without a restart

### DIFF
--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -337,6 +337,16 @@ gateway:
     # still derives runtime_reachable from broker connectivity, so this
     # setting does not yet affect orphan state.
     liveness_interval_s: 15.0        # 1.0 .. 20.0; must be <= expiry window (60s) / 3
+    # Firmware authority becomes effective only when this runtime and the
+    # evidence store agree on the same anchor_epoch_id. Approval records that
+    # obligation durably but cannot itself reach the store, so a confirmation
+    # arriving later needs something to re-examine it — without this a
+    # normally-approved device with no firmware traffic waits for a restart.
+    # Cycles that resolve nothing double the delay, up to a fixed 15-minute
+    # ceiling; a restored transport reconciles immediately and clears the
+    # backoff. The interval is bounded by that same ceiling, since a base
+    # delay above it would leave nowhere to back off to.
+    confirmation_retry_interval_s: 60.0  # 1.0 .. 900.0 (the backoff ceiling)
   reasoning:
     enabled: true                    # Tier 3 request/response on ori/{device_id}/reasoning/*
     timeout_ms: 10000                # per-phase timeout: connect/subscribe and response wait

--- a/ori/config.py
+++ b/ori/config.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import math
 import os
 import re
 from dataclasses import dataclass, field
@@ -1024,8 +1025,40 @@ def _parse_gateway(data: Any) -> GatewayConfig:
             "gateway.firmware_commands.runtime_command_key_env and "
             "gateway.firmware_commands.provisioner_key_env are required when enabled"
         )
+    # Bounded by the reconciler's own backoff ceiling rather than an
+    # independent number. A base interval above the ceiling is incoherent: the
+    # first delay would already exceed the maximum the backoff is allowed to
+    # reach, so there is nothing to back off to and the documented ceiling
+    # would be a false claim for that configuration.
+    from ori.security.firmware_reconciliation import (
+        DEFAULT_INTERVAL_S,
+        DEFAULT_MAX_INTERVAL_S,
+    )
+
+    try:
+        confirmation_retry_interval_s = float(
+            firmware_commands.get("confirmation_retry_interval_s", DEFAULT_INTERVAL_S)
+        )
+    except (TypeError, ValueError) as exc:
+        raise ConfigValidationError(
+            "gateway.firmware_commands.confirmation_retry_interval_s must be a number"
+        ) from exc
+    if not math.isfinite(confirmation_retry_interval_s):
+        # NaN would make every deadline comparison false and stop the worker
+        # retrying while it reported itself healthy, which is the failure the
+        # retry exists to prevent.
+        raise ConfigValidationError(
+            "gateway.firmware_commands.confirmation_retry_interval_s must be finite"
+        )
+    if not 1.0 <= confirmation_retry_interval_s <= DEFAULT_MAX_INTERVAL_S:
+        raise ConfigValidationError(
+            "gateway.firmware_commands.confirmation_retry_interval_s must be "
+            f"between 1 and {DEFAULT_MAX_INTERVAL_S:.0f} seconds, the maximum "
+            "the retry backoff is allowed to reach"
+        )
     firmware_commands["qos"] = command_qos
     firmware_commands["publish_timeout_s"] = publish_timeout_s
+    firmware_commands["confirmation_retry_interval_s"] = confirmation_retry_interval_s
     firmware_commands["runtime_command_key_env"] = runtime_command_key_env
     firmware_commands["provisioner_key_env"] = provisioner_key_env
 

--- a/ori/gateway/firmware_telemetry.py
+++ b/ori/gateway/firmware_telemetry.py
@@ -59,6 +59,7 @@ class MqttFirmwareTelemetrySubscriber:
         deduplicator: EventDeduplicator | None = None,
         client_factory: Callable[..., Any] | None = None,
         liveness_supervisor: FirmwareLivenessSupervisor,
+        on_connected: Callable[[], None] | None = None,
     ) -> None:
         if not _PAHO_AVAILABLE or mqtt is None:
             raise RuntimeError("paho-mqtt is not installed")
@@ -88,6 +89,7 @@ class MqttFirmwareTelemetrySubscriber:
                 "shared with the firmware command service"
             )
         self._liveness_supervisor = liveness_supervisor
+        self._on_connected = on_connected
         self._client_factory = client_factory or _default_client_factory
         self._client: Any = None
         self._loop: asyncio.AbstractEventLoop | None = None
@@ -146,6 +148,13 @@ class MqttFirmwareTelemetrySubscriber:
             logger.warning("[firmware-telemetry] MQTT connect failed rc=%s", rc)
             return
         client.subscribe(self._topic, qos=self._qos)
+        # A restored link is the most likely moment for anything waiting on
+        # the far side to resolve. This runs on the MQTT client's thread, so
+        # the callback is handed to the loop rather than invoked here.
+        callback = self._on_connected
+        loop = self._loop
+        if callback is not None and loop is not None:
+            loop.call_soon_threadsafe(callback)
 
     def _on_message(self, _client: Any, _userdata: Any, message: Any) -> None:
         loop = self._loop

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -98,6 +98,12 @@ from ori.security.firmware_liveness import (
 from ori.security.firmware_mqtt_certificate import FirmwareMqttCertificateAuthority
 from ori.security.firmware_mqtt_provisioning import FirmwareMqttProvisioningService
 from ori.security.firmware_mqtt_workflow import FirmwareMqttProvisioningWorkflow
+from ori.security.firmware_reconciliation import (
+    DEFAULT_INTERVAL_S as CONFIRMATION_RETRY_INTERVAL_S,
+)
+from ori.security.firmware_reconciliation import (
+    FirmwareConfirmationReconciler,
+)
 from ori.security.gateway_messages import (
     GatewayMessageAuthConfig,
     GatewayMessageAuthenticator,
@@ -242,6 +248,9 @@ class OriRuntime:
         self._evidence_attestor: EvidenceAttestor | None = None
         self._firmware_confirmation_coordinator: (
             FirmwareConfirmationCoordinator | None
+        ) = None
+        self._firmware_confirmation_reconciler: (
+            FirmwareConfirmationReconciler | None
         ) = None
         self._health_socket_path: str = ""
         self._firmware_mqtt_operator_socket_path: str = ""
@@ -565,10 +574,31 @@ class OriRuntime:
         ):
             confirmation_chain = evidence_attestor.confirmation_chain()
             if confirmation_chain is not None:
-                self._firmware_confirmation_coordinator = (
-                    FirmwareConfirmationCoordinator(
-                        store=self._state_store, chain=confirmation_chain
-                    )
+                coordinator = FirmwareConfirmationCoordinator(
+                    store=self._state_store, chain=confirmation_chain
+                )
+                self._firmware_confirmation_coordinator = coordinator
+                # Approval alone cannot reach the evidence store, and a
+                # confirmation that arrives later has nothing re-examining
+                # the obligation. This is that missing layer.
+                firmware_cfg = (
+                    config.gateway.firmware_commands
+                    if isinstance(config.gateway.firmware_commands, dict)
+                    else {}
+                )
+                # Config bounds the interval by the backoff ceiling, so the
+                # default maximum always admits it and no compensation is
+                # needed here. An interval already at the ceiling simply has
+                # nowhere to back off to.
+                self._firmware_confirmation_reconciler = FirmwareConfirmationReconciler(
+                    store=self._state_store,
+                    coordinator=coordinator,
+                    interval_s=float(
+                        firmware_cfg.get(
+                            "confirmation_retry_interval_s",
+                            CONFIRMATION_RETRY_INTERVAL_S,
+                        )
+                    ),
                 )
 
         dispatcher = ActionDispatcher(
@@ -1076,6 +1106,10 @@ class OriRuntime:
             event_bus,
             self._state_store,
             self._deduplicator,
+            # Late-bound on purpose: the subscriber is built before the
+            # evidence attestor decides whether a reconciler exists at all,
+            # so the callback reads it when a reconnect actually happens.
+            self._nudge_firmware_confirmations,
         )
         if firmware_telemetry_subscriber is not None:
             self._background_tasks.append(
@@ -1127,6 +1161,15 @@ class OriRuntime:
         await self._start_health_socket_if_enabled(config)
 
         await self._drain_pending_firmware_confirmations()
+        if self._firmware_confirmation_reconciler is not None:
+            self._background_tasks.append(
+                asyncio.create_task(
+                    self._firmware_confirmation_reconciler.serve_until(
+                        self._shutdown_event
+                    ),
+                    name="firmware-confirmation-reconciler",
+                )
+            )
         await self._reconcile_pending_attestations()
 
         if status_indicator is not None:
@@ -2136,55 +2179,50 @@ class OriRuntime:
             remaining,
         )
 
+    def _nudge_firmware_confirmations(self) -> None:
+        """Reconcile outstanding obligations now, because a link came back.
+
+        A restored transport is the most likely moment for a pending
+        confirmation to resolve, so waiting out the remaining backoff would be
+        the wrong response to the one event suggesting a retry will work.
+        """
+        reconciler = self._firmware_confirmation_reconciler
+        if reconciler is not None:
+            reconciler.nudge()
+
     async def _drain_pending_firmware_confirmations(self) -> None:
         """Reconcile every outstanding confirmation obligation once, now.
 
         Approval records a durable confirmation_pending obligation but cannot
         itself reach the evidence store (the provisioner is offline). At the
-        runtime's earliest opportunity, drain every pending obligation
-        through the coordinator, so a normally-approved device -- one with no
-        firmware action waiting -- still gets its epoch confirmed and can
-        publish approvals and receive commands. Recurring reconnect and
-        periodic retries are layered on later around this same coordinator.
+        runtime's earliest opportunity, drain every pending obligation through
+        the coordinator, so a normally-approved device -- one with no firmware
+        action waiting -- still gets its epoch confirmed and can publish
+        approvals and receive commands.
+
+        Recurring retries are the reconciler's `serve_until`, started as a
+        background task. This drives the same worker once, so startup does not
+        wait out an interval before doing what it can immediately.
         """
-        coordinator = self._firmware_confirmation_coordinator
-        store = self._state_store
-        if coordinator is None or store is None:
-            return
-        if not hasattr(store, "list_pending_firmware_confirmations"):
-            return
-        try:
-            pending = await store.list_pending_firmware_confirmations()
-        except Exception:
-            logger.exception("[confirmation] failed to list pending confirmations")
-            return
-        # One confirm() reconciles a device's active epoch, so collapse the
-        # obligations to their distinct devices (order preserved).
-        device_ids: list[str] = []
-        seen: set[str] = set()
-        for row in pending:
-            device_id = str(row.get("device_id", "") or "")
-            if device_id and device_id not in seen:
-                seen.add(device_id)
-                device_ids.append(device_id)
-        if not device_ids:
-            return
-        confirmed = 0
-        for device_id in device_ids:
-            try:
-                status = await coordinator.confirm(device_id)
-            except Exception:
-                logger.warning(
-                    "[confirmation] reconciling %s failed", device_id, exc_info=True
-                )
-                continue
-            if status == _FIRMWARE_CONFIRMED:
-                confirmed += 1
-        logger.info(
-            "[confirmation] startup drain: %d of %d devices confirmed",
-            confirmed,
-            len(device_ids),
-        )
+        reconciler = self._firmware_confirmation_reconciler
+        if reconciler is None:
+            # The coordinator is what decides whether draining is possible;
+            # the reconciler only schedules around it. Building a transient
+            # one here keeps a caller that has a coordinator from getting a
+            # silent no-op because scheduling was not set up.
+            coordinator = self._firmware_confirmation_coordinator
+            if coordinator is None or self._state_store is None:
+                return
+            reconciler = FirmwareConfirmationReconciler(
+                store=self._state_store, coordinator=coordinator
+            )
+        confirmed, seen = await reconciler.reconcile_once()
+        if seen:
+            logger.info(
+                "[confirmation] startup drain: %d of %d devices confirmed",
+                confirmed,
+                seen,
+            )
 
     async def _firmware_source_confirmed(self, row: dict) -> bool:
         """Whether a firmware-sourced action may be signed yet.
@@ -4165,6 +4203,7 @@ def _build_firmware_telemetry_subscriber(
     state_store: StateStore,
     deduplicator: EventDeduplicator | None,
     liveness_supervisor: FirmwareLivenessSupervisor,
+    on_connected: Callable[[], None] | None = None,
 ) -> MqttFirmwareTelemetrySubscriber | None:
     """Instantiate the signed firmware telemetry subscriber when configured."""
     if not bool(config.gateway.enabled):
@@ -4188,6 +4227,7 @@ def _build_firmware_telemetry_subscriber(
             tls_config=getattr(config.gateway, "tls", {}),
             deduplicator=deduplicator,
             liveness_supervisor=liveness_supervisor,
+            on_connected=on_connected,
         )
     except Exception:
         logger.exception("[runtime] invalid firmware telemetry MQTT configuration")
@@ -4266,6 +4306,7 @@ def _build_firmware_liveness_stack(
     event_bus: EventBus,
     state_store: StateStore,
     deduplicator: EventDeduplicator | None,
+    on_telemetry_connected: Callable[[], None] | None = None,
 ) -> tuple[
     FirmwareLivenessSupervisor,
     MqttFirmwareTelemetrySubscriber | None,
@@ -4294,6 +4335,7 @@ def _build_firmware_liveness_stack(
         state_store,
         deduplicator,
         supervisor,
+        on_connected=on_telemetry_connected,
     )
     command_pair = _build_firmware_command_service(
         config,

--- a/ori/security/firmware_reconciliation.py
+++ b/ori/security/firmware_reconciliation.py
@@ -1,0 +1,193 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Recurring reconciliation of outstanding epoch confirmations.
+
+Approval records a durable ``confirmation_pending`` obligation, and authority
+becomes effective only once the runtime store and the evidence store agree on
+the same ``anchor_epoch_id``. The coordinator that reconciles them was reached
+from exactly two places: a drain at startup, and the pre-signing gate on
+firmware-sourced evidence. Its own docstring said recurring retries would be
+"layered on later", and they were not.
+
+That is survivable while confirmation is a same-process call that either works
+or does not. It stops being survivable once confirmation crosses a boundary and
+arrives asynchronously: a normally approved device with no firmware traffic
+then waits for a restart, because nothing re-examines the obligation.
+
+This worker is that missing layer, and it is deliberately thin. The
+coordinator is unchanged — an already-confirmed epoch is left alone, a
+quarantined one is terminal until an operator clears it, an unreachable store
+stays pending rather than optimistic, and attempts are recorded so a stuck
+grant is visibly being worked. The store's pending query already excludes
+terminal rows. All that was missing was something to call it again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Frequent enough that a confirmation arriving out of band is acted on while
+# an operator is still watching, rare enough to be no load at all.
+DEFAULT_INTERVAL_S = 60.0
+# An unreachable evidence store is the expected failure, not an exceptional
+# one. Backing off keeps a site that is offline for a day from retrying
+# thousands of times. It is also the upper bound on the configurable base
+# interval: a base delay above this ceiling would leave the backoff nowhere
+# to go, making the ceiling a false claim for that configuration.
+#
+# Worst case after a long outage is therefore one ceiling — a quarter of an
+# hour — when nothing signals. A restored transport nudges and clears the
+# backoff, so the reachable-again case recovers at once rather than waiting.
+DEFAULT_MAX_INTERVAL_S = 900.0
+# Devices are reconciled concurrently, but not unboundedly: a large pending
+# set must not monopolise the event loop the rest of the runtime shares.
+DEFAULT_MAX_CONCURRENT = 4
+# Rows per cycle, oldest first. A site's firmware fleet is far smaller than
+# this; the bound exists so one cycle cannot read an unbounded set, and a full
+# window is reported rather than silently truncated.
+_PENDING_WINDOW = 100
+
+
+class FirmwareConfirmationReconciler:
+    """Re-drives outstanding confirmation obligations until they resolve."""
+
+    def __init__(
+        self,
+        *,
+        store: Any,
+        coordinator: Any,
+        interval_s: float = DEFAULT_INTERVAL_S,
+        max_interval_s: float = DEFAULT_MAX_INTERVAL_S,
+        max_concurrent: int = DEFAULT_MAX_CONCURRENT,
+    ) -> None:
+        if not (interval_s > 0) or not (max_interval_s >= interval_s):
+            raise ValueError(
+                "reconciliation interval must be positive and no greater than "
+                "the maximum backoff"
+            )
+        if max_concurrent < 1:
+            raise ValueError("reconciliation concurrency must be at least 1")
+        self._store = store
+        self._coordinator = coordinator
+        self._interval_s = float(interval_s)
+        self._max_interval_s = float(max_interval_s)
+        self._semaphore = asyncio.Semaphore(max_concurrent)
+        self._wake = asyncio.Event()
+
+    def nudge(self) -> None:
+        """Ask for a reconciliation now, from any coroutine on this loop.
+
+        A restored transport is new information: it is the most likely moment
+        for a pending confirmation to resolve, so waiting out the remaining
+        backoff would be the wrong response to the one event that suggests
+        retrying will work.
+        """
+        self._wake.set()
+
+    async def reconcile_once(self) -> tuple[int, int]:
+        """Reconcile every outstanding obligation once. Returns (confirmed, seen)."""
+        device_ids = await self._pending_device_ids()
+        if not device_ids:
+            return 0, 0
+        results = await asyncio.gather(
+            *(self._confirm(device_id) for device_id in device_ids)
+        )
+        return sum(1 for confirmed in results if confirmed), len(device_ids)
+
+    async def serve_until(self, shutdown: asyncio.Event) -> None:
+        """Reconcile periodically until *shutdown*, backing off when stuck."""
+        delay = self._interval_s
+        while not shutdown.is_set():
+            if await self._sleep_or_wake(delay, shutdown):
+                # Woken deliberately rather than by the timer, so the backoff
+                # a previous failure earned no longer applies.
+                delay = self._interval_s
+            if shutdown.is_set():
+                return
+            try:
+                confirmed, seen = await self.reconcile_once()
+            except Exception:
+                logger.exception("[confirmation] reconciliation cycle failed")
+                delay = min(delay * 2, self._max_interval_s)
+                continue
+            if seen and not confirmed:
+                # Obligations outstanding and none resolved: the far side is
+                # unreachable or still disagrees. Retrying at full rate would
+                # add load without adding information.
+                delay = min(delay * 2, self._max_interval_s)
+            else:
+                delay = self._interval_s
+            if confirmed:
+                logger.info(
+                    "[confirmation] reconciled %d of %d outstanding obligations",
+                    confirmed,
+                    seen,
+                )
+
+    async def _sleep_or_wake(self, delay: float, shutdown: asyncio.Event) -> bool:
+        """Wait *delay*, returning True when woken by a nudge instead."""
+        waiters = [
+            asyncio.ensure_future(self._wake.wait()),
+            asyncio.ensure_future(shutdown.wait()),
+        ]
+        try:
+            done, _ = await asyncio.wait(
+                waiters, timeout=delay, return_when=asyncio.FIRST_COMPLETED
+            )
+        finally:
+            for waiter in waiters:
+                waiter.cancel()
+        nudged = self._wake.is_set()
+        self._wake.clear()
+        return nudged and not shutdown.is_set()
+
+    async def _pending_device_ids(self) -> list[str]:
+        """Distinct devices with outstanding obligations, order preserved.
+
+        One `confirm()` reconciles a device's active epoch, so several
+        obligations for the same device collapse to one call.
+        """
+        if not hasattr(self._store, "list_pending_firmware_confirmations"):
+            return []
+        try:
+            pending = await self._store.list_pending_firmware_confirmations(
+                limit=_PENDING_WINDOW
+            )
+        except Exception:
+            logger.exception("[confirmation] failed to list pending confirmations")
+            return []
+        if len(pending) >= _PENDING_WINDOW:
+            # The query is oldest-first and bounded, so obligations beyond the
+            # window are not reconciled this cycle. They are reached as earlier
+            # ones resolve — but a window that stays full means they are not
+            # resolving, and newer devices are waiting behind them. Say so
+            # rather than let the shortfall be invisible.
+            logger.warning(
+                "[confirmation] pending obligations fill the %d-row window; "
+                "devices beyond it wait for earlier ones to resolve",
+                _PENDING_WINDOW,
+            )
+        seen: set[str] = set()
+        device_ids: list[str] = []
+        for row in pending:
+            device_id = str(row.get("device_id", "") or "")
+            if device_id and device_id not in seen:
+                seen.add(device_id)
+                device_ids.append(device_id)
+        return device_ids
+
+    async def _confirm(self, device_id: str) -> bool:
+        async with self._semaphore:
+            try:
+                status = await self._coordinator.confirm(device_id)
+            except Exception:
+                logger.warning(
+                    "[confirmation] reconciling %s failed", device_id, exc_info=True
+                )
+                return False
+        return bool(status == "confirmed")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4375,6 +4375,7 @@ actions:
             "enabled": False,
             "qos": 1,
             "publish_timeout_s": 10.0,
+            "confirmation_retry_interval_s": 60.0,
             "runtime_command_key_env": "",
             "provisioner_key_env": "",
         }
@@ -4438,9 +4439,45 @@ actions:
             "enabled": True,
             "qos": 1,
             "publish_timeout_s": 4.5,
+            "confirmation_retry_interval_s": 60.0,
             "runtime_command_key_env": "ORI_FW_RUNTIME_COMMAND_KEY",
             "provisioner_key_env": "ORI_FW_PROVISIONER_KEY",
         }
+
+    @pytest.mark.parametrize(
+        "value", ["not-a-number", ".nan", ".inf", "0", "-1", "900.5", "3600"]
+    )
+    def test_rejects_invalid_confirmation_retry_interval(self, tmp_path, value):
+        """A malformed interval must fail config load, not runtime construction.
+
+        NaN in particular would make every deadline comparison false and stop
+        the worker retrying while it reported itself healthy — the failure the
+        retry exists to prevent.
+        """
+        with pytest.raises(
+            ConfigValidationError, match="confirmation_retry_interval_s"
+        ):
+            Config.load(
+                _write_yaml(
+                    tmp_path,
+                    f"""
+                    device:
+                      id: d
+                      name: n
+                      location: l
+                    sensors:
+                      - id: cpu
+                        type: cpu_percent
+                        protocol: psutil
+                        poll_interval_ms: 1000
+                    gateway:
+                      enabled: true
+                      broker_url: mqtt://127.0.0.1:1883
+                      firmware_commands:
+                        confirmation_retry_interval_s: {value}
+                    """,
+                )
+            )
 
     def test_rejects_enabled_firmware_commands_without_key_envs(self, tmp_path):
         with pytest.raises(ConfigValidationError, match="firmware_commands"):

--- a/tests/test_firmware_confirmation_reconciliation.py
+++ b/tests/test_firmware_confirmation_reconciliation.py
@@ -1,0 +1,439 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Outstanding confirmation obligations must resolve without a restart.
+
+`confirm()` was reached from exactly two places: a drain at startup, and the
+pre-signing gate on firmware-sourced evidence. That is survivable while
+confirmation is a same-process call that either works or does not. Once it
+crosses a boundary and arrives asynchronously, a normally approved device with
+no firmware traffic waits for a restart, because nothing re-examines the
+obligation.
+
+The coordinator is deliberately untouched by this work: an already-confirmed
+epoch is left alone, a quarantined one stays terminal, an unreachable store
+remains pending rather than optimistic, and attempts are recorded. What was
+missing was something to call it again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ori.security.firmware_reconciliation import FirmwareConfirmationReconciler
+
+
+class _Store:
+    """Pending obligations, with terminal rows already excluded as the real one does."""
+
+    def __init__(self, pending: list[str] | None = None) -> None:
+        self.pending = list(pending or [])
+        self.list_calls = 0
+
+    async def list_pending_firmware_confirmations(self, limit: int = 100) -> list[dict]:
+        self.list_calls += 1
+        return [{"device_id": device_id} for device_id in self.pending]
+
+
+class _Coordinator:
+    def __init__(self, results: dict[str, list[str]] | None = None) -> None:
+        self.results = results or {}
+        self.calls: list[str] = []
+        self.concurrent = 0
+        self.peak_concurrent = 0
+
+    async def confirm(self, device_id: str) -> str:
+        self.calls.append(device_id)
+        self.concurrent += 1
+        self.peak_concurrent = max(self.peak_concurrent, self.concurrent)
+        try:
+            await asyncio.sleep(0)
+            outcomes = self.results.get(device_id)
+            if not outcomes:
+                return "confirmation_pending"
+            return outcomes.pop(0) if len(outcomes) > 1 else outcomes[0]
+        finally:
+            self.concurrent -= 1
+
+
+def _reconciler(store, coordinator, **kwargs):
+    kwargs.setdefault("interval_s", 0.01)
+    kwargs.setdefault("max_interval_s", 0.04)
+    return FirmwareConfirmationReconciler(
+        store=store, coordinator=coordinator, **kwargs
+    )
+
+
+# --- one cycle -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nothing_pending_calls_the_coordinator_not_at_all():
+    coordinator = _Coordinator()
+    confirmed, seen = await _reconciler(_Store([]), coordinator).reconcile_once()
+    assert (confirmed, seen) == (0, 0)
+    assert coordinator.calls == []
+
+
+@pytest.mark.asyncio
+async def test_several_obligations_for_one_device_collapse_to_one_call():
+    store = _Store()
+    store.pending = ["dev-a", "dev-a", "dev-b"]
+    coordinator = _Coordinator({"dev-a": ["confirmed"], "dev-b": ["confirmed"]})
+    confirmed, seen = await _reconciler(store, coordinator).reconcile_once()
+    assert coordinator.calls == ["dev-a", "dev-b"]
+    assert (confirmed, seen) == (2, 2)
+
+
+@pytest.mark.asyncio
+async def test_one_failing_device_does_not_stop_the_others():
+    class _Raising(_Coordinator):
+        async def confirm(self, device_id: str) -> str:
+            if device_id == "dev-bad":
+                raise RuntimeError("evidence store unreachable")
+            return await super().confirm(device_id)
+
+    coordinator = _Raising({"dev-a": ["confirmed"], "dev-b": ["confirmed"]})
+    store = _Store(["dev-a", "dev-bad", "dev-b"])
+    confirmed, seen = await _reconciler(store, coordinator).reconcile_once()
+    assert (confirmed, seen) == (2, 3)
+
+
+@pytest.mark.asyncio
+async def test_concurrency_is_bounded():
+    """A large pending set must not monopolise the loop the runtime shares."""
+    store = _Store([f"dev-{index}" for index in range(20)])
+    coordinator = _Coordinator()
+    await _reconciler(store, coordinator, max_concurrent=3).reconcile_once()
+    assert coordinator.peak_concurrent <= 3
+
+
+@pytest.mark.asyncio
+async def test_an_unlistable_store_yields_no_calls_rather_than_raising():
+    class _Broken(_Store):
+        async def list_pending_firmware_confirmations(self, limit: int = 100):
+            raise RuntimeError("database is locked")
+
+    coordinator = _Coordinator()
+    confirmed, seen = await _reconciler(_Broken(), coordinator).reconcile_once()
+    assert (confirmed, seen) == (0, 0)
+    assert coordinator.calls == []
+
+
+# --- the loop --------------------------------------------------------------
+
+
+async def _run_briefly(reconciler, shutdown, seconds=0.12):
+    task = asyncio.create_task(reconciler.serve_until(shutdown))
+    await asyncio.sleep(seconds)
+    shutdown.set()
+    reconciler.nudge()
+    await asyncio.wait_for(task, timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_a_confirmation_arriving_later_is_acted_on_without_a_restart():
+    """The defect: nothing re-examined the obligation between restarts."""
+    store = _Store(["dev-a"])
+    coordinator = _Coordinator({"dev-a": ["confirmation_pending", "confirmed"]})
+    reconciler = _reconciler(store, coordinator)
+    shutdown = asyncio.Event()
+    await _run_briefly(reconciler, shutdown)
+    assert coordinator.calls.count("dev-a") >= 2
+
+
+@pytest.mark.asyncio
+async def test_an_unavailable_store_backs_off_rather_than_hammering():
+    store = _Store(["dev-a"])
+    coordinator = _Coordinator()  # never confirms
+    reconciler = _reconciler(store, coordinator, interval_s=0.01, max_interval_s=0.02)
+    shutdown = asyncio.Event()
+    await _run_briefly(reconciler, shutdown, seconds=0.15)
+    # Without backoff a 10ms interval over 150ms would attempt roughly 15
+    # times; doubling to a 20ms ceiling roughly halves that. The bound is
+    # loose on purpose so the test asserts backoff, not scheduler precision.
+    assert 1 <= coordinator.calls.count("dev-a") <= 12
+
+
+@pytest.mark.asyncio
+async def test_a_nudge_reconciles_without_waiting_out_the_interval():
+    """A restored link is new information; the earned backoff no longer applies."""
+    store = _Store(["dev-a"])
+    coordinator = _Coordinator()
+    reconciler = _reconciler(store, coordinator, interval_s=30.0, max_interval_s=30.0)
+    shutdown = asyncio.Event()
+    task = asyncio.create_task(reconciler.serve_until(shutdown))
+    await asyncio.sleep(0)
+    reconciler.nudge()
+    for _ in range(50):
+        if coordinator.calls:
+            break
+        await asyncio.sleep(0.01)
+    shutdown.set()
+    reconciler.nudge()
+    await asyncio.wait_for(task, timeout=1)
+    assert coordinator.calls == ["dev-a"], "nudge should not wait out a 30s interval"
+
+
+@pytest.mark.asyncio
+async def test_terminal_rows_are_never_retried():
+    """Confirmed and quarantined epochs leave the pending set and stay gone.
+
+    The store excludes them; this asserts the worker adds no path back in.
+    """
+    store = _Store(["dev-a"])
+    coordinator = _Coordinator({"dev-a": ["confirmed"]})
+    reconciler = _reconciler(store, coordinator)
+    await reconciler.reconcile_once()
+    store.pending = []  # resolved, so the store stops returning it
+    await reconciler.reconcile_once()
+    assert coordinator.calls == ["dev-a"]
+
+
+@pytest.mark.asyncio
+async def test_shutdown_ends_the_loop_promptly():
+    reconciler = _reconciler(
+        _Store([]), _Coordinator(), interval_s=30.0, max_interval_s=30.0
+    )
+    shutdown = asyncio.Event()
+    task = asyncio.create_task(reconciler.serve_until(shutdown))
+    await asyncio.sleep(0)
+    shutdown.set()
+    await asyncio.wait_for(task, timeout=1)
+
+
+# --- construction ----------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"interval_s": 0},
+        {"interval_s": -1},
+        {"interval_s": 10, "max_interval_s": 5},
+        {"max_concurrent": 0},
+    ],
+)
+def test_invalid_configuration_is_refused(kwargs):
+    with pytest.raises(ValueError):
+        FirmwareConfirmationReconciler(
+            store=_Store(), coordinator=_Coordinator(), **kwargs
+        )
+
+
+# --- the reconnect path, end to end ----------------------------------------
+#
+# The nudge tests above prove the reconciler responds to being woken. They do
+# not prove anything wakes it. The reconnect criterion is satisfied by a chain
+# — MQTT connect callback, `call_soon_threadsafe`, late-bound runtime
+# callback, reconciler — and every link is somewhere a mistake could hide
+# while every unit test stayed green.
+
+
+class _RecordingLoop:
+    def __init__(self) -> None:
+        self.scheduled: list = []
+
+    def call_soon_threadsafe(self, callback, *args) -> None:
+        self.scheduled.append(callback)
+
+
+def _subscriber_with_hook(on_connected):
+    """A subscriber built without touching MQTT or the network."""
+    from ori.gateway.firmware_telemetry import MqttFirmwareTelemetrySubscriber
+
+    subscriber = object.__new__(MqttFirmwareTelemetrySubscriber)
+    subscriber._topic = "ori/fw/+/telemetry"
+    subscriber._qos = 1
+    subscriber._on_connected = on_connected
+    subscriber._loop = _RecordingLoop()
+    return subscriber
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.subscribed: list = []
+
+    def subscribe(self, topic, qos=0) -> None:
+        self.subscribed.append((topic, qos))
+
+
+def test_successful_connect_schedules_the_hook_on_the_loop():
+    """`_on_connect` runs on the MQTT client's thread, never the event loop."""
+    calls: list[int] = []
+    subscriber = _subscriber_with_hook(lambda: calls.append(1))
+    client = _Client()
+
+    subscriber._on_connect(client, None, None, 0)
+
+    assert client.subscribed == [("ori/fw/+/telemetry", 1)]
+    assert subscriber._loop.scheduled, "hook must be handed to the loop"
+    for scheduled in subscriber._loop.scheduled:
+        scheduled()
+    assert calls == [1]
+
+
+def test_failed_connect_does_not_schedule_the_hook():
+    """A refused connection is not a restored link."""
+    calls: list[int] = []
+    subscriber = _subscriber_with_hook(lambda: calls.append(1))
+    client = _Client()
+
+    subscriber._on_connect(client, None, None, 5)
+
+    assert client.subscribed == []
+    assert subscriber._loop.scheduled == []
+    assert calls == []
+
+
+def test_connect_without_a_hook_is_harmless():
+    subscriber = _subscriber_with_hook(None)
+    client = _Client()
+    subscriber._on_connect(client, None, None, 0)
+    assert client.subscribed == [("ori/fw/+/telemetry", 1)]
+    assert subscriber._loop.scheduled == []
+
+
+def test_runtime_callback_resolves_the_reconciler_when_it_fires():
+    """Late binding is the point: the subscriber outlives the unset attribute.
+
+    The telemetry subscriber is constructed before the evidence attestor
+    decides whether a reconciler exists at all. A callback that captured the
+    attribute at build time would capture None and never recover.
+    """
+    from ori.runtime import OriRuntime
+
+    runtime = object.__new__(OriRuntime)
+    runtime._firmware_confirmation_reconciler = None
+
+    # Built and invoked while the attribute is still unset: must not raise.
+    runtime._nudge_firmware_confirmations()
+
+    reconciler = _reconciler(_Store(["dev-a"]), _Coordinator())
+    runtime._firmware_confirmation_reconciler = reconciler
+    runtime._nudge_firmware_confirmations()
+
+    assert reconciler._wake.is_set()
+
+
+def test_liveness_stack_forwards_the_callback_to_the_subscriber():
+    """A stack that wires each half correctly and connects neither is the
+    mistake this construction site exists to prevent."""
+    from ori import runtime as runtime_module
+
+    captured: dict = {}
+
+    def _fake_builder(*args, **kwargs):
+        captured["on_connected"] = kwargs.get("on_connected")
+        return None
+
+    original = runtime_module._build_firmware_telemetry_subscriber
+    runtime_module._build_firmware_telemetry_subscriber = _fake_builder
+    try:
+        sentinel = object()
+        runtime_module._build_firmware_liveness_stack(
+            _StubConfig(), None, None, None, sentinel
+        )
+    finally:
+        runtime_module._build_firmware_telemetry_subscriber = original
+
+    assert captured["on_connected"] is sentinel
+
+
+class _StubGatewayCfg:
+    enabled = False
+    firmware_telemetry: dict = {}
+    firmware_commands: dict = {}
+
+
+class _StubConfig:
+    gateway = _StubGatewayCfg()
+
+
+# --- the configured interval reaches the worker ----------------------------
+#
+# Rejecting invalid values proves only that the gate exists. These prove the
+# value that survives it is the one the worker actually runs on, and that the
+# two ends agree about the ceiling.
+
+
+def test_config_interval_bound_is_the_backoff_ceiling():
+    """One number, not two that can drift apart.
+
+    A base interval above the ceiling would make the first delay exceed the
+    maximum the backoff may reach, so the documented ceiling would be false
+    for that configuration.
+    """
+    from ori.security.firmware_reconciliation import DEFAULT_MAX_INTERVAL_S
+
+    accepted = _gateway_firmware_commands(DEFAULT_MAX_INTERVAL_S)
+    assert accepted["confirmation_retry_interval_s"] == DEFAULT_MAX_INTERVAL_S
+
+    from ori.config import ConfigValidationError
+
+    with pytest.raises(ConfigValidationError) as excinfo:
+        _gateway_firmware_commands(DEFAULT_MAX_INTERVAL_S + 0.5)
+    assert "confirmation_retry_interval_s" in str(excinfo.value)
+
+
+def _gateway_firmware_commands(interval):
+    """Parse a minimal config and return the normalised firmware_commands."""
+    import tempfile
+    from pathlib import Path
+
+    import yaml as _yaml
+
+    from ori.config import Config
+
+    document = {
+        "device": {"id": "d", "name": "n", "location": "l"},
+        "sensors": [
+            {
+                "id": "cpu",
+                "type": "cpu_percent",
+                "protocol": "psutil",
+                "poll_interval_ms": 1000,
+            }
+        ],
+        "gateway": {
+            "enabled": True,
+            "broker_url": "mqtt://127.0.0.1:1883",
+            "firmware_commands": {"confirmation_retry_interval_s": interval},
+        },
+    }
+    with tempfile.TemporaryDirectory() as workspace:
+        path = Path(workspace) / "ori.yaml"
+        path.write_text(_yaml.safe_dump(document))
+        return Config.load(str(path)).gateway.firmware_commands
+
+
+@pytest.mark.parametrize("interval", [1.0, 5.0, 120.0, 900.0])
+def test_a_configured_interval_runs_the_worker_at_that_interval(interval):
+    """Every value config accepts must construct and be the delay used."""
+    from ori.security.firmware_reconciliation import DEFAULT_MAX_INTERVAL_S
+
+    parsed = _gateway_firmware_commands(interval)
+    reconciler = FirmwareConfirmationReconciler(
+        store=_Store(),
+        coordinator=_Coordinator(),
+        interval_s=parsed["confirmation_retry_interval_s"],
+    )
+    assert reconciler._interval_s == interval
+    assert reconciler._max_interval_s == DEFAULT_MAX_INTERVAL_S
+    assert reconciler._interval_s <= reconciler._max_interval_s
+
+
+def test_the_default_interval_is_the_one_config_applies():
+    """The default lives in one place, so config and worker cannot drift."""
+    from ori.security.firmware_reconciliation import DEFAULT_INTERVAL_S
+
+    document_default = _gateway_firmware_commands(DEFAULT_INTERVAL_S)
+    assert document_default["confirmation_retry_interval_s"] == DEFAULT_INTERVAL_S
+    assert (
+        FirmwareConfirmationReconciler(
+            store=_Store(), coordinator=_Coordinator()
+        )._interval_s
+        == DEFAULT_INTERVAL_S
+    )


### PR DESCRIPTION
## What does this PR do?

Firmware authority becomes effective only when this runtime and the evidence store agree on the same `anchor_epoch_id`. Approval records that obligation durably but cannot itself reach the evidence store, because the provisioner is offline. Something has to re-examine the obligation afterwards, and nothing did.

`confirm()` was reached from exactly two places: a drain at startup, and the pre-signing gate on firmware-sourced evidence. The coordinator's own docstring said recurring retries would be "layered on later", and they were not. That is survivable while confirmation is a same-process call that either works or does not. It stops being survivable once confirmation crosses a boundary and arrives asynchronously: a normally approved device with no firmware traffic then waits for a restart before its epoch can be confirmed, because nothing looks again.

This adds the missing layer. `FirmwareConfirmationCoordinator` is untouched — an already-confirmed epoch is still left alone, a quarantined one is still terminal until an operator clears it, an unreachable store still remains pending rather than optimistic, and attempts are still recorded so a stuck grant is visibly being worked. The store's pending query already excluded terminal rows and already described "the reconciliation worker" that would drain it. What was missing was something to call it again.

**Periodic, with bounded backoff.** A cycle that finds obligations and resolves none means the far side is unreachable or still disagrees; retrying at full rate would add load without adding information, so the delay doubles toward a fixed fifteen-minute ceiling. Any confirmation resets it.

**On reconnect.** A restored transport is the most likely moment for a pending confirmation to resolve, so waiting out an earned backoff would be the wrong response to the one event suggesting a retry will work. The firmware telemetry subscriber's connect callback nudges the worker, which reconciles immediately and clears the backoff. That callback runs on the MQTT client's thread, so it is handed to the event loop rather than invoked there, and it is bound late: the subscriber is constructed before the evidence attestor decides whether a reconciler exists at all, so a callback that captured the attribute at build time would capture nothing and never recover.

**Bounded in both directions.** Devices are reconciled concurrently under a semaphore, because a large pending set must not monopolise the loop the rest of the runtime shares. Several obligations naming one device collapse to a single call. The pending query is windowed, and a window that stays full is reported rather than silently truncated — obligations beyond it wait for earlier ones to resolve, and a window that never drains means newer devices are queued behind stuck ones.

**One number governs the schedule.** `confirmation_retry_interval_s` is validated at config load: non-numeric, non-finite, non-positive and out-of-range values are refused there rather than failing later during runtime construction. NaN matters most — it would make every deadline comparison false and stop the worker retrying while it reported itself healthy, which is the failure the retry exists to prevent. The accepted range is bounded by the backoff ceiling itself rather than an independently chosen number, since a base delay above the ceiling would leave the backoff nowhere to go and make the documented ceiling false for that configuration.

The worker lives in its own module rather than adding weight to `runtime.py`, which the seam extraction has to move later.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

Not marked `security`: the confirmation gate's decisions are unchanged. This changes only how often they are re-evaluated, and every fail-closed outcome the coordinator produces still fails closed.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changed. Cross-store epoch confirmation already existed and its outcomes are identical; this schedules retries around it. The matrix entry for firmware liveness describes what remains open there, and none of it is affected.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. No dependency is added — the worker uses `asyncio` and `logging` only.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable — no bundled skill is modified.

## Related issue

Fixes #330.

## Testing notes

Full suite: 3403 passed, 22 skipped — 25 new tests. `mypy ori/` clean across 127 source files, `scripts/typecheck-boundaries.sh` clean across 30.

`ori/security/firmware_confirmation.py` is byte-for-byte unchanged, and its existing tests still pass.

Mutation-checked rather than assumed. Removing the backoff and the concurrency bound fails their tests; removing the reconnect hook fails the connect test. A test that passes against the old code proves nothing about the fix.

Reconnect is covered through the chain rather than by calling the last link: a successful connect schedules the callback on the loop, a failed connect schedules nothing, the runtime callback resolves the worker at invocation time including while the attribute is still unset, and the liveness stack forwards the callback to the subscriber. Every hop is somewhere a mistake could hide while all other tests stayed green.

Configuration is covered in both directions — invalid values are refused, and every accepted interval is proven to reach the worker as its actual delay, with the bound and the ceiling asserted to be the same constant so the two ends cannot drift apart.

One behaviour worth calling out for review: the startup drain builds a transient worker when scheduling is not wired, so a caller holding only a coordinator still drains. An earlier revision made that path a silent no-op, and an existing test caught it.
