### PR TITLE
docs(readme): state 2.4.x as the stable channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Built for the world's majority condition — unreliable power, intermittent conn
 
 ## Release Status
 
-**Current channel: Stable (`2.3.x`)**
+**Current channel: Stable (`2.4.x`)**
 
 - Runtime core is stable for PoC, demo API, and controlled field deployment,
   with a fail-closed production security posture: staging/production configs
@@ -40,8 +40,12 @@ Built for the world's majority condition — unreliable power, intermittent conn
   verifies the shared golden bytes/signatures without owning firmware
   canonicalization.
 - Safety invariants (tier guards, the runtime action registry, strict skill validation, skill provenance) are CI-enforced on every PR.
-- Public runtime contracts used by companion repos are the MQTT gateway/export contracts and the typed `ori.integration` rule-evaluation boundary — unchanged from v1.0.0.
+- Public runtime contracts used by companion repos are the MQTT gateway/export contracts and the typed `ori.integration` rule-evaluation boundary — unchanged from v1.0.0. The runtime health payload is also read by companion repos and is versioned separately: `2.4.x` serves `ori-specs/runtime-health/v1`, and the next release serves `v2`, which removes the evidence artifact version.
 - Recommended use today: pilots, PoCs, controlled deployments, product provisioning, and downstream demo/API integration.
+- Upgrading from `2.3.x` and scripting the Linux installer? `2.4.0` makes
+  `--scope` explicit, prints a human summary unless `--json` is passed, and
+  drops `--service-user`. See
+  [Migration](docs/releases/v2.4.0.md#migration).
 - Release notes: [`docs/releases/v2.4.0.md`](docs/releases/v2.4.0.md)
 
 Related public repos in the org:
@@ -231,9 +235,11 @@ Ori is designed for [physical actuation trust](PRINCIPLES.md). The safety archit
 - **Alert transport failover** — approval requests use the configured primary channel first, then fail over to the secondary channel if delivery fails
 - **Evidence chain for high-authority actions** — when configured, a private
   evidence artifact signs Tier C/D dispatch records and exposes chain head, gap
-  count, artifact version, and selected action-event vocabulary in health. This
-  is runtime action evidence; device-origin telemetry attestation is the
-  firmware/Layer 1 contract.
+  count, and selected action-event vocabulary in health. The artifact's own
+  version is deliberately absent: it is implementation metadata of a component
+  the operator has no part in, and `available` with `protocol_version` already
+  answer whether this device can sign. This is runtime action evidence;
+  device-origin telemetry attestation is the firmware/Layer 1 contract.
 
 For constrained deployments, a common pattern is MQTT for continuous telemetry plus CoAP for low-overhead command delivery.
 
@@ -489,7 +495,7 @@ See [SECURITY.md](SECURITY.md) for vulnerability reporting, supported versions, 
 
 | Phase             | Status           | Milestone                                                                 |
 | ----------------- | ---------------- | ------------------------------------------------------------------------- |
-| Runtime core      | ✅ Stable v2.2    | Production posture, typed integration boundary, and evidence Layer 2 hooks |
+| Runtime core      | ✅ Stable v2.4    | Production posture, typed integration boundary, and evidence Layer 2 hooks |
 | Product wedge     | ✅ Shipping       | Ori Energy demo/API integration, private APK path, and Phone Starter flows |
 | Evidence hardware | 🔨 In Progress   | Evidence Layer 1 contract and `ori-edge-firmware` bootstrap                |
 | Safety kernel     | 🗓️ Planned       | Rust-owned Tier D kernel after shadow-mode evidence, not a broad rewrite   |


### PR DESCRIPTION
## What does this PR do?

`v2.4.0` is published and stable, and the README had not caught up. The badge read `v2.4.0`, the release status section read `2.3.x`, and the roadmap read `Stable v2.2` — three statements about what is released, disagreeing with each other on the same page.

Three claims around those numbers had also gone stale, which is the part worth reviewing. A version bump that leaves the surrounding prose untouched is how the drift happened in the first place.

**The evidence health list named a field that no longer exists.** It said health exposes the evidence artifact version. Adopting `ori-specs/runtime-health/v2` removed it: the private component's version is implementation metadata an operator has no part in, and `available` with `protocol_version` already answer whether this device can sign and against which public contract. `docs/CAPABILITY_MATRIX.md` already recorded the removal — only the README was behind.

**The public-contract paragraph was incomplete in a way that matters to other repos.** It named the MQTT gateway/export contracts and the typed `ori.integration` boundary as the companion-facing surface, unchanged since `v1.0.0`. Runtime health is read by companion repos too — that is why `ori-cli` renders it — so the paragraph now states which health contract each channel serves: `2.4.x` serves `v1`, and the next release serves `v2`.

**The migration note was not linked.** `v2.4.0` carries three changes for anyone scripting the Linux installer: `--scope` must be passed explicitly, output is a human summary unless `--json` is given, and `--service-user` is gone. For an operator automating an upgrade that is the most consequential fact about the new stable channel, so the release status section links it rather than leaving it to be found further down the release notes.

## What is deliberately unchanged

The roadmap's `Evidence hardware — In Progress` row stays as it is. The release status prose says device-origin telemetry is consumed by the runtime verification gate, which argues for advancing it, but the `ori-edge-firmware` bootstrap is the other half of that milestone and its state is not verifiable from this repository. Advancing a roadmap row on an assumption is how a roadmap starts misreporting.

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changed. This corrects README prose to match behavior the matrix already records; the matrix is the source this change was reconciled against.

### If this touches `/ori/` (core runtime)

No runtime code is touched.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Follows the `v2.4.0` release and the `runtime-health/v2` adoption in #342. Not a fix for a tracked issue.

## Testing notes

Every claim was checked against the code rather than assumed. `artifact_version` is genuinely absent from `_evidence_health()` — it remains inside `ori/security/evidence.py` for artifact feature gating, which is correct and not operator-visible. `available` and `protocol_version` are both present in the health payload as the replacement text describes. All three document links resolve and the `#migration` anchor exists in the release notes.

The README is one of the operator documents the evidence disclosure audit reads by passage, so that check was live for this edit: `tests/test_evidence_disclosure.py` passes, 54 passed and 4 skipped, the skips being the release-only checks that need the private denylist and a built wheelhouse.
