### PR TITLE
test(evidence): reconstruct the evidence/v2 vectors as runtime conformance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,12 @@ jobs:
           python scripts/check_workflows.py
           bash scripts/check_rust_supply_chain.sh
 
+      # Vendored contract vectors are hermetic, which is why the suite works
+      # offline — and also how they could go stale invisibly. This notices.
+      - name: Check vendored evidence vectors against ori-specs
+        if: matrix.python-version == '3.12'
+        run: bash scripts/refresh-evidence-vectors.sh
+
       - name: Type check runtime contract boundaries
         run: bash scripts/typecheck-boundaries.sh
 

--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+#
+# Refresh the vendored ori-specs evidence/v2 vectors.
+#
+# The vectors are vendored rather than fetched at test time so the suite is
+# hermetic and works offline, which is the same reason the firmware repository
+# carries its own copies. The cost of vendoring is drift: upstream can change
+# without anything here noticing. This script is how that is detected, and it
+# reports rather than silently overwrites.
+#
+# Usage:
+#   bash scripts/refresh-evidence-vectors.sh            # report drift only
+#   ORI_VECTORS_APPLY=1 bash scripts/refresh-evidence-vectors.sh   # update
+#
+# ORI_SPECS_DIR points at a local ori-specs checkout; otherwise the public
+# repository is cloned into a temporary directory.
+
+set -euo pipefail
+
+DEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/tests/vectors/evidence_v2"
+APPLY="${ORI_VECTORS_APPLY:-0}"
+CLEANUP=""
+
+if [ -n "${ORI_SPECS_DIR:-}" ]; then
+  SPECS="${ORI_SPECS_DIR}"
+else
+  SPECS="$(mktemp -d)"
+  CLEANUP="${SPECS}"
+  git clone --quiet --depth 1 https://github.com/ori-platform/ori-specs.git "${SPECS}"
+fi
+trap '[ -n "${CLEANUP}" ] && rm -rf "${CLEANUP}"' EXIT
+
+SRC="${SPECS}/evidence/vectors"
+test -d "${SRC}" || { echo "no vectors at ${SRC}" >&2; exit 1; }
+COMMIT="$(git -C "${SPECS}" rev-parse HEAD)"
+
+drift=0
+for file in "${SRC}"/*.json; do
+  name="$(basename "${file}")"
+  if [ ! -f "${DEST}/${name}" ]; then
+    echo "NEW      ${name}"; drift=1; continue
+  fi
+  if ! cmp -s "${file}" "${DEST}/${name}"; then
+    echo "CHANGED  ${name}"; drift=1
+  fi
+done
+for file in "${DEST}"/*.json; do
+  name="$(basename "${file}")"
+  [ "${name}" = "MANIFEST.json" ] && continue
+  [ -f "${SRC}/${name}" ] || { echo "REMOVED  ${name}"; drift=1; }
+done
+
+if [ "${drift}" -eq 0 ]; then
+  echo "vendored vectors match ori-specs at ${COMMIT}"
+  exit 0
+fi
+
+if [ "${APPLY}" != "1" ]; then
+  echo
+  echo "Vendored vectors differ from ori-specs at ${COMMIT}." >&2
+  echo "Re-run with ORI_VECTORS_APPLY=1 to update, then review the diff:" >&2
+  echo "  a vector change is a contract change, not a refresh." >&2
+  exit 1
+fi
+
+# Reconcile the whole set, not just additions and changes. Copying alone would
+# leave a vector upstream had deleted sitting in the destination, where it would
+# be re-recorded in the manifest and reported as drift again on every run.
+for file in "${DEST}"/*.json; do
+  name="$(basename "${file}")"
+  [ "${name}" = "MANIFEST.json" ] && continue
+  if [ ! -f "${SRC}/${name}" ]; then
+    rm -f "${file}"
+    echo "deleted  ${name}"
+  fi
+done
+cp "${SRC}"/*.json "${DEST}/"
+python3 - "${COMMIT}" "${DEST}" <<'PY'
+import hashlib, json, pathlib, sys
+commit, dest = sys.argv[1], pathlib.Path(sys.argv[2])
+manifest = json.loads((dest / "MANIFEST.json").read_text())
+manifest["source_commit"] = commit
+manifest["files"] = {
+    p.name: hashlib.sha256(p.read_bytes()).hexdigest() for p in sorted(dest.glob("*.json"))
+    if p.name != "MANIFEST.json"
+}
+(dest / "MANIFEST.json").write_text(json.dumps(manifest, indent=2) + "\n")
+print(f"updated {len(manifest['files'])} vectors to {commit}")
+PY

--- a/tests/test_evidence_v2_vectors.py
+++ b/tests/test_evidence_v2_vectors.py
@@ -1,0 +1,493 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reconstruct every `ori-specs/evidence/v2` vector from its documented inputs.
+
+These are the runtime's conformance fixtures for issue #326. The runtime is
+becoming a second producer of the evidence chain format, and the contract's
+vectors are what "producing it correctly" means, byte for byte.
+
+Nothing here imports whatever generated the vectors. Every value is rebuilt
+from the inputs each vector publishes — the genesis preimage, the namespace
+URI, the per-event name format, the canonical rules, the seeds — so a vector
+that documents one derivation and was produced by another fails.
+
+What this does *not* establish: cross-language agreement. These vectors were
+generated in Python and this reconstruction is also Python, so passing proves
+the derivations are self-consistent and reproducible, not that a Rust or C
+implementation reaches the same bytes. That remains open under
+`ori-platform/ori-verity#39`, and `evidence/v2` stays a design target until it
+lands.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import math
+import pathlib
+import uuid
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+VECTORS = pathlib.Path(__file__).parent / "vectors" / "evidence_v2"
+
+# From ori-specs evidence/v2.md. Restated rather than imported: a conformance
+# test that reads its expectations from the thing under test proves nothing.
+SCHEMA_VERSION = "ori.evidence.v2"
+GENESIS_PREIMAGE = "ori.evidence.genesis.v2"
+ROTATION_CONTEXT = "ori.evidence.rotation.v2"
+NAMESPACE_URI = "https://oriplatform.dev/specs/evidence/v2/event-id"
+INTEGER_MAX = 9007199254740991
+ENVELOPE_FIELDS = frozenset(
+    {
+        "device_id",
+        "emitted_at_ms",
+        "event_id",
+        "event_type",
+        "payload",
+        "prev_event_hash",
+        "schema_version",
+        "sequence_num",
+    }
+)
+
+
+def load(name: str) -> dict:
+    return json.loads((VECTORS / name).read_text())
+
+
+def canonical(value) -> bytes:
+    """The contract's canonical form. Sorting is recursive; `sort_keys` does that."""
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def sha256_hex(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def in_number_zone(value) -> bool:
+    """The D-011 agreement zone, where CPython and serde_json emit identical bytes."""
+    if isinstance(value, bool):
+        return True
+    if isinstance(value, int):
+        return abs(value) <= INTEGER_MAX
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return False
+        magnitude = abs(value)
+        return magnitude == 0.0 or 1e-4 <= magnitude < 1e16
+    if isinstance(value, dict):
+        return all(isinstance(k, str) and in_number_zone(v) for k, v in value.items())
+    if isinstance(value, (list, tuple)):
+        return all(in_number_zone(v) for v in value)
+    return True
+
+
+# --------------------------------------------------------------------------
+# The vendored copy is intact
+# --------------------------------------------------------------------------
+
+
+def test_vendored_vectors_match_their_manifest():
+    """A locally edited vector would make every test below pass vacuously."""
+    manifest = load("MANIFEST.json")
+    assert manifest["files"], "manifest lists no vectors"
+    for name, digest in manifest["files"].items():
+        actual = sha256_hex((VECTORS / name).read_bytes())
+        assert actual == digest, f"{name} differs from the vendored manifest"
+
+
+def test_every_vector_is_covered_by_the_manifest():
+    present = {p.name for p in VECTORS.glob("*.json")} - {"MANIFEST.json"}
+    assert present == set(load("MANIFEST.json")["files"]), (
+        "a vector file is present that the manifest does not record, or vice versa"
+    )
+
+
+# --------------------------------------------------------------------------
+# Genesis
+# --------------------------------------------------------------------------
+
+
+def test_genesis_derives_from_its_published_preimage():
+    vector = load("genesis.json")
+    assert vector["preimage"] == GENESIS_PREIMAGE
+    assert vector["preimage"].encode().hex() == vector["preimage_utf8_hex"]
+    assert (
+        sha256_hex(vector["preimage"].encode()) == vector["genesis_prev_event_hash"]
+    ), "the genesis value is not the SHA-256 of its own published preimage"
+
+
+def test_genesis_carries_no_branded_preimage():
+    """The whole point of v2's vocabulary. A regression here is the old value."""
+    assert "verity" not in load("genesis.json")["preimage"].lower()
+
+
+# --------------------------------------------------------------------------
+# Canonical form
+# --------------------------------------------------------------------------
+
+
+def test_canonical_accept_cases_reproduce_their_bytes():
+    vector = load("canonical-form.json")
+    assert vector["integer_max"] == INTEGER_MAX
+    for case in vector["accept_cases"]:
+        rebuilt = canonical(case["value"])
+        assert rebuilt.hex() == case["canonical_hex"], f"bytes differ: {case['name']}"
+        assert rebuilt.decode() == case["canonical_utf8"], (
+            f"text differs: {case['name']}"
+        )
+        assert in_number_zone(case["value"]), (
+            f"accepted case is outside the zone: {case['name']}"
+        )
+
+
+def test_negative_zero_survives_canonicalisation():
+    """Distinct from positive zero in the bytes, which is why the rule names it."""
+    vector = load("canonical-form.json")
+    negative = [c for c in vector["accept_cases"] if "negative zero" in c["name"]]
+    assert negative, "no negative-zero case to check"
+    assert "-0.0" in negative[0]["canonical_utf8"]
+
+
+def test_refused_forms_are_enumerated_with_reasons():
+    vector = load("canonical-form.json")
+    assert len(vector["reject_cases"]) >= 8
+    for case in vector["reject_cases"]:
+        assert case.get("why"), f"refusal without a reason: {case['name']}"
+
+
+def _refuse_reason(input_json: str) -> str | None:
+    """Parse an input the way a conforming producer must, and name why it is refused.
+
+    A default loader is not enough. `json.loads` accepts NaN and Infinity, and
+    silently keeps the last of a duplicated key, so both defects would vanish
+    before anything could inspect them.
+    """
+    seen_duplicate = False
+
+    def pairs_hook(pairs):
+        nonlocal seen_duplicate
+        keys = [k for k, _ in pairs]
+        if len(keys) != len(set(keys)):
+            seen_duplicate = True
+        return dict(pairs)
+
+    def constant_hook(name):
+        raise ValueError(f"non-finite constant: {name}")
+
+    try:
+        value = json.loads(
+            input_json, object_pairs_hook=pairs_hook, parse_constant=constant_hook
+        )
+    except ValueError as exc:
+        return "non_finite" if "non-finite" in str(exc) else "unparseable"
+    if seen_duplicate:
+        return "duplicate_key"
+    return _first_structural_refusal(value)
+
+
+def _first_structural_refusal(value) -> str | None:
+    """Walk the whole value. Canonicalisation is recursive, so this must be.
+
+    A top-level-only check would accept `{"a": [1e-5]}` and then emit bytes no
+    other implementation reproduces, which is the failure the zone exists to
+    prevent.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return "integer_range" if abs(value) > INTEGER_MAX else None
+    if isinstance(value, float):
+        return None if in_number_zone(value) else "number_zone"
+    if isinstance(value, dict):
+        if not all(isinstance(k, str) for k in value):
+            return "non_string_key"
+        for nested in value.values():
+            found = _first_structural_refusal(nested)
+            if found:
+                return found
+        return None
+    if isinstance(value, list):
+        for nested in value:
+            found = _first_structural_refusal(nested)
+            if found:
+                return found
+    return None
+
+
+def test_every_published_refusal_is_actually_refused():
+    """Drive the vector's own inputs rather than a hand-written list beside it.
+
+    The earlier version checked six numbers chosen here, which meant the
+    duplicate-key and non-string-key refusals in the contract were never
+    executed by anything.
+    """
+    vector = load("canonical-form.json")
+    for case in vector["reject_cases"]:
+        kind = case["input_kind"]
+        if kind == "json_text":
+            reason = _refuse_reason(case["input_json"])
+        elif kind == "native_pairs":
+            # JSON text cannot carry a non-string key, so the vector describes
+            # the native object instead and it is built here. An earlier version
+            # fed the malformed string `{1:2}`, which was refused as unparseable
+            # without the key's type ever being examined — and the mismatch was
+            # then hidden behind an exemption, which is how a gap survives a
+            # test that appears to cover it.
+            reason = _first_structural_refusal(
+                {key: value for key, value in case["input_pairs"]}
+            )
+        else:
+            raise AssertionError(f"unknown input_kind {kind!r} in {case['name']}")
+        assert reason == case["violates"], (
+            f"{case['name']}: refused as {reason!r}, contract declares "
+            f"{case['violates']!r}"
+        )
+
+
+def test_accepted_forms_are_not_refused():
+    """The refusal path must not reject everything."""
+    for case in load("canonical-form.json")["accept_cases"]:
+        assert _refuse_reason(canonical(case["value"]).decode()) is None, case["name"]
+
+
+# --------------------------------------------------------------------------
+# Event identifier
+# --------------------------------------------------------------------------
+
+
+def test_namespace_derives_from_the_published_uri():
+    vector = load("event-id.json")
+    assert vector["namespace_name_uri"] == NAMESPACE_URI
+    assert (
+        vector["namespace_name_uri"].encode().hex() == vector["namespace_name_utf8_hex"]
+    )
+    derived = uuid.uuid5(
+        uuid.UUID(vector["root_namespace_uuid"]), vector["namespace_name_uri"]
+    )
+    assert str(derived) == vector["event_id_namespace"]
+
+
+def test_namespace_bytes_carry_no_hidden_identifier():
+    """The v1 namespace decoded to ASCII. This asserts v2's does not."""
+    raw = uuid.UUID(load("event-id.json")["event_id_namespace"]).bytes
+    assert "verity" not in raw.decode("ascii", "replace").lower()
+
+
+def test_event_ids_derive_from_the_published_name_format():
+    vector = load("event-id.json")
+    namespace = uuid.UUID(vector["event_id_namespace"])
+    for case in vector["cases"]:
+        name = vector["per_event_name_format"].format(**case)
+        assert name == case["uuid5_name"]
+        assert str(uuid.uuid5(namespace, name)) == case["event_id"]
+
+
+# --------------------------------------------------------------------------
+# Chain rows
+# --------------------------------------------------------------------------
+
+
+def test_rows_chain_hash_and_verify():
+    vector = load("chain-row.json")
+    public = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(vector["device_seed_hex"])
+    ).public_key()
+    assert public.public_bytes_raw().hex() == vector["device_public_key_hex"]
+
+    previous = vector["genesis_prev_event_hash"]
+    for index, row in enumerate(vector["rows"], start=1):
+        envelope = row["envelope"]
+        assert set(envelope) == ENVELOPE_FIELDS, f"row {index}: envelope field set"
+        assert envelope["schema_version"] == SCHEMA_VERSION, (
+            f"row {index}: schema version"
+        )
+        rebuilt = canonical(envelope)
+        assert rebuilt.hex() == row["canonical_hex"], f"row {index}: canonical bytes"
+        assert sha256_hex(rebuilt) == row["event_hash"], f"row {index}: event hash"
+        assert envelope["prev_event_hash"] == previous, (
+            f"row {index}: chains to previous"
+        )
+        public.verify(base64.b64decode(row["signature"].split("ed25519:")[1]), rebuilt)
+        previous = row["event_hash"]
+
+
+ENVELOPE_TO_COLUMN = {
+    5: ("sequence_num", "seq"),
+    6: ("prev_event_hash", "prev_event_hash"),
+    7: ("event_id", "event_id"),
+    8: ("event_type", "event_type"),
+    9: ("device_id", "device_id"),
+    10: ("emitted_at_ms", "emitted_at_ms"),
+}
+
+
+def _rules_violated(case: dict, public_key) -> set[int]:
+    """Independently derive which of the thirteen rules this artifact breaks.
+
+    Written from the contract, not from the case's own claim about itself. A
+    check that trusted `case["rule"]` would confirm the label rather than the
+    artifact, which is what the previous version of this test did.
+    """
+    row = case["row"]
+    # `canonical_json` is what was signed and hashed, so it is the authority on
+    # what the envelope says. The convenience `envelope` object is checked
+    # against it separately: a vector whose two copies disagreed would otherwise
+    # satisfy every rule below while describing bytes nobody signed.
+    signed_bytes = row["canonical_json"].encode()
+    envelope = json.loads(signed_bytes)
+    columns = row["row_columns"]
+    context = case["chain_context"]
+    broken: set[int] = set()
+
+    if columns.get("seq") != context["expected_sequence_num"]:
+        broken.add(1)
+    if columns.get("prev_event_hash") != context["expected_prev_event_hash"]:
+        broken.add(2)
+
+    if sha256_hex(signed_bytes) != row["event_hash"]:
+        broken.add(3)
+    try:
+        public_key.verify(
+            base64.b64decode(row["signature"].split("ed25519:")[1]), signed_bytes
+        )
+    except Exception:
+        broken.add(4)
+
+    for rule, (envelope_field, column) in ENVELOPE_TO_COLUMN.items():
+        if columns.get(column) != envelope.get(envelope_field):
+            broken.add(rule)
+
+    if envelope.get("schema_version") != SCHEMA_VERSION:
+        broken.add(11)
+    if json.loads(row["payload_json"]) != envelope.get("payload"):
+        broken.add(12)
+    if set(envelope) - ENVELOPE_FIELDS:
+        broken.add(13)
+    return broken
+
+
+def test_every_rejection_rule_has_a_case():
+    """Thirteen rules, thirteen concrete rows. A rule without one is untested."""
+    covered = {case["rule"] for case in load("chain-row.json")["rejection_cases"]}
+    assert covered == set(range(1, 14)), (
+        f"rules without a case: {set(range(1, 14)) - covered}"
+    )
+
+
+def test_each_rejection_case_violates_exactly_the_rule_it_names():
+    """The artifact must break its own rule and nothing else.
+
+    Purity is the property under test, not merely presence of a defect. A case
+    that violates a second rule is rejected for the wrong reason and never
+    exercises the rule it was written for, so a suite of impure cases reports
+    coverage it does not have. Two cases in the contract's first draft did
+    exactly that, and this assertion is what found them.
+    """
+    vector = load("chain-row.json")
+    public = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(vector["device_seed_hex"])
+    ).public_key()
+    for case in vector["rejection_cases"]:
+        row = case["row"]
+        signed_bytes = row["canonical_json"].encode()
+        assert canonical(row["envelope"]) == signed_bytes, (
+            f"rule {case['rule']}: the published envelope does not re-canonicalise "
+            "to the bytes that were signed"
+        )
+        assert bytes.fromhex(row["canonical_hex"]) == signed_bytes, (
+            f"rule {case['rule']}: canonical_hex is not the signed bytes"
+        )
+        broken = _rules_violated(case, public)
+        assert broken == {case["rule"]}, (
+            f"case for rule {case['rule']} ({case['name']}) violates {sorted(broken)}; "
+            "it must break exactly its own rule so that rule is the one reached"
+        )
+
+
+def test_a_valid_row_violates_no_rule():
+    """The validator must not reject everything, or the test above proves nothing."""
+    vector = load("chain-row.json")
+    public = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(vector["device_seed_hex"])
+    ).public_key()
+    first = vector["rows"][0]
+    envelope = first["envelope"]
+    clean = {
+        "row": {
+            **first,
+            "row_columns": {
+                "seq": envelope["sequence_num"],
+                "event_id": envelope["event_id"],
+                "event_type": envelope["event_type"],
+                "device_id": envelope["device_id"],
+                "emitted_at_ms": envelope["emitted_at_ms"],
+                "prev_event_hash": envelope["prev_event_hash"],
+            },
+            "payload_json": json.dumps(
+                envelope["payload"], sort_keys=True, separators=(",", ":")
+            ),
+        },
+        "chain_context": {
+            "expected_sequence_num": envelope["sequence_num"],
+            "expected_prev_event_hash": vector["genesis_prev_event_hash"],
+        },
+    }
+    assert _rules_violated(clean, public) == set()
+
+
+def test_a_v1_row_is_rejected_rather_than_reinterpreted():
+    """Rule 11 is what makes version confusion impossible rather than merely unlikely."""
+    case = next(c for c in load("chain-row.json")["rejection_cases"] if c["rule"] == 11)
+    assert case["row"]["envelope"]["schema_version"] != SCHEMA_VERSION
+    assert case["expected"] == "reject"
+
+
+# --------------------------------------------------------------------------
+# Key rotation
+# --------------------------------------------------------------------------
+
+
+def test_rotation_proof_uses_the_neutral_context():
+    vector = load("key-rotation.json")
+    assert vector["proof_context"] == ROTATION_CONTEXT
+    expected = (
+        ROTATION_CONTEXT.encode()
+        + b"\x00"
+        + bytes.fromhex(vector["new_public_key_hex"])
+    )
+    assert expected.hex() == vector["proof_input_hex"]
+
+
+def test_rotation_is_dual_signed():
+    """The row by the outgoing key, the possession proof by the incoming one."""
+    vector = load("key-rotation.json")
+    outgoing = Ed25519PrivateKey.from_private_bytes(
+        bytes.fromhex(vector["old_seed_hex"])
+    ).public_key()
+    incoming_raw = bytes.fromhex(vector["new_public_key_hex"])
+
+    proof = base64.b64decode(
+        vector["row"]["envelope"]["payload"]["rotation_sig"].split("ed25519:")[1]
+    )
+    Ed25519PublicKey.from_public_bytes(incoming_raw).verify(
+        proof, bytes.fromhex(vector["proof_input_hex"])
+    )
+
+    rebuilt = canonical(vector["row"]["envelope"])
+    assert rebuilt.hex() == vector["row"]["canonical_hex"]
+    outgoing.verify(
+        base64.b64decode(vector["row"]["signature"].split("ed25519:")[1]), rebuilt
+    )

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,0 +1,13 @@
+{
+  "source_repository": "ori-platform/ori-specs",
+  "source_path": "evidence/vectors",
+  "source_commit": "789e1a4118665840a5b17e6c9013fd9d304c9088",
+  "note": "Vendored copies of the normative vectors. The runtime must produce bytes these describe, so they are its conformance fixtures. digests detect a local edit; refresh with scripts/refresh-evidence-vectors.sh to detect upstream drift.",
+  "files": {
+    "canonical-form.json": "b2b78ad6c2918b0d59bf992d1ba259e800b6967952deb9f728a852895a0ce229",
+    "chain-row.json": "c69c8c4b9158482beac607c830b3f9f1870e42932242a89ece7c2cc05fcfc646",
+    "event-id.json": "f9b0b0f71237b4b717dc2a92433aebec758444c9be78e3c9f2abf32d5a31c068",
+    "genesis.json": "b838f02c80606148307cca450640a92a71d30d90e0841ccc4a98d10c63b2d190",
+    "key-rotation.json": "b6d2f14ce575fce964ddea6a4f4d33db5cdee9a06091084206b04e0774cda19a"
+  }
+}

--- a/tests/vectors/evidence_v2/canonical-form.json
+++ b/tests/vectors/evidence_v2/canonical-form.json
@@ -1,0 +1,215 @@
+{
+  "artifact": "canonical_form",
+  "schema_version": "ori.evidence.v2",
+  "canonicalisation": "json.dumps(obj, sort_keys=True, separators=(',',':'), ensure_ascii=False, allow_nan=False).encode('utf-8')",
+  "note": "Sorting is recursive at every nesting level and must be applied explicitly, never inherited from insertion order.",
+  "number_rule": "Platform D-011 agreement zone, identical to firmware-telemetry/v1. Integers |n| <= 2^53-1. Non-integer numbers finite and either exactly zero or magnitude in [1e-4, 1e16), emitted as shortest round-trip decimal in fixed notation with a mandatory fractional part. Exponent notation never appears.",
+  "integer_max": 9007199254740991,
+  "float_zone": {
+    "min_magnitude": 0.0001,
+    "max_magnitude_exclusive": 1e+16
+  },
+  "accept_cases": [
+    {
+      "name": "recursive key ordering",
+      "value": {
+        "b": {
+          "z": 1,
+          "a": 2
+        },
+        "a": 3
+      },
+      "canonical_utf8": "{\"a\":3,\"b\":{\"a\":2,\"z\":1}}",
+      "canonical_hex": "7b2261223a332c2262223a7b2261223a322c227a223a317d7d"
+    },
+    {
+      "name": "unicode is not escaped",
+      "value": {
+        "site": "Ikeja",
+        "note": "caf\u00e9 \u2014 na\u00efve"
+      },
+      "canonical_utf8": "{\"note\":\"caf\u00e9 \u2014 na\u00efve\",\"site\":\"Ikeja\"}",
+      "canonical_hex": "7b226e6f7465223a22636166c3a920e28094206e61c3af7665222c2273697465223a22496b656a61227d"
+    },
+    {
+      "name": "RFC 8259 escapes are used where required",
+      "value": {
+        "s": "line\nquote\"back\\slash\ttab"
+      },
+      "canonical_utf8": "{\"s\":\"line\\nquote\\\"back\\\\slash\\ttab\"}",
+      "canonical_hex": "7b2273223a226c696e655c6e71756f74655c226261636b5c5c736c6173685c74746162227d"
+    },
+    {
+      "name": "no whitespace between tokens",
+      "value": {
+        "a": [
+          1,
+          2,
+          {
+            "c": 3,
+            "b": 4
+          }
+        ]
+      },
+      "canonical_utf8": "{\"a\":[1,2,{\"b\":4,\"c\":3}]}",
+      "canonical_hex": "7b2261223a5b312c322c7b2262223a342c2263223a337d5d7d"
+    },
+    {
+      "name": "nested empty containers",
+      "value": {
+        "b": {},
+        "a": []
+      },
+      "canonical_utf8": "{\"a\":[],\"b\":{}}",
+      "canonical_hex": "7b2261223a5b5d2c2262223a7b7d7d"
+    },
+    {
+      "name": "array order is preserved",
+      "value": {
+        "a": [
+          3,
+          1,
+          2
+        ]
+      },
+      "canonical_utf8": "{\"a\":[3,1,2]}",
+      "canonical_hex": "7b2261223a5b332c312c325d7d"
+    },
+    {
+      "name": "integer at the JSON-safe maximum",
+      "value": {
+        "n": 9007199254740991
+      },
+      "canonical_utf8": "{\"n\":9007199254740991}",
+      "canonical_hex": "7b226e223a393030373139393235343734303939317d"
+    },
+    {
+      "name": "integer at the negative bound",
+      "value": {
+        "n": -9007199254740991
+      },
+      "canonical_utf8": "{\"n\":-9007199254740991}",
+      "canonical_hex": "7b226e223a2d393030373139393235343734303939317d"
+    },
+    {
+      "name": "float inside the agreement zone",
+      "value": {
+        "amps": 8.25
+      },
+      "canonical_utf8": "{\"amps\":8.25}",
+      "canonical_hex": "7b22616d7073223a382e32357d"
+    },
+    {
+      "name": "float at the lower bound of the zone",
+      "value": {
+        "n": 0.0001
+      },
+      "canonical_utf8": "{\"n\":0.0001}",
+      "canonical_hex": "7b226e223a302e303030317d"
+    },
+    {
+      "name": "float just inside the upper bound",
+      "value": {
+        "n": 9999999999999998.0
+      },
+      "canonical_utf8": "{\"n\":9999999999999998.0}",
+      "canonical_hex": "7b226e223a393939393939393939393939393939382e307d"
+    },
+    {
+      "name": "integral float keeps its fractional part",
+      "value": {
+        "n": 3.0
+      },
+      "canonical_utf8": "{\"n\":3.0}",
+      "canonical_hex": "7b226e223a332e307d"
+    },
+    {
+      "name": "negative zero is preserved",
+      "value": {
+        "n": -0.0
+      },
+      "canonical_utf8": "{\"n\":-0.0}",
+      "canonical_hex": "7b226e223a2d302e307d"
+    },
+    {
+      "name": "positive zero",
+      "value": {
+        "n": 0.0
+      },
+      "canonical_utf8": "{\"n\":0.0}",
+      "canonical_hex": "7b226e223a302e307d"
+    }
+  ],
+  "reject_cases": [
+    {
+      "name": "NaN",
+      "why": "non-finite numbers are forbidden",
+      "input_json": "{\"n\":NaN}",
+      "violates": "non_finite",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "Infinity",
+      "why": "non-finite numbers are forbidden",
+      "input_json": "{\"n\":Infinity}",
+      "violates": "non_finite",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "-Infinity",
+      "why": "non-finite numbers are forbidden",
+      "input_json": "{\"n\":-Infinity}",
+      "violates": "non_finite",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "float below the agreement zone (1e-5)",
+      "why": "serializers disagree: 0.00001 vs 1e-05",
+      "input_json": "{\"n\":1e-05}",
+      "violates": "number_zone",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "float at or above 1e16",
+      "why": "serializers disagree in exponent notation",
+      "input_json": "{\"n\":1e16}",
+      "violates": "number_zone",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "integer above 2^53-1",
+      "why": "outside the JSON-safe integer range",
+      "input_json": "{\"n\":9007199254740992}",
+      "violates": "integer_range",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "duplicate object keys",
+      "why": "the canonical form of an object with repeated keys is undefined",
+      "input_json": "{\"a\":1,\"a\":2}",
+      "violates": "duplicate_key",
+      "input_kind": "json_text"
+    },
+    {
+      "name": "non-string object key",
+      "why": "JSON object keys are strings; sorting a mixed set is undefined",
+      "violates": "non_string_key",
+      "note": "JSON text cannot represent this: `{1:2}` is malformed rather than an object with a non-string key, and would be refused as unparseable without the key's type ever being examined. input_pairs describes the native object to build \u2014 key 1, value 2 \u2014 which is the input a producer must refuse when its in-memory object has a non-string key. Languages whose objects cannot hold one may record this case as structurally unreachable, but must not skip it silently.",
+      "input_kind": "native_pairs",
+      "input_pairs": [
+        [
+          1,
+          2
+        ]
+      ]
+    }
+  ],
+  "reject_input_note": "Each refusal carries an executable input. input_kind is json_text for inputs expressible as JSON, and native_pairs where it is not. The text cases are deliberately not always valid JSON: NaN and Infinity are extensions some parsers accept, and a duplicate key does not survive an ordinary parse because most parsers silently keep the last occurrence. A verifier must parse with duplicate detection and constant rejection rather than calling a default loader and inspecting the result. Every case must produce exactly its declared violation; an implementation that cannot construct one must say so rather than exempt it.",
+  "violation_kinds": {
+    "non_finite": "NaN, Infinity or -Infinity",
+    "number_zone": "finite but outside [1e-4, 1e16) and not exactly zero",
+    "integer_range": "integer magnitude above 2^53-1",
+    "duplicate_key": "an object carrying the same key twice",
+    "non_string_key": "an object key that is not a string"
+  }
+}

--- a/tests/vectors/evidence_v2/chain-row.json
+++ b/tests/vectors/evidence_v2/chain-row.json
@@ -1,0 +1,580 @@
+{
+  "artifact": "chain_row",
+  "schema_version": "ori.evidence.v2",
+  "warning": "Seeds below are published test values and must never sign anything real.",
+  "signing": "Ed25519 over canonical_json directly. No domain prefix: schema_version inside the envelope separates this format.",
+  "signature_encoding": "ed25519:<standard base64 of the 64-byte signature>",
+  "authenticator_note": "Cases marked authenticator=valid must pass cryptographic verification so the semantic rule under test is actually reached. Cases marked invalid fail verification itself.",
+  "row_columns_note": "Where a case carries row_columns, those are the values stored in the row's own columns, overriding the equally-named envelope fields. The envelope is what was signed; the columns are what a reader queries.",
+  "device_seed_hex": "4242424242424242424242424242424242424242424242424242424242424242",
+  "device_public_key_hex": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+  "other_seed_hex": "4444444444444444444444444444444444444444444444444444444444444444",
+  "genesis_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+  "rows": [
+    {
+      "envelope": {
+        "device_id": "energy-monitor-ikeja-01",
+        "emitted_at_ms": 1751500800000,
+        "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+        "event_type": "SAFETY_ACTION_EXECUTED",
+        "payload": {
+          "kind": "runtime_action",
+          "attestation": "at_emission",
+          "action_log_id": 1
+        },
+        "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+        "schema_version": "ori.evidence.v2",
+        "sequence_num": 1
+      },
+      "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+      "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+      "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+      "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg=="
+    },
+    {
+      "envelope": {
+        "device_id": "energy-monitor-ikeja-01",
+        "emitted_at_ms": 1751500900000,
+        "event_id": "621262cc-45ed-5940-b355-35758976455b",
+        "event_type": "SAFETY_ACTION_EXECUTED",
+        "payload": {
+          "kind": "runtime_action",
+          "attestation": "reconciled_late",
+          "action_log_id": 2
+        },
+        "prev_event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "schema_version": "ori.evidence.v2",
+        "sequence_num": 2
+      },
+      "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500900000,\"event_id\":\"621262cc-45ed-5940-b355-35758976455b\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":2,\"attestation\":\"reconciled_late\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":2}",
+      "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303930303030302c226576656e745f6964223a2236323132363263632d343565642d353934302d623335352d333537353839373634353562222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a322c226174746573746174696f6e223a227265636f6e63696c65645f6c617465222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2230653861646434623638633032656136376436383539613337323165376633353138353963306434333737346136386264303032323938303162393633383637222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a327d",
+      "event_hash": "94217d7b81c1a8a65dbd12e528bf2be3d37dcbde1f3509deb12d4c91336edcee",
+      "signature": "ed25519:9PWI1J4H5bLNvmDAdIUpPcSOxnTQywoiJOC5Lv4v6PQuMQGc3/0U5MI03lyuCQmgtH6H0ceX1c/C0ALpx8hhDg=="
+    }
+  ],
+  "rejection_cases": [
+    {
+      "rule": 1,
+      "name": "sequence_num is not the expected successor",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "Signed consistently, so the signature verifies and the sequence rule is reached.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500900000,
+          "event_id": "621262cc-45ed-5940-b355-35758976455b",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "reconciled_late",
+            "action_log_id": 2
+          },
+          "prev_event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 5
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500900000,\"event_id\":\"621262cc-45ed-5940-b355-35758976455b\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":2,\"attestation\":\"reconciled_late\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":5}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303930303030302c226576656e745f6964223a2236323132363263632d343565642d353934302d623335352d333537353839373634353562222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a322c226174746573746174696f6e223a227265636f6e63696c65645f6c617465222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2230653861646434623638633032656136376436383539613337323165376633353138353963306434333737346136386264303032323938303162393633383637222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a357d",
+        "event_hash": "4ffb6c80275b82ff9472d4d76a0be855478af86719c2ffa3a378ed09e49d226e",
+        "signature": "ed25519:eC5WXeTed1CbxH42WSfD5t9vixrxP8YatjsOfPo4m17bNQhpatQ2T23yb8hrBjwZqY4bzPHWDcFYAxdtzQWiAA==",
+        "row_columns": {
+          "seq": 5,
+          "event_id": "621262cc-45ed-5940-b355-35758976455b",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500900000,
+          "prev_event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867"
+        },
+        "payload_json": "{\"action_log_id\":2,\"attestation\":\"reconciled_late\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 2,
+        "expected_prev_event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867"
+      }
+    },
+    {
+      "rule": 2,
+      "name": "prev_event_hash does not chain to the previous row",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "Signed consistently; the link is what fails.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500900000,
+          "event_id": "621262cc-45ed-5940-b355-35758976455b",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "reconciled_late",
+            "action_log_id": 2
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 2
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500900000,\"event_id\":\"621262cc-45ed-5940-b355-35758976455b\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":2,\"attestation\":\"reconciled_late\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":2}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303930303030302c226576656e745f6964223a2236323132363263632d343565642d353934302d623335352d333537353839373634353562222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a322c226174746573746174696f6e223a227265636f6e63696c65645f6c617465222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a327d",
+        "event_hash": "e4b5e66e228db286bb8ab842e7ea45ca2945cbf7db481e601ab2dde710cce748",
+        "signature": "ed25519:EmAvNYRAaaCtqz0S9VvFdX8m3VGSK4KzFERBNvhRe0mdEkqxfoGdPrC9whitnK/dEIkNcOqUnxGt43PBKOoNCg==",
+        "row_columns": {
+          "seq": 2,
+          "event_id": "621262cc-45ed-5940-b355-35758976455b",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500900000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":2,\"attestation\":\"reconciled_late\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 2,
+        "expected_prev_event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867"
+      }
+    },
+    {
+      "rule": 3,
+      "name": "event_hash disagrees with canonical_json",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "Envelope and signature are untouched; the stored hash is wrong.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "7b4c9b96060680f60b714b15d6a45222ac11ae6e88ccb34dca964f0fd9aad791",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 4,
+      "name": "signature does not verify under the device key",
+      "expected": "reject",
+      "authenticator": "invalid",
+      "note": "Signed by a different key over the correct bytes.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:KwvOcYfEzeNBnk+evGBA7Z7MCP/h7cUy1Ek2ojS1wLP9pUuEB5JH4krs0vHN8LPS2RN9GOd5cDma3NwUwNb+Cg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 5,
+      "name": "row column seq disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The row sits at the right chain position and its stored seq is correct, so the sequence rule passes. The signed envelope says something else, which is the disagreement rule 5 exists to catch.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 7
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":7}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a377d",
+        "event_hash": "8e1047c998c0b502d7987610e0696a0587feec561767dbf3259c56aeb43469e1",
+        "signature": "ed25519:Wk3cVD/yTHDOefYxM1n61zzyUsDlMDrin3mtbi2JMAYBhze/0sv3tV7tLpKrEal7+XCftFMHVl99PHfW9M8bAA==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 6,
+      "name": "row column prev_event_hash disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The row's stored link is correct, so the chain rule passes. The signed envelope carries a different predecessor, which is rule 6.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"0000000000000000000000000000000000000000000000000000000000000000\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2230303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030303030222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "9dbd8f8cb48153a5b2330dab1e76bfa2a3d1f2812847f0ebb62a5404e4166f79",
+        "signature": "ed25519:IJf5kdtF09StJuroJOkC6C08V5w1g0eNNizCueLFxbIMfcyK0CKUwhVM/nuCBQkTdT5Ynn6KNUCMpMiFtKKCBw==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 7,
+      "name": "row column event_id disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The envelope and its signature verify. The row's stored column contradicts them, which is what rules 5 to 10 exist to catch.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0e9f4c6b-98d7-42e0-a905-1055d2253bb5",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 8,
+      "name": "row column event_type disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The envelope and its signature verify. The row's stored column contradicts them, which is what rules 5 to 10 exist to catch.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "UPTIME_HEARTBEAT",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 9,
+      "name": "row column device_id disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The envelope and its signature verify. The row's stored column contradicts them, which is what rules 5 to 10 exist to catch.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "some-other-device",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 10,
+      "name": "row column emitted_at_ms disagrees with the signed envelope",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The envelope and its signature verify. The row's stored column contradicts them, which is what rules 5 to 10 exist to catch.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751599999999,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 11,
+      "name": "schema_version is verity.v1",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "A v1 row fails here rather than being reinterpreted as v2.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "verity.v1",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"verity.v1\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a227665726974792e7631222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "1de366078fa82a5fde2e27f4f58490f93306fa11528696d666e6810eea30ed49",
+        "signature": "ed25519:jwAk0bbq+S8NhaUlS7IvBb9akwbw8M7Wc0rt/4Vrj/SnzjBTrW7y6iIRbyvSV41qulFLurKKGSrjEhgDoZDVBw==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 12,
+      "name": "payload_json disagrees with the envelope payload",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "The envelope is authentic; the separately stored payload column is not.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "0e8add4b68c02ea67d6859a3721e7f351859c0d43774a68bd00229801b963867",
+        "signature": "ed25519:y4hKnrXbxHWOlhTrTG5yxT4uB2EEl8X+IvqY0SF3Wll5s+Xq5m8wjLO9k3OjObmfuanHIoGoya8k0V3o7VzWBg==",
+        "payload_json": "{\"kind\":\"runtime_action\",\"attestation\":\"at_emission\",\"action_log_id\":999}",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        }
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    },
+    {
+      "rule": 13,
+      "name": "envelope carries a field this contract does not define",
+      "expected": "reject",
+      "authenticator": "valid",
+      "note": "Signed consistently, so rule 13 is reached rather than the signature failing first.",
+      "row": {
+        "envelope": {
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1
+          },
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61",
+          "schema_version": "ori.evidence.v2",
+          "sequence_num": 1,
+          "extra": true
+        },
+        "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751500800000,\"event_id\":\"0f8bedda-5214-50f0-8d92-ba387ff55b19\",\"event_type\":\"SAFETY_ACTION_EXECUTED\",\"extra\":true,\"payload\":{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"},\"prev_event_hash\":\"84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":1}",
+        "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530303830303030302c226576656e745f6964223a2230663862656464612d353231342d353066302d386439322d626133383766663535623139222c226576656e745f74797065223a225341464554595f414354494f4e5f4558454355544544222c226578747261223a747275652c227061796c6f6164223a7b22616374696f6e5f6c6f675f6964223a312c226174746573746174696f6e223a2261745f656d697373696f6e222c226b696e64223a2272756e74696d655f616374696f6e227d2c22707265765f6576656e745f68617368223a2238343838303633363034316333373135333936313039613363623533633739383464306464666432333464303061373135383563653337316566623164613631222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a317d",
+        "event_hash": "ef98a21cff3afbfd1a2901cb08c1ef2a2ed09172c39b6ca6da91850b456937e7",
+        "signature": "ed25519:HMkjcb+5cNJg/BCLU2XA5ML1sAVXTxV8xK3Z1YX+vrt429nPO4F/qByK+oV0IXkmAOFyLdiIZD2YQ3l+RtSVDA==",
+        "row_columns": {
+          "seq": 1,
+          "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19",
+          "event_type": "SAFETY_ACTION_EXECUTED",
+          "device_id": "energy-monitor-ikeja-01",
+          "emitted_at_ms": 1751500800000,
+          "prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+        },
+        "payload_json": "{\"action_log_id\":1,\"attestation\":\"at_emission\",\"kind\":\"runtime_action\"}"
+      },
+      "chain_context": {
+        "expected_sequence_num": 1,
+        "expected_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+      }
+    }
+  ],
+  "chain_context_note": "Each rejection case publishes the chain position it was presented at, so a verifier can evaluate the sequence and link rules without inferring them. row_columns are the values stored in the row's own columns; the envelope is what was signed. Rules 5 to 10 are the cases where those two disagree.",
+  "conformance_note": "A conforming verifier must find each case violating exactly the rule it names and no other. A case that violates a second rule would pass a naive check while never exercising the rule it was written for."
+}

--- a/tests/vectors/evidence_v2/event-id.json
+++ b/tests/vectors/evidence_v2/event-id.json
@@ -1,0 +1,33 @@
+{
+  "artifact": "event_id",
+  "schema_version": "ori.evidence.v2",
+  "note": "Deterministic idempotency key for a runtime action attestation. A retry after a crash reproduces it, so a row cannot be double-attested.",
+  "root_namespace": "RFC 4122 URL namespace",
+  "root_namespace_uuid": "6ba7b811-9dad-11d1-80b4-00c04fd430c8",
+  "namespace_name_uri": "https://oriplatform.dev/specs/evidence/v2/event-id",
+  "namespace_name_utf8_hex": "68747470733a2f2f6f7269706c6174666f726d2e6465762f73706563732f65766964656e63652f76322f6576656e742d6964",
+  "namespace_derivation": "EVENT_ID_NAMESPACE = UUIDv5(root_namespace_uuid, namespace_name_uri)",
+  "event_id_namespace": "3f3d6f03-be9c-50ac-b655-db9540cb5c45",
+  "per_event_name_format": "{device_id}:action_log:{action_log_id}",
+  "per_event_derivation": "event_id = UUIDv5(event_id_namespace, per_event_name)",
+  "cases": [
+    {
+      "device_id": "energy-monitor-ikeja-01",
+      "action_log_id": 1,
+      "uuid5_name": "energy-monitor-ikeja-01:action_log:1",
+      "event_id": "0f8bedda-5214-50f0-8d92-ba387ff55b19"
+    },
+    {
+      "device_id": "energy-monitor-ikeja-01",
+      "action_log_id": 42,
+      "uuid5_name": "energy-monitor-ikeja-01:action_log:42",
+      "event_id": "24596e99-e3d9-52ce-aaab-b49747dcd770"
+    },
+    {
+      "device_id": "energy-monitor-ikeja-01",
+      "action_log_id": 1000,
+      "uuid5_name": "energy-monitor-ikeja-01:action_log:1000",
+      "event_id": "32dfde03-e23e-55a0-be7c-63c5582cb4a3"
+    }
+  ]
+}

--- a/tests/vectors/evidence_v2/genesis.json
+++ b/tests/vectors/evidence_v2/genesis.json
@@ -1,0 +1,9 @@
+{
+  "artifact": "genesis",
+  "schema_version": "ori.evidence.v2",
+  "note": "prev_event_hash of a chain's first row. Protocol constant; never configurable.",
+  "derivation": "lowercase_hex(SHA-256(utf8(preimage)))",
+  "preimage": "ori.evidence.genesis.v2",
+  "preimage_utf8_hex": "6f72692e65766964656e63652e67656e657369732e7632",
+  "genesis_prev_event_hash": "84880636041c3715396109a3cb53c7984d0ddfd234d00a71585ce371efb1da61"
+}

--- a/tests/vectors/evidence_v2/key-rotation.json
+++ b/tests/vectors/evidence_v2/key-rotation.json
@@ -1,0 +1,49 @@
+{
+  "artifact": "key_rotation",
+  "schema_version": "ori.evidence.v2",
+  "warning": "Seeds below are published test values and must never sign anything real.",
+  "note": "Dual-signed: the chain row is signed by the outgoing key, and the payload carries a possession proof under the incoming key, so a verifier can walk anchor to current.",
+  "proof_context": "ori.evidence.rotation.v2",
+  "proof_input": "utf8(proof_context) || 0x00 || new_public_key_raw_32",
+  "proof_input_hex": "6f72692e65766964656e63652e726f746174696f6e2e76320022fc297792f0b6ffc0bfcfdb7edb0c0aa14e025a365ec0e342e86e3829cb74b6",
+  "old_seed_hex": "4242424242424242424242424242424242424242424242424242424242424242",
+  "old_public_key_hex": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+  "new_seed_hex": "4343434343434343434343434343434343434343434343434343434343434343",
+  "new_public_key_hex": "22fc297792f0b6ffc0bfcfdb7edb0c0aa14e025a365ec0e342e86e3829cb74b6",
+  "row": {
+    "envelope": {
+      "device_id": "energy-monitor-ikeja-01",
+      "emitted_at_ms": 1751501000000,
+      "event_id": "cdaf24dc-d58d-5458-b77b-31a8604003c8",
+      "event_type": "KEY_ROTATION",
+      "payload": {
+        "kind": "key_rotation",
+        "old_public_key": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
+        "new_public_key": "22fc297792f0b6ffc0bfcfdb7edb0c0aa14e025a365ec0e342e86e3829cb74b6",
+        "rotation_sig": "ed25519:a7iwRFpAUHfQ3bsJGGTSlWZfzKxZXkQK4cbyu7qIScbvAhVwlcJWkoDXF549p9FohveJwrFduLp7suDYasmUCA=="
+      },
+      "prev_event_hash": "94217d7b81c1a8a65dbd12e528bf2be3d37dcbde1f3509deb12d4c91336edcee",
+      "schema_version": "ori.evidence.v2",
+      "sequence_num": 3
+    },
+    "canonical_json": "{\"device_id\":\"energy-monitor-ikeja-01\",\"emitted_at_ms\":1751501000000,\"event_id\":\"cdaf24dc-d58d-5458-b77b-31a8604003c8\",\"event_type\":\"KEY_ROTATION\",\"payload\":{\"kind\":\"key_rotation\",\"new_public_key\":\"22fc297792f0b6ffc0bfcfdb7edb0c0aa14e025a365ec0e342e86e3829cb74b6\",\"old_public_key\":\"2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12\",\"rotation_sig\":\"ed25519:a7iwRFpAUHfQ3bsJGGTSlWZfzKxZXkQK4cbyu7qIScbvAhVwlcJWkoDXF549p9FohveJwrFduLp7suDYasmUCA==\"},\"prev_event_hash\":\"94217d7b81c1a8a65dbd12e528bf2be3d37dcbde1f3509deb12d4c91336edcee\",\"schema_version\":\"ori.evidence.v2\",\"sequence_num\":3}",
+    "canonical_hex": "7b226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c22656d69747465645f61745f6d73223a313735313530313030303030302c226576656e745f6964223a2263646166323464632d643538642d353435382d623737622d333161383630343030336338222c226576656e745f74797065223a224b45595f524f544154494f4e222c227061796c6f6164223a7b226b696e64223a226b65795f726f746174696f6e222c226e65775f7075626c69635f6b6579223a2232326663323937373932663062366666633062666366646237656462306330616131346530323561333635656330653334326538366533383239636237346236222c226f6c645f7075626c69635f6b6579223a2232313532663864313962373931643234343533323432653135663265616236636237636666613762366135656433303039373936306530363938383164623132222c22726f746174696f6e5f736967223a22656432353531393a6137697752467041554866513362734a474754536c575a667a4b785a586b514b346362797537714953636276416856776c634a576b6f4458463534397039466f6876654a77724664754c70377375445961736d5543413d3d227d2c22707265765f6576656e745f68617368223a2239343231376437623831633161386136356462643132653532386266326265336433376463626465316633353039646562313264346339313333366564636565222c22736368656d615f76657273696f6e223a226f72692e65766964656e63652e7632222c2273657175656e63655f6e756d223a337d",
+    "event_hash": "2007049095594f537682094ebc816f79aa3dac944aa1a8112c1595402cd793b8",
+    "signature": "ed25519:D4xqss6d+uve6af9eZesoIwGBaE+ieo1uFfnenPHr99/BoExm+Svkv0tWOkxqrTKgH+Syc1QdZZC9zCiVNeUDA=="
+  },
+  "rejection_cases": [
+    {
+      "name": "old_public_key is not the active key",
+      "expected": "reject"
+    },
+    {
+      "name": "possession proof made under the v1 context",
+      "expected": "reject",
+      "note": "verity.rotation.v1 must not verify under v2."
+    },
+    {
+      "name": "possession proof does not verify under new_public_key",
+      "expected": "reject"
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

The runtime is becoming a second producer of the evidence chain format under #326, and `ori-specs/evidence/v2` is what producing it correctly means, byte for byte. This makes those vectors executable here, so the producer has acceptance criteria that fail when it is wrong rather than a document to be read alongside it.

It is groundwork for #326 and adds no runtime behaviour.

## How it avoids proving nothing

A conformance test is easy to write badly, and three specific ways are guarded against.

**Expectations are restated, not imported.** The schema version, genesis preimage, namespace URI and the eight envelope field names are literals in the test module. A test that reads its expectations from the file under test proves only that the file agrees with itself.

**The rejection cases get a validator, not a headcount.** It derives from the contract which of the thirteen rules an artifact breaks, then asserts each case breaks exactly the one it names. Purity is the property that matters: a case violating a second rule is rejected for the wrong reason and never exercises the rule it was written for, so an impure suite reports coverage it does not have. Writing this found two such cases in the contract itself, corrected in ori-platform/ori-specs#84 — moving a row's stored `seq` to disagree with its signed envelope also moved it off its chain position, so rules 1 and 2 fired and rules 5 and 6 were never reached.

A control asserts a valid row breaks nothing, because a validator that rejects everything would make the purity check meaningless.

**`canonical_json` is authoritative.** It is what was signed and hashed, so the validator parses it as the envelope. The convenience `envelope` object and `canonical_hex` are checked against it separately: a vector whose copies disagreed would otherwise satisfy every rule while describing bytes nobody signed.

## Refusals are driven, not described

Parsing uses duplicate detection and constant rejection, because a default loader accepts `NaN` and `Infinity` and silently keeps the last of a duplicated key — both defects vanish before anything can inspect them.

The non-string-key case is built as a native object. JSON text cannot express one, and the malformed string `{1:2}` is refused as unparseable without the key's type ever being examined. An earlier revision of this branch fed that string and then exempted the case from matching its declared violation, which turns a known gap into a passing test. There is no exemption now: every case must produce exactly the violation it declares.

Number checking walks nested values, matching canonicalisation, so a payload hiding an out-of-zone float inside an array cannot pass. That helper is shaped for reuse: when the producer lands it is the refusal it enforces, not a test-only convenience.

## The vocabulary is asserted negatively

The v1 namespace decoded to the ASCII string `ori veRity evnt1`, which is how it survived review until something had to reproduce it. The namespace bytes are decoded and checked, not merely compared as a value. Same class of defect as #345.

## Vendoring, and the cost of it

Vectors are vendored rather than fetched, so the suite is hermetic and works offline — the arrangement `ori-edge-firmware` already uses for Layer 1. The cost is invisible drift, so there are two guards: a manifest of digests catching a local edit, and `scripts/refresh-evidence-vectors.sh` catching upstream divergence, wired into CI on the 3.12 leg.

The script reports rather than overwrites, because a vector change is a contract change and should be read. Apply mode reconciles the whole set, so a vector removed upstream is deleted rather than lingering and re-reporting drift forever.

## What this does not establish

Cross-language agreement. These vectors were generated in Python and this reconstruction is Python, so it shows the derivations are reproducible, not that a Rust or C implementation reaches the same bytes. That remains open under ori-platform/ori-verity#39, and `evidence/v2` stays a design target until it lands. The module docstring says so, so 22 green tests are not read as more than they are.

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime code and no capability change. The evidence capability is unchanged; this adds conformance fixtures for a format the runtime does not yet produce.

### If this touches `/ori/` (core runtime)

No runtime code is touched.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Groundwork for #326.

## Testing notes

Full suite: 3490 passed, 27 skipped. Ruff clean. Shell syntax clean.

Mutation-checked, each failing its intended assertion:

| Mutation | Fails |
|---|---|
| Re-introduce the rule 5 impurity | purity assertion |
| Published envelope disagrees with its signed bytes | canonical-byte reconstruction |
| Nested out-of-zone float in an accepted case | recursive refusal |
| Mislabel the non-string-key violation | declared-violation match |
| Edit a vendored vector locally | manifest digests |
| Upstream removes a vector | refresh script, and apply mode converges |
