### PR TITLE
feat(evidence): produce chain rows natively, per evidence/v2

### DIFF
--- a/ori/security/evidence_canonical.py
+++ b/ori/security/evidence_canonical.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical JSON for the evidence chain, per `ori-specs/evidence/v2`.
+
+Bytes are the signing contract. Two implementations that disagree on how a
+value serialises produce signatures that verify on one side and not the other,
+so this module refuses anything outside the range where the platform's
+serialisers provably agree rather than emitting bytes a verifier cannot
+reproduce.
+
+That range is the D-011 agreement zone, already normative for Layer 1 in
+`ori-specs/firmware-telemetry/v1.md` and implemented in C, Rust and Python.
+Layer 1 and Layer 2 canonicalise identically, which is what lets a firmware
+signer be cross-checked against a Layer 2 vector at all.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from typing import Any
+
+# 2^53 - 1. Above this an integer is not exactly representable as a double,
+# and a consumer that parses JSON numbers as doubles would read a different
+# value than the one signed.
+INTEGER_MAX = 9007199254740991
+
+# Where CPython and serde_json provably emit identical fixed-notation bytes.
+# Outside it they diverge on exponent form: 0.00001 against 1e-05.
+FLOAT_MIN_MAGNITUDE = 1e-4
+FLOAT_MAX_MAGNITUDE = 1e16
+
+
+class CanonicalisationError(ValueError):
+    """A value cannot be canonicalised into bytes every verifier reproduces."""
+
+
+def _reject(value: Any, path: str) -> None:
+    """Walk the whole value. Canonicalisation is recursive, so this must be.
+
+    A top-level-only check accepts ``{"a": [1e-5]}`` and then emits bytes no
+    other implementation reproduces, which is the failure the zone prevents.
+    """
+    if isinstance(value, bool) or value is None:
+        return
+    if isinstance(value, int):
+        if abs(value) > INTEGER_MAX:
+            raise CanonicalisationError(
+                f"{path}: integer magnitude exceeds 2^53-1 and is not exactly "
+                "representable by a double-precision consumer"
+            )
+        return
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise CanonicalisationError(f"{path}: NaN and infinities have no JSON form")
+        magnitude = abs(value)
+        if magnitude != 0.0 and not (
+            FLOAT_MIN_MAGNITUDE <= magnitude < FLOAT_MAX_MAGNITUDE
+        ):
+            raise CanonicalisationError(
+                f"{path}: float outside the cross-language agreement zone; "
+                "serialisers disagree on exponent notation here"
+            )
+        return
+    if isinstance(value, str):
+        return
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if not isinstance(key, str):
+                raise CanonicalisationError(
+                    f"{path}: object keys must be strings; sorting a mixed-type "
+                    "key set is undefined"
+                )
+            _reject(nested, f"{path}.{key}")
+        return
+    if isinstance(value, (list, tuple)):
+        for index, nested in enumerate(value):
+            _reject(nested, f"{path}[{index}]")
+        return
+    raise CanonicalisationError(f"{path}: {type(value).__name__} has no canonical form")
+
+
+def canonical_json(value: Any) -> bytes:
+    """The exact bytes a chain row is signed and hashed over.
+
+    ``sort_keys`` sorts recursively, which is the property this relies on.
+    Duplicate keys cannot arise here because the input is already a mapping;
+    they are a parsing concern for whoever reads the bytes back.
+    """
+    _reject(value, "$")
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")

--- a/ori/security/evidence_chain.py
+++ b/ori/security/evidence_chain.py
@@ -1,0 +1,326 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The runtime's own evidence chain, per `ori-specs/evidence/v2`.
+
+The runtime produces hash-chained, device-signed rows locally. It does not
+implement an authoritative store: cross-device ordering, receipt issuance, gap
+analysis and insurer-facing retention belong to the off-device authority, and
+reimplementing them here would put the record inside the site whose conduct it
+constrains.
+
+What the device can prove is chain integrity, not chain completeness. A
+device-local attacker can destroy or roll back this file. Completeness rests on
+delivery and checkpointing, not on this table.
+
+Naming follows the contract's rule for operator-reachable components: tables
+describe what they hold. A schema created on the device is as visible as a log
+line — a `.tables` listing, a schema dump, or a trigger named in an integrity
+error all reach whoever holds the device.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import uuid
+from pathlib import Path
+from typing import Any
+
+from ori.security.evidence_canonical import canonical_json
+from ori.security.evidence_device_key import EvidenceDeviceKey
+
+SCHEMA_VERSION = "ori.evidence.v2"
+GENESIS_PREIMAGE = b"ori.evidence.genesis.v2"
+GENESIS_PREV_EVENT_HASH = hashlib.sha256(GENESIS_PREIMAGE).hexdigest()
+
+EVENT_ID_NAMESPACE = uuid.uuid5(
+    uuid.NAMESPACE_URL, "https://oriplatform.dev/specs/evidence/v2/event-id"
+)
+
+EVENT_TYPES = frozenset(
+    {
+        "UPTIME_HEARTBEAT",
+        "OUTAGE_STARTED",
+        "OUTAGE_RESOLVED",
+        "DISPLACEMENT_RECORD",
+        "MAINTENANCE_PERFORMED",
+        "REVENUE_COLLECTED",
+        "UTILISATION_RECORD",
+        "KEY_ROTATION",
+        "SAFETY_ACTION_EXECUTED",
+    }
+)
+
+# Only `exported` and `exported_at_ms` may change after a row is written. The
+# triggers below enforce that in the database rather than by convention: an
+# invariant that holds only because application code remembers to honour it is
+# not an invariant, and this one is what makes a row's history meaningful.
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS evidence_chain (
+    seq             INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id        TEXT    NOT NULL UNIQUE,
+    event_type      TEXT    NOT NULL,
+    device_id       TEXT    NOT NULL,
+    emitted_at_ms   INTEGER NOT NULL,
+    payload_json    TEXT    NOT NULL,
+    canonical_json  TEXT    NOT NULL,
+    event_hash      TEXT    NOT NULL,
+    prev_event_hash TEXT    NOT NULL,
+    signature       TEXT    NOT NULL,
+    exported        INTEGER NOT NULL DEFAULT 0,
+    exported_at_ms  INTEGER,
+    created_at_ms   INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_evidence_chain_exported
+    ON evidence_chain (exported, seq);
+CREATE INDEX IF NOT EXISTS idx_evidence_chain_device
+    ON evidence_chain (device_id, seq);
+
+CREATE TRIGGER IF NOT EXISTS evidence_chain_no_delete
+BEFORE DELETE ON evidence_chain
+BEGIN
+    SELECT RAISE(ABORT, 'evidence chain rows are immutable');
+END;
+
+CREATE TRIGGER IF NOT EXISTS evidence_chain_no_signed_update
+BEFORE UPDATE ON evidence_chain
+WHEN OLD.event_id        IS NOT NEW.event_id
+  OR OLD.event_type      IS NOT NEW.event_type
+  OR OLD.device_id       IS NOT NEW.device_id
+  OR OLD.emitted_at_ms   IS NOT NEW.emitted_at_ms
+  OR OLD.payload_json    IS NOT NEW.payload_json
+  OR OLD.canonical_json  IS NOT NEW.canonical_json
+  OR OLD.event_hash      IS NOT NEW.event_hash
+  OR OLD.prev_event_hash IS NOT NEW.prev_event_hash
+  OR OLD.signature       IS NOT NEW.signature
+  OR OLD.created_at_ms   IS NOT NEW.created_at_ms
+BEGIN
+    SELECT RAISE(ABORT, 'signed evidence columns are immutable');
+END;
+"""
+
+SIGNED_COLUMNS = (
+    "seq",
+    "event_id",
+    "event_type",
+    "device_id",
+    "emitted_at_ms",
+    "payload_json",
+    "canonical_json",
+    "event_hash",
+    "prev_event_hash",
+    "signature",
+    "created_at_ms",
+)
+
+
+class EvidenceChainError(RuntimeError):
+    """The chain could not be opened, appended to, or trusted."""
+
+
+def attestation_event_id(device_id: str, action_log_id: int) -> str:
+    """Deterministic idempotency key for one action_log row.
+
+    A retry after a crash reproduces this identity, so an append that
+    succeeded but whose status update was lost cannot double-attest.
+    """
+    return str(
+        uuid.uuid5(EVENT_ID_NAMESPACE, f"{device_id}:action_log:{int(action_log_id)}")
+    )
+
+
+class EvidenceChain:
+    """Append-only, hash-chained, device-signed rows."""
+
+    def __init__(self, db_path: str | Path, device_key: EvidenceDeviceKey) -> None:
+        self._db_path = str(db_path)
+        self._key = device_key
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(self._db_path, isolation_level=None)
+        self._connection.row_factory = sqlite3.Row
+        self._connection.execute("PRAGMA journal_mode=WAL")
+        # Durability matters more than throughput here: a row acknowledged as
+        # signed and then lost to a power cut is worse than a slower append,
+        # because the action it attests already happened.
+        self._connection.execute("PRAGMA synchronous=FULL")
+        self._connection.execute("PRAGMA foreign_keys=ON")
+        self._connection.executescript(_SCHEMA)
+
+    @property
+    def public_key_hex(self) -> str:
+        return self._key.public_key_hex
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def head(self) -> tuple[int, str]:
+        """The current (seq, event_hash). Genesis when the chain is empty."""
+        row = self._connection.execute(
+            "SELECT seq, event_hash FROM evidence_chain ORDER BY seq DESC LIMIT 1"
+        ).fetchone()
+        if row is None:
+            return 0, GENESIS_PREV_EVENT_HASH
+        return int(row["seq"]), str(row["event_hash"])
+
+    def find_by_event_id(self, event_id: str) -> sqlite3.Row | None:
+        return self._connection.execute(
+            "SELECT * FROM evidence_chain WHERE event_id = ?", (event_id,)
+        ).fetchone()
+
+    def append(
+        self,
+        *,
+        event_id: str,
+        event_type: str,
+        device_id: str,
+        emitted_at_ms: int,
+        payload: dict[str, Any],
+        created_at_ms: int,
+    ) -> sqlite3.Row:
+        """Sign and append one event. Idempotent on ``event_id``.
+
+        The whole append is one transaction: the sequence is read, the row is
+        signed against that head, and the row is written, with nothing able to
+        interleave. Reading the head outside the transaction would let two
+        concurrent appends sign against the same predecessor and produce a
+        forked chain that verifies row by row and is wrong as a whole.
+        """
+        if not event_id:
+            raise EvidenceChainError("event_id must be a non-empty idempotency key")
+        if event_type not in EVENT_TYPES:
+            raise EvidenceChainError(f"{event_type!r} is not an evidence event type")
+
+        existing = self.find_by_event_id(event_id)
+        if existing is not None:
+            return existing
+
+        try:
+            self._connection.execute("BEGIN IMMEDIATE")
+        except sqlite3.Error as exc:
+            raise EvidenceChainError("could not begin an evidence append") from exc
+        try:
+            # Re-check inside the transaction: another writer may have appended
+            # this same event between the lookup above and the lock.
+            existing = self.find_by_event_id(event_id)
+            if existing is not None:
+                self._connection.execute("ROLLBACK")
+                return existing
+
+            previous_seq, previous_hash = self.head()
+            sequence_num = previous_seq + 1
+            envelope = {
+                "device_id": device_id,
+                "emitted_at_ms": int(emitted_at_ms),
+                "event_id": event_id,
+                "event_type": event_type,
+                "payload": payload,
+                "prev_event_hash": previous_hash,
+                "schema_version": SCHEMA_VERSION,
+                "sequence_num": sequence_num,
+            }
+            signed_bytes = canonical_json(envelope)
+            event_hash = hashlib.sha256(signed_bytes).hexdigest()
+            signature = "ed25519:" + _b64(self._key.sign(signed_bytes))
+
+            self._connection.execute(
+                """
+                INSERT INTO evidence_chain (
+                    seq, event_id, event_type, device_id, emitted_at_ms,
+                    payload_json, canonical_json, event_hash, prev_event_hash,
+                    signature, exported, exported_at_ms, created_at_ms
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?)
+                """,
+                (
+                    sequence_num,
+                    event_id,
+                    event_type,
+                    device_id,
+                    int(emitted_at_ms),
+                    canonical_json(payload).decode("utf-8"),
+                    signed_bytes.decode("utf-8"),
+                    event_hash,
+                    previous_hash,
+                    signature,
+                    int(created_at_ms),
+                ),
+            )
+            self._connection.execute("COMMIT")
+        except BaseException:
+            self._connection.execute("ROLLBACK")
+            raise
+        row = self.find_by_event_id(event_id)
+        if row is None:  # pragma: no cover - the insert committed
+            raise EvidenceChainError("the appended row could not be read back")
+        return row
+
+    def mark_exported(self, seq: int, exported_at_ms: int) -> None:
+        """The only mutation the schema permits."""
+        self._connection.execute(
+            "UPDATE evidence_chain SET exported = 1, exported_at_ms = ? WHERE seq = ?",
+            (int(exported_at_ms), int(seq)),
+        )
+
+    def verify_chain(self) -> list[str]:
+        """Walk the chain and report every row that fails a contract rule.
+
+        Reports rather than raises, and names the rule rather than saying a row
+        is bad: a caller needs to know whether the chain was tampered with, was
+        written by another key, or simply has a hash it cannot reproduce.
+        """
+        problems: list[str] = []
+        expected_seq = 1
+        expected_prev = GENESIS_PREV_EVENT_HASH
+        for row in self._connection.execute(
+            "SELECT * FROM evidence_chain ORDER BY seq"
+        ):
+            seq = int(row["seq"])
+            signed_bytes = str(row["canonical_json"]).encode("utf-8")
+            if seq != expected_seq:
+                problems.append(f"seq {seq}: not the expected successor {expected_seq}")
+            if str(row["prev_event_hash"]) != expected_prev:
+                problems.append(f"seq {seq}: prev_event_hash does not chain")
+            if hashlib.sha256(signed_bytes).hexdigest() != str(row["event_hash"]):
+                problems.append(f"seq {seq}: event_hash disagrees with canonical_json")
+            try:
+                self._key.verify(_unb64(str(row["signature"])), signed_bytes)
+            except Exception:
+                problems.append(
+                    f"seq {seq}: signature does not verify under the device key"
+                )
+            envelope = json.loads(signed_bytes)
+            if envelope.get("schema_version") != SCHEMA_VERSION:
+                problems.append(f"seq {seq}: schema_version is not {SCHEMA_VERSION}")
+            for field, column in (
+                ("sequence_num", "seq"),
+                ("prev_event_hash", "prev_event_hash"),
+                ("event_id", "event_id"),
+                ("event_type", "event_type"),
+                ("device_id", "device_id"),
+                ("emitted_at_ms", "emitted_at_ms"),
+            ):
+                if envelope.get(field) != row[column]:
+                    problems.append(
+                        f"seq {seq}: column {column} disagrees with the envelope"
+                    )
+            if json.loads(str(row["payload_json"])) != envelope.get("payload"):
+                problems.append(
+                    f"seq {seq}: payload_json disagrees with the envelope payload"
+                )
+            expected_seq = seq + 1
+            expected_prev = str(row["event_hash"])
+        return problems
+
+
+def _b64(raw: bytes) -> str:
+    import base64
+
+    return base64.b64encode(raw).decode("ascii")
+
+
+def _unb64(wire: str) -> bytes:
+    import base64
+
+    return base64.b64decode(wire.split("ed25519:", 1)[-1])

--- a/ori/security/evidence_chain.py
+++ b/ori/security/evidence_chain.py
@@ -87,7 +87,8 @@ END;
 
 CREATE TRIGGER IF NOT EXISTS evidence_chain_no_signed_update
 BEFORE UPDATE ON evidence_chain
-WHEN OLD.event_id        IS NOT NEW.event_id
+WHEN OLD.seq             IS NOT NEW.seq
+  OR OLD.event_id        IS NOT NEW.event_id
   OR OLD.event_type      IS NOT NEW.event_type
   OR OLD.device_id       IS NOT NEW.device_id
   OR OLD.emitted_at_ms   IS NOT NEW.emitted_at_ms
@@ -101,6 +102,22 @@ BEGIN
     SELECT RAISE(ABORT, 'signed evidence columns are immutable');
 END;
 """
+
+# The eight fields evidence/v2 defines. A row carrying more or fewer is
+# reported rather than tolerated: an unknown field would be covered by the
+# signature while meaning nothing to a verifier.
+ENVELOPE_FIELDS = frozenset(
+    {
+        "device_id",
+        "emitted_at_ms",
+        "event_id",
+        "event_type",
+        "payload",
+        "prev_event_hash",
+        "schema_version",
+        "sequence_num",
+    }
+)
 
 SIGNED_COLUMNS = (
     "seq",
@@ -135,9 +152,14 @@ def attestation_event_id(device_id: str, action_log_id: int) -> str:
 class EvidenceChain:
     """Append-only, hash-chained, device-signed rows."""
 
-    def __init__(self, db_path: str | Path, device_key: EvidenceDeviceKey) -> None:
+    def __init__(
+        self, db_path: str | Path, device_key: EvidenceDeviceKey, device_id: str
+    ) -> None:
+        if not device_id:
+            raise EvidenceChainError("a chain must be bound to a device identity")
         self._db_path = str(db_path)
         self._key = device_key
+        self._device_id = str(device_id)
         Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
         self._connection = sqlite3.connect(self._db_path, isolation_level=None)
         self._connection.row_factory = sqlite3.Row
@@ -148,6 +170,31 @@ class EvidenceChain:
         self._connection.execute("PRAGMA synchronous=FULL")
         self._connection.execute("PRAGMA foreign_keys=ON")
         self._connection.executescript(_SCHEMA)
+        self._assert_single_device()
+
+    def _assert_single_device(self) -> None:
+        """One key, one device, one chain.
+
+        A key that can sign rows for several device identities makes
+        same-device attribution something the producer hopes callers preserve
+        rather than something it enforces, and a verifier resolving a row's
+        signature "to a key registered for that same device identity" would be
+        checking a property the producer never guaranteed. Reopening a chain
+        under a different identity is refused for the same reason.
+        """
+        rows = self._connection.execute(
+            "SELECT DISTINCT device_id FROM evidence_chain"
+        ).fetchall()
+        foreign = sorted({str(row["device_id"]) for row in rows} - {self._device_id})
+        if foreign:
+            raise EvidenceChainError(
+                f"this chain holds rows for {len(foreign)} other device "
+                f"identities; it is bound to {self._device_id!r}"
+            )
+
+    @property
+    def device_id(self) -> str:
+        return self._device_id
 
     @property
     def public_key_hex(self) -> str:
@@ -166,16 +213,53 @@ class EvidenceChain:
         return int(row["seq"]), str(row["event_hash"])
 
     def find_by_event_id(self, event_id: str) -> sqlite3.Row | None:
-        return self._connection.execute(
+        row: sqlite3.Row | None = self._connection.execute(
             "SELECT * FROM evidence_chain WHERE event_id = ?", (event_id,)
         ).fetchone()
+        return row
+
+    @staticmethod
+    def _reconcile_replay(
+        existing: sqlite3.Row, intent: tuple[str, str, int, bytes]
+    ) -> sqlite3.Row:
+        """Return the existing row only when the replay means the same thing.
+
+        Idempotency is "same identity, same intended content". Returning the
+        stored row for a request that differs would report success for
+        evidence that was never recorded — the caller believes its event is
+        attested, and something else is. A deterministic identity colliding
+        with different content is a defect upstream, and it has to surface.
+        """
+        event_type, device_id, emitted_at_ms, payload_bytes = intent
+        stored = (
+            str(existing["event_type"]),
+            str(existing["device_id"]),
+            int(existing["emitted_at_ms"]),
+            str(existing["payload_json"]).encode("utf-8"),
+        )
+        if stored == (event_type, device_id, emitted_at_ms, payload_bytes):
+            return existing
+        differing = [
+            name
+            for name, was, now in zip(
+                ("event_type", "device_id", "emitted_at_ms", "payload"),
+                stored,
+                intent,
+                strict=True,
+            )
+            if was != now
+        ]
+        raise EvidenceChainError(
+            f"event_id {existing['event_id']} is already attested with different "
+            f"content ({', '.join(differing)}); the same identity must mean the "
+            "same event"
+        )
 
     def append(
         self,
         *,
         event_id: str,
         event_type: str,
-        device_id: str,
         emitted_at_ms: int,
         payload: dict[str, Any],
         created_at_ms: int,
@@ -193,9 +277,13 @@ class EvidenceChain:
         if event_type not in EVENT_TYPES:
             raise EvidenceChainError(f"{event_type!r} is not an evidence event type")
 
+        device_id = self._device_id
+        payload_bytes = canonical_json(payload)
+        intent = (event_type, device_id, int(emitted_at_ms), payload_bytes)
+
         existing = self.find_by_event_id(event_id)
         if existing is not None:
-            return existing
+            return self._reconcile_replay(existing, intent)
 
         try:
             self._connection.execute("BEGIN IMMEDIATE")
@@ -207,7 +295,7 @@ class EvidenceChain:
             existing = self.find_by_event_id(event_id)
             if existing is not None:
                 self._connection.execute("ROLLBACK")
-                return existing
+                return self._reconcile_replay(existing, intent)
 
             previous_seq, previous_hash = self.head()
             sequence_num = previous_seq + 1
@@ -239,7 +327,7 @@ class EvidenceChain:
                     event_type,
                     device_id,
                     int(emitted_at_ms),
-                    canonical_json(payload).decode("utf-8"),
+                    payload_bytes.decode("utf-8"),
                     signed_bytes.decode("utf-8"),
                     event_hash,
                     previous_hash,
@@ -290,7 +378,30 @@ class EvidenceChain:
                 problems.append(
                     f"seq {seq}: signature does not verify under the device key"
                 )
-            envelope = json.loads(signed_bytes)
+            try:
+                envelope = json.loads(signed_bytes)
+            except ValueError:
+                # A row whose stored bytes will not parse cannot be evaluated
+                # against the remaining rules, and raising would abandon the
+                # walk — leaving every later row unexamined because one is
+                # corrupt. Report it and carry on.
+                problems.append(f"seq {seq}: canonical_json is not parseable JSON")
+                expected_seq = seq + 1
+                expected_prev = str(row["event_hash"])
+                continue
+            if not isinstance(envelope, dict):
+                problems.append(f"seq {seq}: canonical_json is not a JSON object")
+                expected_seq = seq + 1
+                expected_prev = str(row["event_hash"])
+                continue
+            undefined = sorted(set(envelope) - ENVELOPE_FIELDS)
+            absent = sorted(ENVELOPE_FIELDS - set(envelope))
+            if undefined:
+                problems.append(
+                    f"seq {seq}: envelope carries undefined fields {undefined}"
+                )
+            if absent:
+                problems.append(f"seq {seq}: envelope is missing fields {absent}")
             if envelope.get("schema_version") != SCHEMA_VERSION:
                 problems.append(f"seq {seq}: schema_version is not {SCHEMA_VERSION}")
             for field, column in (
@@ -305,10 +416,15 @@ class EvidenceChain:
                     problems.append(
                         f"seq {seq}: column {column} disagrees with the envelope"
                     )
-            if json.loads(str(row["payload_json"])) != envelope.get("payload"):
-                problems.append(
-                    f"seq {seq}: payload_json disagrees with the envelope payload"
-                )
+            try:
+                stored_payload = json.loads(str(row["payload_json"]))
+            except ValueError:
+                problems.append(f"seq {seq}: payload_json is not parseable JSON")
+            else:
+                if stored_payload != envelope.get("payload"):
+                    problems.append(
+                        f"seq {seq}: payload_json disagrees with the envelope payload"
+                    )
             expected_seq = seq + 1
             expected_prev = str(row["event_hash"])
         return problems

--- a/ori/security/evidence_device_key.py
+++ b/ori/security/evidence_device_key.py
@@ -83,6 +83,7 @@ class EvidenceDeviceKey:
             )
         path = Path(key_path)
         if path.exists():
+            cls._assert_key_file_is_protected(path)
             return cls(cls._unseal(path.read_bytes(), device_secret))
 
         private = Ed25519PrivateKey.generate()
@@ -99,10 +100,53 @@ class EvidenceDeviceKey:
                 handle.flush()
                 os.fsync(handle.fileno())
             os.replace(temporary, path)
+            # fsync the directory as well as the file. Without this the rename
+            # itself can be lost to a power cut while the chain that key signs
+            # survives, stranding a chain whose signing key no longer exists —
+            # every row in it unverifiable and unextendable.
+            cls._fsync_directory(path.parent)
         except BaseException:
             temporary.unlink(missing_ok=True)
             raise
         return cls(private)
+
+    @staticmethod
+    def _fsync_directory(directory: Path) -> None:
+        try:
+            descriptor = os.open(directory, os.O_RDONLY)
+        except OSError:
+            # Some platforms refuse to open a directory for reading. The
+            # rename is still durable on any filesystem this runtime supports;
+            # this is belt to that braces, and must not fail provisioning.
+            return
+        try:
+            os.fsync(descriptor)
+        except OSError:
+            pass
+        finally:
+            os.close(descriptor)
+
+    @staticmethod
+    def _assert_key_file_is_protected(path: Path) -> None:
+        """A key readable by other accounts is not sealed in any useful sense.
+
+        The seal defends against someone holding the file without the secret.
+        It does not defend against a local account that can read both, so a
+        permissive key file is refused rather than used — quietly widening
+        access is how a device ends up signing evidence with a key several
+        accounts can copy.
+        """
+        info = path.stat()
+        if info.st_mode & 0o077:
+            raise DeviceKeyError(
+                f"the evidence key at {path} is readable or writable by other "
+                f"accounts (mode {info.st_mode & 0o777:04o}); it must be 0600"
+            )
+        if hasattr(os, "geteuid") and info.st_uid != os.geteuid():
+            raise DeviceKeyError(
+                f"the evidence key at {path} is owned by another account; the "
+                "runtime must own the key it signs with"
+            )
 
     @staticmethod
     def _seal(seed: bytes, device_secret: str) -> bytes:

--- a/ori/security/evidence_device_key.py
+++ b/ori/security/evidence_device_key.py
@@ -112,17 +112,33 @@ class EvidenceDeviceKey:
 
     @staticmethod
     def _fsync_directory(directory: Path) -> None:
+        """Make the rename durable, and fail loudly when it cannot be.
+
+        An earlier version swallowed both the open and the fsync. That left the
+        original risk in place — a power cut losing the rename and stranding a
+        chain whose signing key no longer exists — while reporting provisioning
+        as successful, which is worse than not trying: the comment claimed a
+        guarantee the code did not provide.
+
+        Failing here is recoverable. The sealed key is already written and
+        renamed, so a restart finds it; what is not established is that the
+        rename survives a power loss, and a caller told provisioning succeeded
+        would never know to check.
+        """
+        flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
         try:
-            descriptor = os.open(directory, os.O_RDONLY)
-        except OSError:
-            # Some platforms refuse to open a directory for reading. The
-            # rename is still durable on any filesystem this runtime supports;
-            # this is belt to that braces, and must not fail provisioning.
-            return
+            descriptor = os.open(directory, flags)
+        except OSError as exc:
+            raise DeviceKeyError(
+                f"could not open {directory} to make the evidence key durable"
+            ) from exc
         try:
             os.fsync(descriptor)
-        except OSError:
-            pass
+        except OSError as exc:
+            raise DeviceKeyError(
+                f"could not flush {directory}; the evidence key rename is not "
+                "known to have reached disk"
+            ) from exc
         finally:
             os.close(descriptor)
 

--- a/ori/security/evidence_device_key.py
+++ b/ori/security/evidence_device_key.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The device's Ed25519 evidence key, sealed at rest.
+
+The key is what makes a chain row attributable to this device. It is generated
+once, at first start, and sealed with a per-install secret so that reading the
+key file alone does not yield a signing key — an attacker needs the file and
+the environment secret, which live in different places.
+
+The public half is this device's verification anchor. It is the device's own
+property and is reported in health; the private half never leaves this module.
+"""
+
+from __future__ import annotations
+
+import os
+import secrets
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+_SEAL_SALT = b"ori.evidence.device_key.seal.v2"
+_SEAL_INFO = b"ori.evidence.device_key.aes256gcm.v2"
+_MAGIC = b"ORIEVK2\x00"
+_NONCE_BYTES = 12
+_SEED_BYTES = 32
+
+
+class DeviceKeyError(RuntimeError):
+    """The device key could not be provisioned, opened, or trusted."""
+
+
+def _derive_seal_key(device_secret: str) -> bytes:
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_SEAL_SALT,
+        info=_SEAL_INFO,
+    ).derive(device_secret.encode("utf-8"))
+
+
+class EvidenceDeviceKey:
+    """An Ed25519 signing key sealed on disk under a per-install secret."""
+
+    def __init__(self, private_key: Ed25519PrivateKey) -> None:
+        self._private = private_key
+        self._public: Ed25519PublicKey = private_key.public_key()
+
+    @property
+    def public_key_hex(self) -> str:
+        """This device's verification anchor."""
+        return self._public.public_bytes_raw().hex()
+
+    def sign(self, message: bytes) -> bytes:
+        return self._private.sign(message)
+
+    def verify(self, signature: bytes, message: bytes) -> None:
+        """Raises on mismatch. Used to prove a row this device wrote is its own."""
+        self._public.verify(signature, message)
+
+    @classmethod
+    def load_or_create(
+        cls, key_path: str | Path, device_secret: str
+    ) -> "EvidenceDeviceKey":
+        """Open the sealed key, provisioning one on first start.
+
+        A configured-but-empty secret fails loudly rather than sealing under a
+        predictable key: a seal whose secret is the empty string protects
+        nothing, and doing it silently would leave a device reporting healthy
+        evidence with an unsealed key.
+        """
+        if not device_secret:
+            raise DeviceKeyError(
+                "the evidence device secret is empty; a key sealed under an "
+                "empty secret is not sealed"
+            )
+        path = Path(key_path)
+        if path.exists():
+            return cls(cls._unseal(path.read_bytes(), device_secret))
+
+        private = Ed25519PrivateKey.generate()
+        sealed = cls._seal(private.private_bytes_raw(), device_secret)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Written 0600 before any content reaches the filesystem, and via a
+        # temporary file so a crash mid-write cannot leave a truncated key that
+        # would look openable and produce garbage signatures.
+        temporary = path.with_suffix(path.suffix + ".tmp")
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(descriptor, "wb") as handle:
+                handle.write(sealed)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary, path)
+        except BaseException:
+            temporary.unlink(missing_ok=True)
+            raise
+        return cls(private)
+
+    @staticmethod
+    def _seal(seed: bytes, device_secret: str) -> bytes:
+        nonce = secrets.token_bytes(_NONCE_BYTES)
+        ciphertext = AESGCM(_derive_seal_key(device_secret)).encrypt(
+            nonce, seed, _MAGIC
+        )
+        return _MAGIC + nonce + ciphertext
+
+    @staticmethod
+    def _unseal(blob: bytes, device_secret: str) -> Ed25519PrivateKey:
+        if not blob.startswith(_MAGIC):
+            raise DeviceKeyError("the evidence key file is not in the expected format")
+        body = blob[len(_MAGIC) :]
+        if len(body) <= _NONCE_BYTES:
+            raise DeviceKeyError("the evidence key file is truncated")
+        nonce, ciphertext = body[:_NONCE_BYTES], body[_NONCE_BYTES:]
+        try:
+            seed = AESGCM(_derive_seal_key(device_secret)).decrypt(
+                nonce, ciphertext, _MAGIC
+            )
+        except Exception as exc:
+            # Wrong secret and tampered file are indistinguishable here, and
+            # deliberately so: AES-GCM authenticates, and reporting which one
+            # failed would tell an attacker whether their secret was close.
+            raise DeviceKeyError(
+                "the evidence key could not be unsealed; the device secret is "
+                "wrong or the file has been altered"
+            ) from exc
+        if len(seed) != _SEED_BYTES:
+            raise DeviceKeyError("the unsealed evidence key is the wrong length")
+        return Ed25519PrivateKey.from_private_bytes(seed)

--- a/tests/test_evidence_chain_producer.py
+++ b/tests/test_evidence_chain_producer.py
@@ -1,0 +1,346 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The native chain producer, measured against `ori-specs/evidence/v2`.
+
+The vectors are the acceptance criteria: what the producer emits must be what
+the contract says, byte for byte, and the rules it must never break are the
+thirteen the contract enumerates. Tests here drive the producer and compare
+against those vectors rather than against the producer's own output.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import pathlib
+import sqlite3
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from ori.security.evidence_canonical import (
+    INTEGER_MAX,
+    CanonicalisationError,
+    canonical_json,
+)
+from ori.security.evidence_chain import (
+    GENESIS_PREV_EVENT_HASH,
+    SCHEMA_VERSION,
+    EvidenceChain,
+    EvidenceChainError,
+    attestation_event_id,
+)
+from ori.security.evidence_device_key import DeviceKeyError, EvidenceDeviceKey
+
+VECTORS = pathlib.Path(__file__).parent / "vectors" / "evidence_v2"
+DEVICE = "energy-monitor-ikeja-01"
+
+
+def load(name: str) -> dict:
+    return json.loads((VECTORS / name).read_text())
+
+
+@pytest.fixture
+def chain(tmp_path):
+    key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "install-secret")
+    produced = EvidenceChain(tmp_path / "chain.db", key)
+    yield produced
+    produced.close()
+
+
+def _append(produced, action_log_id: int, *, emitted: int = 1751500800000):
+    return produced.append(
+        event_id=attestation_event_id(DEVICE, action_log_id),
+        event_type="SAFETY_ACTION_EXECUTED",
+        device_id=DEVICE,
+        emitted_at_ms=emitted,
+        payload={
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": action_log_id,
+        },
+        created_at_ms=emitted + 40,
+    )
+
+
+# --------------------------------------------------------------------------
+# Agreement with the contract's own constants
+# --------------------------------------------------------------------------
+
+
+def test_genesis_matches_the_contract_vector():
+    assert GENESIS_PREV_EVENT_HASH == load("genesis.json")["genesis_prev_event_hash"]
+
+
+def test_event_ids_match_the_contract_vector():
+    vector = load("event-id.json")
+    for case in vector["cases"]:
+        assert (
+            attestation_event_id(case["device_id"], case["action_log_id"])
+            == case["event_id"]
+        )
+
+
+def test_canonical_form_matches_the_contract_vector():
+    for case in load("canonical-form.json")["accept_cases"]:
+        assert canonical_json(case["value"]).hex() == case["canonical_hex"], case[
+            "name"
+        ]
+
+
+# The contract's refusals divide by which side can actually enforce them, and
+# the division is not stated there. A producer serialises a native mapping, and
+# a native mapping cannot hold the same key twice — `{"a":1,"a":2}` has already
+# collapsed to `{"a": 2}` before the producer sees it. So the duplicate-key
+# rule binds whoever parses bytes back, never the producer, and asserting the
+# producer refuses it would be asserting something structurally impossible.
+PARSE_SIDE_VIOLATIONS = frozenset({"duplicate_key"})
+
+
+def test_the_producer_refuses_every_form_it_can_be_handed():
+    """The refusals are the producer's own, not a test-local reimplementation."""
+    checked = 0
+    for case in load("canonical-form.json")["reject_cases"]:
+        if case["violates"] in PARSE_SIDE_VIOLATIONS:
+            continue
+        if case["input_kind"] == "native_pairs":
+            value = {key: item for key, item in case["input_pairs"]}
+        else:
+            # NaN and the infinities have no JSON literal, so they are parsed
+            # with constants allowed and then handed to the producer, which is
+            # the component that must refuse them.
+            value = json.loads(
+                case["input_json"], parse_constant=lambda name: float(name)
+            )
+        with pytest.raises(CanonicalisationError):
+            canonical_json(value)
+        checked += 1
+    assert checked >= 6, "the producer-side refusals were not exercised"
+
+
+def test_duplicate_keys_are_a_parse_side_rule_the_producer_cannot_reach():
+    """Documented as a real division, not waved away as an exception.
+
+    Skipping this case silently would look identical to covering it, so the
+    reason it does not apply to the producer is asserted instead: the defect is
+    destroyed by parsing, which is exactly why a reader must catch it there.
+    """
+    case = next(
+        c
+        for c in load("canonical-form.json")["reject_cases"]
+        if c["violates"] == "duplicate_key"
+    )
+    collapsed = json.loads(case["input_json"])
+    assert collapsed == {"a": 2}, "the duplicate was not collapsed as expected"
+    # Having collapsed, it is an ordinary object the producer will accept.
+    assert canonical_json(collapsed) == b'{"a":2}'
+
+    # A reader must therefore detect it while parsing, before it is lost.
+    seen = []
+
+    def pairs_hook(pairs):
+        seen.append([key for key, _ in pairs])
+        return dict(pairs)
+
+    json.loads(case["input_json"], object_pairs_hook=pairs_hook)
+    assert seen and len(seen[0]) != len(set(seen[0])), (
+        "duplicate detection must happen during parsing"
+    )
+
+
+def test_nested_values_are_refused_too():
+    """Canonicalisation is recursive, so the refusal must be."""
+    with pytest.raises(CanonicalisationError):
+        canonical_json({"readings": [{"amps": 1e-5}]})
+    with pytest.raises(CanonicalisationError):
+        canonical_json({"a": {"b": [INTEGER_MAX + 1]}})
+
+
+# --------------------------------------------------------------------------
+# What the producer emits
+# --------------------------------------------------------------------------
+
+
+def test_first_row_chains_from_genesis_and_verifies(chain):
+    row = _append(chain, 1)
+    envelope = json.loads(row["canonical_json"])
+
+    assert envelope["prev_event_hash"] == GENESIS_PREV_EVENT_HASH
+    assert envelope["schema_version"] == SCHEMA_VERSION
+    assert envelope["sequence_num"] == 1
+    assert set(envelope) == {
+        "device_id",
+        "emitted_at_ms",
+        "event_id",
+        "event_type",
+        "payload",
+        "prev_event_hash",
+        "schema_version",
+        "sequence_num",
+    }
+    signed = row["canonical_json"].encode()
+    assert hashlib.sha256(signed).hexdigest() == row["event_hash"]
+    assert canonical_json(envelope) == signed
+
+
+def test_rows_chain_to_their_predecessor(chain):
+    first = _append(chain, 1)
+    second = _append(chain, 2)
+    assert second["prev_event_hash"] == first["event_hash"]
+    assert second["seq"] == first["seq"] + 1
+    assert chain.verify_chain() == []
+
+
+def test_a_produced_chain_breaks_no_contract_rule(chain):
+    """The whole point: nothing the producer emits violates the thirteen rules."""
+    for index in range(1, 6):
+        _append(chain, index, emitted=1751500800000 + index * 1000)
+    assert chain.verify_chain() == []
+
+
+def test_appending_is_idempotent_on_event_id(chain):
+    """A crash between append and status update must not double-attest."""
+    first = _append(chain, 7)
+    again = _append(chain, 7)
+    assert again["seq"] == first["seq"]
+    assert again["event_hash"] == first["event_hash"]
+    assert chain.head()[0] == 1
+
+
+def test_unknown_event_types_are_refused(chain):
+    with pytest.raises(EvidenceChainError):
+        chain.append(
+            event_id="e1",
+            event_type="NOT_A_PROTOCOL_EVENT",
+            device_id=DEVICE,
+            emitted_at_ms=1,
+            payload={},
+            created_at_ms=1,
+        )
+
+
+def test_an_unrepresentable_payload_is_refused_before_it_is_signed(chain):
+    """Signing bytes no verifier can reproduce would be worse than refusing."""
+    with pytest.raises(CanonicalisationError):
+        chain.append(
+            event_id="e2",
+            event_type="UPTIME_HEARTBEAT",
+            device_id=DEVICE,
+            emitted_at_ms=1,
+            payload={"drift": float("inf")},
+            created_at_ms=1,
+        )
+    assert chain.head() == (0, GENESIS_PREV_EVENT_HASH)
+
+
+# --------------------------------------------------------------------------
+# Immutability is the database's job
+# --------------------------------------------------------------------------
+
+
+def test_signed_columns_cannot_be_updated(chain):
+    """Enforced by trigger, not by application code remembering not to."""
+    _append(chain, 1)
+    connection = sqlite3.connect(chain._db_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute(
+            "UPDATE evidence_chain SET payload_json = '{}' WHERE seq = 1"
+        )
+    connection.close()
+
+
+def test_rows_cannot_be_deleted(chain):
+    _append(chain, 1)
+    connection = sqlite3.connect(chain._db_path)
+    with pytest.raises(sqlite3.IntegrityError):
+        connection.execute("DELETE FROM evidence_chain WHERE seq = 1")
+    connection.close()
+
+
+def test_export_bookkeeping_is_the_one_permitted_mutation(chain):
+    row = _append(chain, 1)
+    chain.mark_exported(row["seq"], 1751500999999)
+    updated = chain.find_by_event_id(row["event_id"])
+    assert updated["exported"] == 1
+    assert updated["exported_at_ms"] == 1751500999999
+    assert chain.verify_chain() == []
+
+
+def test_the_schema_names_nothing_after_the_authority(chain):
+    """Naming is scoped to what an operator can reach, and this runs on the device."""
+    connection = sqlite3.connect(chain._db_path)
+    names = [
+        str(name)
+        for (name,) in connection.execute(
+            "SELECT name FROM sqlite_master WHERE name IS NOT NULL"
+        )
+    ]
+    connection.close()
+    assert names, "no schema objects to inspect"
+    for name in names:
+        assert "verity" not in name.lower(), (
+            f"schema object names the authority: {name}"
+        )
+
+
+# --------------------------------------------------------------------------
+# The device key
+# --------------------------------------------------------------------------
+
+
+def test_the_key_survives_a_restart(tmp_path):
+    path = tmp_path / "device.key"
+    first = EvidenceDeviceKey.load_or_create(path, "secret")
+    second = EvidenceDeviceKey.load_or_create(path, "secret")
+    assert first.public_key_hex == second.public_key_hex
+
+
+def test_the_wrong_secret_cannot_open_the_key(tmp_path):
+    path = tmp_path / "device.key"
+    EvidenceDeviceKey.load_or_create(path, "secret")
+    with pytest.raises(DeviceKeyError):
+        EvidenceDeviceKey.load_or_create(path, "not-the-secret")
+
+
+def test_an_empty_secret_is_refused(tmp_path):
+    """A key sealed under an empty secret is not sealed."""
+    with pytest.raises(DeviceKeyError):
+        EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "")
+
+
+def test_the_key_file_is_not_the_raw_seed(tmp_path):
+    """Reading the file alone must not yield a signing key."""
+    path = tmp_path / "device.key"
+    key = EvidenceDeviceKey.load_or_create(path, "secret")
+    blob = path.read_bytes()
+    assert bytes.fromhex(key.public_key_hex) not in blob
+    for offset in range(0, max(1, len(blob) - 32)):
+        candidate = blob[offset : offset + 32]
+        if len(candidate) < 32:
+            break
+        derived = Ed25519PrivateKey.from_private_bytes(candidate)
+        assert derived.public_key().public_bytes_raw().hex() != key.public_key_hex
+
+
+def test_the_key_file_is_owner_only(tmp_path):
+    path = tmp_path / "device.key"
+    EvidenceDeviceKey.load_or_create(path, "secret")
+    assert path.stat().st_mode & 0o077 == 0
+
+
+def test_a_tampered_key_file_is_refused(tmp_path):
+    path = tmp_path / "device.key"
+    EvidenceDeviceKey.load_or_create(path, "secret")
+    blob = bytearray(path.read_bytes())
+    blob[-1] ^= 0xFF
+    path.write_bytes(bytes(blob))
+    with pytest.raises(DeviceKeyError):
+        EvidenceDeviceKey.load_or_create(path, "secret")
+
+
+def test_signatures_are_base64_under_the_wire_prefix(chain):
+    row = _append(chain, 1)
+    assert row["signature"].startswith("ed25519:")
+    assert len(base64.b64decode(row["signature"].split("ed25519:")[1])) == 64

--- a/tests/test_evidence_chain_producer.py
+++ b/tests/test_evidence_chain_producer.py
@@ -28,6 +28,7 @@ from ori.security.evidence_canonical import (
 from ori.security.evidence_chain import (
     GENESIS_PREV_EVENT_HASH,
     SCHEMA_VERSION,
+    SIGNED_COLUMNS,
     EvidenceChain,
     EvidenceChainError,
     attestation_event_id,
@@ -45,7 +46,7 @@ def load(name: str) -> dict:
 @pytest.fixture
 def chain(tmp_path):
     key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "install-secret")
-    produced = EvidenceChain(tmp_path / "chain.db", key)
+    produced = EvidenceChain(tmp_path / "chain.db", key, DEVICE)
     yield produced
     produced.close()
 
@@ -54,7 +55,6 @@ def _append(produced, action_log_id: int, *, emitted: int = 1751500800000):
     return produced.append(
         event_id=attestation_event_id(DEVICE, action_log_id),
         event_type="SAFETY_ACTION_EXECUTED",
-        device_id=DEVICE,
         emitted_at_ms=emitted,
         payload={
             "kind": "runtime_action",
@@ -214,7 +214,6 @@ def test_unknown_event_types_are_refused(chain):
         chain.append(
             event_id="e1",
             event_type="NOT_A_PROTOCOL_EVENT",
-            device_id=DEVICE,
             emitted_at_ms=1,
             payload={},
             created_at_ms=1,
@@ -227,7 +226,6 @@ def test_an_unrepresentable_payload_is_refused_before_it_is_signed(chain):
         chain.append(
             event_id="e2",
             event_type="UPTIME_HEARTBEAT",
-            device_id=DEVICE,
             emitted_at_ms=1,
             payload={"drift": float("inf")},
             created_at_ms=1,
@@ -240,15 +238,43 @@ def test_an_unrepresentable_payload_is_refused_before_it_is_signed(chain):
 # --------------------------------------------------------------------------
 
 
-def test_signed_columns_cannot_be_updated(chain):
+# One value per signed column that differs from what the producer writes.
+# Parametrised deliberately: an earlier version mutated only `payload_json`,
+# and the trigger was missing `seq` entirely — a column could be rewritten
+# while the test reported immutability enforced.
+COLUMN_MUTATIONS = {
+    "seq": 9,
+    "event_id": "a-different-identity",
+    "event_type": "UPTIME_HEARTBEAT",
+    "device_id": "some-other-device",
+    "emitted_at_ms": 1,
+    "payload_json": "{}",
+    "canonical_json": "{}",
+    "event_hash": "0" * 64,
+    "prev_event_hash": "0" * 64,
+    "signature": "ed25519:AA==",
+    "created_at_ms": 1,
+}
+
+
+def test_every_signed_column_is_covered_by_a_mutation():
+    """The table above must not drift behind the contract's column list."""
+    assert set(COLUMN_MUTATIONS) == set(SIGNED_COLUMNS)
+
+
+@pytest.mark.parametrize("column", sorted(COLUMN_MUTATIONS))
+def test_signed_columns_cannot_be_updated(chain, column):
     """Enforced by trigger, not by application code remembering not to."""
     _append(chain, 1)
     connection = sqlite3.connect(chain._db_path)
-    with pytest.raises(sqlite3.IntegrityError):
-        connection.execute(
-            "UPDATE evidence_chain SET payload_json = '{}' WHERE seq = 1"
-        )
-    connection.close()
+    try:
+        with pytest.raises(sqlite3.IntegrityError):
+            connection.execute(
+                f"UPDATE evidence_chain SET {column} = ? WHERE seq = 1",
+                (COLUMN_MUTATIONS[column],),
+            )
+    finally:
+        connection.close()
 
 
 def test_rows_cannot_be_deleted(chain):
@@ -344,3 +370,149 @@ def test_signatures_are_base64_under_the_wire_prefix(chain):
     row = _append(chain, 1)
     assert row["signature"].startswith("ed25519:")
     assert len(base64.b64decode(row["signature"].split("ed25519:")[1])) == 64
+
+
+# --------------------------------------------------------------------------
+# Idempotency means same identity AND same content
+# --------------------------------------------------------------------------
+
+
+def test_a_replay_with_different_content_is_a_conflict(chain):
+    """Returning the stored row would report success for evidence never recorded.
+
+    The caller believes its event is attested. Something else is. A
+    deterministic identity colliding with different content is a defect
+    upstream, and it has to surface rather than be absorbed.
+    """
+    event_id = attestation_event_id(DEVICE, 1)
+    _append(chain, 1)
+    with pytest.raises(EvidenceChainError, match="different content"):
+        chain.append(
+            event_id=event_id,
+            event_type="SAFETY_ACTION_EXECUTED",
+            emitted_at_ms=1751500800000,
+            payload={
+                "kind": "runtime_action",
+                "attestation": "at_emission",
+                "action_log_id": 999,
+            },
+            created_at_ms=1751500800040,
+        )
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("event_type", "UPTIME_HEARTBEAT"),
+        ("emitted_at_ms", 1751599999999),
+    ],
+)
+def test_each_component_of_intent_is_compared(chain, field, value):
+    event_id = attestation_event_id(DEVICE, 1)
+    _append(chain, 1)
+    request = {
+        "event_id": event_id,
+        "event_type": "SAFETY_ACTION_EXECUTED",
+        "emitted_at_ms": 1751500800000,
+        "payload": {
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": 1,
+        },
+        "created_at_ms": 1751500800040,
+    }
+    request[field] = value
+    with pytest.raises(EvidenceChainError, match="different content"):
+        chain.append(**request)
+
+
+def test_an_identical_replay_still_succeeds(chain):
+    """The conflict check must not break the property it guards."""
+    first = _append(chain, 1)
+    again = _append(chain, 1)
+    assert again["seq"] == first["seq"]
+    assert chain.head()[0] == 1
+
+
+# --------------------------------------------------------------------------
+# One key, one device, one chain
+# --------------------------------------------------------------------------
+
+
+def test_the_chain_signs_only_for_its_bound_device(chain):
+    """append() cannot be handed another identity, because it does not take one."""
+    row = _append(chain, 1)
+    assert row["device_id"] == DEVICE
+    assert json.loads(row["canonical_json"])["device_id"] == DEVICE
+
+
+def test_reopening_under_another_identity_is_refused(tmp_path):
+    """A key that signs for several devices makes attribution unenforceable."""
+    key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "secret")
+    first = EvidenceChain(tmp_path / "chain.db", key, DEVICE)
+    _append(first, 1)
+    first.close()
+
+    with pytest.raises(EvidenceChainError, match="other device identities"):
+        EvidenceChain(tmp_path / "chain.db", key, "a-different-device")
+
+
+def test_a_chain_requires_a_device_identity(tmp_path):
+    key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "secret")
+    with pytest.raises(EvidenceChainError):
+        EvidenceChain(tmp_path / "chain.db", key, "")
+
+
+# --------------------------------------------------------------------------
+# verify_chain reports rather than raises
+# --------------------------------------------------------------------------
+
+
+def test_verification_reports_a_corrupt_row_without_abandoning_the_walk(chain):
+    """Raising would leave every later row unexamined because one is corrupt."""
+    _append(chain, 1)
+    _append(chain, 2)
+    connection = sqlite3.connect(chain._db_path)
+    connection.execute("PRAGMA writable_schema=ON")
+    connection.execute(
+        "UPDATE sqlite_master SET sql = replace(sql, 'evidence_chain_no_signed_update',"
+        " 'disabled_trigger') WHERE name = 'evidence_chain_no_signed_update'"
+    )
+    connection.close()
+
+    direct = sqlite3.connect(chain._db_path)
+    direct.execute("PRAGMA writable_schema=OFF")
+    direct.close()
+
+    problems = chain.verify_chain()
+    assert isinstance(problems, list)
+
+
+def test_verification_flags_an_envelope_with_an_undefined_field(chain, tmp_path):
+    """Rule 13, which the first version of verify_chain did not implement."""
+    _append(chain, 1)
+    row = chain.find_by_event_id(attestation_event_id(DEVICE, 1))
+    envelope = json.loads(row["canonical_json"])
+    envelope["unexpected"] = True
+
+    forged = tmp_path / "forged.db"
+    source = sqlite3.connect(chain._db_path)
+    source.execute("VACUUM INTO ?", (str(forged),))
+    source.close()
+
+    connection = sqlite3.connect(forged)
+    connection.execute("DROP TRIGGER IF EXISTS evidence_chain_no_signed_update")
+    connection.execute(
+        "UPDATE evidence_chain SET canonical_json = ? WHERE seq = 1",
+        (json.dumps(envelope, sort_keys=True, separators=(",", ":")),),
+    )
+    connection.commit()
+    connection.close()
+
+    key = EvidenceDeviceKey.load_or_create(tmp_path.parent / "device.key", "secret")
+    reopened = EvidenceChain(forged, key, DEVICE)
+    try:
+        problems = reopened.verify_chain()
+        assert any("undefined fields" in problem for problem in problems), problems
+    finally:
+        reopened.close()

--- a/tests/test_evidence_chain_producer.py
+++ b/tests/test_evidence_chain_producer.py
@@ -468,24 +468,113 @@ def test_a_chain_requires_a_device_identity(tmp_path):
 # --------------------------------------------------------------------------
 
 
-def test_verification_reports_a_corrupt_row_without_abandoning_the_walk(chain):
-    """Raising would leave every later row unexamined because one is corrupt."""
-    _append(chain, 1)
-    _append(chain, 2)
-    connection = sqlite3.connect(chain._db_path)
-    connection.execute("PRAGMA writable_schema=ON")
-    connection.execute(
-        "UPDATE sqlite_master SET sql = replace(sql, 'evidence_chain_no_signed_update',"
-        " 'disabled_trigger') WHERE name = 'evidence_chain_no_signed_update'"
-    )
+def _forge(chain, tmp_path, name: str, mutations: list[tuple[int, str, object]]):
+    """A copy of the chain with the immutability trigger dropped and rows edited.
+
+    Tampering has to happen outside the producer, because the producer refuses
+    it — which is the point of the trigger. Verification must still describe
+    what it finds in a database someone else has altered.
+    """
+    forged = tmp_path / name
+    source = sqlite3.connect(chain._db_path)
+    source.execute("VACUUM INTO ?", (str(forged),))
+    source.close()
+
+    connection = sqlite3.connect(forged)
+    connection.execute("DROP TRIGGER IF EXISTS evidence_chain_no_signed_update")
+    for seq, column, value in mutations:
+        connection.execute(
+            f"UPDATE evidence_chain SET {column} = ? WHERE seq = ?", (value, seq)
+        )
+    connection.commit()
     connection.close()
 
-    direct = sqlite3.connect(chain._db_path)
-    direct.execute("PRAGMA writable_schema=OFF")
-    direct.close()
+    key = EvidenceDeviceKey.load_or_create(tmp_path / f"{name}.key", "secret")
+    return EvidenceChain(forged, key, DEVICE)
 
-    problems = chain.verify_chain()
-    assert isinstance(problems, list)
+
+def test_verification_reports_a_corrupt_row_without_abandoning_the_walk(
+    chain, tmp_path
+):
+    """An unparseable row must not hide the defects in every row after it.
+
+    Row 1 is made unparseable and row 2 is given a different, distinct defect.
+    Both must be reported: raising on the first would end the walk, and the
+    second finding is the evidence that it continued.
+    """
+    _append(chain, 1)
+    _append(chain, 2)
+    forged = _forge(
+        chain,
+        tmp_path,
+        "walk.db",
+        [(1, "canonical_json", "{not json at all"), (2, "event_hash", "0" * 64)],
+    )
+    try:
+        problems = forged.verify_chain()
+    finally:
+        forged.close()
+
+    assert any("seq 1" in p and "not parseable" in p for p in problems), problems
+    assert any("seq 2" in p and "event_hash" in p for p in problems), problems
+
+    # The rules that read the envelope must not run on a row whose bytes will
+    # not parse. Corrupting `canonical_json` legitimately breaks the hash and
+    # the signature too, so those findings are expected; what must not appear
+    # is a dozen derived complaints about fields that could never be read,
+    # which bury the one finding that explains the row.
+    first_row = [p for p in problems if p.startswith("seq 1:")]
+    derived = [p for p in first_row if "envelope" in p or "schema_version" in p]
+    assert not derived, f"envelope rules ran on an unparseable row: {derived}"
+    assert len(first_row) <= 3, f"corrupt row produced a cascade: {first_row}"
+
+
+def test_verification_reports_a_non_object_envelope(chain, tmp_path):
+    _append(chain, 1)
+    forged = _forge(chain, tmp_path, "notobject.db", [(1, "canonical_json", "[1,2,3]")])
+    try:
+        problems = forged.verify_chain()
+    finally:
+        forged.close()
+    assert any("not a JSON object" in p for p in problems), problems
+
+
+def test_verification_reports_an_unparseable_payload_column(chain, tmp_path):
+    """The payload column is stored separately and can rot on its own."""
+    _append(chain, 1)
+    forged = _forge(chain, tmp_path, "payload.db", [(1, "payload_json", "{broken")])
+    try:
+        problems = forged.verify_chain()
+    finally:
+        forged.close()
+    assert any("payload_json is not parseable" in p for p in problems), problems
+
+
+def test_verification_flags_an_envelope_missing_a_field(chain, tmp_path):
+    """The counterpart to the undefined-field case; the code handles both."""
+    _append(chain, 1)
+    row = chain.find_by_event_id(attestation_event_id(DEVICE, 1))
+    envelope = json.loads(row["canonical_json"])
+    envelope.pop("sequence_num")
+    forged = _forge(
+        chain,
+        tmp_path,
+        "missing.db",
+        [
+            (
+                1,
+                "canonical_json",
+                json.dumps(envelope, sort_keys=True, separators=(",", ":")),
+            )
+        ],
+    )
+    try:
+        problems = forged.verify_chain()
+    finally:
+        forged.close()
+    assert any("missing fields" in p and "sequence_num" in p for p in problems), (
+        problems
+    )
 
 
 def test_verification_flags_an_envelope_with_an_undefined_field(chain, tmp_path):
@@ -494,25 +583,20 @@ def test_verification_flags_an_envelope_with_an_undefined_field(chain, tmp_path)
     row = chain.find_by_event_id(attestation_event_id(DEVICE, 1))
     envelope = json.loads(row["canonical_json"])
     envelope["unexpected"] = True
-
-    forged = tmp_path / "forged.db"
-    source = sqlite3.connect(chain._db_path)
-    source.execute("VACUUM INTO ?", (str(forged),))
-    source.close()
-
-    connection = sqlite3.connect(forged)
-    connection.execute("DROP TRIGGER IF EXISTS evidence_chain_no_signed_update")
-    connection.execute(
-        "UPDATE evidence_chain SET canonical_json = ? WHERE seq = 1",
-        (json.dumps(envelope, sort_keys=True, separators=(",", ":")),),
+    forged = _forge(
+        chain,
+        tmp_path,
+        "undefined.db",
+        [
+            (
+                1,
+                "canonical_json",
+                json.dumps(envelope, sort_keys=True, separators=(",", ":")),
+            )
+        ],
     )
-    connection.commit()
-    connection.close()
-
-    key = EvidenceDeviceKey.load_or_create(tmp_path.parent / "device.key", "secret")
-    reopened = EvidenceChain(forged, key, DEVICE)
     try:
-        problems = reopened.verify_chain()
-        assert any("undefined fields" in problem for problem in problems), problems
+        problems = forged.verify_chain()
     finally:
-        reopened.close()
+        forged.close()
+    assert any("undefined fields" in p for p in problems), problems

--- a/tests/test_evidence_chain_producer.py
+++ b/tests/test_evidence_chain_producer.py
@@ -111,9 +111,7 @@ def test_the_producer_refuses_every_form_it_can_be_handed():
             # NaN and the infinities have no JSON literal, so they are parsed
             # with constants allowed and then handed to the producer, which is
             # the component that must refuse them.
-            value = json.loads(
-                case["input_json"], parse_constant=lambda name: float(name)
-            )
+            value = json.loads(case["input_json"], parse_constant=float)
         with pytest.raises(CanonicalisationError):
             canonical_json(value)
         checked += 1

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -571,6 +571,28 @@ def _supplied_denylist() -> list[str]:
     return [term.strip().lower() for term in raw.split(",") if term.strip()]
 
 
+# The runtime's own evidence modules, by exact path.
+#
+# `VENDORED_IMPLEMENTATION` matches names shaped like an evidence
+# implementation, and until the runtime produced chain rows itself, every such
+# name in the wheel was necessarily somebody else's implementation being
+# vendored in. That assumption ended with #326: the runtime is now a producer,
+# and a module describing what it holds is exactly what should be there.
+#
+# The check therefore becomes a closed registry rather than a blanket refusal.
+# A new evidence-implementation-shaped entry still fails — which is the part
+# worth keeping — until someone adds it here deliberately, and a vendored
+# third-party implementation never appears on this list because nobody would
+# add it.
+FIRST_PARTY_EVIDENCE_MODULES = frozenset(
+    {
+        "ori/security/evidence_chain.py",
+        "ori/security/evidence_canonical.py",
+        "ori/security/evidence_device_key.py",
+    }
+)
+
+
 VENDORED_IMPLEMENTATION = re.compile(
     r"(?:evidence|attest|ledger|chain)[-_]?(?:chain|store|db|impl|core)", re.IGNORECASE
 )
@@ -638,13 +660,29 @@ def test_the_built_wheel_carries_no_compiled_artifact(built_wheel):
     assert not compiled, f"compiled artifacts ship in the wheel: {compiled}"
 
 
-def test_the_built_wheel_names_no_evidence_implementation(built_wheel):
+def test_the_built_wheel_names_no_foreign_evidence_implementation(built_wheel):
+    """First-party evidence modules are expected; anything else is vendored."""
     offenders = [
         name
         for name in _wheel_names(built_wheel)
         if VENDORED_IMPLEMENTATION.search(name)
+        and name not in FIRST_PARTY_EVIDENCE_MODULES
     ]
-    assert not offenders, f"wheel entries name an evidence implementation: {offenders}"
+    assert not offenders, (
+        "wheel entries name an evidence implementation that is not a "
+        f"registered first-party module: {offenders}"
+    )
+
+
+def test_the_first_party_registry_is_not_stale(built_wheel):
+    """A registry naming files that no longer ship would silently widen itself.
+
+    Each entry suppresses a real check, so an entry that stopped corresponding
+    to anything is an exemption nobody is watching.
+    """
+    shipped = set(_wheel_names(built_wheel))
+    missing = sorted(FIRST_PARTY_EVIDENCE_MODULES - shipped)
+    assert not missing, f"registered first-party modules no longer ship: {missing}"
 
 
 def test_wheel_metadata_and_record_disclose_nothing_structural(built_wheel):
@@ -659,11 +697,15 @@ def test_wheel_metadata_and_record_disclose_nothing_structural(built_wheel):
     record = _wheel_record(built_wheel)
     assert record, "wheel has no RECORD to inspect"
     offenders = [
-        line.split(",")[0]
+        path
         for line in record.splitlines()
-        if line and VENDORED_IMPLEMENTATION.search(line.split(",")[0])
+        if line
+        and VENDORED_IMPLEMENTATION.search(path := line.split(",")[0])
+        and path not in FIRST_PARTY_EVIDENCE_MODULES
     ]
-    assert not offenders, f"wheel RECORD ships: {offenders}"
+    assert not offenders, (
+        f"wheel RECORD ships a foreign evidence implementation: {offenders}"
+    )
 
     metadata = _wheel_metadata(built_wheel)
     assert metadata, "wheel has no METADATA to inspect"


### PR DESCRIPTION
## What does this PR do?

The runtime signs and hash-chains its own evidence rows instead of driving a private compiled artifact. This is the first step of #326, and it is what the topology requires: the evidence authority runs as its own deployment off-device, so an in-process chain cannot be the thing that talks to it.

It is deliberately standalone. Nothing calls the producer yet, so it lands without touching the live evidence path. The delivery ledger, envelope and checkpoint sealing, ingest, and retiring the artifact loader are separate work.

## Three modules, one job each

**`evidence_canonical`** refuses anything it cannot serialise into bytes every verifier reproduces. Bytes are the signing contract, so a value outside the cross-language agreement zone is refused at source rather than signed — emitting a float two serialisers disagree about produces a signature that verifies on one side and not the other. The walk is recursive because canonicalisation is: a top-level-only check accepts an out-of-zone float nested in an array and then signs it.

**`evidence_device_key`** seals the Ed25519 key under a key derived from a per-install secret, so the file alone is not a signing key. A configured-but-empty secret fails loudly rather than sealing under a predictable key. Unsealing does not distinguish a wrong secret from a tampered file, because saying which would tell an attacker whether their guess was close. The key is written through a temporary file at 0600, and both the file and its directory are flushed — a lost rename would strand a chain whose signing key no longer exists, every row unverifiable and unextendable.

**`evidence_chain`** appends. Immutability is enforced by triggers, not by application code remembering: an invariant that holds only while every caller behaves is not an invariant, and this one is what makes a row's history mean anything. The head is read inside the transaction that writes the row, because reading it outside lets two concurrent appends sign against the same predecessor and fork a chain that verifies row by row and is wrong as a whole.

## What review caught

Three defects worth naming, because each let through something the contract assumes cannot happen.

**`seq` was not immutable.** Ten of eleven signed columns were covered by the trigger. The test that should have caught it mutated only `payload_json` — so a missing column looked exactly like enforced immutability. The test is now parametrised over every `SIGNED_COLUMNS` entry, with a guard asserting the mutation table has not drifted behind that list.

**A conflicting replay succeeded silently.** Any existing `event_id` was returned as success without checking the request matched it, so a caller could be told its event was attested when something else was. Event type, device, emission time and canonical payload are now compared, on both the pre-lock and in-transaction paths.

**One key could sign for several device identities.** That contradicts one runtime meaning one device, and makes same-device attribution — which a verifier is required to check — a property the producer merely hoped callers would preserve. A chain is constructed with its identity, `append()` no longer takes one, and reopening a database holding another device's rows is refused.

Also corrected: `verify_chain` did not implement rule 13; it raised on unparseable stored JSON despite promising to report findings, abandoning the walk and leaving later rows unexamined because one was corrupt; and an existing key file is now checked for ownership and mode, because a seal defends against someone holding the file without the secret, not against a local account that can read both.

## A contract rule that cannot bind a producer

A native mapping cannot hold a duplicate key — `{"a":1,"a":2}` has collapsed before the producer sees it — so that refusal binds whoever parses bytes back. Asserting the producer refuses it would assert something structurally impossible, and skipping it silently looks identical to covering it, so the division is asserted instead. Filed as ori-platform/ori-specs#85 to formalise which side each refusal binds.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

No capability changed: the producer is not wired to anything, so no runtime behaviour differs. The matrix entry changes when the ledger lands and the evidence path switches over.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `cryptography` and `sqlite3` are existing dependencies.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

First step of #326.

## Testing notes

Full suite: 3537 passed, 27 skipped. Strict mypy clean on all three modules. Ruff clean.

Tests drive the contract's vectors rather than the producer's own output, so the producer is measured against the specification and not against itself.

Mutation-checked, each failing its intended assertion:

| Mutation | Fails |
|---|---|
| Branded schema names | naming assertion |
| Wrong genesis preimage | contract-vector agreement |
| Bypass canonicalisation | canonical byte reconstruction |
| Remove both idempotency guards | idempotency, with the unique constraint as backstop |
| Restore the raise on unparseable JSON | continuation |
| Drop the `continue` | cascade assertion — that row yields twelve findings instead of three |
| Drop the missing-field check | missing-field case |
| Register a module that does not ship | stale-registry guard |

The three reported attacks were reproduced directly and are now refused: `UPDATE ... SET seq = 9`, a replay with another device and payload, and a second device identity on the same key.

## Note on the disclosure audit

Its implementation-naming check treated any evidence-chain-shaped name in the wheel as a vendored third-party implementation. That was true while the runtime had no chain of its own and stopped being true here. It is now a closed registry of first-party modules: a new evidence-shaped entry still fails until someone adds it deliberately, and an entry that stops corresponding to a shipped file fails too, because a stale exemption is one nobody is watching.
