### PR TITLE
test(evidence): read refusal ownership from the contract, not from input shape

### DIFF
--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -52,9 +52,27 @@ for file in "${DEST}"/*.json; do
   [ -f "${SRC}/${name}" ] || { echo "REMOVED  ${name}"; drift=1; }
 done
 
-if [ "${drift}" -eq 0 ]; then
+# Contents matching is not the whole story. The manifest also records which
+# ori-specs commit the vectors came from, and that pin is the cross-repository
+# provenance trail. A squash merge rewrites the commit while leaving every byte
+# identical, so a contents-only check reports "match" and leaves the manifest
+# naming a commit that no longer exists on main — provenance pointing at
+# nothing, which is worse than no pin because it looks authoritative.
+PINNED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_commit"])'   "${DEST}/MANIFEST.json" 2>/dev/null || echo "")"
+
+if [ "${drift}" -eq 0 ] && [ "${PINNED}" = "${COMMIT}" ]; then
   echo "vendored vectors match ori-specs at ${COMMIT}"
   exit 0
+fi
+
+if [ "${drift}" -eq 0 ]; then
+  if [ "${APPLY}" != "1" ]; then
+    echo "vector contents match, but the manifest pins ${PINNED:-<none>}" >&2
+    echo "and ori-specs is now at ${COMMIT}." >&2
+    echo "Re-run with ORI_VECTORS_APPLY=1 to update the provenance pin." >&2
+    exit 1
+  fi
+  echo "contents unchanged; updating the provenance pin to ${COMMIT}"
 fi
 
 if [ "${APPLY}" != "1" ]; then

--- a/tests/test_evidence_chain_producer.py
+++ b/tests/test_evidence_chain_producer.py
@@ -96,14 +96,20 @@ def test_canonical_form_matches_the_contract_vector():
 # collapsed to `{"a": 2}` before the producer sees it. So the duplicate-key
 # rule binds whoever parses bytes back, never the producer, and asserting the
 # producer refuses it would be asserting something structurally impossible.
-PARSE_SIDE_VIOLATIONS = frozenset({"duplicate_key"})
+PRODUCER_BINDINGS = frozenset({"producer", "both"})
+
+
+def test_the_contract_declares_an_owner_for_every_refusal():
+    """An unowned refusal is one nobody is obliged to enforce."""
+    for case in load("canonical-form.json")["reject_cases"]:
+        assert case["binds"] in {"producer", "verifier", "both"}, case["name"]
 
 
 def test_the_producer_refuses_every_form_it_can_be_handed():
     """The refusals are the producer's own, not a test-local reimplementation."""
     checked = 0
     for case in load("canonical-form.json")["reject_cases"]:
-        if case["violates"] in PARSE_SIDE_VIOLATIONS:
+        if case["binds"] not in PRODUCER_BINDINGS:
             continue
         if case["input_kind"] == "native_pairs":
             value = {key: item for key, item in case["input_pairs"]}
@@ -128,8 +134,9 @@ def test_duplicate_keys_are_a_parse_side_rule_the_producer_cannot_reach():
     case = next(
         c
         for c in load("canonical-form.json")["reject_cases"]
-        if c["violates"] == "duplicate_key"
+        if c["binds"] == "verifier"
     )
+    assert case["violates"] == "duplicate_key"
     collapsed = json.loads(case["input_json"])
     assert collapsed == {"a": 2}, "the duplicate was not collapsed as expected"
     # Having collapsed, it is an ordinary object the producer will accept.

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,10 +1,10 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "789e1a4118665840a5b17e6c9013fd9d304c9088",
+  "source_commit": "32ba96b605866790e9a2ccaf6933e44cd38eb877",
   "note": "Vendored copies of the normative vectors. The runtime must produce bytes these describe, so they are its conformance fixtures. digests detect a local edit; refresh with scripts/refresh-evidence-vectors.sh to detect upstream drift.",
   "files": {
-    "canonical-form.json": "b2b78ad6c2918b0d59bf992d1ba259e800b6967952deb9f728a852895a0ce229",
+    "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",
     "chain-row.json": "c69c8c4b9158482beac607c830b3f9f1870e42932242a89ece7c2cc05fcfc646",
     "event-id.json": "f9b0b0f71237b4b717dc2a92433aebec758444c9be78e3c9f2abf32d5a31c068",
     "genesis.json": "b838f02c80606148307cca450640a92a71d30d90e0841ccc4a98d10c63b2d190",

--- a/tests/vectors/evidence_v2/canonical-form.json
+++ b/tests/vectors/evidence_v2/canonical-form.json
@@ -146,49 +146,56 @@
       "why": "non-finite numbers are forbidden",
       "input_json": "{\"n\":NaN}",
       "violates": "non_finite",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "Infinity",
       "why": "non-finite numbers are forbidden",
       "input_json": "{\"n\":Infinity}",
       "violates": "non_finite",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "-Infinity",
       "why": "non-finite numbers are forbidden",
       "input_json": "{\"n\":-Infinity}",
       "violates": "non_finite",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "float below the agreement zone (1e-5)",
       "why": "serializers disagree: 0.00001 vs 1e-05",
       "input_json": "{\"n\":1e-05}",
       "violates": "number_zone",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "float at or above 1e16",
       "why": "serializers disagree in exponent notation",
       "input_json": "{\"n\":1e16}",
       "violates": "number_zone",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "integer above 2^53-1",
       "why": "outside the JSON-safe integer range",
       "input_json": "{\"n\":9007199254740992}",
       "violates": "integer_range",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "both"
     },
     {
       "name": "duplicate object keys",
       "why": "the canonical form of an object with repeated keys is undefined",
       "input_json": "{\"a\":1,\"a\":2}",
       "violates": "duplicate_key",
-      "input_kind": "json_text"
+      "input_kind": "json_text",
+      "binds": "verifier"
     },
     {
       "name": "non-string object key",
@@ -201,7 +208,8 @@
           1,
           2
         ]
-      ]
+      ],
+      "binds": "producer"
     }
   ],
   "reject_input_note": "Each refusal carries an executable input. input_kind is json_text for inputs expressible as JSON, and native_pairs where it is not. The text cases are deliberately not always valid JSON: NaN and Infinity are extensions some parsers accept, and a duplicate key does not survive an ordinary parse because most parsers silently keep the last occurrence. A verifier must parse with duplicate detection and constant rejection rather than calling a default loader and inspecting the result. Every case must produce exactly its declared violation; an implementation that cannot construct one must say so rather than exempt it.",
@@ -211,5 +219,6 @@
     "integer_range": "integer magnitude above 2^53-1",
     "duplicate_key": "an object carrying the same key twice",
     "non_string_key": "an object key that is not a string"
-  }
+  },
+  "binds_note": "binds names which side can enforce the refusal: 'both', 'producer' for a defect only a native value can carry, or 'verifier' for one only present in bytes and destroyed by an ordinary parse. A conformance suite asserts this rather than inferring it from input_kind, so a case skipped as unreachable is recorded as such instead of quietly passing."
 }


### PR DESCRIPTION
## What does this PR do?

`ori-specs` now names which side enforces each canonical refusal (ori-platform/ori-specs#86). This makes the runtime's conformance suite read that ownership rather than infer it.

The inference was already fragile. The suite selected producer-side cases by input shape — `native_pairs` versus `json_text` — which worked only because the case expressed as native pairs happened to also be the one a producer could be handed. Nothing held those two facts together. A producer-bound refusal that became expressible as JSON text would have silently pulled a verifier-bound case into the producer's loop, where it would fail for a reason nobody was testing.

A guard asserts every refusal declares an owner, so an unowned case fails rather than falling through whichever branch its shape happens to pick.

## The refresh script had a provenance gap

Re-vendoring the vectors for this exposed something worth fixing rather than working around.

`scripts/refresh-evidence-vectors.sh` compared file contents only. A squash merge rewrites the commit while leaving every byte identical, so the script reported "vendored vectors match" while `MANIFEST.json` went on naming a commit that no longer exists on `ori-specs` main.

That pin is the cross-repository provenance trail — it is how someone reading this repository finds the contract revision these bytes came from. A pin pointing at nothing is worse than no pin, because it still looks authoritative. The script now treats a stale pin as drift: it reports in check mode and updates it in apply mode, even when no byte changed.

Caught by following the stated procedure rather than by the tooling, which is the argument for the tooling doing it.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime code and no capability change. This updates a conformance test's selection criterion and a maintenance script.

### If this touches `/ori/` (core runtime)

No runtime code is touched.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Companion to ori-platform/ori-specs#86, which closes ori-platform/ori-specs#85. Part of the groundwork for #326.

## Testing notes

Full suite: 3538 passed, 27 skipped. Ruff clean. `git diff --check` clean.

The vendored manifest pins `32ba96b`, verified present on `ori-specs` main.

Mutation-checked in both directions:

| Mutation | Fails |
|---|---|
| Mark the duplicate-key case `producer`-bound | the producer is asked for something structurally impossible |
| Remove the ownership field | the owner-declared guard |
| Stale provenance pin with identical contents | the refresh script, in check mode |
