### PR TITLE
feat(evidence): verify and apply what arrives back from the courier

### DIFF
--- a/ori/security/evidence_authority_keys.py
+++ b/ori/security/evidence_authority_keys.py
@@ -1,0 +1,174 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The authority keys this device will verify evidence artifacts against.
+
+Receipts and epoch confirmations are the authority telling a device what it may
+believe: that evidence arrived, that an epoch is active. The keys that make
+those statements trustworthy are therefore trust roots, and where they come
+from decides whether any of it means anything.
+
+They come from the signed release, and only from there. `evidence-exchange/v1`
+is explicit: a device MUST NOT accept an authority key delivered through the
+exchange itself. An authority that can hand a device new trust roots over the
+channel it is being trusted on has no independent standing — it could replace
+the keys that check its own claims, and every subsequent verification would
+succeed by construction.
+
+Purposes are disjoint and enforced. A key held for issuing receipts must not
+verify an epoch confirmation, because those assert different things: one says
+evidence was recorded, the other says an anchor is active. Accepting either
+under the other's key collapses a distinction the fail-closed rules depend on.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+PURPOSE_RECEIPT = "evidence_authority_receipt"
+PURPOSE_EPOCH = "evidence_authority_epoch"
+AUTHORITY_PURPOSES = frozenset({PURPOSE_RECEIPT, PURPOSE_EPOCH})
+
+REGISTRY_SCHEMA = "ori.evidence_authority_keys.v1"
+
+# `active` signs and verifies, `verify_only` verifies what it signed before a
+# rotation, `revoked` verifies nothing. A retired key that still verified would
+# make rotation cosmetic.
+STATUS_ACTIVE = "active"
+STATUS_VERIFY_ONLY = "verify_only"
+STATUS_REVOKED = "revoked"
+_VERIFYING_STATUSES = frozenset({STATUS_ACTIVE, STATUS_VERIFY_ONLY})
+_STATUSES = _VERIFYING_STATUSES | {STATUS_REVOKED}
+
+_REGISTRY_FIELDS = {"schema", "keys"}
+_KEY_FIELDS = {"key_id", "public_key_hex", "purpose", "status"}
+
+
+class AuthorityKeyError(RuntimeError):
+    """The authority key registry could not be loaded or trusted."""
+
+
+@dataclass(frozen=True)
+class AuthorityKey:
+    key_id: str
+    public_key_hex: str
+    purpose: str
+    status: str
+
+    @property
+    def verifies(self) -> bool:
+        return self.status in _VERIFYING_STATUSES
+
+
+def _require_exact_fields(
+    obj: dict[str, object], expected: set[str], label: str
+) -> None:
+    actual = set(obj)
+    if actual != expected:
+        unexpected = sorted(actual - expected)
+        missing = sorted(expected - actual)
+        raise AuthorityKeyError(
+            f"{label} fields are wrong: unexpected {unexpected}, missing {missing}"
+        )
+
+
+def load_authority_key_registry(
+    path: str | Path,
+) -> dict[tuple[str, str], AuthorityKey]:
+    """Load the release-shipped registry, keyed by `(purpose, key_id)`.
+
+    Keyed by the pair deliberately. A verifier selects by purpose *and*
+    identity, so the same `key_id` under two purposes is two different keys and
+    a lookup that ignored purpose would let one stand in for the other.
+    """
+    source = Path(path)
+    try:
+        raw = json.loads(source.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise AuthorityKeyError(f"no authority key registry at {source}") from exc
+    except ValueError as exc:
+        raise AuthorityKeyError("the authority key registry is not valid JSON") from exc
+
+    if not isinstance(raw, dict):
+        raise AuthorityKeyError("the authority key registry must be an object")
+    _require_exact_fields(raw, _REGISTRY_FIELDS, "authority key registry")
+    if raw.get("schema") != REGISTRY_SCHEMA:
+        raise AuthorityKeyError(
+            f"unsupported authority key registry schema {raw.get('schema')!r}"
+        )
+    entries = raw.get("keys")
+    if not isinstance(entries, list) or not entries:
+        raise AuthorityKeyError("the authority key registry must contain keys")
+
+    registry: dict[tuple[str, str], AuthorityKey] = {}
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise AuthorityKeyError(f"authority key #{index + 1} is not an object")
+        _require_exact_fields(entry, _KEY_FIELDS, f"authority key #{index + 1}")
+        key_id = str(entry["key_id"])
+        purpose = str(entry["purpose"])
+        status = str(entry["status"])
+        public_key_hex = str(entry["public_key_hex"])
+        if not key_id:
+            raise AuthorityKeyError(f"authority key #{index + 1} has no key_id")
+        if purpose not in AUTHORITY_PURPOSES:
+            raise AuthorityKeyError(
+                f"authority key {key_id!r} carries purpose {purpose!r}, which this "
+                "registry does not govern"
+            )
+        if status not in _STATUSES:
+            raise AuthorityKeyError(f"authority key {key_id!r} has status {status!r}")
+        try:
+            raw_key = bytes.fromhex(public_key_hex)
+        except ValueError as exc:
+            raise AuthorityKeyError(
+                f"authority key {key_id!r} public key is not hex"
+            ) from exc
+        if len(raw_key) != 32:
+            raise AuthorityKeyError(
+                f"authority key {key_id!r} is {len(raw_key)} bytes, not 32"
+            )
+        identity = (purpose, key_id)
+        if identity in registry:
+            raise AuthorityKeyError(
+                f"authority key {key_id!r} appears twice for purpose {purpose!r}"
+            )
+        registry[identity] = AuthorityKey(
+            key_id=key_id,
+            public_key_hex=public_key_hex,
+            purpose=purpose,
+            status=status,
+        )
+    return registry
+
+
+def select_verifying_key(
+    registry: dict[tuple[str, str], AuthorityKey], purpose: str, key_id: str
+) -> AuthorityKey:
+    """Find the key an artifact names, refusing every near miss distinctly.
+
+    "Unknown", "held for something else" and "revoked" are three different
+    findings, and collapsing them into one would make a rotation error look
+    identical to an attack.
+    """
+    held = registry.get((purpose, key_id))
+    if held is None:
+        # Named under another purpose is worth saying, because it is the shape
+        # of a cross-purpose substitution rather than a missing key.
+        elsewhere = sorted(
+            other
+            for (other, held_id) in registry
+            if held_id == key_id and other != purpose
+        )
+        if elsewhere:
+            raise AuthorityKeyError(
+                f"key {key_id!r} is held for {elsewhere}, not for {purpose!r}"
+            )
+        raise AuthorityKeyError(f"no key {key_id!r} is held for purpose {purpose!r}")
+    if not held.verifies:
+        raise AuthorityKeyError(
+            f"key {key_id!r} for {purpose!r} is {held.status} and verifies nothing"
+        )
+    return held

--- a/ori/security/evidence_ingest.py
+++ b/ori/security/evidence_ingest.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verifying what arrives back, per `ori-specs/evidence-exchange/v1`.
+
+The runtime seals evidence and hands it to a courier. Three things come back,
+and each says something different that the runtime is entitled to act on only
+once it has been proven:
+
+* a **custody acknowledgement** — the gateway holds these bytes durably;
+* a **delivery receipt** — the authority recorded this contiguous range;
+* an **epoch confirmation** — this anchor epoch is active.
+
+None is interchangeable, and the verification is what stops them being. A
+receipt signed under the epoch key would say "the authority recorded your
+evidence" using a key held to say something else entirely, and accepting it
+collapses a distinction the fail-closed rules rest on.
+
+Every rejection is recorded rather than raised past the caller. An artifact
+that fails to verify is information — about the courier, the authority, or an
+attacker — and discarding it silently would leave the device unable to explain
+why its evidence never reached anyone.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+from dataclasses import dataclass
+from typing import Any
+
+from ori.security.evidence_authority_keys import (
+    PURPOSE_EPOCH,
+    PURPOSE_RECEIPT,
+    AuthorityKey,
+    AuthorityKeyError,
+    select_verifying_key,
+)
+from ori.security.evidence_canonical import CanonicalisationError, canonical_json
+
+CUSTODY_DOMAIN = b"ori.evidence_custody_ack.v1\x00"
+RECEIPT_DOMAIN = b"ori.evidence_delivery_receipt.v1\x00"
+EPOCH_DOMAIN = b"ori.evidence_epoch_confirmation.v1\x00"
+
+PURPOSE_CUSTODY = "gateway_custody"
+
+ARTIFACT_VERSION = 1
+
+CUSTODY_FIELDS = frozenset(
+    {"v", "device_id", "local_seq", "envelope_digest", "custody_at_ms", "key_id", "mac"}
+)
+RECEIPT_FIELDS = frozenset(
+    {
+        "v",
+        "device_id",
+        "from_seq",
+        "to_seq",
+        "range_digest",
+        "accepted_at_ms",
+        "key_id",
+        "signature",
+    }
+)
+EPOCH_FIELDS = frozenset(
+    {
+        "v",
+        "device_id",
+        "anchor_epoch_id",
+        "pubkey_hex",
+        "actor",
+        "confirmed_at_ms",
+        "key_id",
+        "signature",
+    }
+)
+
+# Why an artifact was refused. A closed set for the same reason delivery
+# failure reasons are: this is recorded where an operator can read it, and a
+# rejection quoting an endpoint or a private identity would disclose through
+# the diagnostic channel.
+REJECT_UNRECOGNISED_VERSION = "unrecognised_version"
+REJECT_MALFORMED = "malformed"
+REJECT_UNKNOWN_KEY = "unknown_key"
+REJECT_WRONG_PURPOSE = "wrong_purpose"
+REJECT_BAD_AUTHENTICATOR = "bad_authenticator"
+REJECT_UNKNOWN_SEQUENCE = "unknown_sequence"
+REJECT_BINDING_MISMATCH = "binding_mismatch"
+REJECT_NON_CONTIGUOUS = "non_contiguous_range"
+REJECT_REASONS = frozenset(
+    {
+        REJECT_UNRECOGNISED_VERSION,
+        REJECT_MALFORMED,
+        REJECT_UNKNOWN_KEY,
+        REJECT_WRONG_PURPOSE,
+        REJECT_BAD_AUTHENTICATOR,
+        REJECT_UNKNOWN_SEQUENCE,
+        REJECT_BINDING_MISMATCH,
+        REJECT_NON_CONTIGUOUS,
+    }
+)
+
+
+class IngestRejectedError(Exception):
+    """An arriving artifact did not verify. Carries a closed-set reason."""
+
+    def __init__(self, reason: str, detail: str) -> None:
+        if reason not in REJECT_REASONS:
+            raise ValueError(f"{reason!r} is not a recognised rejection reason")
+        super().__init__(detail)
+        self.reason = reason
+        self.detail = detail
+
+
+@dataclass(frozen=True)
+class VerifiedCustody:
+    device_id: str
+    local_seq: int
+    envelope_digest: str
+    custody_at_ms: int
+    key_id: str
+
+
+@dataclass(frozen=True)
+class VerifiedReceipt:
+    device_id: str
+    from_seq: int
+    to_seq: int
+    range_digest: str
+    accepted_at_ms: int
+    key_id: str
+
+
+@dataclass(frozen=True)
+class VerifiedEpochConfirmation:
+    device_id: str
+    anchor_epoch_id: str
+    pubkey_hex: str
+    actor: str
+    confirmed_at_ms: int
+    key_id: str
+
+
+def _require_shape(artifact: Any, fields: frozenset[str], label: str) -> dict[str, Any]:
+    if not isinstance(artifact, dict):
+        raise IngestRejectedError(REJECT_MALFORMED, f"the {label} is not an object")
+    present = set(artifact)
+    if present != set(fields):
+        raise IngestRejectedError(
+            REJECT_MALFORMED,
+            f"the {label} carries {sorted(present - set(fields))} and is missing "
+            f"{sorted(set(fields) - present)}",
+        )
+    # Version is checked before anything else is trusted: an unrecognised
+    # version means the rest of the object is not this contract's to interpret,
+    # and guessing at it is how a future field gets silently ignored.
+    if artifact.get("v") != ARTIFACT_VERSION:
+        raise IngestRejectedError(
+            REJECT_UNRECOGNISED_VERSION,
+            f"the {label} declares version {artifact.get('v')!r}",
+        )
+    return dict(artifact)
+
+
+def _signing_bytes(
+    artifact: dict[str, Any], authenticator: str, domain: bytes
+) -> bytes:
+    body = {k: v for k, v in artifact.items() if k != authenticator}
+    try:
+        return domain + canonical_json(body)
+    except CanonicalisationError as exc:
+        raise IngestRejectedError(
+            REJECT_MALFORMED, "the artifact is not canonicalisable"
+        ) from exc
+
+
+def _decode_ed25519(wire: Any) -> bytes:
+    text = str(wire)
+    if not text.startswith("ed25519:"):
+        raise IngestRejectedError(
+            REJECT_MALFORMED, "a signature must carry exactly one 'ed25519:' prefix"
+        )
+    body = text[len("ed25519:") :]
+    if "ed25519:" in body:
+        raise IngestRejectedError(
+            REJECT_MALFORMED, "a signature must carry exactly one prefix"
+        )
+    try:
+        raw = base64.b64decode(body, validate=True)
+    except Exception as exc:
+        raise IngestRejectedError(
+            REJECT_MALFORMED, "a signature must be standard Base64"
+        ) from exc
+    if len(raw) != 64:
+        raise IngestRejectedError(
+            REJECT_MALFORMED, f"a signature is 64 bytes, not {len(raw)}"
+        )
+    return raw
+
+
+def _select(
+    registry: dict[tuple[str, str], AuthorityKey], purpose: str, key_id: Any
+) -> AuthorityKey:
+    try:
+        return select_verifying_key(registry, purpose, str(key_id))
+    except AuthorityKeyError as exc:
+        reason = (
+            REJECT_WRONG_PURPOSE if "is held for" in str(exc) else REJECT_UNKNOWN_KEY
+        )
+        raise IngestRejectedError(reason, str(exc)) from exc
+
+
+def _verify_ed25519(
+    key: AuthorityKey, signature: bytes, signed: bytes, label: str
+) -> None:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+    try:
+        Ed25519PublicKey.from_public_bytes(bytes.fromhex(key.public_key_hex)).verify(
+            signature, signed
+        )
+    except Exception as exc:
+        raise IngestRejectedError(
+            REJECT_BAD_AUTHENTICATOR, f"the {label} signature does not verify"
+        ) from exc
+
+
+def verify_custody_acknowledgement(
+    artifact: Any,
+    *,
+    device_id: str,
+    shared_secret: str,
+    expected_digest: str,
+    expected_local_seq: int,
+) -> VerifiedCustody:
+    """Prove the gateway acknowledged the envelope this device actually sealed.
+
+    Authenticated with the runtime–gateway shared secret rather than a
+    signature, because the gateway signs nothing on the evidence path. The MAC
+    is what stops any process on the site network forging custody: the runtime
+    uses custody state to manage its queue, so a forged acknowledgement would
+    let an attacker cause evidence to be deprioritised that was never carried.
+    """
+    parsed = _require_shape(artifact, CUSTODY_FIELDS, "custody acknowledgement")
+    if not shared_secret:
+        raise IngestRejectedError(
+            REJECT_UNKNOWN_KEY, "no runtime-gateway secret is configured"
+        )
+
+    mac_wire = str(parsed["mac"])
+    if not mac_wire.startswith("hmac-sha256:"):
+        raise IngestRejectedError(
+            REJECT_MALFORMED, "a custody MAC must carry its algorithm prefix"
+        )
+    signed = _signing_bytes(parsed, "mac", CUSTODY_DOMAIN)
+    expected_mac = hmac.new(
+        shared_secret.encode("utf-8"), signed, hashlib.sha256
+    ).hexdigest()
+    if not hmac.compare_digest(mac_wire[len("hmac-sha256:") :], expected_mac):
+        raise IngestRejectedError(
+            REJECT_BAD_AUTHENTICATOR, "the custody MAC does not verify"
+        )
+
+    if str(parsed["device_id"]) != device_id:
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH, "the custody names another device"
+        )
+    if int(parsed["local_seq"]) != int(expected_local_seq):
+        raise IngestRejectedError(
+            REJECT_UNKNOWN_SEQUENCE, "the custody names another envelope"
+        )
+    if str(parsed["envelope_digest"]) != expected_digest:
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH,
+            "the custody digest does not match the envelope this device sealed",
+        )
+    return VerifiedCustody(
+        device_id=str(parsed["device_id"]),
+        local_seq=int(parsed["local_seq"]),
+        envelope_digest=str(parsed["envelope_digest"]),
+        custody_at_ms=int(parsed["custody_at_ms"]),
+        key_id=str(parsed["key_id"]),
+    )
+
+
+def verify_delivery_receipt(
+    artifact: Any,
+    *,
+    device_id: str,
+    registry: dict[tuple[str, str], AuthorityKey],
+    envelope_digests: dict[int, str],
+) -> VerifiedReceipt:
+    """Prove the authority recorded exactly the range it claims.
+
+    The range digest is what makes the prefix claim checkable: it covers the
+    raw digests of every envelope in the closed interval, in order, so a
+    receipt cannot assert a range it did not actually receive. Recomputing it
+    locally is the difference between a receipt that says something and one
+    that merely looks signed.
+    """
+    parsed = _require_shape(artifact, RECEIPT_FIELDS, "delivery receipt")
+    key = _select(registry, PURPOSE_RECEIPT, parsed["key_id"])
+    signature = _decode_ed25519(parsed["signature"])
+    _verify_ed25519(
+        key, signature, _signing_bytes(parsed, "signature", RECEIPT_DOMAIN), "receipt"
+    )
+
+    if str(parsed["device_id"]) != device_id:
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH, "the receipt names another device"
+        )
+
+    from_seq, to_seq = int(parsed["from_seq"]), int(parsed["to_seq"])
+    if from_seq < 1 or to_seq < from_seq:
+        raise IngestRejectedError(
+            REJECT_NON_CONTIGUOUS, "the receipt range is not a closed interval"
+        )
+
+    missing = [
+        seq for seq in range(from_seq, to_seq + 1) if seq not in envelope_digests
+    ]
+    if missing:
+        raise IngestRejectedError(
+            REJECT_UNKNOWN_SEQUENCE,
+            f"the receipt covers {len(missing)} sequences this device never sealed",
+        )
+    concatenated = b"".join(
+        bytes.fromhex(envelope_digests[seq].split("sha256:", 1)[-1])
+        for seq in range(from_seq, to_seq + 1)
+    )
+    expected = "sha256:" + hashlib.sha256(concatenated).hexdigest()
+    if str(parsed["range_digest"]) != expected:
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH,
+            "the receipt range digest does not match the envelopes this device sealed",
+        )
+    return VerifiedReceipt(
+        device_id=str(parsed["device_id"]),
+        from_seq=from_seq,
+        to_seq=to_seq,
+        range_digest=str(parsed["range_digest"]),
+        accepted_at_ms=int(parsed["accepted_at_ms"]),
+        key_id=str(parsed["key_id"]),
+    )
+
+
+def verify_epoch_confirmation(
+    artifact: Any,
+    *,
+    device_id: str,
+    registry: dict[tuple[str, str], AuthorityKey],
+    expected_pubkey_hex: str,
+) -> VerifiedEpochConfirmation:
+    """Prove the authority confirmed this device's anchor for an epoch.
+
+    The confirmation names the public key it is confirming, and it must be this
+    device's. Without that binding an authority statement about some other
+    device's anchor would advance this one's epoch — which is the substitution
+    the whole `(purpose, key_id)` and device-binding apparatus exists to stop.
+    """
+    parsed = _require_shape(artifact, EPOCH_FIELDS, "epoch confirmation")
+    key = _select(registry, PURPOSE_EPOCH, parsed["key_id"])
+    signature = _decode_ed25519(parsed["signature"])
+    _verify_ed25519(
+        key,
+        signature,
+        _signing_bytes(parsed, "signature", EPOCH_DOMAIN),
+        "epoch confirmation",
+    )
+
+    if str(parsed["device_id"]) != device_id:
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH, "the confirmation names another device"
+        )
+    if str(parsed["pubkey_hex"]).lower() != expected_pubkey_hex.lower():
+        raise IngestRejectedError(
+            REJECT_BINDING_MISMATCH,
+            "the confirmation names a verification key that is not this device's",
+        )
+    if not str(parsed["anchor_epoch_id"]):
+        raise IngestRejectedError(REJECT_MALFORMED, "the confirmation names no epoch")
+    return VerifiedEpochConfirmation(
+        device_id=str(parsed["device_id"]),
+        anchor_epoch_id=str(parsed["anchor_epoch_id"]),
+        pubkey_hex=str(parsed["pubkey_hex"]),
+        actor=str(parsed["actor"]),
+        confirmed_at_ms=int(parsed["confirmed_at_ms"]),
+        key_id=str(parsed["key_id"]),
+    )

--- a/ori/security/evidence_ingest.py
+++ b/ori/security/evidence_ingest.py
@@ -204,10 +204,12 @@ def _select(
     try:
         return select_verifying_key(registry, purpose, str(key_id))
     except AuthorityKeyError as exc:
-        reason = (
-            REJECT_WRONG_PURPOSE if "is held for" in str(exc) else REJECT_UNKNOWN_KEY
-        )
-        raise IngestRejectedError(reason, str(exc)) from exc
+        # Named at each branch rather than computed into a variable, so every
+        # call site states its reason literally and can be checked statically.
+        # A reason assembled at runtime is one nothing can audit.
+        if "is held for" in str(exc):
+            raise IngestRejectedError(REJECT_WRONG_PURPOSE, str(exc)) from exc
+        raise IngestRejectedError(REJECT_UNKNOWN_KEY, str(exc)) from exc
 
 
 def _verify_ed25519(

--- a/ori/security/evidence_ingest_service.py
+++ b/ori/security/evidence_ingest_service.py
@@ -1,0 +1,204 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The only route from an arriving artifact to a change in evidence state.
+
+`evidence_ingest` proves an artifact is what it claims. `evidence_ledger` holds
+what the device believes. This joins them, and it exists as a single seam on
+purpose: the ledger's `_apply_verified_*` methods cannot check what they are
+told, so if there were two ways to reach them one of them would eventually be
+the unverified one.
+
+Nothing here decides anything. It verifies, applies what verified, and records
+what did not — because a rejection is information about the courier, the
+authority, or an attacker, and a device that silently drops them cannot explain
+why its evidence never arrived.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ori.security.evidence_authority_keys import AuthorityKey
+from ori.security.evidence_ingest import (
+    IngestRejectedError,
+    verify_custody_acknowledgement,
+    verify_delivery_receipt,
+    verify_epoch_confirmation,
+)
+from ori.security.evidence_ledger import EvidenceDeliveryLedger
+
+ACCEPTED = "accepted"
+REJECTED = "rejected"
+
+
+@dataclass(frozen=True)
+class IngestOutcome:
+    """What happened to one arriving artifact, and why."""
+
+    artifact: str
+    state: str
+    reason: str | None = None
+    detail: str | None = None
+    applied_sequences: tuple[int, ...] = ()
+
+    @property
+    def accepted(self) -> bool:
+        return self.state == ACCEPTED
+
+
+class EvidenceIngestService:
+    """Verifies arriving artifacts and applies the ones that prove out."""
+
+    def __init__(
+        self,
+        *,
+        ledger: EvidenceDeliveryLedger,
+        registry: dict[tuple[str, str], AuthorityKey],
+        device_id: str,
+        device_pubkey_hex: str,
+        gateway_shared_secret: str = "",
+    ) -> None:
+        self._ledger = ledger
+        self._registry = registry
+        self._device_id = str(device_id)
+        self._device_pubkey_hex = str(device_pubkey_hex)
+        self._gateway_shared_secret = str(gateway_shared_secret)
+        self._rejections: list[IngestOutcome] = []
+
+    @property
+    def rejections(self) -> tuple[IngestOutcome, ...]:
+        """Every artifact refused since this service was constructed."""
+        return tuple(self._rejections)
+
+    def _refuse(self, artifact: str, exc: IngestRejectedError) -> IngestOutcome:
+        outcome = IngestOutcome(
+            artifact=artifact, state=REJECTED, reason=exc.reason, detail=exc.detail
+        )
+        self._rejections.append(outcome)
+        return outcome
+
+    def accept_custody(self, artifact: object) -> IngestOutcome:
+        """Record that the gateway holds an envelope — never that it arrived."""
+        local_seq = _int_field(artifact, "local_seq")
+        if local_seq is None:
+            return self._refuse(
+                "custody_acknowledgement",
+                IngestRejectedError("malformed", "the custody names no local_seq"),
+            )
+        sealed = self._ledger.find_by_local_seq(local_seq)
+        if sealed is None:
+            return self._refuse(
+                "custody_acknowledgement",
+                IngestRejectedError(
+                    "unknown_sequence",
+                    "the custody names an envelope never sealed here",
+                ),
+            )
+        try:
+            verified = verify_custody_acknowledgement(
+                artifact,
+                device_id=self._device_id,
+                shared_secret=self._gateway_shared_secret,
+                expected_digest=str(sealed["envelope_digest"]),
+                expected_local_seq=local_seq,
+            )
+        except IngestRejectedError as exc:
+            return self._refuse("custody_acknowledgement", exc)
+
+        self._ledger._apply_verified_custody(
+            verified.local_seq,
+            custody_at_ms=verified.custody_at_ms,
+            key_id=verified.key_id,
+        )
+        return IngestOutcome(
+            artifact="custody_acknowledgement",
+            state=ACCEPTED,
+            applied_sequences=(verified.local_seq,),
+        )
+
+    def accept_receipt(self, artifact: object) -> IngestOutcome:
+        """Mark a contiguous range delivered, on the authority's signature alone."""
+        from_seq = _int_field(artifact, "from_seq")
+        to_seq = _int_field(artifact, "to_seq")
+        digests = (
+            self._ledger.envelope_digests(from_seq, to_seq)
+            if from_seq is not None and to_seq is not None and to_seq >= from_seq
+            else {}
+        )
+        try:
+            verified = verify_delivery_receipt(
+                artifact,
+                device_id=self._device_id,
+                registry=self._registry,
+                envelope_digests=digests,
+            )
+        except IngestRejectedError as exc:
+            return self._refuse("delivery_receipt", exc)
+
+        applied = tuple(range(verified.from_seq, verified.to_seq + 1))
+        for local_seq in applied:
+            self._ledger._apply_verified_receipt(
+                local_seq, receipt_at_ms=verified.accepted_at_ms, key_id=verified.key_id
+            )
+        return IngestOutcome(
+            artifact="delivery_receipt", state=ACCEPTED, applied_sequences=applied
+        )
+
+    def accept_epoch_confirmation(self, artifact: object) -> IngestOutcome:
+        """Persist a confirmed epoch, which is what makes firmware authority effective.
+
+        The device's own verification key is the binding that matters here: a
+        confirmation naming another device's anchor must not advance this
+        one's, and that check is the difference between an authority statement
+        about someone else and one about us.
+        """
+        try:
+            verified = verify_epoch_confirmation(
+                artifact,
+                device_id=self._device_id,
+                registry=self._registry,
+                expected_pubkey_hex=self._device_pubkey_hex,
+            )
+        except IngestRejectedError as exc:
+            return self._refuse("epoch_confirmation", exc)
+
+        self._ledger._apply_verified_epoch(
+            verified.device_id,
+            anchor_epoch_id=verified.anchor_epoch_id,
+            pubkey_hex=verified.pubkey_hex,
+            actor=verified.actor,
+            confirmed_at_ms=verified.confirmed_at_ms,
+            key_id=verified.key_id,
+        )
+        return IngestOutcome(artifact="epoch_confirmation", state=ACCEPTED)
+
+
+class ConfirmedEpochReader:
+    """The confirmation coordinator's view of proven epoch state.
+
+    The coordinator was written against a chain object that answered
+    `active_anchor_epoch_id` from the private artifact in this process. Under
+    the off-device topology that answer arrives as a signed confirmation and is
+    persisted by ingest, so this is the same question asked of the same
+    conceptual authority — reached differently.
+
+    Registration is deliberately absent. Pushing an anchor to the authority is
+    an outbound artifact this runtime does not yet produce, tracked as #350;
+    until it exists a confirmation cannot be *caused* from here, only observed.
+    """
+
+    def __init__(self, ledger: EvidenceDeliveryLedger) -> None:
+        self._ledger = ledger
+
+    def active_anchor_epoch_id(self, device_id: str) -> str | None:
+        return self._ledger.active_anchor_epoch_id(device_id)
+
+
+def _int_field(artifact: object, name: str) -> int | None:
+    if not isinstance(artifact, dict):
+        return None
+    value = artifact.get(name)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value

--- a/ori/security/evidence_ledger.py
+++ b/ori/security/evidence_ledger.py
@@ -124,6 +124,23 @@ CREATE INDEX IF NOT EXISTS idx_evidence_ledger_undelivered
 -- Locally observed delivery failures. Separate from the ledger because a
 -- failure is not an envelope: several attempts can fail for one row, and a
 -- failure to seal produces no row at all.
+-- Anchor epochs this device has seen confirmed by the authority.
+--
+-- The confirmation coordinator needs to know whether an epoch is active before
+-- firmware authority becomes effective, and under the off-device topology that
+-- answer arrives as a signed epoch confirmation rather than from a chain object
+-- in this process. This is where the answer is kept once it has been proven.
+CREATE TABLE IF NOT EXISTS evidence_device_epochs (
+    device_id       TEXT PRIMARY KEY,
+    anchor_epoch_id TEXT    NOT NULL,
+    pubkey_hex      TEXT    NOT NULL,
+    actor           TEXT    NOT NULL,
+    confirmed_at_ms INTEGER NOT NULL,
+    key_id          TEXT    NOT NULL,
+    CHECK (length(anchor_epoch_id) > 0),
+    CHECK (length(key_id) > 0)
+);
+
 -- One row, holding the boot counter. Durable and strictly increasing across
 -- restarts, so a restart is visible to the authority as a new boot rather than
 -- reading as a sequence regression.
@@ -693,6 +710,80 @@ class EvidenceDeliveryLedger:
 
     # -- delivery state --------------------------------------------------
 
+    def _apply_verified_epoch(
+        self,
+        device_id: str,
+        *,
+        anchor_epoch_id: str,
+        pubkey_hex: str,
+        actor: str,
+        confirmed_at_ms: int,
+        key_id: str,
+    ) -> None:
+        """Persist an epoch confirmation whose signature and bindings are proven.
+
+        Not a public boundary, for the same reason the delivery transitions are
+        not: this method cannot check what it is told. A caller able to assert
+        an active epoch without an authority signature could make firmware
+        authority effective on its own say-so, which is the decision the epoch
+        confirmation exists to take out of the device's hands.
+
+        Last confirmation wins. The authority is the sole source of epoch
+        truth, so a later statement supersedes an earlier one rather than
+        conflicting with it; a device holding two and choosing between them
+        would be adjudicating something it does not decide.
+        """
+        self._connection.execute(
+            """
+            INSERT INTO evidence_device_epochs (
+                device_id, anchor_epoch_id, pubkey_hex, actor, confirmed_at_ms, key_id
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            ON CONFLICT(device_id) DO UPDATE SET
+                anchor_epoch_id = excluded.anchor_epoch_id,
+                pubkey_hex      = excluded.pubkey_hex,
+                actor           = excluded.actor,
+                confirmed_at_ms = excluded.confirmed_at_ms,
+                key_id          = excluded.key_id
+            """,
+            (
+                str(device_id),
+                str(anchor_epoch_id),
+                str(pubkey_hex),
+                str(actor),
+                int(confirmed_at_ms),
+                str(key_id),
+            ),
+        )
+
+    def active_anchor_epoch_id(self, device_id: str) -> str | None:
+        """The epoch the authority last confirmed for this device, if any.
+
+        The read the confirmation coordinator performs. `None` means no
+        confirmation has been proven — which keeps the obligation pending
+        rather than granting authority by default.
+        """
+        row = self._connection.execute(
+            "SELECT anchor_epoch_id FROM evidence_device_epochs WHERE device_id = ?",
+            (str(device_id),),
+        ).fetchone()
+        return str(row["anchor_epoch_id"]) if row is not None else None
+
+    def confirmed_epoch(self, device_id: str) -> sqlite3.Row | None:
+        row: sqlite3.Row | None = self._connection.execute(
+            "SELECT * FROM evidence_device_epochs WHERE device_id = ?",
+            (str(device_id),),
+        ).fetchone()
+        return row
+
+    def envelope_digests(self, from_seq: int, to_seq: int) -> dict[int, str]:
+        """Digests for a closed interval, for checking a receipt's range claim."""
+        rows = self._connection.execute(
+            "SELECT local_seq, envelope_digest FROM evidence_delivery_ledger"
+            " WHERE local_seq BETWEEN ? AND ?",
+            (int(from_seq), int(to_seq)),
+        )
+        return {int(r["local_seq"]): str(r["envelope_digest"]) for r in rows}
+
     def _require_sealed(self, local_seq: int) -> sqlite3.Row:
         """Refuse to act on a sequence this ledger never allocated.
 
@@ -824,6 +915,13 @@ class EvidenceDeliveryLedger:
     def find(self, event_id: str) -> sqlite3.Row | None:
         row: sqlite3.Row | None = self._connection.execute(
             "SELECT * FROM evidence_delivery_ledger WHERE event_id = ?", (event_id,)
+        ).fetchone()
+        return row
+
+    def find_by_local_seq(self, local_seq: int) -> sqlite3.Row | None:
+        row: sqlite3.Row | None = self._connection.execute(
+            "SELECT * FROM evidence_delivery_ledger WHERE local_seq = ?",
+            (int(local_seq),),
         ).fetchone()
         return row
 

--- a/tests/test_evidence_delivery_ledger.py
+++ b/tests/test_evidence_delivery_ledger.py
@@ -1254,3 +1254,123 @@ def test_complete_delivery_state_is_still_accepted(rig):
     stored = ledger.find(row["event_id"])
     assert stored["custody_state"] == CUSTODY_HELD
     assert stored["receipt_state"] == RECEIPT_ACCEPTED
+
+
+# --------------------------------------------------------------------------
+# Rejection cases must still contain their defect
+#
+# A regeneration that re-signed every case whose `authenticator` was "valid"
+# erased two of them: both rejections in `delivery-receipt.json` became
+# byte-identical to the valid case, and one was then refused as
+# `unknown_sequence` — the right outcome for the wrong reason, which is
+# indistinguishable from working.
+#
+# "valid" marks a case that must verify so the semantic rule under test is
+# actually reached. It does not mark a case that is correct.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(p.name for p in EXCHANGE.glob("*.json") if p.name != "MANIFEST.json"),
+)
+def test_no_rejection_case_is_identical_to_the_valid_case(name):
+    """The defect a case is named for has to be present in it."""
+    vector = exchange(name)
+    cases = vector.get("cases") or []
+    valid = next((c for c in cases if c["name"] == "valid"), None)
+    if valid is None:
+        pytest.skip(f"{name} publishes no valid case to compare against")
+
+    for case in cases:
+        if case["name"] == "valid" or case.get("expected") != "reject":
+            continue
+        differing = sorted(
+            key
+            for key in set(case["artifact"]) | set(valid["artifact"])
+            if case["artifact"].get(key) != valid["artifact"].get(key)
+        )
+        assert differing, (
+            f"{name}: rejection case {case['name']!r} is byte-identical to the "
+            "valid case, so whatever defect it is named for has been erased"
+        )
+
+
+@pytest.mark.parametrize(
+    "name",
+    sorted(p.name for p in EXCHANGE.glob("*.json") if p.name != "MANIFEST.json"),
+)
+def test_every_rejection_case_differs_in_its_authenticator_or_a_field(name):
+    """A case differing only in bookkeeping would not exercise anything.
+
+    Distinguishing this from the check above: that one catches an exact
+    duplicate; this one catches a case whose only difference is a field the
+    rule under test does not read.
+    """
+    vector = exchange(name)
+    cases = vector.get("cases") or []
+    valid = next((c for c in cases if c["name"] == "valid"), None)
+    if valid is None:
+        pytest.skip(f"{name} publishes no valid case")
+
+    for case in cases:
+        if case["name"] == "valid" or case.get("expected") != "reject":
+            continue
+        artifact, reference = case["artifact"], valid["artifact"]
+        authenticator = "signature" if "signature" in artifact else "mac"
+        differing = {
+            key
+            for key in set(artifact) | set(reference)
+            if artifact.get(key) != reference.get(key)
+        }
+        # Either the authenticator itself differs — a wrong key or a forged one
+        # — or some substantive field does. A case where only the authenticator
+        # changed because the content changed is covered by the latter.
+        assert differing - {authenticator} or authenticator in differing, (
+            f"{name}: rejection case {case['name']!r} differs from valid in "
+            "nothing that a rule would read"
+        )
+
+
+def test_the_cross_purpose_receipt_is_signed_by_the_epoch_key():
+    """The specific case an over-broad regeneration destroyed.
+
+    Asserted directly rather than through the generic checks above, because
+    this is the one that was silently flattened and the generic checks are new.
+    A receipt naming the receipt key id but signed by the epoch authority is
+    what purpose separation exists to refuse.
+    """
+    vector = exchange("delivery-receipt.json")
+    case = next(c for c in vector["cases"] if c["name"] == "signed_with_epoch_key")
+    artifact = case["artifact"]
+    valid = next(c for c in vector["cases"] if c["name"] == "valid")["artifact"]
+
+    assert artifact["key_id"] == valid["key_id"], (
+        "the case is only meaningful while it names the receipt key id"
+    )
+    assert artifact["signature"] != valid["signature"], (
+        "the cross-purpose signature has been re-signed with the receipt key"
+    )
+
+    body = canonical_json({k: v for k, v in artifact.items() if k != "signature"})
+    signed = b"ori.evidence_delivery_receipt.v1\x00" + body
+    signature = base64.b64decode(artifact["signature"].split("ed25519:")[1])
+
+    def verifies_under(seed_hex: str) -> bool:
+        public = Ed25519PrivateKey.from_private_bytes(
+            bytes.fromhex(seed_hex)
+        ).public_key()
+        try:
+            public.verify(signature, signed)
+        except Exception:
+            return False
+        return True
+
+    assert verifies_under(vector["epoch_authority_seed_hex"]), (
+        "the case must verify under the epoch key, or it is not cryptographically "
+        "sound and never reaches the purpose rule"
+    )
+    assert not verifies_under(vector["authority_receipt_seed_hex"]), (
+        "the case must fail under the receipt key, or purpose separation is "
+        "not what refuses it"
+    )

--- a/tests/test_evidence_ingest.py
+++ b/tests/test_evidence_ingest.py
@@ -32,8 +32,10 @@ from ori.security.evidence_authority_keys import (
 from ori.security.evidence_ingest import (
     REJECT_BAD_AUTHENTICATOR,
     REJECT_BINDING_MISMATCH,
+    REJECT_MALFORMED,
     REJECT_NON_CONTIGUOUS,
     REJECT_REASONS,
+    REJECT_UNKNOWN_KEY,
     REJECT_UNKNOWN_SEQUENCE,
     REJECT_UNRECOGNISED_VERSION,
     REJECT_WRONG_PURPOSE,
@@ -42,6 +44,27 @@ from ori.security.evidence_ingest import (
     verify_delivery_receipt,
     verify_epoch_confirmation,
 )
+
+# Every rejection reason, by the name the verifiers use for it. Written out
+# rather than gathered from `globals()`: a dynamically resolved import looks
+# unused to a linter and gets stripped, which silently shrinks the scan below
+# to whatever happened to survive.
+REASON_CONSTANTS = {
+    "REJECT_BAD_AUTHENTICATOR": REJECT_BAD_AUTHENTICATOR,
+    "REJECT_BINDING_MISMATCH": REJECT_BINDING_MISMATCH,
+    "REJECT_MALFORMED": REJECT_MALFORMED,
+    "REJECT_NON_CONTIGUOUS": REJECT_NON_CONTIGUOUS,
+    "REJECT_UNKNOWN_KEY": REJECT_UNKNOWN_KEY,
+    "REJECT_UNKNOWN_SEQUENCE": REJECT_UNKNOWN_SEQUENCE,
+    "REJECT_UNRECOGNISED_VERSION": REJECT_UNRECOGNISED_VERSION,
+    "REJECT_WRONG_PURPOSE": REJECT_WRONG_PURPOSE,
+}
+
+
+def test_this_module_knows_every_published_reason():
+    """The map above is the scan's vocabulary; a gap in it shrinks the scan."""
+    assert set(REASON_CONSTANTS.values()) == REJECT_REASONS
+
 
 VECTORS = pathlib.Path(__file__).parent / "vectors" / "evidence_exchange"
 DEVICE = "energy-monitor-ikeja-01"
@@ -497,8 +520,12 @@ def test_a_free_text_rejection_reason_cannot_be_constructed():
     might forget — and the text here is the shape of what would leak, an
     endpoint reaching a diagnostic an operator reads.
     """
+
+    def construct(reason: str) -> IngestRejectedError:
+        return IngestRejectedError(reason, "detail")
+
     with pytest.raises(ValueError, match="not a recognised rejection reason"):
-        _ = IngestRejectedError("connection to private.host failed", "detail")
+        construct("connection to private.host failed")
 
 
 @pytest.mark.parametrize("reason", sorted(REJECT_REASONS))
@@ -524,8 +551,6 @@ def test_the_verifiers_only_use_published_reasons():
         / "security"
         / "evidence_ingest.py"
     ).read_text()
-    import ori.security.evidence_ingest as module
-
     used: set[str] = set()
     unresolved: list[str] = []
     for node in ast.walk(ast.parse(source)):
@@ -543,7 +568,7 @@ def test_the_verifiers_only_use_published_reasons():
             # Call sites name the constants rather than repeating the strings,
             # which an earlier version of this scan did not handle — and it
             # said so rather than reporting full coverage of nothing.
-            resolved = getattr(module, first.id, None)
+            resolved = REASON_CONSTANTS.get(first.id)
             if isinstance(resolved, str):
                 used.add(resolved)
             else:

--- a/tests/test_evidence_ingest.py
+++ b/tests/test_evidence_ingest.py
@@ -1,0 +1,494 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verifying what arrives back, per `ori-specs/evidence-exchange/v1`.
+
+Driven from the contract's own vectors, including the cases it publishes as
+rejections. The two cross-purpose cases matter most: a receipt signed with the
+epoch key, and a confirmation signed with the receipt key. Both verify
+cryptographically and both must be refused, which is exactly the kind of
+failure a signature check alone reports as success.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import pathlib
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from ori.security.evidence_authority_keys import (
+    PURPOSE_EPOCH,
+    PURPOSE_RECEIPT,
+    REGISTRY_SCHEMA,
+    STATUS_REVOKED,
+    STATUS_VERIFY_ONLY,
+    AuthorityKeyError,
+    load_authority_key_registry,
+    select_verifying_key,
+)
+from ori.security.evidence_ingest import (
+    REJECT_BAD_AUTHENTICATOR,
+    REJECT_BINDING_MISMATCH,
+    REJECT_NON_CONTIGUOUS,
+    REJECT_UNKNOWN_SEQUENCE,
+    REJECT_UNRECOGNISED_VERSION,
+    REJECT_WRONG_PURPOSE,
+    IngestRejectedError,
+    verify_custody_acknowledgement,
+    verify_delivery_receipt,
+    verify_epoch_confirmation,
+)
+
+VECTORS = pathlib.Path(__file__).parent / "vectors" / "evidence_exchange"
+DEVICE = "energy-monitor-ikeja-01"
+
+
+def vector(name: str) -> dict:
+    return json.loads((VECTORS / f"{name}.json").read_text())
+
+
+def case(name: str, case_name: str) -> dict:
+    return next(c for c in vector(name)["cases"] if c["name"] == case_name)
+
+
+def public_hex(seed_hex: str) -> str:
+    key = Ed25519PrivateKey.from_private_bytes(bytes.fromhex(seed_hex))
+    return key.public_key().public_bytes_raw().hex()
+
+
+@pytest.fixture
+def registry(tmp_path):
+    """A release-shipped registry holding both authority purposes."""
+    receipt_seed = vector("delivery-receipt")["authority_receipt_seed_hex"]
+    epoch_seed = vector("epoch-confirmation")["signing_key_seed_hex"]
+    path = tmp_path / "authority-keys.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": REGISTRY_SCHEMA,
+                "keys": [
+                    {
+                        "key_id": case("delivery-receipt", "valid")["artifact"][
+                            "key_id"
+                        ],
+                        "public_key_hex": public_hex(receipt_seed),
+                        "purpose": PURPOSE_RECEIPT,
+                        "status": "active",
+                    },
+                    {
+                        "key_id": case("epoch-confirmation", "valid")["artifact"][
+                            "key_id"
+                        ],
+                        "public_key_hex": public_hex(epoch_seed),
+                        "purpose": PURPOSE_EPOCH,
+                        "status": "active",
+                    },
+                ],
+            }
+        )
+    )
+    return load_authority_key_registry(path)
+
+
+# --------------------------------------------------------------------------
+# The registry is a trust root, and where it comes from decides everything
+# --------------------------------------------------------------------------
+
+
+def test_a_key_held_for_another_purpose_does_not_verify(registry):
+    """Purposes are disjoint, and the failure says which is which.
+
+    "Unknown" and "held for something else" are different findings: one is a
+    missing key, the other is the shape of a cross-purpose substitution.
+    """
+    receipt_key_id = case("delivery-receipt", "valid")["artifact"]["key_id"]
+    with pytest.raises(AuthorityKeyError, match="is held for"):
+        select_verifying_key(registry, PURPOSE_EPOCH, receipt_key_id)
+
+
+def test_an_unknown_key_is_distinguished_from_a_misplaced_one(registry):
+    with pytest.raises(AuthorityKeyError, match="no key"):
+        select_verifying_key(registry, PURPOSE_RECEIPT, "never-issued")
+
+
+@pytest.mark.parametrize("status", [STATUS_REVOKED])
+def test_a_revoked_key_verifies_nothing(tmp_path, status):
+    """A retired key that still verified would make rotation cosmetic."""
+    path = tmp_path / "keys.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": REGISTRY_SCHEMA,
+                "keys": [
+                    {
+                        "key_id": "old",
+                        "public_key_hex": "aa" * 32,
+                        "purpose": PURPOSE_RECEIPT,
+                        "status": status,
+                    }
+                ],
+            }
+        )
+    )
+    loaded = load_authority_key_registry(path)
+    with pytest.raises(AuthorityKeyError, match="verifies nothing"):
+        select_verifying_key(loaded, PURPOSE_RECEIPT, "old")
+
+
+def test_a_verify_only_key_still_verifies(tmp_path):
+    """Rotation keeps artifacts signed before it verifiable."""
+    path = tmp_path / "keys.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": REGISTRY_SCHEMA,
+                "keys": [
+                    {
+                        "key_id": "outgoing",
+                        "public_key_hex": "bb" * 32,
+                        "purpose": PURPOSE_RECEIPT,
+                        "status": STATUS_VERIFY_ONLY,
+                    }
+                ],
+            }
+        )
+    )
+    assert select_verifying_key(
+        load_authority_key_registry(path), PURPOSE_RECEIPT, "outgoing"
+    )
+
+
+@pytest.mark.parametrize(
+    "mutate,expected",
+    [
+        (lambda r: r.__setitem__("schema", "something.else"), "schema"),
+        (lambda r: r.__setitem__("keys", []), "must contain keys"),
+        (
+            lambda r: r["keys"][0].__setitem__("purpose", "evidence_device"),
+            "does not govern",
+        ),
+        (lambda r: r["keys"][0].__setitem__("status", "probationary"), "status"),
+        (lambda r: r["keys"][0].__setitem__("public_key_hex", "aa"), "32"),
+        (lambda r: r.__setitem__("extra", True), "fields are wrong"),
+    ],
+)
+def test_a_malformed_registry_is_refused(tmp_path, mutate, expected):
+    raw = {
+        "schema": REGISTRY_SCHEMA,
+        "keys": [
+            {
+                "key_id": "k1",
+                "public_key_hex": "cc" * 32,
+                "purpose": PURPOSE_RECEIPT,
+                "status": "active",
+            }
+        ],
+    }
+    mutate(raw)
+    path = tmp_path / "keys.json"
+    path.write_text(json.dumps(raw))
+    with pytest.raises(AuthorityKeyError, match=expected):
+        load_authority_key_registry(path)
+
+
+# --------------------------------------------------------------------------
+# Delivery receipts
+# --------------------------------------------------------------------------
+
+
+def _digests_for(
+    from_seq: int, to_seq: int, expected_range_digest: str
+) -> dict[int, str]:
+    """Envelope digests that reproduce the vector's published range digest."""
+    published = vector("delivery-envelope")
+    valid = next(c for c in published["cases"] if c["name"] == "valid")["artifact"]
+    reordered = next(c for c in published["cases"] if c["name"] == "reordered_batch")[
+        "artifact"
+    ]
+    digests = {
+        int(valid["local_seq"]): "sha256:"
+        + hashlib.sha256(valid["chain_row"]["canonical_json"].encode()).hexdigest(),
+        int(reordered["local_seq"]): "sha256:"
+        + hashlib.sha256(reordered["chain_row"]["canonical_json"].encode()).hexdigest(),
+    }
+    concatenated = b"".join(
+        bytes.fromhex(digests[seq].split("sha256:")[1])
+        for seq in range(from_seq, to_seq + 1)
+    )
+    assert (
+        "sha256:" + hashlib.sha256(concatenated).hexdigest() == expected_range_digest
+    ), "the fixture does not reproduce the vector's range digest"
+    return digests
+
+
+def test_the_valid_receipt_verifies(registry):
+    artifact = case("delivery-receipt", "valid")["artifact"]
+    digests = _digests_for(
+        artifact["from_seq"], artifact["to_seq"], artifact["range_digest"]
+    )
+    verified = verify_delivery_receipt(
+        artifact, device_id=DEVICE, registry=registry, envelope_digests=digests
+    )
+    assert verified.from_seq == artifact["from_seq"]
+    assert verified.to_seq == artifact["to_seq"]
+
+
+def test_a_receipt_signed_with_the_epoch_key_is_refused(registry):
+    """Purpose separation is what refuses this, and it shows up as a bad signature.
+
+    The artifact names the correct receipt key id and is signed with the epoch
+    private key — cryptographically sound, and asserting something a receipt
+    key is not held to say. Selecting by `(purpose, key_id)` forces
+    verification against the *receipt* key, under which that signature does not
+    verify. So the mechanism is purpose separation and the observable outcome
+    is a signature failure; a verifier that trial-verified against every key it
+    holds would accept this.
+    """
+    artifact = case("delivery-receipt", "signed_with_epoch_key")["artifact"]
+    assert (
+        artifact["key_id"] == case("delivery-receipt", "valid")["artifact"]["key_id"]
+    ), "this case is only meaningful while it names the correct key id"
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact, device_id=DEVICE, registry=registry, envelope_digests={}
+        )
+    assert raised.value.reason == REJECT_BAD_AUTHENTICATOR
+
+
+def test_a_non_contiguous_receipt_is_refused(registry):
+    artifact = case("delivery-receipt", "non_contiguous_range")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact, device_id=DEVICE, registry=registry, envelope_digests={}
+        )
+    assert raised.value.reason in {REJECT_NON_CONTIGUOUS, REJECT_UNKNOWN_SEQUENCE}
+
+
+def test_a_receipt_for_another_device_is_refused(registry):
+    artifact = dict(case("delivery-receipt", "valid")["artifact"])
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact,
+            device_id="some-other-device",
+            registry=registry,
+            envelope_digests=_digests_for(
+                artifact["from_seq"], artifact["to_seq"], artifact["range_digest"]
+            ),
+        )
+    assert raised.value.reason == REJECT_BINDING_MISMATCH
+
+
+def test_a_receipt_covering_unsealed_sequences_is_refused(registry):
+    """A receipt cannot assert a range this device never produced."""
+    artifact = case("delivery-receipt", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact, device_id=DEVICE, registry=registry, envelope_digests={}
+        )
+    assert raised.value.reason == REJECT_UNKNOWN_SEQUENCE
+
+
+def test_a_receipt_whose_range_digest_disagrees_is_refused(registry):
+    """Recomputing the digest is what makes the prefix claim checkable."""
+    artifact = dict(case("delivery-receipt", "valid")["artifact"])
+    digests = _digests_for(
+        artifact["from_seq"], artifact["to_seq"], artifact["range_digest"]
+    )
+    digests[artifact["to_seq"]] = "sha256:" + "0" * 64
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact, device_id=DEVICE, registry=registry, envelope_digests=digests
+        )
+    assert raised.value.reason == REJECT_BINDING_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# Epoch confirmations
+# --------------------------------------------------------------------------
+
+
+def test_the_valid_epoch_confirmation_verifies(registry):
+    artifact = case("epoch-confirmation", "valid")["artifact"]
+    verified = verify_epoch_confirmation(
+        artifact,
+        device_id=DEVICE,
+        registry=registry,
+        expected_pubkey_hex=artifact["pubkey_hex"],
+    )
+    assert verified.anchor_epoch_id == artifact["anchor_epoch_id"]
+
+
+def test_a_confirmation_signed_with_the_receipt_key_is_refused(registry):
+    """A receipt key cannot assert that an epoch became effective."""
+    artifact = case("epoch-confirmation", "signed_with_receipt_key")["artifact"]
+    assert (
+        artifact["key_id"] == case("epoch-confirmation", "valid")["artifact"]["key_id"]
+    )
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_epoch_confirmation(
+            artifact, device_id=DEVICE, registry=registry, expected_pubkey_hex="00" * 32
+        )
+    assert raised.value.reason == REJECT_BAD_AUTHENTICATOR
+
+
+def test_an_artifact_naming_a_key_held_for_another_purpose_is_refused(registry):
+    """The other shape of the same attack, and it fails at selection instead.
+
+    Here the artifact names a key id this device holds — but under a different
+    purpose. Selection refuses it before any signature is checked, which is why
+    both shapes need covering: one fails at the lookup, the other at the
+    signature, and a verifier could easily catch one and not the other.
+    """
+    artifact = dict(case("delivery-receipt", "valid")["artifact"])
+    artifact["key_id"] = case("epoch-confirmation", "valid")["artifact"]["key_id"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_delivery_receipt(
+            artifact, device_id=DEVICE, registry=registry, envelope_digests={}
+        )
+    assert raised.value.reason == REJECT_WRONG_PURPOSE
+
+
+def test_a_confirmation_naming_another_key_is_refused(registry):
+    """Without this binding, a statement about another device's anchor would advance this one's."""
+    artifact = case("epoch-confirmation", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_epoch_confirmation(
+            artifact, device_id=DEVICE, registry=registry, expected_pubkey_hex="11" * 32
+        )
+    assert raised.value.reason == REJECT_BINDING_MISMATCH
+
+
+def test_a_confirmation_for_another_device_is_refused(registry):
+    artifact = case("epoch-confirmation", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_epoch_confirmation(
+            artifact,
+            device_id="some-other-device",
+            registry=registry,
+            expected_pubkey_hex=artifact["pubkey_hex"],
+        )
+    assert raised.value.reason == REJECT_BINDING_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# Custody acknowledgements
+# --------------------------------------------------------------------------
+
+
+def _custody_secret() -> str:
+    published = vector("custody-acknowledgement")
+    return bytes.fromhex(published["gateway_secret_hex"]).decode("latin-1")
+
+
+def test_the_valid_custody_acknowledgement_verifies():
+    published = vector("custody-acknowledgement")
+    artifact = case("custody-acknowledgement", "valid")["artifact"]
+    secret = _custody_secret()
+    verified = verify_custody_acknowledgement(
+        artifact,
+        device_id=DEVICE,
+        shared_secret=secret,
+        expected_digest=artifact["envelope_digest"],
+        expected_local_seq=artifact["local_seq"],
+    )
+    assert verified.local_seq == artifact["local_seq"]
+    assert published["domain_ascii"] == "ori.evidence_custody_ack.v1"
+
+
+def test_a_forged_custody_mac_is_refused():
+    """Anything on the site network could otherwise claim custody."""
+    artifact = case("custody-acknowledgement", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_custody_acknowledgement(
+            artifact,
+            device_id=DEVICE,
+            shared_secret="not-the-shared-secret",
+            expected_digest=artifact["envelope_digest"],
+            expected_local_seq=artifact["local_seq"],
+        )
+    assert raised.value.reason == REJECT_BAD_AUTHENTICATOR
+
+
+def test_custody_for_an_envelope_this_device_did_not_seal_is_refused():
+    artifact = case("custody-acknowledgement", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_custody_acknowledgement(
+            artifact,
+            device_id=DEVICE,
+            shared_secret=_custody_secret(),
+            expected_digest=artifact["envelope_digest"],
+            expected_local_seq=int(artifact["local_seq"]) + 1,
+        )
+    assert raised.value.reason == REJECT_UNKNOWN_SEQUENCE
+
+
+def test_custody_over_different_bytes_is_refused():
+    """Custody commits to the artifact the gateway actually holds."""
+    artifact = case("custody-acknowledgement", "valid")["artifact"]
+    with pytest.raises(IngestRejectedError) as raised:
+        verify_custody_acknowledgement(
+            artifact,
+            device_id=DEVICE,
+            shared_secret=_custody_secret(),
+            expected_digest="sha256:" + "0" * 64,
+            expected_local_seq=artifact["local_seq"],
+        )
+    assert raised.value.reason == REJECT_BINDING_MISMATCH
+
+
+# --------------------------------------------------------------------------
+# Shape and version
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "verifier,name,kwargs",
+    [
+        (verify_delivery_receipt, "delivery-receipt", {"envelope_digests": {}}),
+        (
+            verify_epoch_confirmation,
+            "epoch-confirmation",
+            {"expected_pubkey_hex": "00" * 32},
+        ),
+    ],
+)
+def test_an_unrecognised_version_is_rejected_before_anything_is_trusted(
+    registry, verifier, name, kwargs
+):
+    """A version this contract does not define means the rest is not ours to read.
+
+    Checked before the signature, because interpreting fields from an unknown
+    version is how a future meaning gets silently assigned an old one.
+    """
+    artifact = dict(case(name, "valid")["artifact"])
+    artifact["v"] = 2
+    with pytest.raises(IngestRejectedError) as raised:
+        verifier(artifact, device_id=DEVICE, registry=registry, **kwargs)
+    assert raised.value.reason == REJECT_UNRECOGNISED_VERSION
+
+
+@pytest.mark.parametrize("name", ["delivery-receipt", "epoch-confirmation"])
+def test_an_undefined_field_is_rejected(registry, name):
+    artifact = dict(case(name, "valid")["artifact"])
+    artifact["unexpected"] = True
+    kwargs = (
+        {"envelope_digests": {}}
+        if name == "delivery-receipt"
+        else {"expected_pubkey_hex": "00" * 32}
+    )
+    verifier = (
+        verify_delivery_receipt
+        if name == "delivery-receipt"
+        else verify_epoch_confirmation
+    )
+    with pytest.raises(IngestRejectedError):
+        verifier(artifact, device_id=DEVICE, registry=registry, **kwargs)
+
+
+def test_every_rejection_reason_is_from_the_closed_set():
+    """A reason outside the set would put free text where an operator reads it."""
+    with pytest.raises(ValueError, match="not a recognised rejection reason"):
+        IngestRejectedError("connection to private.host failed", "detail")

--- a/tests/test_evidence_ingest.py
+++ b/tests/test_evidence_ingest.py
@@ -33,6 +33,7 @@ from ori.security.evidence_ingest import (
     REJECT_BAD_AUTHENTICATOR,
     REJECT_BINDING_MISMATCH,
     REJECT_NON_CONTIGUOUS,
+    REJECT_REASONS,
     REJECT_UNKNOWN_SEQUENCE,
     REJECT_UNRECOGNISED_VERSION,
     REJECT_WRONG_PURPOSE,
@@ -488,7 +489,72 @@ def test_an_undefined_field_is_rejected(registry, name):
         verifier(artifact, device_id=DEVICE, registry=registry, **kwargs)
 
 
-def test_every_rejection_reason_is_from_the_closed_set():
-    """A reason outside the set would put free text where an operator reads it."""
+def test_a_free_text_rejection_reason_cannot_be_constructed():
+    """Construction is the action under test: the reason is validated in `__init__`.
+
+    That placement is the point. A free-text reason cannot be created at all,
+    rather than being created and filtered somewhere downstream where a caller
+    might forget — and the text here is the shape of what would leak, an
+    endpoint reaching a diagnostic an operator reads.
+    """
     with pytest.raises(ValueError, match="not a recognised rejection reason"):
-        IngestRejectedError("connection to private.host failed", "detail")
+        _ = IngestRejectedError("connection to private.host failed", "detail")
+
+
+@pytest.mark.parametrize("reason", sorted(REJECT_REASONS))
+def test_every_published_reason_can_be_constructed(reason):
+    """The closed set must not reject the reasons the verifiers actually use."""
+    assert IngestRejectedError(reason, "detail").reason == reason
+
+
+def test_the_verifiers_only_use_published_reasons():
+    """A verifier raising an unpublished reason would fail at the point of failure.
+
+    Asserted structurally rather than by exercising every path: the constructor
+    refuses an unknown reason, so any such call site raises `ValueError` instead
+    of the rejection it meant to report — losing the finding it was trying to
+    make.
+    """
+    import ast
+    import pathlib as _pathlib
+
+    source = (
+        _pathlib.Path(__file__).parent.parent
+        / "ori"
+        / "security"
+        / "evidence_ingest.py"
+    ).read_text()
+    import ori.security.evidence_ingest as module
+
+    used: set[str] = set()
+    unresolved: list[str] = []
+    for node in ast.walk(ast.parse(source)):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "IngestRejectedError"
+            and node.args
+        ):
+            continue
+        first = node.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            used.add(first.value)
+        elif isinstance(first, ast.Name):
+            # Call sites name the constants rather than repeating the strings,
+            # which an earlier version of this scan did not handle — and it
+            # said so rather than reporting full coverage of nothing.
+            resolved = getattr(module, first.id, None)
+            if isinstance(resolved, str):
+                used.add(resolved)
+            else:
+                unresolved.append(first.id)
+        else:
+            unresolved.append(ast.dump(first)[:40])
+
+    assert not unresolved, f"rejection reasons the scan could not resolve: {unresolved}"
+    assert len(used) >= 6, (
+        f"only {len(used)} reasons found in use; the scan is not working"
+    )
+    assert used <= REJECT_REASONS, (
+        f"unpublished reasons in use: {sorted(used - REJECT_REASONS)}"
+    )

--- a/tests/test_evidence_ingest_service.py
+++ b/tests/test_evidence_ingest_service.py
@@ -1,0 +1,492 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The production path from an arriving artifact to a change in evidence state.
+
+Verification alone proves an artifact is genuine. These prove the genuine ones
+reach state and the rest do not — which is a different claim, and the one that
+matters once anything acts on the result.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from ori.security.evidence_authority_keys import (
+    PURPOSE_EPOCH,
+    PURPOSE_RECEIPT,
+    REGISTRY_SCHEMA,
+    load_authority_key_registry,
+)
+from ori.security.evidence_canonical import canonical_json
+from ori.security.evidence_chain import EvidenceChain, attestation_event_id
+from ori.security.evidence_device_key import EvidenceDeviceKey
+from ori.security.evidence_ingest import (
+    REJECT_BAD_AUTHENTICATOR,
+    REJECT_BINDING_MISMATCH,
+    REJECT_UNKNOWN_SEQUENCE,
+    REJECT_WRONG_PURPOSE,
+)
+from ori.security.evidence_ingest_service import (
+    ConfirmedEpochReader,
+    EvidenceIngestService,
+)
+from ori.security.evidence_ledger import (
+    CUSTODY_HELD,
+    RECEIPT_ACCEPTED,
+    RECEIPT_NONE,
+    EvidenceDeliveryLedger,
+)
+
+DEVICE = "energy-monitor-ikeja-01"
+EPOCH = "epoch-0002"
+KEY_ID = "anchor-key-2"
+GATEWAY_SECRET = "site-gateway-secret"
+
+RECEIPT_SEED = bytes([0x7A] * 32)
+EPOCH_SEED = bytes([0x6B] * 32)
+IMPOSTOR_SEED = bytes([0x5C] * 32)
+
+RECEIPT_DOMAIN = b"ori.evidence_delivery_receipt.v1\x00"
+EPOCH_DOMAIN = b"ori.evidence_epoch_confirmation.v1\x00"
+CUSTODY_DOMAIN = b"ori.evidence_custody_ack.v1\x00"
+
+
+def _pub(seed: bytes) -> str:
+    return (
+        Ed25519PrivateKey.from_private_bytes(seed).public_key().public_bytes_raw().hex()
+    )
+
+
+def _sign(artifact: dict, domain: bytes, seed: bytes) -> dict:
+    body = {k: v for k, v in artifact.items() if k != "signature"}
+    key = Ed25519PrivateKey.from_private_bytes(seed)
+    artifact["signature"] = (
+        "ed25519:" + base64.b64encode(key.sign(domain + canonical_json(body))).decode()
+    )
+    return artifact
+
+
+def _mac(artifact: dict, secret: str) -> dict:
+    import hmac
+
+    body = {k: v for k, v in artifact.items() if k != "mac"}
+    artifact["mac"] = (
+        "hmac-sha256:"
+        + hmac.new(
+            secret.encode(), CUSTODY_DOMAIN + canonical_json(body), hashlib.sha256
+        ).hexdigest()
+    )
+    return artifact
+
+
+@pytest.fixture
+def rig(tmp_path):
+    key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "install-secret")
+    chain = EvidenceChain(tmp_path / "chain.db", key, DEVICE)
+    ledger = EvidenceDeliveryLedger(
+        tmp_path / "ledger.db", key, DEVICE, anchor_epoch_id=EPOCH, key_id=KEY_ID
+    )
+    registry_path = tmp_path / "authority.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema": REGISTRY_SCHEMA,
+                "keys": [
+                    {
+                        "key_id": "auth-receipt-1",
+                        "public_key_hex": _pub(RECEIPT_SEED),
+                        "purpose": PURPOSE_RECEIPT,
+                        "status": "active",
+                    },
+                    {
+                        "key_id": "auth-epoch-1",
+                        "public_key_hex": _pub(EPOCH_SEED),
+                        "purpose": PURPOSE_EPOCH,
+                        "status": "active",
+                    },
+                ],
+            }
+        )
+    )
+    service = EvidenceIngestService(
+        ledger=ledger,
+        registry=load_authority_key_registry(registry_path),
+        device_id=DEVICE,
+        device_pubkey_hex=key.public_key_hex,
+        gateway_shared_secret=GATEWAY_SECRET,
+    )
+    yield key, chain, ledger, service
+    chain.close()
+    ledger.close()
+
+
+def _seal(chain, ledger, n: int):
+    row = chain.append(
+        event_id=attestation_event_id(DEVICE, n),
+        event_type="SAFETY_ACTION_EXECUTED",
+        emitted_at_ms=1751500800000 + n * 1000,
+        payload={
+            "kind": "runtime_action",
+            "attestation": "at_emission",
+            "action_log_id": n,
+        },
+        created_at_ms=1751500800040 + n * 1000,
+    )
+    return ledger.seal(row, sealed_at_ms=1000 + n)
+
+
+def _receipt(
+    ledger, from_seq: int, to_seq: int, seed=RECEIPT_SEED, key_id="auth-receipt-1"
+):
+    digests = ledger.envelope_digests(from_seq, to_seq)
+    raw = b"".join(
+        bytes.fromhex(digests[s].split("sha256:")[1])
+        for s in range(from_seq, to_seq + 1)
+    )
+    return _sign(
+        {
+            "v": 1,
+            "device_id": DEVICE,
+            "from_seq": from_seq,
+            "to_seq": to_seq,
+            "range_digest": "sha256:" + hashlib.sha256(raw).hexdigest(),
+            "accepted_at_ms": 1787000001000,
+            "key_id": key_id,
+        },
+        RECEIPT_DOMAIN,
+        seed,
+    )
+
+
+def _confirmation(
+    pubkey_hex: str, seed=EPOCH_SEED, key_id="auth-epoch-1", device=DEVICE
+):
+    return _sign(
+        {
+            "v": 1,
+            "device_id": device,
+            "anchor_epoch_id": EPOCH,
+            "pubkey_hex": pubkey_hex,
+            "actor": "commissioning-operator",
+            "confirmed_at_ms": 1787000002000,
+            "key_id": key_id,
+        },
+        EPOCH_DOMAIN,
+        seed,
+    )
+
+
+def _custody(ledger, local_seq: int, secret=GATEWAY_SECRET):
+    sealed = ledger.find_by_local_seq(local_seq)
+    return _mac(
+        {
+            "v": 1,
+            "device_id": DEVICE,
+            "local_seq": local_seq,
+            "envelope_digest": str(sealed["envelope_digest"]),
+            "custody_at_ms": 1787000000900,
+            "key_id": "gw-secret-1",
+        },
+        secret,
+    )
+
+
+# --------------------------------------------------------------------------
+# Only verified artifacts reach state
+# --------------------------------------------------------------------------
+
+
+def test_a_verified_receipt_marks_its_range_delivered(rig):
+    _, chain, ledger, service = rig
+    for n in (1, 2, 3):
+        _seal(chain, ledger, n)
+
+    outcome = service.accept_receipt(_receipt(ledger, 1, 2))
+    assert outcome.accepted
+    assert outcome.applied_sequences == (1, 2)
+    assert [r["local_seq"] for r in ledger.undelivered()] == [3]
+
+
+# Each case is re-signed after being corrupted, except the one whose defect
+# *is* the signature. Mutating a signed artifact without re-signing makes every
+# case fail as `bad_authenticator`, and the semantic rule it was written for is
+# never reached — the same trap that flattened the contract's own rejection
+# vectors.
+@pytest.mark.parametrize(
+    "corrupt,expected,resign",
+    [
+        (
+            lambda a: a.__setitem__(
+                "signature", "ed25519:" + base64.b64encode(b"\x00" * 64).decode()
+            ),
+            REJECT_BAD_AUTHENTICATOR,
+            False,
+        ),
+        (
+            lambda a: a.__setitem__("device_id", "some-other-device"),
+            REJECT_BINDING_MISMATCH,
+            True,
+        ),
+        (
+            lambda a: a.__setitem__("range_digest", "sha256:" + "0" * 64),
+            REJECT_BINDING_MISMATCH,
+            True,
+        ),
+        (lambda a: a.__setitem__("to_seq", 99), REJECT_UNKNOWN_SEQUENCE, True),
+        (lambda a: a.__setitem__("key_id", "auth-epoch-1"), REJECT_WRONG_PURPOSE, True),
+    ],
+)
+def test_an_unverified_receipt_changes_nothing(rig, corrupt, expected, resign):
+    """Every binding must survive into application, not merely verification."""
+    _, chain, ledger, service = rig
+    for n in (1, 2):
+        _seal(chain, ledger, n)
+    artifact = _receipt(ledger, 1, 2)
+    corrupt(artifact)
+    if resign:
+        _sign(artifact, RECEIPT_DOMAIN, RECEIPT_SEED)
+
+    outcome = service.accept_receipt(artifact)
+    assert not outcome.accepted
+    assert outcome.reason == expected
+    assert [r["local_seq"] for r in ledger.undelivered()] == [1, 2], "state changed"
+    assert service.rejections[-1].reason == expected
+
+
+def test_a_forged_custody_changes_nothing(rig):
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    artifact = _custody(ledger, 1, secret="not-the-gateway-secret")
+
+    outcome = service.accept_custody(artifact)
+    assert not outcome.accepted
+    assert outcome.reason == REJECT_BAD_AUTHENTICATOR
+    assert ledger.find_by_local_seq(1)["custody_state"] == "none"
+
+
+def test_custody_for_an_envelope_never_sealed_changes_nothing(rig):
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    artifact = _custody(ledger, 1)
+    artifact["local_seq"] = 99
+    _mac(artifact, GATEWAY_SECRET)  # re-authenticated, so the sequence rule is reached
+
+    outcome = service.accept_custody(artifact)
+    assert not outcome.accepted
+    assert outcome.reason == REJECT_UNKNOWN_SEQUENCE
+
+
+# --------------------------------------------------------------------------
+# Custody and receipt stay distinct through application
+# --------------------------------------------------------------------------
+
+
+def test_custody_does_not_deliver_and_receipt_does(rig):
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+
+    assert service.accept_custody(_custody(ledger, 1)).accepted
+    held = ledger.find_by_local_seq(1)
+    assert held["custody_state"] == CUSTODY_HELD
+    assert held["receipt_state"] == RECEIPT_NONE
+    assert [r["local_seq"] for r in ledger.undelivered()] == [1]
+
+    assert service.accept_receipt(_receipt(ledger, 1, 1)).accepted
+    delivered = ledger.find_by_local_seq(1)
+    assert delivered["custody_state"] == CUSTODY_HELD
+    assert delivered["receipt_state"] == RECEIPT_ACCEPTED
+    assert ledger.undelivered() == []
+
+
+# --------------------------------------------------------------------------
+# Replay
+# --------------------------------------------------------------------------
+
+
+def test_replaying_the_same_receipt_is_idempotent(rig):
+    """A courier that redelivers must not produce different state."""
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    artifact = _receipt(ledger, 1, 1)
+
+    first = service.accept_receipt(artifact)
+    before = dict(ledger.find_by_local_seq(1))
+    second = service.accept_receipt(json.loads(json.dumps(artifact)))
+    after = dict(ledger.find_by_local_seq(1))
+
+    assert first.accepted and second.accepted
+    assert before == after
+
+
+def test_a_conflicting_receipt_over_the_same_range_is_rejected(rig):
+    """Two authorities cannot both be right about one range.
+
+    The final-state triggers refuse a rewrite, so a second receipt claiming a
+    different acceptance time or key for an already-delivered range cannot
+    quietly replace what the first one established.
+    """
+    import sqlite3
+
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    assert service.accept_receipt(_receipt(ledger, 1, 1)).accepted
+
+    conflicting = _receipt(ledger, 1, 1)
+    conflicting["accepted_at_ms"] = 1787000009999
+    _sign(conflicting, RECEIPT_DOMAIN, RECEIPT_SEED)
+
+    with pytest.raises(sqlite3.IntegrityError, match="receipt"):
+        service.accept_receipt(conflicting)
+    assert ledger.find_by_local_seq(1)["receipt_at_ms"] == 1787000001000
+
+
+def test_replaying_custody_is_idempotent(rig):
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    artifact = _custody(ledger, 1)
+    assert service.accept_custody(artifact).accepted
+    before = dict(ledger.find_by_local_seq(1))
+    assert service.accept_custody(json.loads(json.dumps(artifact))).accepted
+    assert dict(ledger.find_by_local_seq(1)) == before
+
+
+# --------------------------------------------------------------------------
+# Epoch state, and what the coordinator reads
+# --------------------------------------------------------------------------
+
+
+def test_a_verified_confirmation_is_what_the_coordinator_reads(rig):
+    """The whole point of the wiring: proven state reaches the consumer.
+
+    The coordinator asks `active_anchor_epoch_id`, which under the off-device
+    topology is answered from confirmations this device has verified rather
+    than from an artifact in this process.
+    """
+    key, _, ledger, service = rig
+    reader = ConfirmedEpochReader(ledger)
+    assert reader.active_anchor_epoch_id(DEVICE) is None, "authority by default"
+
+    assert service.accept_epoch_confirmation(_confirmation(key.public_key_hex)).accepted
+    assert reader.active_anchor_epoch_id(DEVICE) == EPOCH
+
+
+@pytest.mark.parametrize(
+    "corrupt,expected",
+    [
+        (
+            lambda a, k: a.__setitem__("device_id", "some-other-device"),
+            REJECT_BINDING_MISMATCH,
+        ),
+        (lambda a, k: a.__setitem__("pubkey_hex", "11" * 32), REJECT_BINDING_MISMATCH),
+        (lambda a, k: a.__setitem__("key_id", "auth-receipt-1"), REJECT_WRONG_PURPOSE),
+    ],
+)
+def test_an_unverified_confirmation_leaves_the_epoch_unset(rig, corrupt, expected):
+    """A statement about another device's anchor must not advance this one's."""
+    key, _, ledger, service = rig
+    artifact = _confirmation(key.public_key_hex)
+    corrupt(artifact, key)
+    # Re-signed so the artifact is cryptographically sound and the binding rule
+    # is what refuses it.
+    _sign(artifact, EPOCH_DOMAIN, EPOCH_SEED)
+
+    outcome = service.accept_epoch_confirmation(artifact)
+    assert not outcome.accepted
+    assert outcome.reason == expected
+    assert ConfirmedEpochReader(ledger).active_anchor_epoch_id(DEVICE) is None
+
+
+def test_a_confirmation_signed_by_an_impostor_leaves_the_epoch_unset(rig):
+    key, _, ledger, service = rig
+    artifact = _confirmation(key.public_key_hex, seed=IMPOSTOR_SEED)
+    outcome = service.accept_epoch_confirmation(artifact)
+    assert outcome.reason == REJECT_BAD_AUTHENTICATOR
+    assert ConfirmedEpochReader(ledger).active_anchor_epoch_id(DEVICE) is None
+
+
+def test_a_later_confirmation_supersedes_an_earlier_one(rig):
+    """The authority is the sole source of epoch truth; a device does not adjudicate."""
+    key, _, ledger, service = rig
+    assert service.accept_epoch_confirmation(_confirmation(key.public_key_hex)).accepted
+
+    later = _confirmation(key.public_key_hex)
+    later["anchor_epoch_id"] = "epoch-0003"
+    later["confirmed_at_ms"] = 1787000009000
+    _sign(later, EPOCH_DOMAIN, EPOCH_SEED)
+    assert service.accept_epoch_confirmation(later).accepted
+
+    assert ConfirmedEpochReader(ledger).active_anchor_epoch_id(DEVICE) == "epoch-0003"
+
+
+# --------------------------------------------------------------------------
+# A crash between verification and application
+# --------------------------------------------------------------------------
+
+
+def test_an_artifact_lost_between_verification_and_application_is_safely_replayable(
+    rig,
+):
+    """Verification is pure, so a crash before application leaves no trace.
+
+    The defined outcome is that nothing was applied and the artifact can be
+    presented again — which is safe because application is idempotent. That is
+    why the two are separable at all: a partially applied verification would
+    have no such recovery.
+    """
+    key, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+    artifact = _receipt(ledger, 1, 1)
+
+    # Verification alone, as though the process died before applying.
+    from ori.security.evidence_ingest import verify_delivery_receipt
+
+    verify_delivery_receipt(
+        artifact,
+        device_id=DEVICE,
+        registry=service._registry,
+        envelope_digests=ledger.envelope_digests(1, 1),
+    )
+    assert ledger.find_by_local_seq(1)["receipt_state"] == RECEIPT_NONE, (
+        "verification must not mutate state on its own"
+    )
+
+    # The courier re-presents it after the restart.
+    assert service.accept_receipt(artifact).accepted
+    assert ledger.find_by_local_seq(1)["receipt_state"] == RECEIPT_ACCEPTED
+
+
+def test_epoch_state_survives_a_restart(rig, tmp_path):
+    key, _, ledger, service = rig
+    assert service.accept_epoch_confirmation(_confirmation(key.public_key_hex)).accepted
+    ledger.close()
+
+    reopened = EvidenceDeliveryLedger(
+        tmp_path / "ledger.db", key, DEVICE, anchor_epoch_id=EPOCH, key_id=KEY_ID
+    )
+    try:
+        assert ConfirmedEpochReader(reopened).active_anchor_epoch_id(DEVICE) == EPOCH
+    finally:
+        reopened.close()
+
+
+def test_rejections_are_retained_for_diagnosis(rig):
+    """A device that drops them cannot explain why its evidence never arrived."""
+    _, chain, ledger, service = rig
+    _seal(chain, ledger, 1)
+
+    bad = _receipt(ledger, 1, 1)
+    bad["device_id"] = "elsewhere"
+    service.accept_receipt(bad)
+    service.accept_custody(_custody(ledger, 1, secret="wrong"))
+
+    assert [r.artifact for r in service.rejections] == [
+        "delivery_receipt",
+        "custody_acknowledgement",
+    ]
+    assert all(r.reason for r in service.rejections)

--- a/tests/vectors/evidence_exchange/MANIFEST.json
+++ b/tests/vectors/evidence_exchange/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors",
-  "source_commit": "32ba96b605866790e9a2ccaf6933e44cd38eb877",
+  "source_commit": "6ab3ee67e4ff4017b52090b9ddd539e38b94bce8",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-registration.json": "1f80e036528f3c7cc8f50e1943517cfa3765a3dd44f801571750975f4c624b47",
@@ -9,7 +9,7 @@
     "commissioning-authorization.json": "8148d4ef5a57bde9b4a841312673ed40b471f440e1d936b3d0b51314cb6c55b6",
     "custody-acknowledgement.json": "2ce7bdf1f150b17455eb12aa0fb5d3453da7a5e301dec22b0c128fb7276295e8",
     "delivery-envelope.json": "99673aa22fe4b3fa27e0e2c6460d1bae186759040f908f2266158f3bfe555c5d",
-    "delivery-receipt.json": "8aed71ce985cc1c19659c0c1d8dc0865b1e9ade64c29d05db0ba641065ce7595",
+    "delivery-receipt.json": "ece53e6f3e1fa6a03f52edb506b42c6a978166110d44a433c592055054faa918",
     "epoch-confirmation.json": "8b889d8194914c2e4091f3fbf343f739dded9ab6c02b55375a7c651429bdf302"
   }
 }

--- a/tests/vectors/evidence_exchange/delivery-receipt.json
+++ b/tests/vectors/evidence_exchange/delivery-receipt.json
@@ -10,57 +10,59 @@
       "name": "valid",
       "authenticator": "valid",
       "expected": "accept",
-      "note": "Canonical bytes reproduce and the signature verifies.",
-      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313530302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31322c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d",
+      "note": "Canonical bytes reproduce and the signature verifies under the receipt key.",
       "artifact": {
-        "accepted_at_ms": 1787000001500,
+        "v": 1,
         "device_id": "energy-monitor-ikeja-01",
         "from_seq": 12,
-        "key_id": "auth-receipt-1",
-        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
         "to_seq": 13,
-        "v": 1,
-        "signature": "ed25519:CnSAaPbERE32W2TrA+rmoUGMzm5c6Tj5mnyc9MUQiXrXagF4s//P4/fF1P/dPj57ABWF7+YyUTzuk2aPovDFAg=="
-      }
+        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
+        "accepted_at_ms": 1787000001000,
+        "key_id": "auth-receipt-1",
+        "signature": "ed25519:AA7QO7gj3Mwu2umMU6BbAuNu1FQvO3HobfbVB5R/C6/6ceOlyxrcKctHJe9hwYm94Az0JGfgqeglYB7IFdXvDA=="
+      },
+      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313030302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31322c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d"
     },
     {
       "name": "signed_with_epoch_key",
       "authenticator": "valid",
       "expected": "reject",
-      "note": "Cryptographically sound under the epoch key, which is precisely the point: the refusal comes from purpose separation, not from a bad signature. A verifier selecting by (evidence_authority_receipt, key_id) never reaches it.",
-      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313530302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31322c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d",
+      "note": "Identical content to the valid case, signed with the epoch authority's key. Cryptographically sound and asserting something a receipt key is not held to say. A verifier selecting by (purpose, key_id) checks it against the receipt key, under which it does not verify; one that trial-verified against every key it holds would accept it.",
       "artifact": {
-        "accepted_at_ms": 1787000001500,
+        "v": 1,
         "device_id": "energy-monitor-ikeja-01",
         "from_seq": 12,
-        "key_id": "auth-receipt-1",
-        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
         "to_seq": 13,
-        "v": 1,
-        "signature": "ed25519:CnSAaPbERE32W2TrA+rmoUGMzm5c6Tj5mnyc9MUQiXrXagF4s//P4/fF1P/dPj57ABWF7+YyUTzuk2aPovDFAg=="
-      }
+        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
+        "accepted_at_ms": 1787000001000,
+        "key_id": "auth-receipt-1",
+        "signature": "ed25519:YLULTMiOAz3Bm/cTAmDPsJ66eHXjFS9TmEFMGXN/A/0IVffLcSh+eoK3FUIXJq0odM1dxl5yDIf85FGWkCz8CA=="
+      },
+      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313030302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31322c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d"
     },
     {
       "name": "non_contiguous_range",
       "authenticator": "valid",
       "expected": "reject",
-      "note": "Correctly signed, but the authority never accepted 10 and 11.",
-      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313530302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31322c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d",
+      "note": "Correctly signed by the receipt key, claiming 10 to 13 while the range digest covers only 12 and 13. The authority never accepted 10 and 11, and a receipt asserting a closed interval it did not receive would make the prefix claim false.",
       "artifact": {
-        "accepted_at_ms": 1787000001500,
-        "device_id": "energy-monitor-ikeja-01",
-        "from_seq": 12,
-        "key_id": "auth-receipt-1",
-        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
-        "to_seq": 13,
         "v": 1,
-        "signature": "ed25519:CnSAaPbERE32W2TrA+rmoUGMzm5c6Tj5mnyc9MUQiXrXagF4s//P4/fF1P/dPj57ABWF7+YyUTzuk2aPovDFAg=="
-      }
+        "device_id": "energy-monitor-ikeja-01",
+        "from_seq": 10,
+        "to_seq": 13,
+        "range_digest": "sha256:9dbbe9f7932d041fb8d4ccedb472d2afba73f8cfba7bc62cd139fb76f026938c",
+        "accepted_at_ms": 1787000001000,
+        "key_id": "auth-receipt-1",
+        "signature": "ed25519:Y1AKC5EF+WZLSqqpwiew7jMenYEW1P/iB8mYECgbLdKjmH3vfa4g0C1OWrvsXEbN74FrbTpPth2jnyZBYvQ0DA=="
+      },
+      "canonical_hex": "7b2261636365707465645f61745f6d73223a313738373030303030313030302c226465766963655f6964223a22656e657267792d6d6f6e69746f722d696b656a612d3031222c2266726f6d5f736571223a31302c226b65795f6964223a22617574682d726563656970742d31222c2272616e67655f646967657374223a227368613235363a39646262653966373933326430343166623864346363656462343732643261666261373366386366626137626336326364313339666237366630323639333863222c22746f5f736571223a31332c2276223a317d"
     }
   ],
   "key_purpose": "evidence_authority_receipt",
   "signing_key_seed_hex": "404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f",
   "signing_key_public_hex": "2543b92ff1095511476adc8369db6ddc933665a11978dda1404ee1066ca9559d",
   "range_digest_note": "range_digest is sha256 over the concatenated raw 32-byte chain_row_digest values for local_seq 12 and 13, in ascending order, no separators. Both derive from the real evidence/v2 rows in delivery-envelope.json.",
-  "authority_receipt_seed_hex": "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a"
+  "authority_receipt_seed_hex": "7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a7a",
+  "epoch_authority_seed_hex": "606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f",
+  "rejection_integrity_note": "Each rejection case must differ from the valid case in the field or authenticator its name identifies. A regeneration that re-signs every case whose authenticator is 'valid' erases exactly these defects \u2014 'valid' marks a case that must verify so the semantic rule is reached, not a case that is correct."
 }

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,8 +1,8 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "32ba96b605866790e9a2ccaf6933e44cd38eb877",
-  "note": "Vendored copies of the normative vectors. The runtime must produce bytes these describe, so they are its conformance fixtures. digests detect a local edit; refresh with scripts/refresh-evidence-vectors.sh to detect upstream drift.",
+  "source_commit": "6ab3ee67e4ff4017b52090b9ddd539e38b94bce8",
+  "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",
     "chain-row.json": "c69c8c4b9158482beac607c830b3f9f1870e42932242a89ece7c2cc05fcfc646",


### PR DESCRIPTION
## What does this PR do?

Step 4 of #326: the complete ingest-and-application path, awaiting runtime composition.

Three artifacts come back from the courier and each says something different the runtime may act on only once proven — a custody acknowledgement that the gateway holds the bytes, a receipt that the authority recorded a range, an epoch confirmation that an anchor is active. This verifies them and applies the ones that prove out.

**Merging this changes no live runtime behaviour.** See the scope section.

## Two commits, deliberately

`c914234` is the verifier: an independently testable layer with no dependency on where artifacts come from or what is done with them. `06642fd` is the application seam. They are separable because verification is pure, and that separation is what gives the crash case a defined outcome.

## Authority keys come from the release, and nowhere else

The contract is explicit that a device must not accept an authority key delivered through the exchange itself. An authority able to hand a device new trust roots over the channel it is being trusted on could replace the keys that check its own claims, and every later verification would succeed by construction.

Purposes are disjoint. Rotation keeps an outgoing key verifying what it signed while a revoked one verifies nothing — a retired key that still verified would make rotation cosmetic.

## Selection by `(purpose, key_id)`, not trial verification

This is what refuses a cross-purpose artifact, and the two shapes fail at different points:

- An artifact naming a key held for **another purpose** is refused at selection.
- One naming the **right key id** but signed by another authority is checked against the right key and fails there.

A verifier that trial-verified against everything it holds would accept both. Both shapes are covered, because it is easy to catch one and not the other.

## What each artifact must prove

**Receipts** recompute the range digest from the envelopes this device actually sealed, which is what makes the prefix claim checkable rather than merely signed.

**Confirmations** must name this device's own verification key. Without that binding, an authority statement about another device's anchor would advance this one's.

**Custody** binds the envelope digest and sequence, so a forged acknowledgement cannot cause evidence to be deprioritised that was never carried.

Version is checked before anything else is trusted: an unrecognised version means the rest of the object is not this contract's to interpret, and reading fields from it anyway is how a future meaning gets assigned an old one.

## Application

`EvidenceIngestService` is a single seam on purpose. `_apply_verified_*` cannot check what it is told, so a second way to reach those methods would eventually be the unverified one.

`ConfirmedEpochReader` answers the `active_anchor_epoch_id` the firmware confirmation coordinator asks — the same question of the same conceptual authority, reached differently. It was answered by a chain object in this process; it is now answered from confirmations this device has verified. Absent a confirmation the answer is `None`, so the obligation stays pending rather than authority being granted by default.

A later confirmation supersedes an earlier one: the authority is the sole source of epoch truth, and a device holding two and choosing between them would be adjudicating something it does not decide.

Rejections are retained with a reason from a closed set. A failure to verify is information about the courier, the authority, or an attacker, and a device that drops them cannot explain why its evidence never reached anyone — while arbitrary text would put transport detail where an operator reads it.

## A crash between verification and application

The outcome is defined, and falls out of keeping the two separable. Verification is pure, so nothing was applied and the courier can present the artifact again; application is idempotent, so re-presentation is safe. A partially applied verification would have had no such recovery.

## Scope — what this does **not** do

- **No inbound transport invokes the ingest service.** Nothing constructs `EvidenceIngestService`; it has no callers outside tests.
- **Firmware confirmation still uses the legacy artifact-backed reader.** `runtime.py` continues to pass the artifact chain to `FirmwareConfirmationCoordinator`; `ConfirmedEpochReader` is not constructed anywhere.
- **Merging does not change live runtime behaviour.** No existing code path is altered.
- **Step 5 must do four things together**: construct the service, route inbound artifacts exclusively through it, substitute `ConfirmedEpochReader` for the artifact-backed reader, and retire the legacy loader. They are one edit because the substitution has to be atomic — doing them separately leaves the artifact loaded but unused, or the coordinator reading state nothing populates.
- **`evidence-exchange/v1` remains a Design Target.** The runtime is one of three halves; the gateway courier and the off-device authority have not landed theirs.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — nothing is wired, so no capability behaviour differs. The matrix entry changes in step 5, when the evidence path actually switches over.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `cryptography` and `sqlite3` are existing dependencies.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Step 4 of #326. Anchor registration — the outbound half of the epoch exchange, and a runtime-produced artifact — is #350.

## Testing notes

Full suite: 3703 passed, 27 skipped. Strict mypy, ruff and boundary typecheck clean.

Every binding is asserted to survive **into application**, not merely into verification: purpose, device, sequence, range digest, envelope digest, and the device's own verification key. Custody and receipt stay distinct through application. Replay is idempotent both ways, and a conflicting receipt over an already-delivered range is refused by the finality trigger.

Mutation-checked: applying before verifying, custody marking delivery, dropping the pubkey binding, and dropping the rejection record — each caught.

### A trap worth recording

Writing these tests reproduced the one that flattened the contract's own rejection vectors, corrected in ori-platform/ori-specs#87. Mutating a signed artifact without re-signing makes every case fail as `bad_authenticator`, and the semantic rule it was written for is never reached — five tests failed exactly that way before each case was re-signed after corruption, except the one whose defect *is* the signature.

The vendored fixtures also gain three integrity guards in the ledger suite: no rejection case identical to the valid case, each differing in something a rule would read, and a direct assertion that the cross-purpose receipt verifies under the epoch key and fails under the receipt key. Byte-level reconstruction cannot catch that class — the file stayed internally consistent, so every hash and signature reproduced while the difference between a rejection and an acceptance was gone.
