### PR TITLE
feat(evidence): produce this device's anchor registration

### DIFF
--- a/ori/security/evidence_registration.py
+++ b/ori/security/evidence_registration.py
@@ -1,0 +1,183 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Producing this device's anchor registration, per `evidence-exchange/v1`.
+
+Chain verification starts from the device's verification key. Until that key is
+registered against the epoch authorising it, a receiver holding a perfectly
+signed chain row has nothing to attribute it to — the evidence is well-formed
+and unattributable, which is worse than absent because it looks complete.
+
+**Control is not authorisation, and this is the distinction the artifact is
+built around.** A registration is signed by the key being registered, which
+proves whoever holds that key wrote it and nothing more. Anyone with a fresh
+keypair can produce one claiming any actor and any reason. The right to deploy
+a key comes from a separately signed commissioning authorisation, issued under
+a key the evidence authority holds against a registry established out of band,
+and the registration binds it by digest rather than restating its claims.
+
+Verifying that authorisation is the authority's, not this device's, because the
+authority holds the trust root the check would need.
+
+The digest covers the **complete** authorisation including its signature.
+Binding to the unsigned body would let a valid body be paired with a different
+signature, which is exactly the substitution the binding exists to prevent.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from typing import Any
+
+from ori.security.evidence_canonical import canonical_json
+from ori.security.evidence_device_key import EvidenceDeviceKey
+
+REGISTRATION_VERSION = 1
+REGISTRATION_DOMAIN = b"ori.evidence_anchor_registration.v1\x00"
+ALGORITHM = "ed25519"
+
+REGISTRATION_FIELDS = frozenset(
+    {
+        "v",
+        "device_id",
+        "pubkey_hex",
+        "anchor_epoch_id",
+        "alg",
+        "posture",
+        "registered_at_ms",
+        "commissioning_digest",
+        "key_id",
+        "signature",
+    }
+)
+
+# What a commissioning authorisation must carry for this device to bind it.
+#
+# The runtime does not cryptographically verify the authorisation, because it
+# does not hold the commissioning authority's trust root: that registry is
+# established out of band and lives with the evidence authority, which is where
+# authorisation verification belongs. Checking the signature here would prove
+# signer authenticity if the device held an independently trusted key — it is
+# not that the check is meaningless, it is that this topology deliberately does
+# not give a device that key.
+#
+# It must still refuse to bind an authorisation that does not describe this
+# registration, which is a structural check requiring no trust root at all.
+COMMISSIONING_FIELDS = frozenset(
+    {
+        "v",
+        "device_id",
+        "pubkey_hex",
+        "anchor_epoch_id",
+        "actor",
+        "reason",
+        "issued_at_ms",
+        "key_id",
+        "signature",
+    }
+)
+
+
+class RegistrationError(RuntimeError):
+    """An anchor registration could not be produced."""
+
+
+def commissioning_digest(authorisation: dict[str, Any]) -> str:
+    """`sha256:` over the canonical bytes of the complete authorisation.
+
+    Including its signature, deliberately. A digest over the unsigned body
+    would let the same body travel with a different signature, so the
+    registration would bind a claim rather than the signed artifact making it.
+    """
+    return "sha256:" + hashlib.sha256(canonical_json(authorisation)).hexdigest()
+
+
+def build_anchor_registration(
+    *,
+    device_key: EvidenceDeviceKey,
+    device_id: str,
+    anchor_epoch_id: str,
+    posture: str,
+    key_id: str,
+    registered_at_ms: int,
+    authorisation: dict[str, Any],
+) -> dict[str, Any]:
+    """Build and sign this device's registration for one epoch.
+
+    Idempotent by construction rather than by bookkeeping: every input is
+    either fixed or supplied, so the same arguments produce the same bytes.
+    `(device_id, anchor_epoch_id)` is the identity a receiver deduplicates on,
+    and re-presenting an identical binding has no effect there either.
+    """
+    if not device_id or not anchor_epoch_id or not key_id:
+        raise RegistrationError(
+            "a registration must name a device, an epoch and the key it registers"
+        )
+    _require_authorisation_describes_this(
+        authorisation,
+        device_id=device_id,
+        anchor_epoch_id=anchor_epoch_id,
+        pubkey_hex=device_key.public_key_hex,
+    )
+
+    registration: dict[str, Any] = {
+        "v": REGISTRATION_VERSION,
+        "device_id": str(device_id),
+        "pubkey_hex": device_key.public_key_hex,
+        "anchor_epoch_id": str(anchor_epoch_id),
+        "alg": ALGORITHM,
+        "posture": str(posture),
+        "registered_at_ms": int(registered_at_ms),
+        "commissioning_digest": commissioning_digest(authorisation),
+        "key_id": str(key_id),
+    }
+    signature = device_key.sign(REGISTRATION_DOMAIN + canonical_json(registration))
+    registration["signature"] = "ed25519:" + base64.b64encode(signature).decode("ascii")
+    return registration
+
+
+def _require_authorisation_describes_this(
+    authorisation: Any,
+    *,
+    device_id: str,
+    anchor_epoch_id: str,
+    pubkey_hex: str,
+) -> None:
+    """Refuse to bind an authorisation that does not cover this registration.
+
+    Structural agreement only — the same device, key and epoch. The evidence
+    authority performs the authoritative check, since it holds the
+    commissioning trust root and this device does not, so this is not the
+    security boundary.
+
+    It is the difference between producing something obviously wrong and
+    producing something the authority must quarantine, and a quarantine is an
+    incident rather than a retry.
+    """
+    if not isinstance(authorisation, dict):
+        raise RegistrationError("the commissioning authorisation is not an object")
+    present = set(authorisation)
+    if present != set(COMMISSIONING_FIELDS):
+        raise RegistrationError(
+            f"the commissioning authorisation carries {sorted(present - COMMISSIONING_FIELDS)} "
+            f"and is missing {sorted(COMMISSIONING_FIELDS - present)}"
+        )
+    if authorisation.get("v") != REGISTRATION_VERSION:
+        raise RegistrationError(
+            f"the commissioning authorisation declares version {authorisation.get('v')!r}"
+        )
+    for field, expected in (
+        ("device_id", device_id),
+        ("anchor_epoch_id", anchor_epoch_id),
+    ):
+        if str(authorisation.get(field)) != str(expected):
+            raise RegistrationError(
+                f"the commissioning authorisation names {field} "
+                f"{authorisation.get(field)!r}, not {expected!r}"
+            )
+    if str(authorisation.get("pubkey_hex", "")).lower() != pubkey_hex.lower():
+        raise RegistrationError(
+            "the commissioning authorisation authorises a different key than this "
+            "device holds"
+        )

--- a/tests/test_evidence_delivery_ledger.py
+++ b/tests/test_evidence_delivery_ledger.py
@@ -819,14 +819,17 @@ def test_the_checkpoint_reproduces_the_contract_vector_byte_for_byte(tmp_path):
 # authorisation is not the runtime's artifact at all. Filing work under whoever
 # has not done it yet is how an obligation ends up owned by nobody.
 
-# Produced by the runtime, in this step.
-PRODUCED_HERE = {"delivery-envelope.json", "checkpoint.json"}
+# Produced by the runtime.
+PRODUCED_HERE = {
+    "delivery-envelope.json",
+    "checkpoint.json",
+    # Registration binds this device's verification key to the epoch
+    # authorising it, and is signed by the key being registered. It was
+    # outstanding through steps 2 and 3, and is produced as of #350.
+    "anchor-registration.json",
+}
 
-# Produced by the runtime, still outstanding: ori-platform/ori-runtime#350.
-# Registration binds this device's verification key to the epoch authorising
-# it, and is signed by the key being registered — a runtime obligation, not an
-# ingest one.
-RUNTIME_PRODUCER_OUTSTANDING = {"anchor-registration.json"}
+RUNTIME_PRODUCER_OUTSTANDING: set[str] = set()
 
 # Received by the runtime and verified on ingest, step 4.
 STEP_FOUR_INGEST_VECTORS = {
@@ -872,8 +875,21 @@ def test_the_owner_sets_do_not_overlap():
 
 @pytest.mark.parametrize("name", sorted(PRODUCED_HERE))
 def test_vectors_produced_here_have_a_valid_case(name):
-    """The two this step owes must each carry a case to reproduce."""
+    """Each artifact the runtime produces must carry a case to reproduce."""
     assert _valid_case(exchange(name))["expected"] == "accept"
+
+
+def test_nothing_the_runtime_produces_is_still_outstanding():
+    """Empty once every runtime-produced artifact has a producer.
+
+    Kept rather than deleted: the next artifact this contract assigns to the
+    runtime lands here first, and a set that exists is harder to forget than
+    one that has to be reinvented.
+    """
+    assert RUNTIME_PRODUCER_OUTSTANDING == set(), (
+        f"runtime-produced artifacts with no producer: "
+        f"{sorted(RUNTIME_PRODUCER_OUTSTANDING)}"
+    )
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_evidence_registration.py
+++ b/tests/test_evidence_registration.py
@@ -1,0 +1,270 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Anchor registration, per `ori-specs/evidence-exchange/v1`.
+
+Driven against the contract's vector. Reproducing its bytes is the whole
+acceptance criterion: a registration this device signs differently from what
+the authority expects is a registration the authority cannot use, and the
+device's evidence stays unattributable.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import pathlib
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from ori.security.evidence_canonical import canonical_json
+from ori.security.evidence_device_key import EvidenceDeviceKey
+from ori.security.evidence_registration import (
+    REGISTRATION_DOMAIN,
+    REGISTRATION_FIELDS,
+    RegistrationError,
+    build_anchor_registration,
+    commissioning_digest,
+)
+
+VECTORS = pathlib.Path(__file__).parent / "vectors" / "evidence_exchange"
+
+
+def vector(name: str) -> dict:
+    return json.loads((VECTORS / f"{name}.json").read_text())
+
+
+def case(name: str, case_name: str) -> dict:
+    return next(c for c in vector(name)["cases"] if c["name"] == case_name)
+
+
+@pytest.fixture
+def device_key(tmp_path):
+    """A key holding the seed the registration vector was signed with."""
+    key = EvidenceDeviceKey.load_or_create(tmp_path / "device.key", "secret")
+    seed = bytes.fromhex(vector("anchor-registration")["signing_key_seed_hex"])
+    key._private = Ed25519PrivateKey.from_private_bytes(seed)
+    key._public = key._private.public_key()
+    return key
+
+
+@pytest.fixture
+def authorisation():
+    return case("commissioning-authorization", "valid")["artifact"]
+
+
+# --------------------------------------------------------------------------
+# Agreement with the contract
+# --------------------------------------------------------------------------
+
+
+def test_the_registration_reproduces_the_contract_vector_byte_for_byte(
+    device_key, authorisation
+):
+    published = case("anchor-registration", "valid")["artifact"]
+    built = build_anchor_registration(
+        device_key=device_key,
+        device_id=published["device_id"],
+        anchor_epoch_id=published["anchor_epoch_id"],
+        posture=published["posture"],
+        key_id=published["key_id"],
+        registered_at_ms=published["registered_at_ms"],
+        authorisation=authorisation,
+    )
+    assert built == published, "the registration differs from the contract's artifact"
+
+
+def test_the_registration_carries_exactly_the_contract_field_set(
+    device_key, authorisation
+):
+    built = build_anchor_registration(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0002",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=authorisation,
+    )
+    assert set(built) == set(REGISTRATION_FIELDS)
+
+
+def test_it_is_signed_by_the_key_it_registers(device_key, authorisation):
+    """Self-signed by construction: it proves control of the key, and only that."""
+    built = build_anchor_registration(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0002",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=authorisation,
+    )
+    body = {k: v for k, v in built.items() if k != "signature"}
+    Ed25519PublicKey.from_public_bytes(bytes.fromhex(built["pubkey_hex"])).verify(
+        base64.b64decode(built["signature"].split("ed25519:")[1]),
+        REGISTRATION_DOMAIN + canonical_json(body),
+    )
+
+
+# --------------------------------------------------------------------------
+# The commissioning binding
+# --------------------------------------------------------------------------
+
+
+def test_the_digest_covers_the_complete_authorisation(authorisation):
+    """Including its signature.
+
+    A digest over the unsigned body would let the same body travel with a
+    different signature, so the registration would bind a claim rather than the
+    signed artifact making it.
+    """
+    complete = commissioning_digest(authorisation)
+    body_only = (
+        "sha256:"
+        + hashlib.sha256(
+            canonical_json({k: v for k, v in authorisation.items() if k != "signature"})
+        ).hexdigest()
+    )
+
+    assert (
+        complete
+        == case("anchor-registration", "valid")["artifact"]["commissioning_digest"]
+    )
+    assert complete != body_only, "the digest excludes the signature"
+
+
+def test_a_different_signature_changes_the_digest(authorisation):
+    """The substitution the binding exists to prevent."""
+    swapped = dict(authorisation)
+    swapped["signature"] = "ed25519:" + base64.b64encode(b"\x00" * 64).decode()
+    assert commissioning_digest(swapped) != commissioning_digest(authorisation)
+
+
+@pytest.mark.parametrize(
+    "field,value,expected",
+    [
+        ("device_id", "some-other-device", "names device_id"),
+        ("anchor_epoch_id", "epoch-9999", "names anchor_epoch_id"),
+        ("pubkey_hex", "11" * 32, "authorises a different key"),
+    ],
+)
+def test_an_authorisation_that_does_not_describe_this_registration_is_refused(
+    device_key, authorisation, field, value, expected
+):
+    """A structural check, not a cryptographic one.
+
+    The evidence authority verifies the authorisation, because it holds the
+    commissioning trust root and this device does not. Agreement on device, key
+    and epoch needs no trust root, and catching a mismatch here is the
+    difference between producing something obviously wrong and producing
+    something the authority must quarantine — which is an incident, not a retry.
+    """
+    mismatched = dict(authorisation)
+    mismatched[field] = value
+    with pytest.raises(RegistrationError, match=expected):
+        build_anchor_registration(
+            device_key=device_key,
+            device_id="energy-monitor-ikeja-01",
+            anchor_epoch_id="epoch-0002",
+            posture="hardware_key",
+            key_id="dev-key-2",
+            registered_at_ms=1787000000000,
+            authorisation=mismatched,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate,expected",
+    [
+        (lambda a: a.pop("actor"), "missing"),
+        (lambda a: a.__setitem__("unexpected", True), "carries"),
+        (lambda a: a.__setitem__("v", 2), "version"),
+    ],
+)
+def test_a_malformed_authorisation_is_refused(
+    device_key, authorisation, mutate, expected
+):
+    malformed = dict(authorisation)
+    mutate(malformed)
+    with pytest.raises(RegistrationError, match=expected):
+        build_anchor_registration(
+            device_key=device_key,
+            device_id="energy-monitor-ikeja-01",
+            anchor_epoch_id="epoch-0002",
+            posture="hardware_key",
+            key_id="dev-key-2",
+            registered_at_ms=1787000000000,
+            authorisation=malformed,
+        )
+
+
+# --------------------------------------------------------------------------
+# Idempotency
+# --------------------------------------------------------------------------
+
+
+def test_the_same_inputs_produce_the_same_bytes(device_key, authorisation):
+    """`(device_id, anchor_epoch_id)` is what a receiver deduplicates on.
+
+    Idempotent by construction rather than by bookkeeping: every input is fixed
+    or supplied, so re-presenting an identical binding is genuinely identical
+    rather than merely equivalent.
+    """
+    kwargs = dict(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0002",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=authorisation,
+    )
+    assert build_anchor_registration(**kwargs) == build_anchor_registration(**kwargs)
+
+
+def test_a_different_epoch_produces_a_different_registration(device_key, authorisation):
+    """One registration per epoch; the epoch is half the identity."""
+    other = dict(authorisation)
+    other["anchor_epoch_id"] = "epoch-0003"
+    first = build_anchor_registration(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0002",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=authorisation,
+    )
+    second = build_anchor_registration(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0003",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=other,
+    )
+    assert first["anchor_epoch_id"] != second["anchor_epoch_id"]
+    assert first["signature"] != second["signature"]
+
+
+@pytest.mark.parametrize("missing", ["device_id", "anchor_epoch_id", "key_id"])
+def test_the_identity_fields_are_required(device_key, authorisation, missing):
+    kwargs = dict(
+        device_key=device_key,
+        device_id="energy-monitor-ikeja-01",
+        anchor_epoch_id="epoch-0002",
+        posture="hardware_key",
+        key_id="dev-key-2",
+        registered_at_ms=1787000000000,
+        authorisation=authorisation,
+    )
+    kwargs[missing] = ""
+    with pytest.raises(RegistrationError, match="must name"):
+        build_anchor_registration(**kwargs)


### PR DESCRIPTION
## What does this PR do?

Produces this device's anchor registration, per `evidence-exchange/v1`. Closes #350.

Chain verification starts from the device's verification key. Until that key is registered against the epoch authorising it, a receiver holding a perfectly signed chain row has nothing to attribute it to — the evidence is well-formed and unattributable, which is worse than absent because everything else looks complete.

This was unowned until it surfaced while classifying the exchange vectors during step 3. It had been swept into a set labelled "ingest" alongside receipts and confirmations; those are artifacts the runtime *receives*, and this is one it *produces*.

## Control is not authorisation

The artifact is built around that distinction, and it is the reason it has the shape it does.

A registration is signed by the key being registered. That proves whoever holds the key wrote it, and nothing more — anyone with a fresh keypair could produce one claiming any actor and any reason. The right to deploy a key comes from a separately signed **commissioning authorisation**, issued under a key the evidence authority holds against a registry established out of band.

The registration binds that authorisation **by digest** rather than restating its claims, and the digest covers the **complete** authorisation *including its signature*. Over the unsigned body, a valid body could travel with a different signature — precisely the substitution the binding exists to prevent. Asserted directly, because the two digests differ in a way nothing else would notice.

## Where verification belongs

The runtime does not cryptographically verify the authorisation, because it does not hold the commissioning authority's trust root. That registry lives with the evidence authority, which is where authorisation verification belongs.

This is a topology decision, not a claim that the check would be worthless: checking the signature here *would* prove signer authenticity if the device held an independently trusted key. It deliberately does not.

What the runtime does instead is structural, and needs no trust root — the authorisation must name the same device, the same public key and the same epoch as the registration being built. Catching a mismatch here is the difference between producing something obviously wrong and producing something the authority must **quarantine**, and a quarantine is an incident rather than a retry.

## Idempotency

By construction, not by bookkeeping. Every input is fixed or supplied, so the same arguments produce identical bytes — which is what `(device_id, anchor_epoch_id)` deduplication on the receiving side assumes. Re-presenting an identical binding is genuinely identical rather than merely equivalent.

## Scope — what this does **not** do

- **Nothing transmits registrations.** This produces the artifact; the outbound route is runtime composition plus the gateway courier.
- **No runtime code constructs it.** `runtime.py` is untouched, and `FirmwareConfirmationCoordinator` still pushes anchors through the artifact-backed chain.
- **Merging changes no live behaviour.**
- **`evidence-exchange/v1` remains a Design Target.** The gateway and the off-device authority have not landed their halves.

## Type of change

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — nothing is wired, so no capability behaviour differs. The matrix entry changes when the evidence path switches over in step 5.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `cryptography` is an existing dependency.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Closes #350. Unblocks step 5 of #326, which was waiting on this: the confirmation coordinator uses the artifact-backed chain for two things, and this is the replacement for the second.

## Testing notes

Full suite: 3731 passed, 27 skipped. Focused: 132. Strict mypy, ruff, boundary typecheck and diff check clean.

Reproduces `evidence-exchange/vectors/anchor-registration.json` byte for byte — mutation-checked before being believed:

| Mutation | Fails |
|---|---|
| Digest excludes the authorisation's signature | vector reproduction, digest completeness, signature-swap |
| Wrong signing domain | vector reproduction |
| Drop the structural authorisation check | all three mismatch cases |
| Extra field in the registration | vector reproduction, field set |

The vector-ownership set that recorded this as a runtime obligation with no producer is now empty, and a test asserts it stays that way — so the next artifact this contract assigns to the runtime lands somewhere visible rather than being rediscovered by accident.
