### PR TITLE
fix(security): refuse non-finite floats in gateway MQTT canonicalisation

### DIFF
--- a/ori/security/gateway_messages.py
+++ b/ori/security/gateway_messages.py
@@ -506,7 +506,18 @@ def _payload_without_auth(payload: Mapping[str, Any]) -> dict[str, Any]:
 
 
 def _canonical_json(value: Any) -> str:
-    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    # allow_nan=False refuses NaN and Infinity, which json.dumps would otherwise
+    # emit as bare NaN/Infinity tokens that no conforming JSON parser accepts --
+    # the Go gateway rejects them outright, so the message would be unverifiable.
+    # This is a validity constraint, not evidence/v2's D-011 agreement zone: gateway
+    # MQTT carries operational telemetry whose numeric range is deliberately broader.
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
 
 
 def _derive_encryption_key(shared_secret: str) -> bytes:

--- a/tests/test_gateway_messages.py
+++ b/tests/test_gateway_messages.py
@@ -13,6 +13,7 @@ from ori.security.gateway_messages import (
     GatewayMessageEncryptionError,
     GatewayMessageEncryptor,
     GatewayReplayCache,
+    _canonical_json,
 )
 
 
@@ -507,3 +508,27 @@ def test_authenticator_rejects_replay_across_cache_restart(tmp_path):
             expected_request_id="req-001",
             now_ms_value=11_000,
         )
+
+
+def test_canonical_json_refuses_non_finite_numbers() -> None:
+    """NaN and Infinity are not valid JSON and must never reach the wire.
+
+    ``json.dumps`` emits them as bare ``NaN``/``Infinity`` tokens by default. No
+    conforming parser accepts those, so the Go gateway rejects the payload and the
+    message becomes unverifiable rather than merely odd.
+    """
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError):
+            _canonical_json({"reading": value})
+
+
+def test_canonical_json_keeps_operational_telemetry_range() -> None:
+    """Gateway MQTT is not evidence/v2 and must not impose the D-011 zone.
+
+    A small leakage-current reading is ordinary telemetry. Constraining this
+    serializer to the evidence agreement zone would turn it into an authentication
+    failure.
+    """
+    assert _canonical_json({"value": 5e-05}) == '{"value":5e-05}'
+    assert _canonical_json({"value": 1e-05}) == '{"value":1e-05}'
+    assert _canonical_json({"value": 1e300}) == '{"value":1e+300}'


### PR DESCRIPTION
## What does this PR do?

The runtime-gateway MQTT canonicaliser called `json.dumps` without `allow_nan=False`. With the default `allow_nan=True` a non-finite float is serialised as a bare `NaN`, `Infinity` or `-Infinity` token, none of which is valid JSON. Every conforming parser rejects them, including the Go gateway, so a payload carrying one is not merely unusual — it is unverifiable, and it surfaces as an authentication failure rather than as a data error, which is a considerably harder thing to diagnose in the field.

A non-finite reading is reachable without any explicit intent to emit one: a sensor computation dividing by a zero interval, or an adapter returning a NaN sentinel. Refusing at source turns a silent unverifiable message into a loud error where the value originates.

This is a JSON validity constraint and deliberately nothing more. It is not the D-011 agreement zone from `evidence/v2`. That zone constrains evidence artifacts, which control their own numeric domain. Gateway MQTT carries operational sensor and reasoning data whose range is deliberately broader — a `5e-05` leakage-current reading is valid telemetry, and imposing the evidence zone on this transport would convert working telemetry into authentication failures. The tests assert both halves, so the distinction cannot erode into the wrong one later.

Found while investigating the cross-language canonicalisation divergence in ori-gateway#78. The two changes are independent and require no lockstep deployment: this one prevents invalid JSON at its source, while the gateway fix is backward-compatible for payloads that already worked.

## Type of change

- [x] `security` — touches a safety invariant (requires maintainer review even for skills)
- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. The serialiser refuses a value that was previously emitted in a form no receiver could parse; no capability is gained, lost, or degraded.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Verification

Full suite green: 3733 passed, 27 skipped. `ruff` clean.

The refusal test is mutation-checked: removing `allow_nan=False` fails `test_canonical_json_refuses_non_finite_numbers`, so the guard is load-bearing rather than incidentally true.

Closes #354
