### PR TITLE
test(installer): make fixtures umask-invariant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,16 @@ jobs:
             --cov-report=xml \
             -m "not hardware"
 
+      # GitHub's runner normally starts at 0022. Debian private-user-group
+      # hosts, including stock Raspberry Pi OS Trixie, commonly use 0002;
+      # installer fixtures must not depend on the runner's ambient umask.
+      - name: Installer checks under private-group umask
+        run: |
+          umask 0002
+          pytest -q \
+            tests/test_linux_installer.py \
+            tests/test_installer_activation.py
+
       # System scope is only meaningful as root: the execution guard returns
       # immediately for any other account, so an unprivileged run of these
       # would pass without exercising anything. They assert `geteuid() == 0`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,16 @@ jobs:
       - name: Run test suite
         run: pytest tests/ -q -m "not hardware"
 
+      # The ordinary runner umask is 0022, while Debian private-user-group
+      # hosts commonly use 0002. The tag gate must exercise installer fixtures
+      # under the target host's ambient umask too.
+      - name: Installer checks under private-group umask
+        run: |
+          umask 0002
+          pytest -q \
+            tests/test_linux_installer.py \
+            tests/test_installer_activation.py
+
       # System scope is only meaningful as root: the execution guard returns
       # immediately for any other account, so an unprivileged run of these
       # would pass without exercising anything. They assert `geteuid() == 0`

--- a/tests/test_installer_activation.py
+++ b/tests/test_installer_activation.py
@@ -831,7 +831,6 @@ def test_a_real_user_scope_install_passes_the_real_gate(tmp_path: Path) -> None:
     from ori import doctor
 
     root = tmp_path / "ori"
-    root.mkdir()
     _release, identity = _install_release_for_real(root, "user")
 
     reported = _as_reported(doctor.check_permissions(identity))
@@ -857,7 +856,6 @@ def test_a_real_system_scope_install_is_blocked_when_code_is_writable(
     from ori import doctor
 
     root = tmp_path / "ori"
-    root.mkdir()
     _release, identity = _install_release_for_real(root, "system")
 
     reported = _as_reported(doctor.check_permissions(identity))

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -323,6 +323,36 @@ def test_first_install_activates_only_after_prepare_and_validate(
     assert layout.current.resolve() == layout.release("2.3.0")
 
 
+def test_first_install_scaffolding_is_private_under_group_writable_umask(
+    tmp_path: Path,
+) -> None:
+    """Exercise the real first-install order without a pre-created root.
+
+    Debian's private-user-group setup commonly supplies 0002. Host-owned
+    parents may inherit that umask, while the outermost-first installer loop
+    creates each managed directory explicitly and pins it to 0700.
+    """
+    layout = InstallLayout.resolve(tmp_path / "home" / ".local" / "ori")
+    previous_umask = os.umask(0o002)
+    try:
+        install_release(
+            layout=layout,
+            version="2.3.0",
+            prepare=_prepare,
+            validate=_validate,
+            restart_service=lambda: None,
+            stop_service=lambda: None,
+            check_health=lambda _path: None,
+        )
+    finally:
+        os.umask(previous_umask)
+
+    assert [
+        stat.S_IMODE(directory.stat().st_mode)
+        for directory in (layout.root, layout.releases, layout.data)
+    ] == [0o700, 0o700, 0o700]
+
+
 def test_composed_install_orders_assets_health_and_enablement(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1148,7 +1178,8 @@ def test_releases_symlink_is_rejected(tmp_path: Path) -> None:
 
 def test_dangling_managed_current_pointer_is_repaired(tmp_path: Path) -> None:
     layout = InstallLayout.resolve(tmp_path / "ori")
-    layout.releases.mkdir(parents=True)
+    layout.root.mkdir(mode=0o700)
+    layout.releases.mkdir(mode=0o700)
     layout.current.symlink_to(Path("releases") / "2.2.0")
     install_release(
         layout=layout,
@@ -1452,8 +1483,10 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     layout = InstallLayout.resolve(tmp_path / "ori")
-    layout.releases.mkdir(parents=True)
-    layout.data.mkdir()
+    layout.root.mkdir(mode=0o700)
+    layout.root.chmod(0o755)
+    layout.releases.mkdir(mode=0o700)
+    layout.data.mkdir(mode=0o700)
     monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 501)
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
         apply_system_service_permissions(layout, SystemdServiceProfile.system())
@@ -1518,7 +1551,7 @@ def test_system_upgrade_preserves_access_and_reapplies_permissions(
     destination = layout.release("2.3.0")
     destination.mkdir(parents=True)
     _prepare(destination)
-    layout.data.mkdir()
+    layout.data.mkdir(mode=0o700)
     layout.root.chmod(0o750)
     layout.releases.chmod(0o750)
     observed_modes: list[tuple[int, int]] = []


### PR DESCRIPTION
## What does this PR do?

Issue #362 originally attributed five installer-suite failures under `umask 0002` to production scaffolding. Reproduction against the real call order established that production already creates `root`, `releases`, and `data` outermost-first and pins each managed directory to `0700`. The failures came from test fixtures that pre-created managed paths with a bare `mkdir()` and therefore inherited the runner's ambient umask.

Under `0002`, those fixtures created genuinely group-writable `0775` paths. The installer was correct to refuse them: accepting a pre-existing group-writable installation root would let another account replace what the runtime executes.

This PR corrects only the test and gate:

- First-install fixtures no longer pre-create the managed root.
- Fixtures that require pre-existing managed directories give them explicit modes.
- A regression test exercises the real first-install order under `0002` and asserts that the managed directories finish at `0700`.
- Branch and tag workflows rerun both installer suites under `0002`, matching the private-user-group default used by Raspberry Pi OS.

No production file changes. No permission check is relaxed, and no host-owned parent directory is modified.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — the final diff changes only tests and GitHub workflows. Production and capability behavior are unchanged.

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable. The final diff contains no production runtime files and adds no dependency or Tier D path.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Closes #362.

## Testing notes

The regression is demonstrated in both directions with the identical focused command:

- Untouched `origin/main` snapshot under `umask 0002`: **5 failed, 163 passed** — exactly the five fixtures listed in #362.
- This branch under `umask 0022`: **169 passed**.
- This branch under `umask 0002`: **169 passed**.

The additional passing test is the new real-order first-install regression. Production `ori/installer/linux.py` is byte-for-byte identical to `origin/main` in the final diff.

Also clean:

- `ruff check ori/ tests/ skills/`
- `ruff format --check ori/ tests/ skills/`
- `scripts/check_workflows.py`
- `scripts/typecheck-boundaries.sh`
- pre-commit and pre-push hooks
- `git diff --check`

The full-suite checkbox remains unchecked until the GitHub matrix completes. Local environment-specific SQLite and Pi dependency behavior is not characterised here as a repository failure.
