### PR TITLE
test(security): keep the evidence authority's identity out of this repository

### DIFF
--- a/tests/fixtures/firmware_fault_vectors.json
+++ b/tests/fixtures/firmware_fault_vectors.json
@@ -1,7 +1,7 @@
 {
   "contract": "ori-specs/firmware-telemetry/v1.md",
   "version": 1,
-  "comment": "Cross-language golden vectors for Verity Layer 1 signed fault events, covering every code in the closed fault vocabulary. Shared with ori-verity and ori-runtime; all implementations must produce and verify these bytes exactly. Signed with the TEST-ONLY seed in test_keypair.json — never provision that seed.",
+  "comment": "Cross-language golden vectors for Layer 1 signed fault events, covering every code in the closed fault vocabulary. Shared with the independent verifier and ori-runtime; all implementations must produce and verify these bytes exactly. Signed with the TEST-ONLY seed in test_keypair.json — never provision that seed.",
   "signature_encoding": "ed25519:<standard-base64-64-byte-signature>",
   "public_key_hex": "2152f8d19b791d24453242e15f2eab6cb7cffa7b6a5ed30097960e069881db12",
   "public_key_b64": "IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -5,7 +5,7 @@
 The corpus (``tests/fixtures/device_lifecycle_vectors.json``) is the
 contract in executable form: ori-specs/device-provisioning/v1.md requires
 lifecycle vectors "agreed byte-for-byte by every implementing repository"
-before an implementation may claim the contract. ori-verity holds the
+before an implementation may claim the contract. The independent verifier holds the
 same bytes and derives the same epoch identifiers from them with its own
 canonicalizer. It does not yet implement the anchor lifecycle, so it
 executes the epoch half of this corpus and declares the scenario half
@@ -38,7 +38,7 @@ from ori.state.store import StateStore
 FIXTURE = Path(__file__).parent / "fixtures" / "device_lifecycle_vectors.json"
 VECTORS = json.loads(FIXTURE.read_text())
 
-# SHA-256 of the complete corpus. ori-verity pins this same constant over
+# SHA-256 of the complete corpus. The independent verifier pins this same constant over
 # its own copy, and both must be updated together. Pinning it in only one
 # repository would not catch drift: each copy would still match its own
 # stale constant while the two files diverged. Asserting the identical
@@ -91,13 +91,13 @@ async def store(tmp_path):
 def test_fixture_digest_is_pinned():
     """Changing the corpus must be a deliberate, cross-repo act.
 
-    ori-verity consumes these exact bytes. Regenerating here without
+    The independent verifier consumes these exact bytes. Regenerating here without
     mirroring there would leave the two stores disagreeing about the
     contract while both test suites stayed green.
     """
     digest = hashlib.sha256(FIXTURE.read_bytes()).hexdigest()
     assert digest == FIXTURE_SHA256, (
-        "the lifecycle corpus changed. Copy it to ori-verity's "
+        "the lifecycle corpus changed. Copy it to the verifier's "
         "tests/fixtures/ and update the pinned digest in BOTH "
         f"repositories to {digest}"
     )
@@ -106,7 +106,7 @@ def test_fixture_digest_is_pinned():
 def test_fixture_matches_its_generator():
     """The committed corpus must be exactly what the generator produces.
 
-    ori-verity consumes this file byte-for-byte. If it could drift
+    The independent verifier consumes this file byte-for-byte. If it could drift
     from its generator, a hand-edit would become the cross-store contract
     without anything noticing, and regenerating would then silently
     revert another repository's expectations.
@@ -136,7 +136,7 @@ def test_epoch_ids_match_the_corpus(vector):
     """Independent derivations must agree.
 
     ``anchor_epoch_id`` is the value cross-store agreement is expressed
-    in, so if the runtime and Verity derive it differently, "both stores
+    in, so if the runtime and the verifier derive it differently, "both stores
     accepted the same epoch" becomes unfalsifiable.
     """
     i = vector["input"]
@@ -356,7 +356,7 @@ def test_a_superseded_anchor_that_is_re_registered_is_covered():
 
 def test_scenario_names_are_unique():
     """Two scenarios sharing a name makes one invisible to every check
-    keyed on it, here and in ori-verity's unimplemented-scenario list."""
+    keyed on it, here and in the verifier's unimplemented-scenario list."""
     names = [s["name"] for s in VECTORS["scenarios"]]
     assert len(names) == len(set(names))
 

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -805,6 +805,111 @@ def _printable_strings(blob: bytes, minimum: int = 4) -> str:
     return "\n".join(out)
 
 
+#: Paths where a denylisted term legitimately appears, each with its reason.
+#:
+#: An exemption is a path and a justification. It never carries the term, so
+#: this list can live in the public repository alongside the check.
+TEXT_SCAN_EXEMPT = {
+    "tests/test_evidence_v2_vectors.py": (
+        "asserts that produced vector bytes carry no foreign vocabulary; the "
+        "literal is the assertion, and sourcing it from the denylist would turn "
+        "an always-on guard into a release-only one"
+    ),
+    "tests/test_evidence_chain_producer.py": (
+        "the same guard, over names the producer emits"
+    ),
+}
+
+#: Trees excluded from the text scan, each because the bytes are not ours.
+TEXT_SCAN_EXCLUDED_TREES = {
+    # Vendored from ori-specs and drift-checked. Their content is the
+    # contract's to decide, and a schema value naming a superseded vocabulary
+    # is a negative test case there rather than a disclosure here.
+    "tests/vectors",
+}
+
+_TEXT_SCAN_SUFFIXES = {
+    ".py",
+    ".md",
+    ".sh",
+    ".toml",
+    ".yaml",
+    ".yml",
+    ".json",
+    ".cfg",
+    ".txt",
+}
+
+
+def _text_scan_paths() -> list[pathlib.Path]:
+    for root in ("ori", "tests", "docs", "scripts"):
+        base = REPO_ROOT / root
+        if not base.is_dir():
+            continue
+        for path in sorted(base.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in _TEXT_SCAN_SUFFIXES:
+                continue
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            if any(
+                relative.startswith(f"{tree}/") for tree in TEXT_SCAN_EXCLUDED_TREES
+            ):
+                continue
+            if relative in TEXT_SCAN_EXEMPT:
+                continue
+            yield path
+
+
+@pytest.mark.disclosure_release
+def test_no_denylisted_term_appears_anywhere_in_the_repository():
+    """The private identifier must not be written here, in any file.
+
+    The module audit reads log messages out of `ori/` and the document audits
+    read an enumerated set under `docs/`. Neither reaches a test, and tests are
+    where this is most likely to happen: a test has to say who owns a
+    behaviour, and that is the sentence in which an implementation gets named.
+    A name in a test file is as public as a name in a module.
+
+    Findings report a path and a category, never the matched text, for the same
+    reason the wheelhouse audit does: this runs in a public log.
+    """
+    required = os.environ.get("ORI_REQUIRE_WHEELHOUSE_AUDIT") == "1"
+
+    def _skip_or_fail(reason: str) -> None:
+        if required:
+            pytest.fail(f"ORI_REQUIRE_WHEELHOUSE_AUDIT=1 but {reason}")
+        pytest.skip(reason)
+
+    terms = _supplied_denylist()
+    if not terms:
+        _skip_or_fail("ORI_DISCLOSURE_DENYLIST is not set")
+
+    findings = []
+    for path in _text_scan_paths():
+        try:
+            body = path.read_text(errors="ignore").lower()
+        except OSError:
+            continue
+        if any(term in body for term in terms):
+            findings.append(
+                _opaque(path.relative_to(REPO_ROOT).as_posix(), PRIVATE_IDENTIFIER)
+            )
+
+    assert not findings, "private identifiers present in tracked files: " + "; ".join(
+        sorted(findings)
+    )
+
+
+def test_every_text_scan_exemption_still_exists_and_is_justified():
+    """An exemption that outlives its file silently widens the scan's blind spot."""
+    for relative, reason in TEXT_SCAN_EXEMPT.items():
+        assert (REPO_ROOT / relative).is_file(), (
+            f"{relative} is exempted from the disclosure text scan but does not exist"
+        )
+        assert len(reason) > 40, f"{relative} is exempted without a real reason"
+    for tree in TEXT_SCAN_EXCLUDED_TREES:
+        assert (REPO_ROOT / tree).is_dir(), f"{tree} is excluded but does not exist"
+
+
 @pytest.mark.disclosure_release
 def test_wheelhouse_distributions_disclose_nothing():
     """The wheelhouse is what actually reaches the device.

--- a/tests/test_evidence_v2_vectors.py
+++ b/tests/test_evidence_v2_vectors.py
@@ -16,7 +16,7 @@ What this does *not* establish: cross-language agreement. These vectors were
 generated in Python and this reconstruction is also Python, so passing proves
 the derivations are self-consistent and reproducible, not that a Rust or C
 implementation reaches the same bytes. That remains open under
-`ori-platform/ori-verity#39`, and `evidence/v2` stays a design target until it
+the verifier's own tracking issue, and `evidence/v2` stays a design target until it
 lands.
 """
 

--- a/tests/test_firmware_telemetry.py
+++ b/tests/test_firmware_telemetry.py
@@ -115,7 +115,7 @@ TELEMETRY_CASES = [name for name, case in CASES.items() if case["kind"] == "tele
 MANIFEST_CASES = [name for name, case in CASES.items() if case["kind"] == "manifest"]
 
 # Signed fault-event vectors, shared byte-for-byte with ori-edge-firmware
-# (C producer) and ori-verity (Rust verifier). The runtime is the
+# (C producer) and the independent verifier. The runtime is the
 # receiving end: these bytes and signatures are the contract it must
 # accept, not a shape it gets to reinterpret.
 FAULT_VECTORS = json.loads(
@@ -311,7 +311,7 @@ class TestGoldenVectors:
 class TestGoldenFaultVectors:
     """The runtime's own verifier, run over the committed shared fault
     vectors. This is the receiving end of the cross-language loop: the C
-    producer signs these bytes, ori-verity's ring verifier accepts them,
+    producer signs these bytes, the independent verifier accepts them,
     and the ingestion gate must accept the identical bytes here."""
 
     @pytest.mark.parametrize("name", list(FAULT_CASES))


### PR DESCRIPTION
## What does this PR do?

The evidence disclosure audit reads log messages out of `ori/` and prose out of an enumerated set of operator documents. **Neither reaches a test**, and the wheelhouse audit cannot help because `pyproject` packages `ori*` and tests are not shipped. A private identifier written into a test file was caught by nothing.

Tests are where it is most likely to happen. A test has to say *who owns a behaviour*, and that is the sentence in which an implementation gets named.

Eleven such sentences existed, describing cross-language vector interop and corpus ownership. They now name the role — *the independent verifier*, *the evidence authority* — which is the vocabulary `evidence_anchor.py` and `evidence_registration.py` already use, and which loses nothing a reader needed.

## The scan

Repository-wide across `ori/`, `tests/`, `docs/` and `scripts/`, using the **same secret-supplied denylist** as the module audit, so no real name enters this repository in order to express the check. Findings report a path and a category and never the matched text, because it runs in a public log.

Proven in both directions rather than asserted:

- seeded with a term that **is** present, the scan fails
- seeded with the real boundary term, it **passes**

The second is the evidence the cleanup is complete.

## Two deliberate limits

**Release-gated, not branch-gated.** `ORI_DISCLOSURE_DENYLIST` is a release secret, so a leak is caught when a release is cut rather than on the pull request that introduced it. That is the posture the wheelhouse audit already has. Moving it earlier means deciding whether the denylist may reach ordinary CI — a separate call about where the name may live, not one to make silently here.

**Three guards keep the literal, by named exemption.** They assert that produced bytes and emitted names carry no foreign vocabulary, so there the literal *is* the assertion. Sourcing it from the denylist would convert an always-on guard into a release-only one — weakening a real check in order to satisfy a scan. Each is exempted by path with its reason, and a second test fails if an exemption outlives the file it names, so the blind spot cannot widen unnoticed.

`tests/vectors/` is excluded as a tree: those bytes are vendored from ori-specs and drift-checked, and a schema value naming a superseded vocabulary is a negative test case there rather than a disclosure here.

## Type of change

- [x] `test` — tests only
- [x] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. This alters test prose and adds a release-gated audit; no runtime path is affected.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Closes #373

## Testing notes

3901 passed, 27 skipped. The scan skips locally, which is the extra skip — the denylist is a release secret.

Ruff, `ruff format --check` and `git diff --check` clean.


