### PR TITLE
fix(evidence): key custody from the custody secret's exact bytes

### DIFF
--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -305,6 +305,14 @@ gateway:
     # purpose: this one authenticates the gateway's claim that it is carrying
     # evidence. Reusing the envelope secret would let anything holding it for
     # one purpose mint artifacts for the other.
+    #
+    # Generate it from a CSPRNG with at least 256 bits of entropy -- for
+    # example `openssl rand -base64 32` -- and provision it with no surrounding
+    # whitespace, since the key is the secret's exact UTF-8 bytes and a stray
+    # newline derives an identifier the gateway does not hold. A passphrase is
+    # not acceptable: the custody MAC is what stands between this runtime's
+    # queue and anything on the site network that can reach the broker, and
+    # nothing at startup can measure entropy, so this one is yours to keep.
     secret_env: ""                   # env var name only; never put the secret in ori.yaml
     previous_secret_env: ""          # optional verify-only previous generation during rotation
     # A retired generation is named, never re-derived: retiring it destroys the

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -4154,6 +4154,12 @@ def _envelope_secrets(config: Config) -> tuple[str, ...]:
     Handed to the custody registry so reuse is refused on the bytes. Two
     environment variables can hold the same value, so comparing the names an
     operator wrote would report that configuration as correct.
+
+    Each value is contributed both as provisioned and stripped of surrounding
+    whitespace. A custody secret differing from an envelope secret only by a
+    trailing newline is the same secret to any peer that trims one of them, and
+    treating those as distinct key material would let a stray keystroke defeat
+    the separation rather than report it.
     """
     raw_auth = getattr(config.gateway, "auth", {})
     auth_cfg = raw_auth if isinstance(raw_auth, dict) else {}
@@ -4161,13 +4167,15 @@ def _envelope_secrets(config: Config) -> tuple[str, ...]:
         str(auth_cfg.get("shared_secret_env", "") or "").strip(),
         str(auth_cfg.get("previous_shared_secret_env", "") or "").strip(),
     )
-    return tuple(
-        value
-        for name in names
-        if name
-        for value in (os.environ.get(name, ""),)
-        if value
-    )
+    resolved: list[str] = []
+    for name in names:
+        if not name:
+            continue
+        value = os.environ.get(name, "")
+        for candidate in (value, value.strip()):
+            if candidate and candidate not in resolved:
+                resolved.append(candidate)
+    return tuple(resolved)
 
 
 def _custody_key_registry(config: Config) -> CustodyKeyRegistry | None:
@@ -4194,7 +4202,11 @@ def _custody_key_registry(config: Config) -> CustodyKeyRegistry | None:
     # runtime silently refusing every acknowledgement.
     if not env_name:
         return None
-    active = os.environ.get(env_name, "").strip()
+    # Read exactly as provisioned. The custody MAC keys from these bytes, so
+    # trimming would key from bytes the operator did not set; the registry
+    # refuses surrounding whitespace instead of silently deriving a different
+    # identifier from the one the gateway holds.
+    active = os.environ.get(env_name, "")
     if not active:
         raise ValueError(
             f"gateway.custody.secret_env names {env_name}, but that environment "
@@ -4205,7 +4217,7 @@ def _custody_key_registry(config: Config) -> CustodyKeyRegistry | None:
     previous_env = str(custody_cfg.get("previous_secret_env", "") or "").strip()
     previous = ""
     if previous_env:
-        previous = os.environ.get(previous_env, "").strip()
+        previous = os.environ.get(previous_env, "")
         if not previous:
             raise ValueError(
                 f"gateway.custody.previous_secret_env names {previous_env}, but "

--- a/ori/security/custody_keys.py
+++ b/ori/security/custody_keys.py
@@ -57,9 +57,24 @@ class CustodyKeyRegistryError(ValueError):
 
 
 def derive_custody_key_id(secret: str) -> str:
-    """The `(gateway_custody, key_id)` selector for one secret generation."""
+    """The `(gateway_custody, key_id)` selector for one secret generation.
+
+    Keys from the secret's exact UTF-8 bytes, and normalises nothing. A secret
+    carrying a stray newline -- the ordinary shape of one read from a file or a
+    systemd `EnvironmentFile` -- is refused rather than trimmed, because
+    trimming would key from bytes the operator never provisioned and derive an
+    identifier no conforming peer reproduces. That divergence presents as
+    `bad_authenticator` on every acknowledgement instead of as the
+    configuration error it is, and the two sides can only agree here by
+    agreeing exactly.
+    """
     if not secret:
         raise CustodyKeyRegistryError("a custody secret must not be empty")
+    if secret != secret.strip():
+        raise CustodyKeyRegistryError(
+            "a custody secret must not carry leading or trailing whitespace; "
+            "the key is the secret's exact UTF-8 bytes"
+        )
     material = HKDF(
         algorithm=hashes.SHA256(),
         length=CUSTODY_KEY_ID_BYTES,

--- a/tests/test_evidence_config.py
+++ b/tests/test_evidence_config.py
@@ -362,3 +362,60 @@ class TestCustodyKeysReachTheIngestPath:
         attestor = _build_evidence_attestor(self._config(tmp_path, {"secret_env": ""}))
         assert attestor is not None
         assert attestor._custody_keys is None
+
+    @pytest.mark.parametrize(
+        "provisioned",
+        ["custody-secret\n", "custody-secret ", " custody-secret", "\tcustody-secret"],
+    )
+    def test_a_custody_secret_carrying_whitespace_stops_startup(
+        self, tmp_path, monkeypatch, provisioned
+    ) -> None:
+        """The key is the secret's exact bytes, so the runtime must not trim.
+
+        Trimming here and not on the far side -- or the reverse -- derives two
+        identifiers from one provisioned secret, and every acknowledgement then
+        fails as `bad_authenticator` while both sides believe they hold the
+        same key. Refusing at startup is the only outcome that cannot diverge
+        silently.
+        """
+        monkeypatch.setenv("ORI_TEST_DEVICE_SECRET", "a-random-install-secret")
+        monkeypatch.setenv("ORI_TEST_ENVELOPE", self.ENVELOPE)
+        monkeypatch.setenv("ORI_TEST_CUSTODY_UNTRIMMED", provisioned)
+
+        with pytest.raises(ValueError, match="whitespace"):
+            _build_evidence_attestor(
+                self._config(
+                    tmp_path,
+                    {
+                        "secret_env": "ORI_TEST_CUSTODY_UNTRIMMED",
+                        "previous_secret_env": "",
+                        "retired_key_ids": [],
+                    },
+                )
+            )
+
+    def test_whitespace_cannot_smuggle_the_envelope_secret_into_custody(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """Separation compares key material, not the keystrokes around it.
+
+        An envelope secret provisioned with a trailing newline is the same
+        secret as the custody one to any peer that trims it, so comparing only
+        the bytes as provisioned would call this configuration separated while
+        both purposes ran on one key.
+        """
+        monkeypatch.setenv("ORI_TEST_DEVICE_SECRET", "a-random-install-secret")
+        monkeypatch.setenv("ORI_TEST_ENVELOPE", self.ENVELOPE + "\n")
+        monkeypatch.setenv("ORI_TEST_CUSTODY_TRIMMED", self.ENVELOPE)
+
+        with pytest.raises(ValueError, match="envelope secret"):
+            _build_evidence_attestor(
+                self._config(
+                    tmp_path,
+                    {
+                        "secret_env": "ORI_TEST_CUSTODY_TRIMMED",
+                        "previous_secret_env": "",
+                        "retired_key_ids": [],
+                    },
+                )
+            )


### PR DESCRIPTION
## What does this PR do?

The custody secret was stripped where it was read from the environment and again where the identifier was derived. `evidence-exchange/v1` keys the MAC from the secret's UTF-8 bytes as provisioned, so trimming keys from bytes the operator never set: a secret carrying a stray newline — the ordinary shape of one read from a file or a systemd `EnvironmentFile` — derives an identifier and a MAC that no conforming peer reproduces. The two sides then disagree without saying so, and every acknowledgement fails as `bad_authenticator` rather than reporting the configuration error it is.

Nothing is normalised now. Surrounding whitespace is refused where the identifier is derived, so both generations are covered wherever a registry is built. Refusing at startup is the only outcome that cannot diverge quietly from the far side: a secret whose bytes are meant to include surrounding whitespace is not something anyone provisions, so the choice is between a loud refusal and a silent disagreement.

Separation from the runtime-gateway envelope secret is now compared against effective key material. The envelope path normalises its own secret before use, so an envelope secret provisioned with a trailing newline and a custody secret without one are one key in practice. Contributing each envelope value both as provisioned and stripped keeps a stray keystroke from defeating the separation instead of reporting it.

`ori.yaml.example` carries the entropy requirement: a CSPRNG-generated secret of at least 256 bits, provisioned without surrounding whitespace, and not a passphrase. The custody MAC is what stands between this runtime's queue and anything on the site network that can reach the broker, and no startup check can measure entropy, so the requirement is stated where the operator sets the value.

The gateway side of the same contract is corrected in ori-gateway#83. Both sides must derive identically against the same vectors.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes state or posture here. The change is how one secret's bytes are read and compared; it adds no capability, and it does not alter whether any capability reports available, simulated, or refused.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. Custody acknowledgements are evidence-path state and carry no action authority.

## Related issue

Follows the custody key material work in #374.

## Testing notes

The whitespace rule and the widened separation comparison are each covered through the real constructor seam in `tests/test_evidence_config.py`, so they exercise config → environment → registry → attestor rather than the derivation in isolation.

Both were mutation-checked: dropping the whitespace rule, restoring the trim at the environment read, and narrowing the forbidden set back to as-provisioned bytes each fail their own test and nothing else.

Full suite 3906 passed, 27 skipped. Pyright reports 0 errors on every changed file. The release-gated disclosure scan was driven locally with `ORI_DISCLOSURE_DENYLIST` supplied, since it skips silently when unset.
