### PR TITLE
fix(installer): bind managed paths to verified inodes

### DIFF
--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -2410,15 +2410,15 @@ def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
             )
 
         mode = stat.S_IMODE(info.st_mode)
-        if not created and mode & 0o020:
-            # Never silently adopt a shared pre-existing directory. Its exact
-            # mode is evidence that another account could replace entries.
+        if not created and mode & 0o022:
+            # Never silently adopt a pre-existing directory another account
+            # can modify. Its exact mode is evidence that entries are replaceable.
             raise LinuxInstallError(
-                "unsafe_install_root", f"{path.name} is group-writable"
+                "unsafe_install_root", f"{path.name} is writable by another account"
             )
         if created or mode & 0o007:
             # Pin created directories despite umask/default ACLs, and tighten
-            # only the previously accepted (non-group-writable) existing case.
+            # only an existing directory no other account can modify.
             fchmod(descriptor, 0o700)
             info = os.fstat(descriptor)
             if stat.S_IMODE(info.st_mode) != 0o700:
@@ -2454,7 +2454,7 @@ def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
 def _private_directory_error_detail(
     path: Path, *, created: bool, error: OSError
 ) -> str:
-    """Explain a kernel refusal without using pathname state as authority."""
+    """Explain a kernel refusal; pathname inspection here is diagnostic only."""
     if created and isinstance(error, PermissionError):
         return (
             f"{path.name} was created but is not accessible; "

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -499,7 +499,12 @@ def provision_runtime_config(
     }
     encoded = yaml.safe_dump(document, sort_keys=False).encode("utf-8")
     try:
-        config_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        # In the composed transaction this is ``layout.data``, already created
+        # by the managed-scaffolding loop. Keep the standalone API equally
+        # strict: creation provenance and any mode repair must come from the
+        # same no-follow descriptor primitive, not a pathname check followed by
+        # recursive mkdir/chmod operations.
+        _ensure_private_directory(config_path.parent)
         previous: tuple[bytes, int, int, int] | None = None
         if config_path.is_file():
             previous_stat = config_path.stat()
@@ -509,6 +514,10 @@ def provision_runtime_config(
                 previous_stat.st_uid,
                 previous_stat.st_gid,
             )
+    except LinuxInstallError as exc:
+        raise LinuxInstallError(
+            "config_validation_failed", "config destination could not be prepared"
+        ) from exc
     except OSError as exc:
         raise LinuxInstallError(
             "config_validation_failed", "config destination could not be prepared"
@@ -906,6 +915,12 @@ class SystemdServiceManager:
             raise LinuxInstallError(
                 "service_start_failed", "systemd unit directory must not be a symlink"
             )
+        # This is deliberately not installer-owned scaffolding. System scope
+        # writes inside a root-owned systemd hierarchy; user scope writes below
+        # the invoking account's private home. Recursive creation may prepare
+        # host-owned parents, which must keep the host's policy and must never
+        # be adopted or chmodded by ``_ensure_private_directory``. The unit
+        # itself is still placed with O_EXCL/O_NOFOLLOW in ``_atomic_write``.
         parent.mkdir(parents=True, exist_ok=True, mode=self._directory_mode())
         previous: tuple[bytes, int] | None = None
         installed = False
@@ -2100,12 +2115,24 @@ def install_release(
     # result only after the last element, so a root that exists while `data` is
     # a symlink would create `releases/`, raise, and leave it behind with no
     # record that this run had made it.
-    scaffolding: list[Path] = []
+    scaffolding: list[_CreatedDirectory] = []
     try:
+        # ``root`` is the first boundary the installer owns. Its parent may be
+        # a host-owned directory such as ``~/.local`` and is intentionally
+        # governed by host policy. Prepare it separately; every managed entry
+        # below it is then created exactly one component at a time so implicit
+        # parents cannot escape descriptor validation or rollback provenance.
+        try:
+            layout.root.parent.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            raise LinuxInstallError(
+                "unsafe_install_root", "install root parent could not be prepared"
+            ) from exc
         for directory in (layout.root, layout.releases, layout.data):
             # Ordered outermost first, so cleanup can unwind it in reverse.
-            if _ensure_private_directory(directory):
-                scaffolding.append(directory)
+            created_directory = _ensure_private_directory(directory)
+            if created_directory is not None:
+                scaffolding.append(created_directory)
         return _install_release(
             layout=layout,
             version=version,
@@ -2325,28 +2352,147 @@ def _assert_managed_path(layout: InstallLayout, path: Path) -> None:
         ) from exc
 
 
-def _ensure_private_directory(path: Path) -> bool:
-    if path.is_symlink():
-        raise LinuxInstallError(
-            "unsafe_install_root", f"{path.name} must not be a symlink"
-        )
-    created = not path.exists()
-    path.mkdir(parents=True, exist_ok=True, mode=0o700)
-    if not path.is_dir():
-        raise LinuxInstallError(
-            "unsafe_install_root", f"{path.name} is not a directory"
+@dataclass(frozen=True)
+class _CreatedDirectory:
+    path: Path
+    device: int
+    inode: int
+
+
+def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
+    """Create one managed directory privately, or validate the existing inode.
+
+    A successful ``mkdir`` is the only creation-provenance signal. An earlier
+    ``exists`` result cannot say whether ``mkdir(exist_ok=True)`` later met a
+    different entry. Once opened, type and mode decisions stay bound to that
+    no-follow descriptor, and the pathname is rechecked before success so a
+    concurrent replacement fails closed instead of becoming the install root.
+
+    Linux and macOS both provide the required O_DIRECTORY/O_NOFOLLOW and
+    fchmod contract. A platform without it is rejected explicitly; silently
+    falling back to stat-then-chmod would restore the race this function closes.
+    """
+    created = False
+    completed = False
+    descriptor = -1
+    created_identity: tuple[int, int] | None = None
+    try:
+        try:
+            os.mkdir(path, 0o700)
+            created = True
+            created_info = os.stat(path, follow_symlinks=False)
+            created_identity = (created_info.st_dev, created_info.st_ino)
+        except FileExistsError:
+            # EEXIST establishes no trust. It only says this invocation did not
+            # create the entry; the descriptor checks below decide whether the
+            # existing object is acceptable and it is never rollback-owned.
+            pass
+
+        try:
+            open_flags = os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW
+            fchmod = os.fchmod
+        except AttributeError as exc:
+            raise LinuxInstallError(
+                "unsafe_install_root",
+                "platform lacks no-follow directory descriptor support",
+            ) from exc
+
+        descriptor = os.open(path, open_flags)
+        info = os.fstat(descriptor)
+        if not stat.S_ISDIR(info.st_mode):  # O_DIRECTORY also enforces this.
+            raise LinuxInstallError(
+                "unsafe_install_root", f"{path.name} is not a directory"
+            )
+        descriptor_identity = (info.st_dev, info.st_ino)
+        if created_identity is not None and descriptor_identity != created_identity:
+            raise LinuxInstallError(
+                "unsafe_install_root", f"{path.name} changed during preparation"
+            )
+
+        mode = stat.S_IMODE(info.st_mode)
+        if not created and mode & 0o020:
+            # Never silently adopt a shared pre-existing directory. Its exact
+            # mode is evidence that another account could replace entries.
+            raise LinuxInstallError(
+                "unsafe_install_root", f"{path.name} is group-writable"
+            )
+        if created or mode & 0o007:
+            # Pin created directories despite umask/default ACLs, and tighten
+            # only the previously accepted (non-group-writable) existing case.
+            fchmod(descriptor, 0o700)
+            info = os.fstat(descriptor)
+            if stat.S_IMODE(info.st_mode) != 0o700:
+                raise LinuxInstallError(
+                    "unsafe_install_root", f"{path.name} could not be made private"
+                )
+
+        current = os.stat(path, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != descriptor_identity:
+            raise LinuxInstallError(
+                "unsafe_install_root", f"{path.name} changed during preparation"
+            )
+        completed = True
+        if created:
+            return _CreatedDirectory(
+                path=path,
+                device=descriptor_identity[0],
+                inode=descriptor_identity[1],
+            )
+        return None
+    except LinuxInstallError:
+        raise
+    except OSError as exc:
+        detail = _private_directory_error_detail(path, created=created, error=exc)
+        raise LinuxInstallError("unsafe_install_root", detail) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if created and not completed:
+            _remove_created_directory(path, created_identity)
+
+
+def _private_directory_error_detail(
+    path: Path, *, created: bool, error: OSError
+) -> str:
+    """Explain a kernel refusal without using pathname state as authority."""
+    if created and isinstance(error, PermissionError):
+        return (
+            f"{path.name} was created but is not accessible; "
+            "owner-stripping umasks are unsupported"
         )
     if created:
-        path.chmod(0o700)
-    mode = stat.S_IMODE(path.stat().st_mode)
-    if mode & 0o020:
-        raise LinuxInstallError("unsafe_install_root", f"{path.name} is group-writable")
-    if mode & 0o007:
-        path.chmod(0o700)
-    return created
+        return f"{path.name} could not be verified after creation"
+    try:
+        info = os.stat(path, follow_symlinks=False)
+    except FileNotFoundError:
+        return f"{path.name} parent is unavailable"
+    except OSError:
+        return f"{path.name} could not be prepared"
+    if stat.S_ISLNK(info.st_mode):
+        return f"{path.name} must not be a symlink"
+    if not stat.S_ISDIR(info.st_mode):
+        return f"{path.name} is not a directory"
+    return f"{path.name} could not be prepared"
 
 
-def _remove_created_scaffolding(directories: Sequence[Path]) -> None:
+def _remove_created_directory(path: Path, identity: tuple[int, int] | None) -> None:
+    """Best-effort cleanup only when the pathname still names our inode."""
+    if identity is None:
+        return
+    try:
+        current = os.stat(path, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != identity:
+            return
+        path.rmdir()
+    except OSError:
+        # Replacement, content, disappearance, or permissions all mean leave it
+        # alone. Cleanup must never replace the original installer diagnosis.
+        return
+
+
+def _remove_created_scaffolding(
+    directories: Sequence[_CreatedDirectory],
+) -> None:
     """Undo the empty directory tree this invocation brought into being.
 
     Only directories this run created are considered, and only while they are
@@ -2359,9 +2505,12 @@ def _remove_created_scaffolding(directories: Sequence[Path]) -> None:
     unsafe. Raising here would replace the operator's real diagnosis with a
     cleanup error.
     """
-    for directory in reversed(list(directories)):
+    for created in reversed(list(directories)):
         try:
-            directory.rmdir()
+            current = os.stat(created.path, follow_symlinks=False)
+            if (current.st_dev, current.st_ino) != (created.device, created.inode):
+                continue
+            created.path.rmdir()
         except OSError:
             # Not empty, not present, or not permitted — all fine to leave, and
             # none of them says anything about the next one. Stopping here would

--- a/ori/security/release_bundles.py
+++ b/ori/security/release_bundles.py
@@ -377,9 +377,7 @@ def extract_verified_bundle(
 ) -> ExtractedReleaseBundle:
     """Validate, extract, and manifest-check an authenticated bundle."""
     destination_path = Path(destination)
-    if destination_path.exists():
-        _fail("unsafe_bundle_archive", "extraction destination already exists")
-    destination_path.mkdir(mode=0o700, parents=True)
+    _create_private_extraction_root(destination_path)
 
     try:
         with _open_artifact(verified.artifact) as artifact_handle:
@@ -512,9 +510,18 @@ def _extract_member(
 ) -> None:
     target = destination.joinpath(*PurePosixPath(member.name).parts)
     if member.isdir():
+        # ``destination`` was created as an exact 0700 boundary before archive
+        # parsing. Every validated member stays beneath it, so recursive parent
+        # creation cannot expose content even when an implicit directory
+        # inherits a permissive umask. The caller later normalises the verified
+        # release tree for its service scope.
         target.mkdir(mode=0o700, parents=True, exist_ok=True)
         return
 
+    # Same private-ancestor invariant as directory members: file parents can be
+    # recursive only because the authenticated path is relative and the 0700
+    # extraction root already exists. ``_copy_new_file`` still uses exclusive
+    # creation, so an archive member never replaces an existing entry.
     target.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     source = archive.extractfile(member)
     if source is None:
@@ -537,6 +544,49 @@ def _copy_new_file(source: IO[bytes], target: Path, expected_size: int) -> None:
             output.write(chunk)
     if written != expected_size:
         _fail("unsafe_bundle_archive", "archive member was truncated")
+
+
+def _create_private_extraction_root(path: Path) -> None:
+    """Create exactly one private workspace component and pin its mode."""
+    descriptor = -1
+    created = False
+    completed = False
+    identity: tuple[int, int] | None = None
+    try:
+        os.mkdir(path, 0o700)
+        created = True
+        created_info = os.stat(path, follow_symlinks=False)
+        identity = (created_info.st_dev, created_info.st_ino)
+        descriptor = os.open(
+            path,
+            os.O_RDONLY | os.O_CLOEXEC | os.O_DIRECTORY | os.O_NOFOLLOW,
+        )
+        os.fchmod(descriptor, 0o700)
+        info = os.fstat(descriptor)
+        if not stat.S_ISDIR(info.st_mode) or stat.S_IMODE(info.st_mode) != 0o700:
+            _fail("unsafe_bundle_archive", "extraction workspace is not private")
+        if (info.st_dev, info.st_ino) != identity:
+            _fail("unsafe_bundle_archive", "extraction workspace changed")
+        current = os.stat(path, follow_symlinks=False)
+        if (current.st_dev, current.st_ino) != identity:
+            _fail("unsafe_bundle_archive", "extraction workspace changed")
+        completed = True
+    except FileExistsError:
+        _fail("unsafe_bundle_archive", "extraction destination already exists")
+    except ReleaseBundleError:
+        raise
+    except (AttributeError, OSError):
+        _fail("unsafe_bundle_archive", "extraction workspace could not be prepared")
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if created and not completed and identity is not None:
+            try:
+                current = os.stat(path, follow_symlinks=False)
+                if (current.st_dev, current.st_ino) == identity:
+                    path.rmdir()
+            except OSError:
+                pass
 
 
 def _verify_extracted_manifest(

--- a/ori/security/release_bundles.py
+++ b/ori/security/release_bundles.py
@@ -513,8 +513,9 @@ def _extract_member(
         # ``destination`` was created as an exact 0700 boundary before archive
         # parsing. Every validated member stays beneath it, so recursive parent
         # creation cannot expose content even when an implicit directory
-        # inherits a permissive umask. The caller later normalises the verified
-        # release tree for its service scope.
+        # inherits a permissive umask. This temporary tree supplies the verified
+        # wheelhouse used to build a separate release staging directory; the
+        # extracted directories are not installed directly.
         target.mkdir(mode=0o700, parents=True, exist_ok=True)
         return
 

--- a/ori/security/release_bundles.py
+++ b/ori/security/release_bundles.py
@@ -586,6 +586,9 @@ def _create_private_extraction_root(path: Path) -> None:
                 if (current.st_dev, current.st_ino) == identity:
                     path.rmdir()
             except OSError:
+                # Cleanup is best effort after preparation has already failed.
+                # Disappearance, replacement, content, or permissions must not
+                # replace the original release-bundle diagnosis.
                 pass
 
 

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -351,6 +351,181 @@ def test_first_install_scaffolding_is_private_under_group_writable_umask(
         stat.S_IMODE(directory.stat().st_mode)
         for directory in (layout.root, layout.releases, layout.data)
     ] == [0o700, 0o700, 0o700]
+    assert stat.S_IMODE((tmp_path / "home" / ".local").stat().st_mode) == 0o775
+
+
+def test_creation_provenance_race_refuses_existing_entry_and_rolls_back_only_ours(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """EEXIST after an absence observation must not become `created=True`.
+
+    Replacing the hardened helper with main's exists/mkdir/chmod sequence makes
+    this test silently adopt ``data`` and complete the install. The assertion
+    therefore pins both creation-result provenance and rollback ownership.
+    """
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.root.mkdir(mode=0o700)
+    real_mkdir = os.mkdir
+
+    def mkdir_with_race(
+        candidate: str | bytes | os.PathLike[str] | os.PathLike[bytes],
+        mode: int = 0o777,
+        *,
+        dir_fd: int | None = None,
+    ) -> None:
+        if Path(candidate) == layout.data:
+            real_mkdir(candidate, mode, dir_fd=dir_fd)
+            os.chmod(candidate, 0o775, dir_fd=dir_fd)
+            raise FileExistsError(17, "simulated concurrent creation", str(candidate))
+        real_mkdir(candidate, mode, dir_fd=dir_fd)
+
+    monkeypatch.setattr(installer_linux.os, "mkdir", mkdir_with_race)
+
+    with pytest.raises(LinuxInstallError, match="data is group-writable"):
+        install_release(
+            layout=layout,
+            version="2.3.0",
+            prepare=_prepare,
+            validate=_validate,
+            restart_service=lambda: None,
+            stop_service=lambda: None,
+            check_health=lambda _path: None,
+        )
+
+    assert stat.S_IMODE(layout.data.stat().st_mode) == 0o775
+    assert layout.root.exists(), "the pre-existing root is not rollback-owned"
+    assert not layout.releases.exists(), "only our successful mkdir is rolled back"
+
+
+def test_path_substitution_never_chmods_or_accepts_the_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mode repair stays on the opened inode and substitution fails closed.
+
+    The test hooks both mutation APIs so it also mutation-checks the old
+    pathname implementation: Path.chmod would change and accept the substitute;
+    descriptor-backed fchmod changes only the displaced, already-open inode.
+    """
+    path = tmp_path / "ori"
+    displaced = tmp_path / "opened-inode"
+    path.mkdir(mode=0o700)
+    path.chmod(0o701)
+    real_mkdir = os.mkdir
+    real_fchmod = os.fchmod
+    real_path_chmod = Path.chmod
+    replaced = False
+
+    def replace_entry() -> None:
+        nonlocal replaced
+        if replaced:
+            return
+        path.rename(displaced)
+        real_mkdir(path, 0o755)
+        os.chmod(path, 0o755)
+        replaced = True
+
+    def raced_fchmod(descriptor: int, mode: int) -> None:
+        replace_entry()
+        real_fchmod(descriptor, mode)
+
+    def raced_path_chmod(candidate: Path, *args: object, **kwargs: object) -> None:
+        if candidate == path:
+            replace_entry()
+        real_path_chmod(candidate, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(installer_linux.os, "fchmod", raced_fchmod)
+    monkeypatch.setattr(Path, "chmod", raced_path_chmod)
+
+    with pytest.raises(LinuxInstallError, match="changed during preparation"):
+        installer_linux._ensure_private_directory(path)
+
+    assert replaced is True
+    assert stat.S_IMODE(path.stat().st_mode) == 0o755
+    assert stat.S_IMODE(displaced.stat().st_mode) == 0o700
+
+
+def test_scaffolding_cleanup_refuses_a_substituted_inode(tmp_path: Path) -> None:
+    path = tmp_path / "ori"
+    displaced = tmp_path / "created-by-installer"
+    created = installer_linux._ensure_private_directory(path)
+    assert created is not None
+    path.rename(displaced)
+    path.mkdir(mode=0o700)
+
+    installer_linux._remove_created_scaffolding([created])
+
+    assert path.exists(), "the replacement was not created by this invocation"
+    assert displaced.exists(), "the proven inode is no longer at its recorded path"
+
+
+@pytest.mark.parametrize("mode", [0o770, 0o775, 0o720, 0o2775])
+def test_preexisting_group_writable_directory_is_refused_unmodified(
+    tmp_path: Path, mode: int
+) -> None:
+    path = tmp_path / "ori"
+    path.mkdir(mode=0o700)
+    path.chmod(mode)
+
+    with pytest.raises(LinuxInstallError, match="group-writable"):
+        installer_linux._ensure_private_directory(path)
+
+    assert stat.S_IMODE(path.stat().st_mode) == mode
+
+
+@pytest.mark.parametrize(
+    ("kind", "detail"),
+    [
+        ("symlink", "must not be a symlink"),
+        ("file", "is not a directory"),
+        ("missing_parent", "parent is unavailable"),
+    ],
+)
+def test_private_directory_object_failures_are_stable_and_non_creating(
+    tmp_path: Path, kind: str, detail: str
+) -> None:
+    path = tmp_path / "ori"
+    if kind == "symlink":
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        path.symlink_to(outside, target_is_directory=True)
+    elif kind == "file":
+        path.write_text("not a directory", encoding="utf-8")
+    else:
+        path = tmp_path / "missing" / "ori"
+
+    with pytest.raises(LinuxInstallError) as raised:
+        installer_linux._ensure_private_directory(path)
+
+    assert detail in raised.value.detail
+    if kind == "missing_parent":
+        assert not path.parent.exists()
+
+
+def test_owner_stripping_umask_is_rejected_stably_and_cleaned_up(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "ori"
+    previous_umask = os.umask(0o500)
+    try:
+        with pytest.raises(LinuxInstallError) as raised:
+            installer_linux._ensure_private_directory(path)
+    finally:
+        os.umask(previous_umask)
+
+    assert "owner-stripping umasks are unsupported" in raised.value.detail
+    assert not path.exists()
+
+
+def test_missing_descriptor_platform_contract_fails_without_partial_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = tmp_path / "ori"
+    monkeypatch.delattr(installer_linux.os, "O_NOFOLLOW")
+
+    with pytest.raises(LinuxInstallError, match="descriptor support"):
+        installer_linux._ensure_private_directory(path)
+
+    assert not path.exists()
 
 
 def test_composed_install_orders_assets_health_and_enablement(
@@ -751,6 +926,36 @@ def test_systemd_manager_installs_atomically_without_enabling(tmp_path: Path) ->
     assert unit.read_text(encoding="utf-8").startswith("# Copyright")
     assert unit.stat().st_mode & 0o777 == 0o600
     assert commands == [["systemctl", "--user", "daemon-reload"]]
+
+
+def test_user_systemd_recursive_parents_remain_below_private_home(
+    tmp_path: Path,
+) -> None:
+    """Systemd parents are host-owned, not managed install scaffolding.
+
+    Recursive mkdir may leave host-policy modes on implicit parents. They are
+    safe here because the user service hierarchy stays beneath the invoking
+    account's pre-existing 0700 home, which the installer leaves untouched.
+    """
+    home = tmp_path / "home"
+    home.mkdir(mode=0o700)
+    unit = (home / ".config" / "systemd" / "user" / "ori-runtime.service").resolve()
+    manager = SystemdServiceManager(
+        profile=SystemdServiceProfile.user(),
+        unit_path=unit,
+        runner=lambda command: subprocess.CompletedProcess(command, 0, "", ""),
+        effective_uid=1001,
+    )
+    previous_umask = os.umask(0o002)
+    try:
+        manager.install_unit(_rendered_unit(tmp_path, SystemdServiceProfile.user()))
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(home.stat().st_mode) == 0o700
+    assert stat.S_IMODE((home / ".config").stat().st_mode) == 0o775
+    assert stat.S_IMODE((home / ".config" / "systemd").stat().st_mode) == 0o775
+    assert stat.S_IMODE(unit.parent.stat().st_mode) == 0o700
 
 
 def test_systemd_unit_transaction_can_remove_new_unit(tmp_path: Path) -> None:
@@ -1728,11 +1933,49 @@ def test_installer_config_is_validated_by_runtime_bridge_and_written_privately(
     assert list(config_path.parent.glob(".ori.yaml.*.tmp")) == []
 
 
+def test_config_parent_uses_managed_directory_policy_under_umask_0002(
+    tmp_path: Path,
+) -> None:
+    config_path = (tmp_path / "data" / "ori.yaml").resolve()
+    previous_umask = os.umask(0o002)
+    try:
+        provision_runtime_config(
+            values=InstallerConfigInput("ori-01", "Office", "Lagos"),
+            config_path=config_path,
+            release_python=Path(sys.executable),
+            health_socket_path=config_path.parent / "health.sock",
+        )
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(config_path.parent.stat().st_mode) == 0o700
+
+
+def test_config_parent_refuses_group_writable_directory_without_mutation(
+    tmp_path: Path,
+) -> None:
+    config_path = (tmp_path / "data" / "ori.yaml").resolve()
+    config_path.parent.mkdir(mode=0o700)
+    config_path.parent.chmod(0o775)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        provision_runtime_config(
+            values=InstallerConfigInput("ori-01", "Office", "Lagos"),
+            config_path=config_path,
+            release_python=Path(sys.executable),
+            health_socket_path=config_path.parent / "health.sock",
+        )
+
+    assert raised.value.code == "config_validation_failed"
+    assert stat.S_IMODE(config_path.parent.stat().st_mode) == 0o775
+    assert not config_path.exists()
+
+
 def test_successful_config_provision_can_restore_previous_content_and_mode(
     tmp_path: Path,
 ) -> None:
     config_path = (tmp_path / "data" / "ori.yaml").resolve()
-    config_path.parent.mkdir()
+    config_path.parent.mkdir(mode=0o700)
     config_path.write_text("previous\n", encoding="utf-8")
     config_path.chmod(0o640)
 
@@ -1791,8 +2034,11 @@ def test_config_destination_error_uses_stable_failure(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setattr(
-        "ori.installer.linux.Path.mkdir",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("denied")),
+        installer_linux,
+        "_ensure_private_directory",
+        lambda _path: (_ for _ in ()).throw(
+            LinuxInstallError("unsafe_install_root", "denied")
+        ),
     )
     with pytest.raises(LinuxInstallError) as raised:
         provision_runtime_config(
@@ -1806,7 +2052,7 @@ def test_config_destination_error_uses_stable_failure(
 
 def test_invalid_generated_config_preserves_existing_file(tmp_path: Path) -> None:
     config_path = (tmp_path / "data" / "ori.yaml").resolve()
-    config_path.parent.mkdir()
+    config_path.parent.mkdir(mode=0o700)
     config_path.write_text("existing\n", encoding="utf-8")
 
     def runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
@@ -1867,7 +2113,7 @@ def test_config_directory_sync_failure_restores_previous_config(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     config_path = (tmp_path / "data" / "ori.yaml").resolve()
-    config_path.parent.mkdir()
+    config_path.parent.mkdir(mode=0o700)
     config_path.write_text("existing\n", encoding="utf-8")
     config_path.chmod(0o640)
     real_fsync = os.fsync
@@ -2285,8 +2531,18 @@ def test_cleanup_removes_every_empty_directory_it_created(tmp_path: Path) -> Non
     for directory in (root, releases, data):
         directory.mkdir()
     (data / "ori.yaml").write_text("device: {}\n", encoding="utf-8")
+    created = []
+    for directory in (root, releases, data):
+        info = directory.stat()
+        created.append(
+            installer_linux._CreatedDirectory(
+                path=directory,
+                device=info.st_dev,
+                inode=info.st_ino,
+            )
+        )
 
-    installer_linux._remove_created_scaffolding([root, releases, data])
+    installer_linux._remove_created_scaffolding(created)
 
     assert not releases.exists()
     assert data.exists(), "operator data must never be removed by cleanup"

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -381,7 +381,7 @@ def test_creation_provenance_race_refuses_existing_entry_and_rolls_back_only_our
 
     monkeypatch.setattr(installer_linux.os, "mkdir", mkdir_with_race)
 
-    with pytest.raises(LinuxInstallError, match="data is group-writable"):
+    with pytest.raises(LinuxInstallError, match="data is writable by another account"):
         install_release(
             layout=layout,
             version="2.3.0",
@@ -458,15 +458,15 @@ def test_scaffolding_cleanup_refuses_a_substituted_inode(tmp_path: Path) -> None
     assert displaced.exists(), "the proven inode is no longer at its recorded path"
 
 
-@pytest.mark.parametrize("mode", [0o770, 0o775, 0o720, 0o2775])
-def test_preexisting_group_writable_directory_is_refused_unmodified(
+@pytest.mark.parametrize("mode", [0o770, 0o775, 0o720, 0o2775, 0o707])
+def test_preexisting_directory_writable_by_another_account_is_refused_unmodified(
     tmp_path: Path, mode: int
 ) -> None:
     path = tmp_path / "ori"
     path.mkdir(mode=0o700)
     path.chmod(mode)
 
-    with pytest.raises(LinuxInstallError, match="group-writable"):
+    with pytest.raises(LinuxInstallError, match="writable by another account"):
         installer_linux._ensure_private_directory(path)
 
     assert stat.S_IMODE(path.stat().st_mode) == mode

--- a/tests/test_release_bundles.py
+++ b/tests/test_release_bundles.py
@@ -8,6 +8,8 @@ import builtins
 import hashlib
 import io
 import json
+import os
+import stat
 import tarfile
 from pathlib import Path
 
@@ -161,6 +163,34 @@ def test_verifies_and_extracts_exact_signed_bundle(tmp_path: Path) -> None:
     assert extracted.python == "3.12"
     assert extracted.file_count == 4
     assert extracted.root.name == artifact.name.removesuffix(".tar.gz")
+
+
+def test_extraction_members_remain_below_exact_private_workspace_under_umask_0002(
+    tmp_path: Path,
+) -> None:
+    """Recursive member parents are safe only below the pinned 0700 root."""
+    files = {"deep/implicit/payload.txt": b"verified payload"}
+    artifact = _write_archive(tmp_path, files=files)
+    envelope = _write_envelope(tmp_path, artifact)
+    verified = verify_release_bundle(
+        artifact_path=artifact,
+        envelope_path=envelope,
+        key_registry={KEY_ID: _release_key()},
+    )
+    destination = tmp_path / "extract"
+    previous_umask = os.umask(0o002)
+    try:
+        extracted = extract_verified_bundle(verified, destination=destination)
+    finally:
+        os.umask(previous_umask)
+
+    assert stat.S_IMODE(destination.stat().st_mode) == 0o700
+    assert stat.S_IMODE(extracted.root.stat().st_mode) == 0o700
+    assert stat.S_IMODE((extracted.root / "deep").stat().st_mode) == 0o775
+    assert stat.S_IMODE((extracted.root / "deep" / "implicit").stat().st_mode) == 0o700
+    assert (extracted.root / "deep" / "implicit" / "payload.txt").read_bytes() == (
+        b"verified payload"
+    )
 
 
 def test_verify_only_key_can_verify_existing_release(tmp_path: Path) -> None:
@@ -655,3 +685,15 @@ def test_extraction_destination_must_be_new(tmp_path: Path) -> None:
         extract_verified_bundle(verified, destination=destination)
 
     assert exc.value.code == "unsafe_bundle_archive"
+
+
+def test_extraction_destination_parent_must_already_exist(tmp_path: Path) -> None:
+    _, verified = _verify(tmp_path)
+    destination = tmp_path / "missing" / "extract"
+
+    with pytest.raises(ReleaseBundleError) as exc:
+        extract_verified_bundle(verified, destination=destination)
+
+    assert exc.value.code == "unsafe_bundle_archive"
+    assert "workspace could not be prepared" in exc.value.detail
+    assert not destination.parent.exists()


### PR DESCRIPTION
## What does this PR do?

Issue #378 is deliberately separate from #362. The `umask 0002` failures fixed by #364 were fixture defects; this PR does not recharacterise them as a production installer defect. It closes a distinct defence-in-depth gap: managed directory creation, validation, permission repair, and rollback previously relied on separate pathname operations, so a concurrent replacement could make the inode inspected differ from the inode later changed.

This PR makes the managed-path transaction explicit:

- A successful `mkdir` is the only creation-provenance signal. `EEXIST` is never treated as proof that this invocation created an entry.
- Directory type and mode are validated through `O_DIRECTORY | O_NOFOLLOW` descriptors, and permission repair uses `fchmod` on the opened inode.
- The pathname is revalidated against the opened `(device, inode)` before success.
- Rollback records the created inode identity and refuses to remove a substituted path.
- Pre-existing managed directories writable by either group or other accounts are refused without modifying their modes.
- Config data-parent preparation reuses the hardened managed-directory primitive.
- Verified bundle extraction requires a pre-existing workspace and creates an exact `0700` extraction root before any recursive archive member path is materialised.

The five related `mkdir(parents=True, mode=...)` sites are classified rather than mechanically rewritten. Managed config and extraction-root paths use hardened primitives. Systemd parents remain host-owned: system scope is under the root-owned systemd hierarchy, while user scope remains below the invoking account's private home. Archive directory and file parents remain recursive only beneath the newly established `0700` extraction root and validated relative member paths. The extracted tree is temporary authenticated input: its wheelhouse builds a separate release staging directory and is not itself installed as the release.

No process umask is changed. Realistic `0022` and `0002` postures finish with exact private managed directories. An owner-stripping umask is rejected with a stable diagnosis and cleanup rather than falling back to pathname chmod. Linux and macOS retain an explicit descriptor contract; a platform missing the required no-follow flags fails closed.

A pre-existing managed directory that the invoking account cannot open through that descriptor path — including a mode-`0000` directory in unprivileged user scope — now fails closed with the generic `could not be prepared` diagnosis. Main previously accepted that case. The refusal is intentional; no inaccessible pathname is adopted when its inode cannot be verified.

## Type of change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — this hardens filesystem transaction mechanics without changing an advertised runtime capability, deployment scope, release trust root, dependency, or Tier authority.

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

Issue #378 defines the threat model and required evidence. No Tier D, actuation, reasoning, runtime-loop, or dependency path changes.

### If this adds or modifies a bundled skill (`/skills/`)

Not applicable.

## Related issue

Closes #378.

## Testing notes

The two race regressions are mutation-checked against the exact pathname helper from `main`:

- creation provenance race: old implementation did not raise and silently adopted the concurrently created entry;
- path substitution race: old implementation did not raise and chmodded the substitute.

Both fail against the old helper and pass with this branch. The focused hardening matrix now covers those races; the `0770`, `0775`, `0720`, `2775`, and other-writable `0707` refusal-without-mutation cases; symlinks; regular files; missing parents; restrictive-umask cleanup; missing descriptor support; inode-bound rollback; config and systemd dispositions; and bundle extraction boundaries.

Complete affected user-space suites:

- `umask 0022`: **227 passed**
- `umask 0002`: **227 passed**

The 12 root-only system-scope cases skip locally by design and are exercised by CI's explicit privileged job.

Also clean:

- `ruff check ori/ tests/ skills/`
- `ruff format --check ori/ tests/ skills/`
- `scripts/check_workflows.py`
- `scripts/typecheck-boundaries.sh`
- pre-commit and pre-push hooks
- `git diff --check`

The reviewer independently confirmed the full non-hardware suite at **3978 passed / 27 skipped**, and the GitHub matrix was green on Python 3.11, 3.12, and 3.13 before this review follow-up. The fresh matrix for the final commit provides the merge gate. The only local Python links SQLite 3.37.2 while current `main` intentionally requires SQLite 3.39 or newer, which explains the previously disclosed local full-suite failures; no affected installer or release-bundle test failed.
