### PR TITLE
fix(typing): clear production pyright diagnostics and gate them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,15 @@ jobs:
       - name: Type check the whole package
         run: python -m mypy ori/
 
+      # Pyright catches what mypy does not: unbound locals behind optional
+      # imports, attributes missing from a None-typed handle, and async context
+      # managers entered synchronously. Scoped to `ori/` because the test tree
+      # still carries stub-typing diagnostics; widening it is #358's remaining
+      # half. A ratchet only holds if the clean half is enforced.
+      - name: Type check production code (pyright)
+        if: matrix.python-version == '3.12'
+        run: npx --yes pyright@latest ori/
+
       - name: Pre-commit (lint + format + hygiene)
         env:
           SKIP: no-commit-to-branch

--- a/ori/actions/relay.py
+++ b/ori/actions/relay.py
@@ -67,6 +67,7 @@ class _RelayDevice(Protocol):
     @property
     def value(self) -> float:
         """Current pin value; non-zero while the relay is energised."""
+        ...
 
     def on(self) -> None:
         """Energise the pin."""

--- a/ori/actions/sms.py
+++ b/ori/actions/sms.py
@@ -254,7 +254,7 @@ class SMSAction:
 
             # Africa's Talking SDK is synchronous — offload to thread.
             def _send_sync() -> dict[Any, Any]:
-                sms = africastalking.SMS
+                sms = cast(Any, africastalking.SMS)
                 return cast(
                     dict[Any, Any], sms.send(message, [to_number], self._sender_id)
                 )

--- a/ori/actions/whatsapp.py
+++ b/ori/actions/whatsapp.py
@@ -219,7 +219,7 @@ class TwilioProvider:
                 ),
                 timeout=self._request_timeout_s,
             )
-            return [m.body for m in messages]
+            return [m.body for m in messages if m.body is not None]
         except Exception as exc:
             status = getattr(exc, "status", None)
             code = getattr(exc, "code", None)

--- a/ori/firmware_mqtt_operator.py
+++ b/ori/firmware_mqtt_operator.py
@@ -607,8 +607,9 @@ def _peer_uid(peer_socket: Any) -> int:
             "authentication_failed",
             "peer credentials are unavailable",
         )
-    if sys.platform.startswith("linux") and hasattr(socket, "SO_PEERCRED"):
-        raw = peer_socket.getsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, 12)
+    so_peercred = getattr(socket, "SO_PEERCRED", None)
+    if sys.platform.startswith("linux") and so_peercred is not None:
+        raw = peer_socket.getsockopt(socket.SOL_SOCKET, so_peercred, 12)
         _, uid, _ = struct.unpack("=3i", raw)
         return int(uid)
     if sys.platform == "darwin" and hasattr(socket, "LOCAL_PEERCRED"):

--- a/ori/gateway/export.py
+++ b/ori/gateway/export.py
@@ -527,8 +527,9 @@ def _default_client_factory(*, client_id: str) -> Any:
     if mqtt is None:
         raise RuntimeError("paho-mqtt is not installed")
     kwargs: dict[str, Any] = {"client_id": client_id}
-    if hasattr(mqtt, "CallbackAPIVersion"):
-        kwargs["callback_api_version"] = mqtt.CallbackAPIVersion.VERSION2
+    callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+    if callback_api_version is not None:
+        kwargs["callback_api_version"] = callback_api_version.VERSION2
     try:
         return mqtt.Client(**kwargs)
     except TypeError:

--- a/ori/gateway/heartbeat.py
+++ b/ori/gateway/heartbeat.py
@@ -225,8 +225,9 @@ def _default_client_factory(*, client_id: str) -> Any:
     if mqtt is None:
         raise RuntimeError("paho-mqtt is not installed")
     kwargs: dict[str, Any] = {"client_id": client_id}
-    if hasattr(mqtt, "CallbackAPIVersion"):
-        kwargs["callback_api_version"] = mqtt.CallbackAPIVersion.VERSION2
+    callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+    if callback_api_version is not None:
+        kwargs["callback_api_version"] = callback_api_version.VERSION2
     try:
         return mqtt.Client(**kwargs)
     except TypeError:

--- a/ori/gateway/node_heartbeat.py
+++ b/ori/gateway/node_heartbeat.py
@@ -274,8 +274,9 @@ def _default_client_factory(*, client_id: str) -> Any:
     if mqtt is None:
         raise RuntimeError("paho-mqtt is not installed")
     kwargs: dict[str, Any] = {"client_id": client_id}
-    if hasattr(mqtt, "CallbackAPIVersion"):
-        kwargs["callback_api_version"] = mqtt.CallbackAPIVersion.VERSION2
+    callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+    if callback_api_version is not None:
+        kwargs["callback_api_version"] = callback_api_version.VERSION2
     try:
         return mqtt.Client(**kwargs)
     except TypeError:

--- a/ori/gateway/reasoning.py
+++ b/ori/gateway/reasoning.py
@@ -364,8 +364,9 @@ def _default_client_factory(*, client_id: str) -> Any:
     if mqtt is None:
         raise RuntimeError("paho-mqtt is not installed")
     kwargs: dict[str, Any] = {"client_id": client_id}
-    if hasattr(mqtt, "CallbackAPIVersion"):
-        kwargs["callback_api_version"] = mqtt.CallbackAPIVersion.VERSION2
+    callback_api_version = getattr(mqtt, "CallbackAPIVersion", None)
+    if callback_api_version is not None:
+        kwargs["callback_api_version"] = callback_api_version.VERSION2
     try:
         return mqtt.Client(**kwargs)
     except TypeError:

--- a/ori/hal/growatt_adapter.py
+++ b/ori/hal/growatt_adapter.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 from ori.hal.base import (
     AdapterConnectionError,
@@ -181,7 +181,8 @@ class GrowattAdapter(BaseAdapter):
             try:
                 return _PySolarmanV5(self._host, self._serial, port=self._port)
             except TypeError:
-                return _PySolarmanV5(self._host, self._serial, self._port)
+                # Older releases take the port positionally.
+                return cast(Any, _PySolarmanV5)(self._host, self._serial, self._port)
         except Exception as exc:
             raise AdapterConnectionError(
                 f"GrowattAdapter: failed to create Solarman client for "

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -23,14 +23,16 @@ try:
     import smbus2 as smbus  # type: ignore[import-untyped]
 
     _SMBUS_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+    smbus = None
     _SMBUS_AVAILABLE = False
 
 try:
     import bme280 as _bme280_lib  # type: ignore[import-untyped]
 
     _BME280_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+    _bme280_lib = None
     _BME280_AVAILABLE = False
 
 try:
@@ -40,14 +42,19 @@ try:
     import busio as _busio  # type: ignore[import-untyped]
 
     _ADS1115_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+    _ads1115 = None
+    _analog_in = None
+    _board = None
+    _busio = None
     _ADS1115_AVAILABLE = False
 
 try:
     import adafruit_scd4x  # type: ignore[import-untyped]
 
     _SCD40_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+    adafruit_scd4x = None
     _SCD40_AVAILABLE = False
 
 # Sensor types that require the ADS1115 ADC
@@ -86,6 +93,12 @@ def _get_shared_busio_i2c(bus_number: int) -> Any:
         raise AdapterConnectionError(
             f"I2CAdapter: Adafruit sensor drivers currently only support "
             f"I2C bus 1 on Raspberry Pi. You requested bus {bus_number}."
+        )
+
+    if _busio is None or _board is None:
+        raise AdapterConnectionError(
+            "I2CAdapter: Adafruit I2C drivers are not installed. "
+            "Run: pip install adafruit-blinka adafruit-circuitpython-ads1x15"
         )
 
     with _shared_busio_lock:
@@ -214,11 +227,11 @@ class I2CAdapter(BaseAdapter):
             self._connect_scd40()
 
     def _connect_bme280(self) -> None:
-        if not _SMBUS_AVAILABLE:
+        if not _SMBUS_AVAILABLE or smbus is None:
             raise AdapterConnectionError(
                 "I2CAdapter: 'smbus2' is not installed. Run: pip install smbus2"
             )
-        if not _BME280_AVAILABLE:
+        if not _BME280_AVAILABLE or _bme280_lib is None or smbus is None:
             raise AdapterConnectionError(
                 "I2CAdapter: 'RPi.bme280' is not installed. Run: pip install RPi.bme280"
             )
@@ -228,7 +241,7 @@ class I2CAdapter(BaseAdapter):
         )
 
     def _connect_ads1115(self) -> None:
-        if not _ADS1115_AVAILABLE:
+        if not _ADS1115_AVAILABLE or _ads1115 is None or _analog_in is None:
             raise AdapterConnectionError(
                 "I2CAdapter: Adafruit ADS1x15 library is not installed. "
                 "Run: pip install adafruit-circuitpython-ads1x15"
@@ -237,12 +250,12 @@ class I2CAdapter(BaseAdapter):
         self._ads = _ads1115.ADS1115(i2c, address=self._address)
 
     def _connect_scd40(self) -> None:
-        if not _SCD40_AVAILABLE:
+        if not _SCD40_AVAILABLE or adafruit_scd4x is None:
             raise AdapterConnectionError(
                 "I2CAdapter: 'adafruit-circuitpython-scd4x' is not installed. "
                 "Run: pip install adafruit-circuitpython-scd4x"
             )
-        if not _ADS1115_AVAILABLE:
+        if not _ADS1115_AVAILABLE or _ads1115 is None or _analog_in is None:
             # busio/board come from the same adafruit-blinka bundle
             raise AdapterConnectionError(
                 "I2CAdapter: 'adafruit-blinka' (busio/board) is not installed."
@@ -334,6 +347,10 @@ class I2CAdapter(BaseAdapter):
     # ── BME280 ────────────────────────────────────────────────────────────────
 
     def _read_bme280(self, sensor_id: str) -> SensorReading:
+        if _bme280_lib is None:
+            raise AdapterConnectionError(
+                "I2CAdapter: the BME280 driver is not loaded; connect() must run first"
+            )
         data = _bme280_lib.sample(self._bus, self._address, self._bme280_params)
         # bme280.sample returns an object with .temperature (°C), .pressure (hPa),
         # .humidity (%).  Temperature is the primary value; the other two travel
@@ -354,6 +371,10 @@ class I2CAdapter(BaseAdapter):
     # ── ADS1115 current ───────────────────────────────────────────────────────
 
     def _read_ads1115_current(self, sensor_id: str) -> SensorReading:
+        if _analog_in is None:
+            raise AdapterConnectionError(
+                "I2CAdapter: the ADS1115 driver is not loaded; connect() must run first"
+            )
         chan = _analog_in.AnalogIn(self._ads, self._channel)
         adc_voltage = chan.voltage  # volts
         current_amps = adc_voltage / self._sensitivity
@@ -374,6 +395,10 @@ class I2CAdapter(BaseAdapter):
     # ── ADS1115 voltage ───────────────────────────────────────────────────────
 
     def _read_ads1115_voltage(self, sensor_id: str) -> SensorReading:
+        if _analog_in is None:
+            raise AdapterConnectionError(
+                "I2CAdapter: the ADS1115 driver is not loaded; connect() must run first"
+            )
         chan = _analog_in.AnalogIn(self._ads, self._channel)
         voltage = chan.voltage
         return SensorReading(

--- a/ori/hal/mqtt_base.py
+++ b/ori/hal/mqtt_base.py
@@ -207,6 +207,10 @@ class MqttCachedAdapter(BaseAdapter):
 
         try:
             client_kwargs = self._build_mqtt_client_kwargs(config)
+            if _aiomqtt is None:
+                raise AdapterConnectionError(
+                    "MQTT adapter: 'aiomqtt' is not installed. Run: pip install aiomqtt"
+                )
             client = _aiomqtt.Client(
                 hostname=self._broker_host,
                 port=self._port,

--- a/ori/hal/opcua_adapter.py
+++ b/ori/hal/opcua_adapter.py
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+from collections.abc import Awaitable, Callable
 from numbers import Real
-from typing import Any
+from typing import Any, cast
 
 from ori.hal.base import (
     AdapterConnectionError,
@@ -129,11 +130,17 @@ class OpcUaAdapter(BaseAdapter):
         if self._node is None:
             raise AdapterReadError("OpcUaAdapter: node is not initialized")
 
-        read_data_value = getattr(self._node, "read_data_value", None)
+        read_data_value = cast(
+            Callable[[], Awaitable[Any]] | None,
+            getattr(self._node, "read_data_value", None),
+        )
         if callable(read_data_value):
             return await read_data_value()
 
-        read_value = getattr(self._node, "read_value", None)
+        read_value = cast(
+            Callable[[], Awaitable[Any]] | None,
+            getattr(self._node, "read_value", None),
+        )
         if callable(read_value):
             return await read_value()
 

--- a/ori/hal/psutil_adapter.py
+++ b/ori/hal/psutil_adapter.py
@@ -254,8 +254,9 @@ class PsutilAdapter(BaseAdapter):
         system = platform.system()
 
         # (i) psutil.sensors_temperatures — Linux / WSL
-        if hasattr(psutil, "sensors_temperatures"):
-            temps = await asyncio.to_thread(psutil.sensors_temperatures)
+        sensors_temperatures = getattr(psutil, "sensors_temperatures", None)
+        if sensors_temperatures is not None:
+            temps = await asyncio.to_thread(sensors_temperatures)
             for key in ("coretemp", "k10temp", "cpu_thermal", "acpitz"):
                 if key in temps and temps[key]:
                     readings = temps[key]

--- a/ori/hal/serial_adapter.py
+++ b/ori/hal/serial_adapter.py
@@ -22,7 +22,8 @@ try:
     import serial  # type: ignore[import-untyped]
 
     _SERIAL_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised without pyserial
+    serial = None
     _SERIAL_AVAILABLE = False
 
 # ── Modbus RTU constants ───────────────────────────────────────────────────────
@@ -253,6 +254,10 @@ class SerialAdapter(BaseAdapter):
         self._connected = True
 
     def _open_port(self) -> None:
+        if serial is None:
+            raise AdapterConnectionError(
+                "SerialAdapter: 'pyserial' is not installed. Run: pip install pyserial"
+            )
         self._serial = serial.Serial(
             port=self._port,
             baudrate=self._baudrate,

--- a/ori/hal/solarman_modbus_adapter.py
+++ b/ori/hal/solarman_modbus_adapter.py
@@ -3,7 +3,7 @@
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, cast
 
 from ori.hal.base import (
     AdapterConnectionError,
@@ -213,7 +213,10 @@ class SolarmanModbusAdapter(BaseAdapter):
                     port=self._port,
                 )
             except TypeError:
-                self._client = _PySolarmanV5(self._host, self._serial, self._port)
+                # Older releases take the port positionally.
+                self._client = cast(Any, _PySolarmanV5)(
+                    self._host, self._serial, self._port
+                )
         except Exception as exc:
             raise AdapterConnectionError(
                 f"SolarmanModbusAdapter: failed to create client for "

--- a/ori/network/sms_webhook.py
+++ b/ori/network/sms_webhook.py
@@ -9,7 +9,7 @@ import logging
 import time
 from dataclasses import dataclass
 from ipaddress import ip_address, ip_network
-from typing import Any
+from typing import Any, cast
 from urllib.parse import parse_qs, urlsplit
 
 from ori.security.webhook_signatures import WebhookSignatureVerifier
@@ -122,7 +122,10 @@ class SMSWebhookServer:
         self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
     ) -> None:
         get_extra = getattr(writer, "get_extra_info", None)
-        peer = get_extra("peername") if callable(get_extra) else None
+        peer = cast(
+            "tuple[Any, ...] | None",
+            get_extra("peername") if callable(get_extra) else None,
+        )
         peer_ip = str(peer[0]) if peer else "unknown"
         try:
             if not self._source_allowed(peer_ip):

--- a/ori/reasoning/local_llm.py
+++ b/ori/reasoning/local_llm.py
@@ -15,7 +15,11 @@ try:
     from llama_cpp import Llama  # pyright: ignore[reportMissingImports]
 
     _LLAMA_AVAILABLE = True
-except ImportError:
+except ImportError:  # pragma: no cover - exercised without llama-cpp-python
+    # A sentinel, not a type. mypy reads the imported name as `type[Llama]`;
+    # binding it here is what lets the call site check availability directly
+    # rather than relying on a module flag no checker can correlate.
+    Llama = None  # type: ignore[assignment,misc]
     _LLAMA_AVAILABLE = False
 
 
@@ -147,6 +151,8 @@ class LocalLLM:
             logger.info("LocalLLM: model loaded")
 
     def _load_model(self) -> object:
+        if Llama is None:
+            raise RuntimeError("LocalLLM: llama-cpp-python is not installed")
         return Llama(
             model_path=self._model_path,
             n_ctx=self._context_window,

--- a/ori/skills/os_sandbox.py
+++ b/ori/skills/os_sandbox.py
@@ -316,6 +316,8 @@ class OSSandboxHookRunner:
 
         async def _read_stderr() -> None:
             nonlocal stderr_bytes
+            if proc.stderr is None:
+                return
             while True:
                 chunk = await proc.stderr.read(1024)
                 if not chunk:
@@ -327,8 +329,10 @@ class OSSandboxHookRunner:
 
         try:
             timeout_s = float(self._cfg["exec_timeout_ms"]) / 1000.0
-            with asyncio.timeout(timeout_s):
+            async with asyncio.timeout(timeout_s):
                 while True:
+                    if proc.stdout is None:
+                        break
                     line = await proc.stdout.readline()
                     if not line:
                         break
@@ -726,7 +730,7 @@ def _install_landlock_readonly(paths: list[str]) -> None:
         raise OSError(err, "landlock_create_ruleset failed")
     try:
         for path in paths:
-            fd = os.open(path, os.O_PATH | os.O_CLOEXEC)
+            fd = os.open(path, getattr(os, "O_PATH", 0) | os.O_CLOEXEC)
             try:
                 rule = _LandlockPathBeneathAttr(
                     allowed_access=_LANDLOCK_READ_EXEC,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,6 +216,15 @@ warn_return_any = true
 warn_unused_ignores = true
 
 [[tool.mypy.overrides]]
+# llama-cpp-python is optional and absent from the hash-locked CI environment.
+# With it installed the ImportError fallback rebinds an imported class and needs
+# an ignore; without it the same ignore is unused. The comment cannot be correct
+# in both, so this module opts out of the unused-ignore check rather than
+# carrying a comment whose correctness depends on which extras are present.
+module = ["ori.reasoning.local_llm"]
+warn_unused_ignores = false
+
+[[tool.mypy.overrides]]
 module = [
     "ori.gateway.*",
     "ori.integration.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,10 @@ ignore = ["E501"]
 # and reported an unresolved import in the editor; declaring the path once
 # fixes both rather than scattering per-file suppressions.
 [tool.pyright]
+# Without an explicit include, pyright resolves `ori/hal/x.py` a second time as
+# `hal/x.py` through the package root and reports every diagnostic twice. The
+# duplicate is invisible in a total and makes the count untrackable.
+include = ["ori", "tests", "scripts"]
 extraPaths = ["scripts"]
 
 [tool.mypy]

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -123,6 +123,7 @@ class TestConnect:
         adapter = I2CAdapter()
         with (
             patch("ori.hal.i2c_adapter._SMBUS_AVAILABLE", True),
+            patch("ori.hal.i2c_adapter.smbus"),
             patch("ori.hal.i2c_adapter._BME280_AVAILABLE", False),
             pytest.raises(AdapterConnectionError, match="RPi.bme280"),
         ):
@@ -165,7 +166,11 @@ class TestConnect:
 
     async def test_connect_adafruit_unsupported_bus_raises(self):
         adapter = I2CAdapter()
-        with patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True):
+        with (
+            patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
+            patch("ori.hal.i2c_adapter._ads1115"),
+            patch("ori.hal.i2c_adapter._analog_in"),
+        ):
             with pytest.raises(
                 AdapterConnectionError, match="currently only support I2C bus 1"
             ):
@@ -178,6 +183,7 @@ class TestConnect:
             patch("ori.hal.i2c_adapter._busio", create=True),
             patch("ori.hal.i2c_adapter._board", create=True),
             patch("ori.hal.i2c_adapter._ads1115", create=True),
+            patch("ori.hal.i2c_adapter._analog_in", create=True),
         ):
             await adapter.connect(
                 _config(sensor_type="ads1115_current", sensitivity=0.05)
@@ -191,6 +197,7 @@ class TestConnect:
             patch("ori.hal.i2c_adapter._busio", create=True),
             patch("ori.hal.i2c_adapter._board", create=True),
             patch("ori.hal.i2c_adapter._ads1115", create=True),
+            patch("ori.hal.i2c_adapter._analog_in", create=True),
         ):
             await adapter.connect(_config(sensor_type="ads1115_current", channel=2))
         assert adapter._channel == 2


### PR DESCRIPTION
## What does this PR do?

Clears every pyright diagnostic under `ori/` and gates it, so subsequent work lands on an enforced clean baseline rather than a snapshot that regrows.

### The count was wrong twice over

#358 recorded 91 diagnostics across six test files. The tree had **490 raw / 352 unique**, and 66 of them were in production, not tests.

Two distortions, both fixed here:

- **`[tool.pyright]` had no `include`.** Every `ori/hal/x.py` resolved a second time as `hal/x.py` through the package root and reported twice. Production dropped 66 → 31 on that alone.
- **Nothing enforced pyright.** CI runs `mypy ori/` and the 30-file boundary script. Diagnostics accumulated freely between reviews, which is exactly how 91 became 352. A sweep without a gate buys a clean snapshot and nothing more.

### A real bug was underneath the noise

`ori/skills/os_sandbox.py` entered `asyncio.timeout(...)` with a plain `with`. It is an **async** context manager:

```
TypeError: 'Timeout' object does not support the context manager protocol
```

That raises before the guarded read loop runs, so the execution timeout that path depends on never applied. Community hook execution is refused entirely today, which is why nothing exercised it. Now `async with`.

### The optional-import guards were two facts that could disagree

The mandated HAL pattern binds a driver name only on the success branch of its import, then gates use on a separate `_X_AVAILABLE` flag. The flag and the binding could drift, and only the binding is what gets called.

Each guard now checks the binding it actually uses, and the read paths that assume `connect()` bound a driver say so rather than failing with `AttributeError` mid-read.

Two `test_i2c_adapter.py` fixtures were asserting the impossible state directly — flag `True`, binding absent — and passed only because nothing checked. They now bind what they claim is available.

### The rest

Platform-conditional attributes (`socket.SO_PEERCRED`, `os.O_PATH`, `psutil.sensors_temperatures`) reach through `getattr` rather than an attribute access no checker can resolve off Linux. Handles from untyped SDKs are cast where the surrounding guard has already established their shape. Twilio message bodies are `Optional`, so a `None` body is no longer returned as a message.

### Scope

Production only. The 424 test-tree diagnostics are overwhelmingly stub and mock typing with low defect risk, and broadly editing test files during the integration freeze collides with the safety and evidence paths. They stay outside the gate, and #358 is re-scoped to carry them.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes state, posture or availability. The HAL guards raise the same adapter errors on the same conditions; they check the binding rather than only the flag that stood for it.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path changes. `pyright` is invoked through `npx` in CI, matching the local workflow; it is not added as a project dependency.

## Related issue

Re-scopes and partially closes #358.

## Testing notes

Full suite 3981 passed, 27 skipped. Whole-package mypy clean across 142 files. `pyright ori/` reports **0 errors**. Boundary typecheck, ruff, formatting, the supply-chain workflow guard and `git diff --check` all clean.

The `asyncio.timeout` misuse was confirmed against the interpreter rather than inferred from the diagnostic: `hasattr(t, '__enter__')` is `False`, and entering it with `with` raises `TypeError`.
