### PR TITLE
fix(installer): make the Raspberry Pi wheelhouse target buildable

### DIFF
--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -1,0 +1,123 @@
+# Raspberry Pi Support
+
+What Ori needs from a Raspberry Pi, and why the interpreter version decides
+whether GPIO works at all.
+
+## Supported hardware
+
+| Requirement | Value |
+| --- | --- |
+| Model | **Raspberry Pi 4 Model B or newer** |
+| Architecture | `aarch64` (64-bit) |
+| OS | Raspberry Pi OS **Trixie** (Debian 13), 64-bit |
+| Python | **3.13**, from the system (`/usr/bin/python3.13`) |
+
+**Pi 4 is the floor for the Python 3.13 target.** Trixie's 64-bit images and the
+`aarch64` release bundles assume a BCM2711 or later. Earlier boards are either
+32-bit only or run an OS whose Python predates the supported set, and no
+`linux-armv7`/`python3.10` bundle is published. A Pi 3 will not install from a
+3.13 bundle, and nothing about the failure will make that obvious — so do not
+plan a deployment around one.
+
+Reference bench: Pi 4 Model B, BCM2711, 4GB.
+
+## Why the interpreter version is not cosmetic
+
+Ori drives GPIO through `gpiozero`. It never imports `RPi.GPIO` directly.
+
+`gpiozero` declares **no pin factory** of its own — it selects one at import
+from whatever is installed. On Trixie that is `LGPIOFactory`, backed by
+`python3-lgpio` from apt.
+
+That package ships a compiled extension built **per interpreter version**:
+
+```
+/usr/lib/python3/dist-packages/_lgpio.cpython-313-aarch64-linux-gnu.so
+```
+
+A runtime on any interpreter other than the one apt built for cannot import it.
+The consequence is quiet rather than loud: `gpiozero` finds no usable factory,
+the HAL guards catch the ImportError, and the adapter enters simulation mode. A
+relay configured under `deployment_profile: development` then reports healthy
+while no pin is ever driven.
+
+This is why running Ori on a bundled 3.12 interpreter beside a 3.13 system is
+not a workaround. It produces a runtime that cannot actuate and does not say so.
+
+## Why there is no pin factory in `requirements/pi.txt`
+
+Two dead ends, both checked:
+
+- **`RPi.GPIO` publishes sdists only.** The wheelhouse build resolves with
+  `--only-binary=:all:`, which reduces its candidate set to nothing. The `pi`
+  wheelhouse target could never be built while it was pinned.
+- **`lgpio` on PyPI is a placeholder.** The only installable release is
+  `0.0.0.2`, whose wheel contains a zero-byte `lgpio.py`. `rpi-lgpio` depends on
+  it and inherits the same emptiness. Neither yields a working factory.
+
+So the pin factory comes from the operating system. `requirements/pi.in` carries
+`gpiozero` and `smbus2` only, and the image supplies the rest:
+
+```bash
+sudo apt install python3-lgpio python3-rpi-lgpio
+```
+
+Both are present on a stock Trixie image; the command is for a minimal one.
+
+## The venv must be able to see it
+
+The installer creates an isolated virtual environment. An isolated venv cannot
+import apt packages, so a Pi install needs the system site directory visible for
+the GPIO layer — otherwise `gpiozero` is present but factory-less, which fails
+in exactly the silent way described above.
+
+Check a deployed install:
+
+```bash
+sudo /opt/ori/current/venv/bin/python -c \
+  "from gpiozero import Device; Device.ensure_pin_factory(); print(type(Device.pin_factory).__name__)"
+```
+
+`LGPIOFactory` means GPIO is live. `ModuleNotFoundError` or a factory error
+means the runtime will simulate every relay operation.
+
+## Verifying a Pi before you rely on it
+
+Run these on the device, not on a laptop. Simulation mode makes a developer
+machine look identical to a working Pi, which is the point of it and also the
+trap.
+
+```bash
+# 1. The platform is what you think it is.
+grep VERSION_CODENAME /etc/os-release && uname -m && python3 -V
+
+# 2. The pin factory resolves under the system interpreter.
+python3 -c "from gpiozero import Device; Device.ensure_pin_factory(); \
+  print(type(Device.pin_factory).__module__)"
+
+# 3. The runtime's own venv resolves it too.
+sudo /opt/ori/current/venv/bin/python -c \
+  "from gpiozero import Device; Device.ensure_pin_factory(); print('ok')"
+
+# 4. The interpreter the service actually runs.
+systemctl cat ori-runtime.service | grep ExecStart
+```
+
+Step 3 is the one that matters. Steps 1 and 2 can pass on a device whose Ori
+install still cannot drive a pin.
+
+## Before a demo
+
+Anything that must physically actuate has to be proven on the device, under a
+profile that refuses to pretend:
+
+1. Install from a release bundle carrying a `linux-aarch64-python3.13` target.
+2. Confirm step 3 above returns `ok`.
+3. Wire the relay to **normally closed** terminals and declare its `gpio_pin`.
+4. Move `deployment_profile` off `development`. A hardened profile fails
+   startup when a configured GPIO path has no `gpiozero` behind it, which is
+   the behaviour you want — it turns a silent simulation into a refusal.
+5. Trip a Tier D condition and confirm the relay physically opens.
+
+Step 4 is what converts every preceding assumption into something the runtime
+will refuse to fake.

--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -35,14 +35,32 @@ That package ships a compiled extension built **per interpreter version**:
 /usr/lib/python3/dist-packages/_lgpio.cpython-313-aarch64-linux-gnu.so
 ```
 
-A runtime on any interpreter other than the one apt built for cannot import it.
-The consequence is quiet rather than loud: `gpiozero` finds no usable factory,
-the HAL guards catch the ImportError, and the adapter enters simulation mode. A
-relay configured under `deployment_profile: development` then reports healthy
-while no pin is ever driven.
+A runtime on any interpreter other than the one apt built for cannot import it,
+and the consequence is worse than a failure.
+
+`gpiozero` does not raise when no real factory is available. It warns and falls
+back to `NativeFactory`, its own experimental implementation. Measured on the
+bench Pi, installing this lock into an isolated virtual environment gives:
+
+```
+PinFactoryFallback: Falling back from pigpio: No module named 'pigpio'
+NativePinFactoryFallback: Falling back to the experimental pin factory
+NativeFactory because no other pin factory could be loaded.
+pin factory: NativeFactory
+```
+
+So `from gpiozero import DigitalOutputDevice, OutputDevice` succeeds,
+`gpio_backend_importable()` returns true, and the hardened-posture check passes.
+The runtime reports GPIO as available and drives Tier D through an experimental
+fallback rather than refusing to start.
+
+That is the opposite of failing closed. `relay.py` says as much in its own
+docstring -- the import check "proves dependency availability only" -- but
+nothing between that check and a Tier D trip asks *which* factory was loaded.
 
 This is why running Ori on a bundled 3.12 interpreter beside a 3.13 system is
-not a workaround. It produces a runtime that cannot actuate and does not say so.
+not a workaround, and why the check below is on the factory rather than on the
+import.
 
 ## Why there is no pin factory in `requirements/pi.txt`
 
@@ -78,8 +96,9 @@ sudo /opt/ori/current/venv/bin/python -c \
   "from gpiozero import Device; Device.ensure_pin_factory(); print(type(Device.pin_factory).__name__)"
 ```
 
-`LGPIOFactory` means GPIO is live. `ModuleNotFoundError` or a factory error
-means the runtime will simulate every relay operation.
+`LGPIOFactory` means GPIO is live. **`NativeFactory` means it is not** -- the
+import succeeded, every availability check passes, and the pins are driven by an
+experimental fallback. Treat that result as a failed check, not a partial pass.
 
 ## Verifying a Pi before you rely on it
 
@@ -97,14 +116,16 @@ python3 -c "from gpiozero import Device; Device.ensure_pin_factory(); \
 
 # 3. The runtime's own venv resolves it too.
 sudo /opt/ori/current/venv/bin/python -c \
-  "from gpiozero import Device; Device.ensure_pin_factory(); print('ok')"
+  "from gpiozero import Device; Device.ensure_pin_factory(); \
+   print(type(Device.pin_factory).__name__)"
 
 # 4. The interpreter the service actually runs.
 systemctl cat ori-runtime.service | grep ExecStart
 ```
 
-Step 3 is the one that matters. Steps 1 and 2 can pass on a device whose Ori
-install still cannot drive a pin.
+Step 3 is the one that matters, and read its output rather than its exit code:
+it prints `ok` for any factory at all, including the experimental fallback.
+Steps 1 and 2 can pass on a device whose Ori install still cannot drive a pin.
 
 ## Before a demo
 

--- a/requirements/pi.in
+++ b/requirements/pi.in
@@ -1,5 +1,24 @@
 # Raspberry Pi hardware dependencies. Keep these out of requirements/runtime.in so
 # phone and generic Linux deployments do not install Pi GPIO packages.
+#
+# There is deliberately no pin factory here, and that is the whole subtlety of
+# this file.
+#
+# `RPi.GPIO` was pinned here and could never satisfy this target: it publishes
+# sdists only, so the wheelhouse build's `--only-binary` filter reduced its
+# candidate set to nothing. Raspberry Pi OS Trixie has also moved on from it --
+# GPIO is driven through /dev/gpiochip, the image ships `python3-rpi-lgpio` (a
+# shim over lgpio) rather than the classic package, and gpiozero 2.x selects
+# `LGPIOFactory` there.
+#
+# `lgpio` cannot replace it from PyPI. The installable release is 0.0.0.2, whose
+# wheel contains a zero-byte `lgpio.py` -- a placeholder, not the library. The
+# working module is apt's `python3-lgpio`, whose extension is built per
+# interpreter: `_lgpio.cpython-313-aarch64-linux-gnu.so`.
+#
+# So the pin factory comes from the operating system, and the runtime venv must
+# be able to see it. That is also why the interpreter matters: a venv on any
+# version other than the one apt built for cannot import that extension, and
+# GPIO silently degrades to simulation. See docs/RASPBERRY_PI_SUPPORT.md.
 gpiozero>=2.0.1.post3
 smbus2>=0.4
-RPi.GPIO>=0.7

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -11,19 +11,11 @@ colorzero==2.0 \
 gpiozero==2.0.1.post3 \
     --hash=sha256:745feab6df463ac2e9de10c67e2dd9f396e668ba4e281e92381d6c460100a8f7 \
     --hash=sha256:d491734803a9bc6036602e6b8bbd73fb25c33da88de0fcd11a40e890b8bc2d3b
-    # via -r pi.in
-rpi-gpio==0.7.1 \
-    --hash=sha256:15311d3b063b71dee738cd26570effc9985a952454d162937c34e08c0fc99902 \
-    --hash=sha256:29226823da8b5ccb9001d795a944f2e00924eeae583490f0bc7317581172c624 \
-    --hash=sha256:57b6c044ef5375a78c8dda27cdfadf329e76aa6943cd6cffbbbd345a9adf9ca5 \
-    --hash=sha256:77afb817b81331ce3049a4b8f94a85e41b7c404d8e56b61ac0f1eb75c3120868 \
-    --hash=sha256:b86b66dc02faa5461b443a1e1f0c1d209d64ab5229696f32fb3b0215e0600c8c \
-    --hash=sha256:cd61c4b03c37b62bba4a5acfea9862749c33c618e0295e7e90aa4713fb373b70
-    # via -r pi.in
+    # via -r requirements/pi.in
 smbus2==0.6.1 \
     --hash=sha256:2b043372abf8f6029a632c3aab36b641c5d5872b1cbad599fc68e17ac4fd90a5 \
     --hash=sha256:650feeb27ca0ed58b07db4c10201c2a662c41305b7bf6e5fab9d888056f48180
-    # via -r pi.in
+    # via -r requirements/pi.in
 
 # The following packages are considered to be unsafe in a requirements file:
 setuptools==83.0.0 \

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -1146,6 +1146,7 @@ PASSAGE_AUDITS = {
     # one of them gains a passage, it is audited without anyone remembering.
     "docs/MQTT_SECURITY.md": 0,
     "docs/SMS_WEBHOOK_SECURITY.md": 0,
+    "docs/RASPBERRY_PI_SUPPORT.md": 0,
     "docs/android-runtime-mobile.md": 0,
     "docs/alpha-release-notes.md": 0,
     "docs/beta-release-notes.md": 0,


### PR DESCRIPTION
## What does this PR do?

Makes `ORI_WHEELHOUSE_TARGET=pi` buildable, and documents the interpreter constraint that decides whether a Pi can drive GPIO at all.

Verified on the bench Pi — Pi 4 Model B, BCM2711, Trixie, `aarch64`, system Python 3.13.5 — not inferred.

### The pin could never have worked

`rpi-gpio==0.7.1` publishes **sdists only**. The wheelhouse resolves with `--only-binary=:all:`, so its candidate set was empty on every interpreter and architecture. No release caught it because the pipeline builds the `generic` target.

Removing it is a correctness fix rather than a build workaround. The runtime imports `gpiozero` and **never** `RPi.GPIO`. On the bench Pi:

- `gpiozero` selects `gpiozero.pins.lgpio.LGPIOFactory`.
- `import RPi.GPIO` succeeds, but `dpkg -S` shows the file belongs to **`python3-rpi-lgpio`** — a shim over lgpio.
- The classic `python3-rpi.gpio` package **is not installed at all**.

### Nothing replaces it in the lock, because nothing can

- **`lgpio` on PyPI is a placeholder.** The only installable release is `0.0.0.2`, whose wheel contains a **zero-byte `lgpio.py`**. `0.2.2.0` exists but is sdist-only — the same trap.
- **`rpi-lgpio` requires `lgpio>=0.1.0.1`**, so it resolves to that empty stub and inherits its emptiness.
- **`gpiozero` declares no pin factory** of its own — only `colorzero`.

The working module is apt's `python3-lgpio`, whose extension is built per interpreter:

```
/usr/lib/python3/dist-packages/_lgpio.cpython-313-aarch64-linux-gnu.so
```

So `pi.in` carries `gpiozero` and `smbus2`, and the operating system supplies the factory.

### Why this matters past the build

That `cpython-313` tag is the whole point, and the failure it produces is worse than a crash.

Measured on the bench Pi, installing this lock into an **isolated** venv does not raise. `gpiozero` warns and falls back to **`NativeFactory`**, its own experimental implementation:

```
system-site venv:  pin factory: gpiozero.pins.lgpio.LGPIOFactory
isolated venv:     pin factory: NativeFactory
```

So `from gpiozero import DigitalOutputDevice, OutputDevice` succeeds, `gpio_backend_importable()` returns true, and the hardened-posture gate at `runtime.py:3944` **passes**. The runtime reports GPIO available and drives Tier D through an experimental fallback rather than refusing to start — the opposite of failing closed.

`relay.py` already hedges correctly in its docstring ("proves dependency availability only"), but nothing between that gate and a Tier D trip asks *which* factory loaded. That gap is filed separately; this PR corrects the documentation and the verification step, which previously printed `ok` for any factory including the failing one.

The bench Pi is in exactly that state today: its venv runs a bundled Python 3.12, is isolated (`include-system-site-packages = false`), and has no `gpiozero` at all. Tier D is not physically armed there, and nothing says so.

`docs/RASPBERRY_PI_SUPPORT.md` records the floor — **Pi 4 Model B or newer**, Trixie, system Python 3.13 — and the checks that separate a working install from one that will silently simulate. The Pi 4 floor is stated explicitly so nobody plans a deployment on a Pi 3 and discovers the gap at the wrong moment.

## Type of change

- [x] `fix` — bug fix
- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale

`[skip-cap-matrix]` — no runtime code changes. A dependency lock and a support document; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Related issue

Closes #360.

## Testing notes

The lock now resolves binary-only on every published target, which it has never done before:

```
py3.11 aarch64 binary-only: RESOLVES
py3.12 aarch64 binary-only: RESOLVES
py3.13 aarch64 binary-only: RESOLVES
```

Installer suites pass (185). Ruff clean.

The lock was installed on the device, not only resolved on a laptop. Two throwaway venvs on the bench Pi, neither touching the running service:

```
python3.13 -m venv --system-site-packages  → LGPIOFactory   (correct)
python3.13 -m venv                         → NativeFactory  (silent fallback)
```

Both installed with `--require-hashes --only-binary=:all:` from this exact lock.

Every platform claim was checked on the device over SSH rather than reasoned from the OS version: the selected pin factory, the owning apt package for `RPi/GPIO`, the interpreter tag on the lgpio extension, and the deployed venv's isolation setting.

Not yet proven: driving a physical pin. Nothing is wired to the header — `gpioinfo` shows no line claimed and `i2cdetect` finds no device — so that step waits on a deliberate loopback test.

## Follow-up this exposes

Fixing the lock does not by itself give the Pi a working GPIO path. Two things remain, and both are separate from this change:

1. **No release ships a `python3.13` bundle.** The targets were added in `28a0ff1` (2026-08-23); v2.4.0 was cut 2026-08-21, and `git merge-base --is-ancestor` confirms the target commit is not an ancestor of the tag. A 3.13 install is impossible until a release carries those assets.
2. **The isolated venv cannot see apt's pin factory.** A Pi install needs the system site directory visible for the GPIO layer, or `gpiozero` is installed and factory-less.

