### PR TITLE
fix(relay): refuse a GPIO backend that does not own its lines

### DIFF
--- a/ori/actions/relay.py
+++ b/ori/actions/relay.py
@@ -81,6 +81,13 @@ class _RelayDevice(Protocol):
 _VALID_BCM_PINS: frozenset[int] = frozenset(range(2, 28))
 
 
+#: gpiozero's fallback when no real pin factory loads. It drives pins by mapping
+#: /dev/gpiomem directly and registers no claim with the kernel, so the line
+#: still reads as an unused input while it is being held. Nothing refuses a
+#: second writer, which is the property a safety cutoff depends on.
+_UNARBITRATED_PIN_FACTORY = "NativeFactory"
+
+
 def gpio_backend_importable() -> bool:
     """Return whether gpiozero exposes the required output classes.
 
@@ -95,6 +102,41 @@ def gpio_backend_importable() -> bool:
     except ImportError:
         return False
     return DigitalOutputDevice is not None and OutputDevice is not None
+
+
+def resolved_pin_factory_name() -> str:
+    """The pin factory gpiozero actually loads, or "" when none can be.
+
+    Asked separately from :func:`gpio_backend_importable` because the two answer
+    different questions and only one of them is cheap. The import proves the
+    dependency is installed; this proves something can drive a pin, and finding
+    out costs opening the GPIO chip.
+
+    gpiozero never raises for a missing backend -- it warns and falls back --
+    so an import-level check cannot tell a kernel-arbitrated factory from the
+    fallback. Only the resolved name can.
+    """
+    try:
+        from gpiozero import Device  # pyright: ignore[reportMissingImports]
+
+        Device.ensure_pin_factory()
+    except Exception:
+        # Includes BadPinFactory, a missing gpiozero, and any chip-open error.
+        # All mean the same thing to a caller: nothing here can drive a pin.
+        return ""
+    factory = getattr(Device, "pin_factory", None)
+    return type(factory).__name__ if factory is not None else ""
+
+
+def gpio_backend_arbitrated() -> bool:
+    """Whether a resolved factory claims its lines through the kernel.
+
+    A hardened runtime needs this rather than the import check. The fallback
+    does drive pins, so a smoke test passes; it drives them without exclusive
+    ownership, so nothing keeps a Tier D pin where the safety path put it.
+    """
+    name = resolved_pin_factory_name()
+    return bool(name) and name != _UNARBITRATED_PIN_FACTORY
 
 
 class RelayAction:

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -32,7 +32,12 @@ from ori.actions.alert_failover import AlertFailoverSender
 from ori.actions.coap import CoAPAction, coap_backend_available
 from ori.actions.logger import LoggerAction
 from ori.actions.process_manager import ProcessManagerAction
-from ori.actions.relay import RelayAction, gpio_backend_importable
+from ori.actions.relay import (
+    RelayAction,
+    gpio_backend_arbitrated,
+    gpio_backend_importable,
+    resolved_pin_factory_name,
+)
 from ori.actions.sms import SMSAction
 from ori.actions.system_control import SystemControlAction
 from ori.actions.whatsapp import TwilioProvider, WhatsAppAction
@@ -3941,9 +3946,7 @@ def _validate_required_runtime_capabilities(
         config.device.deployment_type != "phone" and "gpio_pin" in config.actions.relay
     )
     status_signaling_requested = is_truthy(status_cfg.get("enabled", False))
-    if (
-        relay_requested or status_signaling_requested
-    ) and not gpio_backend_importable():
+    if relay_requested or status_signaling_requested:
         requested_by = (
             "relay control and status signaling"
             if relay_requested and status_signaling_requested
@@ -3951,7 +3954,19 @@ def _validate_required_runtime_capabilities(
             if relay_requested
             else "status signaling"
         )
-        missing.append(f"gpiozero is unavailable but {requested_by} is configured")
+        if not gpio_backend_importable():
+            missing.append(f"gpiozero is unavailable but {requested_by} is configured")
+        elif not gpio_backend_arbitrated():
+            # The dependency is present and pins would move, so the import check
+            # passes. gpiozero fell back to a factory that drives /dev/gpiomem
+            # without claiming the line, so the kernel refuses no second writer.
+            # A hardened runtime must not report a physical capability it cannot
+            # hold exclusively.
+            factory = resolved_pin_factory_name() or "none"
+            missing.append(
+                f"{requested_by} is configured but the resolved GPIO backend "
+                f"({factory}) does not claim its lines through the kernel"
+            )
 
     coap_requested = is_truthy(config.actions.coap.get("enabled", False)) or any(
         sensor.protocol == "coap" for sensor in config.sensors

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -9,9 +9,11 @@ that require real hardware.
 """
 
 import sys
+import types
 
 import pytest
 
+from ori.actions import relay as relay_module
 from ori.actions.relay import RelayAction
 
 # ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -200,3 +202,78 @@ async def test_connect_rejects_pin_zero():
     r = RelayAction()
     with pytest.raises(ValueError, match="BCM range"):
         await r.connect(gpio_pin=0)
+
+
+class TestResolvedPinFactory:
+    """What gpiozero loaded, as distinct from what imported.
+
+    gpiozero never raises for a missing backend. It warns and falls back to
+    NativeFactory, which drives /dev/gpiomem directly and registers no claim
+    with the kernel. Measured on a Pi 4: a line held by the arbitrated factory
+    reports `consumer="lg"`, while the same line held by the fallback still
+    reads as an unused input. Nothing refuses a second writer.
+    """
+
+    def test_no_gpiozero_resolves_to_nothing(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def refuse_gpiozero(name, *args, **kwargs):
+            if name == "gpiozero":
+                raise ImportError("no gpiozero here")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", refuse_gpiozero)
+
+        assert relay_module.resolved_pin_factory_name() == ""
+        assert relay_module.gpio_backend_arbitrated() is False
+
+    def test_a_factory_that_cannot_open_the_chip_resolves_to_nothing(self, monkeypatch):
+        """A raise means the same thing as a fallback to the caller: no backend.
+
+        gpiozero raises BadPinFactory when an explicitly requested factory is
+        unavailable, and chip-open errors surface here too.
+        """
+        module = types.ModuleType("gpiozero")
+
+        class _Device:
+            pin_factory = None
+
+            @staticmethod
+            def ensure_pin_factory():
+                raise RuntimeError("could not open /dev/gpiochip0")
+
+        module.Device = _Device  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gpiozero", module)
+
+        assert relay_module.resolved_pin_factory_name() == ""
+        assert relay_module.gpio_backend_arbitrated() is False
+
+    @pytest.mark.parametrize(
+        "factory_name, arbitrated",
+        [
+            ("LGPIOFactory", True),
+            ("RPiGPIOFactory", True),
+            ("PiGPIOFactory", True),
+            ("NativeFactory", False),
+        ],
+    )
+    def test_only_the_unarbitrated_fallback_is_refused(
+        self, monkeypatch, factory_name, arbitrated
+    ):
+        module = types.ModuleType("gpiozero")
+        factory = type(factory_name, (), {})()
+
+        class _Device:
+            pin_factory = factory
+
+            @staticmethod
+            def ensure_pin_factory():
+                return None
+
+        module.Device = _Device  # type: ignore[attr-defined]
+        monkeypatch.setitem(sys.modules, "gpiozero", module)
+
+        assert relay_module.resolved_pin_factory_name() == factory_name
+        assert relay_module.gpio_backend_arbitrated() is arbitrated

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -624,6 +624,61 @@ class TestRequiredRuntimeCapabilities:
         with pytest.raises(ConfigValidationError, match="gpiozero.*status signaling"):
             _validate_required_runtime_capabilities(config, str(tmp_path / "ori.yaml"))
 
+    @pytest.mark.parametrize("profile", ["staging", "production"])
+    def test_hardened_gpio_refuses_an_unarbitrated_backend(
+        self, profile, monkeypatch, tmp_path
+    ):
+        """gpiozero present and pins moving is not the same as pins owned.
+
+        The fallback drives /dev/gpiomem directly and claims no line, so the
+        kernel refuses no second writer. Measured on a Pi 4: a claimed line
+        reports `consumer="lg"` and an unclaimed one still reads as an input
+        while it is being held high.
+
+        The import check cannot see the difference -- it passes either way --
+        which is what made this reachable.
+        """
+        config = _capability_config(
+            profile=profile,
+            relay={"enabled": True, "gpio_pin": 26},
+        )
+        monkeypatch.setattr("ori.runtime.gpio_backend_importable", lambda: True)
+        monkeypatch.setattr("ori.runtime.gpio_backend_arbitrated", lambda: False)
+        monkeypatch.setattr(
+            "ori.runtime.resolved_pin_factory_name", lambda: "NativeFactory"
+        )
+
+        with pytest.raises(ConfigValidationError, match="NativeFactory"):
+            _validate_required_runtime_capabilities(config, str(tmp_path / "ori.yaml"))
+
+    def test_hardened_gpio_accepts_an_arbitrated_backend(self, monkeypatch, tmp_path):
+        config = _capability_config(
+            profile="production",
+            relay={"enabled": True, "gpio_pin": 26},
+        )
+        monkeypatch.setattr("ori.runtime.gpio_backend_importable", lambda: True)
+        monkeypatch.setattr("ori.runtime.gpio_backend_arbitrated", lambda: True)
+
+        _validate_required_runtime_capabilities(config, str(tmp_path / "ori.yaml"))
+
+    def test_a_missing_dependency_is_reported_as_such_not_as_a_bad_factory(
+        self, monkeypatch, tmp_path
+    ):
+        """The two failures need different fixes, so they must read differently.
+
+        One means install a package; the other means the package is installed
+        and the platform cannot back it.
+        """
+        config = _capability_config(
+            profile="production",
+            relay={"enabled": True, "gpio_pin": 26},
+        )
+        monkeypatch.setattr("ori.runtime.gpio_backend_importable", lambda: False)
+        monkeypatch.setattr("ori.runtime.gpio_backend_arbitrated", lambda: False)
+
+        with pytest.raises(ConfigValidationError, match="gpiozero is unavailable"):
+            _validate_required_runtime_capabilities(config, str(tmp_path / "ori.yaml"))
+
     def test_hardened_unwired_relay_without_gpio_pin_needs_no_gpiozero(
         self, monkeypatch, tmp_path
     ):
@@ -722,6 +777,9 @@ class TestRequiredRuntimeCapabilities:
         config.actions.relay = {"enabled": True, "gpio_pin": 26}
         monkeypatch.setattr("ori.runtime.Config.load", lambda _path: config)
         monkeypatch.setattr("ori.runtime.gpio_backend_importable", lambda: True)
+        # The posture check now also asks which factory resolved, so reaching
+        # relay initialisation means claiming an arbitrated backend as well.
+        monkeypatch.setattr("ori.runtime.gpio_backend_arbitrated", lambda: True)
         connect = AsyncMock(side_effect=RuntimeError("GPIO chip unavailable"))
         monkeypatch.setattr("ori.runtime.RelayAction.connect", connect)
         runtime = OriRuntime(config_path=str(minimal_config))


### PR DESCRIPTION
## What does this PR do?

The hardened posture check asked whether `gpiozero` exposes `DigitalOutputDevice` and `OutputDevice`. That answers whether the dependency is installed — and nothing about whether anything can drive a pin.

`gpiozero` never raises for a missing backend. It warns and falls back to `NativeFactory`, so the import succeeds, the check passes, and a hardened runtime certifies a Tier D actuation path it does not have.

### The fallback is not inert, which is what made this reachable

Measured on the bench Pi with GPIO26 (physical pin 37) jumpered to GPIO20 (pin 38), driven through `gpiozero.DigitalOutputDevice` — the same class `relay.py` uses — and read back through `lgpio` in a separate process:

```
while NativeFactory drives GPIO26 HIGH, GPIO20 reads: 1
```

The pin moves. A smoke test passes. What it does not do is **claim the line**:

```
idle:                   line 26: "GPIO26"  input
LGPIOFactory driving:   line 26: "GPIO26"  output consumer="lg"
NativeFactory driving:  line 26: "GPIO26"  input
```

`NativeFactory` maps `/dev/gpiomem` directly, so the kernel still reads GPIO26 as an unused input while it is being held high, and refuses no second writer. Any other process — another runtime, a diagnostic script, a stray `gpioset` — can drive the same pin, with neither side notified.

For a Tier D cutoff that is the property worth protecting. **The pin moving is not the same as the pin being owned**, and only the resolved factory distinguishes them.

### The fix

`resolved_pin_factory_name()` asks what actually loaded; `gpio_backend_arbitrated()` refuses the fallback. The posture check uses the second, with a diagnosis naming the factory so the two failures read differently — one means install a package, the other means the package is installed and the platform cannot back it.

`gpio_backend_importable()` keeps its documented meaning and its existing callers. Resolving a factory opens the GPIO chip, and that cost belongs beside the other hardened-capability probes rather than at import time.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — this tightens an existing hardened-posture refusal rather than changing what any capability offers. GPIO availability, relay behaviour and Tier D authority are unchanged; a posture that was wrongly accepted is now refused.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No new Tier D path. This governs whether an existing one may be reported as available under a hardened profile.

## Related issue

Closes #383.

## Testing notes

Verified on the bench Pi — Pi 4B, Trixie, `aarch64`, system Python 3.13.5 — running the real module against both environment shapes:

```
system-site venv:  importable=True  factory='LGPIOFactory'   arbitrated=True
isolated venv:     importable=True  factory='NativeFactory'  arbitrated=False
```

**`importable` is `True` in both.** That is the whole finding: the old check could not have distinguished these, and the deployed environment on that Pi is the isolated shape.

Unit coverage without hardware: a missing `gpiozero`, a factory that raises on chip open, and each of `LGPIOFactory` / `RPiGPIOFactory` / `PiGPIOFactory` / `NativeFactory`. Posture coverage asserts the refusal under staging and production, acceptance with an arbitrated backend, and that a missing dependency still reports as a missing dependency rather than as a bad factory.

One existing test needed updating: `test_hardened_relay_initialization_failure_aborts_startup` patched `gpio_backend_importable` to reach relay initialisation, and now also has to claim an arbitrated backend to get there.

Full suite 3993 passed, 27 skipped. mypy, pyright, ruff and the boundary typecheck are clean.

## Not covered here

The issue also asked for the resolved factory to appear in capability posture. `capability_posture` is a contract-pinned object in `ori-specs/runtime-health/v2.md` with an enumerated field list, so adding a field needs a contract amendment first. Filed as follow-up rather than slipped in — the refusal is the safety half and does not depend on it.
