### PR TITLE
chore(release): prepare v2.5.0-rc.1

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.4.0` are collected here until the next
-release is cut.
+Changes merged to `main` after `v2.5.0-rc.1` are collected here until the next
+candidate or release is cut.
 
 _No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -1,0 +1,133 @@
+# Ori Runtime — v2.5.0 Release Notes
+
+## Release Type
+
+Minor release, in progress. `v2.5.0-rc.1` is the first candidate.
+
+**Do not install a candidate on anything you depend on.** A candidate is
+published to be exercised on hardware, and this one exists because a class of
+defect was only reachable there.
+
+## Compare
+
+`v2.4.0...v2.5.0`
+
+https://github.com/ori-platform/ori-runtime/compare/v2.4.0...v2.5.0
+
+## Summary
+
+v2.4.0 published no Python 3.13 target. Raspberry Pi OS Trixie ships Python
+3.13 as its system interpreter, so the platform named as the primary production
+target could be installed only against a hand-placed 3.12 build.
+
+That workaround cost more than being unsupported. The only working GPIO pin
+factory on Trixie is packaged per interpreter version, so a runtime on 3.12
+cannot import it, and the device has no actuator at all — while continuing to
+report itself healthy. This release publishes the 3.13 targets, makes the
+Raspberry Pi wheelhouse buildable for the first time, and stops the runtime
+certifying a GPIO backend it does not exclusively own.
+
+It also carries the runtime half of the evidence exchange: signed chain rows
+produced here rather than imported, sealed into a delivery ledger, with a
+destination for the artifacts an authority returns.
+
+## Release candidates
+
+Every candidate is retained. None is moved or deleted, and none should be
+installed.
+
+| Tag | Reached | Outcome |
+|---|---|---|
+| `v2.5.0-rc.1` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
+
+## What this candidate is for
+
+`v2.5.0-rc.1` exists to be installed on real hardware. Specifically:
+
+1. It must install on Raspberry Pi OS Trixie using the **system** `python3.13`,
+   with no hand-placed interpreter and no symlink.
+2. The deployed environment must resolve `LGPIOFactory` rather than
+   `NativeFactory` — see below for why that distinction is not cosmetic.
+3. A wired relay must physically actuate under a hardened deployment profile.
+
+Nothing below is proven until those hold on a device.
+
+## Raspberry Pi
+
+### Python 3.13 targets are published
+
+`linux-aarch64-python3.13` and `linux-x86_64-python3.13` join the release
+matrix. The installer already preferred `python3.13` when present; until now it
+computed a target no release carried.
+
+**Minimum supported board is a Raspberry Pi 4 Model B.** Trixie's 64-bit images
+and the `aarch64` bundles assume BCM2711 or later, and no 32-bit target is
+published. See `docs/RASPBERRY_PI_SUPPORT.md`.
+
+### The Pi wheelhouse target builds
+
+`ORI_WHEELHOUSE_TARGET=pi` has never completed. It pinned `rpi-gpio`, which
+publishes source distributions only, while the build resolves binary-only — so
+its candidate set was always empty. No release exercised it, because the
+pipeline builds the generic target.
+
+The pin is removed rather than worked around. The runtime imports `gpiozero`
+and never `RPi.GPIO`, and Trixie drives GPIO through `/dev/gpiochip`: the image
+ships a shim over lgpio rather than the classic package.
+
+No pin factory replaces it in the lock, because none can be installed from
+PyPI — the installable `lgpio` release carries an empty module. The factory
+comes from the operating system, which is why the interpreter version decides
+whether GPIO works at all.
+
+### A GPIO backend must own its lines
+
+`gpiozero` does not fail when no real backend is available. It warns and falls
+back to `NativeFactory`, so an availability check based on importing succeeds
+and a hardened runtime reports a physical capability it does not have.
+
+The fallback is not inert, which is what made this easy to miss. It drives
+pins. What it does not do is claim the line: it maps `/dev/gpiomem` directly,
+so the kernel still reads the pin as an unused input while it is held, and
+refuses no second writer.
+
+For a Tier D cutoff that is the property worth having. Hardened startup now
+asks which factory resolved and refuses the unarbitrated one, naming it, so a
+missing dependency and an unusable platform read differently.
+
+## Evidence
+
+The runtime produces its own signed, hash-chained rows per `evidence/v2`,
+replacing the previously imported artifact and its loader. Rows are sealed into
+a delivery ledger that allocates `local_seq` gaplessly, and checkpoints are
+separately signed.
+
+Inbound authority artifacts now have a destination. Custody acknowledgements,
+delivery receipts and epoch confirmations are verified against the published
+vectors and applied on the evidence worker thread. Custody uses key material
+dedicated to it, selected by a derived identifier rather than by trial
+verification.
+
+**Still partial.** No release ships an authority-key registry, so receipts and
+epoch confirmations are refused as unknown-key — fail-closed and correct.
+Nothing publishes an artifact outbound yet.
+
+## Installer and platform
+
+- Managed installation paths are bound to verified inodes, so a concurrent
+  substitution between validation and mutation fails closed rather than being
+  adopted.
+- The state store declares and enforces the minimum SQLite version it needs.
+- Production code is free of pyright diagnostics, and the check is enforced in
+  CI so the clean half cannot regrow.
+- An installation keeps the identity it already carries across upgrades.
+
+## Known gaps in this candidate
+
+- WhatsApp alerts cannot be delivered outside a sandbox: the provider models a
+  free-form string and business-initiated messages require an approved
+  template.
+- The startup notification claims the runtime is "protecting your site" on the
+  evidence of connected sensors and loaded skills alone.
+- Release rollback remains described and unit-tested but unproven end to end on
+  a systemd host.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.4.0"
+version = "2.5.0rc1"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -1142,6 +1142,7 @@ PASSAGE_AUDITS = {
     "docs/releases/evidence/systemd-host-runbook.md": 1,
     "docs/RELEASE_SIGNING.md": 1,
     "docs/releases/v2.4.0.md": 1,
+    "docs/releases/v2.5.0.md": 1,
     # No evidence passages today. Listed rather than exempted so that the day
     # one of them gains a passage, it is audited without anyone remembering.
     "docs/MQTT_SECURITY.md": 0,


### PR DESCRIPTION
## What does this PR do?

Prepares the first v2.5.0 candidate. The version bump and the release notes only — no runtime behaviour changes.

## Why this candidate exists

**No published release carries a Python 3.13 target.** They were added in `28a0ff1` on 2026-08-23; v2.4.0 was cut on 2026-08-21. Raspberry Pi OS Trixie ships 3.13 as its system interpreter, so the platform named as the primary production target could only be installed against a hand-placed 3.12 build.

That workaround costs more than being unsupported. The only working GPIO pin factory on Trixie is packaged per interpreter version, so a runtime on 3.12 cannot import it — the device has no actuator at all, while continuing to report itself healthy.

## Version identity

The tag is the SemVer spelling and the package is the PEP 440 one, so `v2.5.0-rc.1` requires `2.5.0rc1`:

```
tag v2.5.0-rc.1 expects '2.5.0rc1'; pyproject declares '2.5.0rc1'; match=True
$ python scripts/check_release_identity.py --tag v2.5.0-rc.1
version=2.5.0-rc.1
```

Checked locally because that gate is the one `v2.4.0-rc.1` and `v2.4.0-rc.2` were spent proving: both passed preflight and the full matrix, then failed at a point where the tag was already immutable.

## Release notes

`docs/releases/v2.5.0.md` follows the shape v2.4.0 established — one document per final version, with candidates recorded in a table as they are published and retained whatever they reach.

It states plainly what this candidate exists to prove, because none of it is established until it runs on a device:

1. It installs on Trixie using the **system** `python3.13`, with no hand-placed interpreter and no symlink.
2. The deployed environment resolves `LGPIOFactory`, not `NativeFactory`.
3. A wired relay physically actuates under a hardened profile.

Known gaps are listed rather than omitted: WhatsApp cannot deliver outside a sandbox, the startup notification overclaims, and release rollback is still unproven end to end.

`docs/releases/unreleased.md` is reset to collect what lands after this candidate. It had gone stale — it read "No changes yet" while 32 commits had merged since v2.4.0.

## Type of change

- [x] `chore` — release preparation

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — a version string and release documentation. No runtime code changes; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Related issue

Prepares the release requested in #386.

## Testing notes

Full suite 3994 passed, 27 skipped. The release-gated disclosure audit was run with `ORI_DISCLOSURE_DENYLIST` supplied, since it skips silently when unset.

The new notes needed one rewording to pass that audit: a Summary sentence used "off-device", which is an operator-instruction pattern the evidence-passage audit refuses in a public document. The sentence now describes the same work without it.

## After merge

The tag is signed and pushed separately, and `release-signing` requires a second approver — the tagger cannot self-approve, so that deployment approval is the release approval.