### PR TITLE
fix(disclosure): stop the audit flagging the project for naming itself

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,17 +305,25 @@ jobs:
           # the secret values, but the audit's own failure output is sanitised
           # independently: it reports a location and a category, never a match.
           terms=""
-          for value in "${ARTIFACT_MODULE}" "${ARTIFACT_CLASS}" \
-                       "${ARTIFACT_REPOSITORY}" "${DENYLIST_EXTRA}"; do
-            [ -n "${value}" ] || continue
-            # A dotted module or an owner/name repository yields useful terms
-            # only once split; the bare string would miss a symbol carrying
-            # just the leaf.
-            for part in $(printf '%s' "${value}" | tr './,' ' '); do
+          add_terms() {
+            # A dotted module yields useful terms only once split; the bare
+            # string would miss a symbol carrying just the leaf.
+            for part in $(printf '%s' "$1" | tr './,' ' '); do
               [ ${#part} -ge 4 ] || continue
               terms="${terms}${terms:+,}${part}"
             done
+          }
+          for value in "${ARTIFACT_MODULE}" "${ARTIFACT_CLASS}" \
+                       "${DENYLIST_EXTRA}"; do
+            [ -n "${value}" ] || continue
+            add_terms "${value}"
           done
+          # Only the name half is private. The owner appears in every install
+          # URL here, so emitting it as a term flags the project for naming
+          # itself. v2.5.0-rc.1 was spent discovering that.
+          if [ -n "${ARTIFACT_REPOSITORY}" ]; then
+            add_terms "${ARTIFACT_REPOSITORY##*/}"
+          fi
           if [ -z "${terms}" ]; then
             echo "no artifact identifiers are configured; the audit cannot" >&2
             echo "know what to look for and must not report success" >&2

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -39,6 +39,7 @@ import pathlib
 import re
 import subprocess
 import zipfile
+from collections.abc import Sequence
 
 import pytest
 
@@ -602,6 +603,21 @@ def _supplied_denylist() -> list[str]:
     return [term.strip().lower() for term in raw.split(",") if term.strip()]
 
 
+def _mentions(haystack: str, terms: Sequence[str]) -> bool:
+    """Whether *haystack* names any denylisted term, on word boundaries.
+
+    A term inside an unrelated word is not a disclosure: `severity` contains
+    the authority's name and says nothing about it. Separators count as
+    boundaries, so a repository path still matches the identifier inside it.
+    """
+    lowered = haystack.lower()
+    for term in terms:
+        pattern = rf"(?<![0-9a-z]){re.escape(term)}(?![0-9a-z])"
+        if re.search(pattern, lowered):
+            return True
+    return False
+
+
 # The runtime's own evidence modules, by exact path.
 #
 # `VENDORED_IMPLEMENTATION` matches names shaped like an evidence
@@ -892,7 +908,7 @@ def test_no_denylisted_term_appears_anywhere_in_the_repository():
             body = path.read_text(errors="ignore").lower()
         except OSError:
             continue
-        if any(term in body for term in terms):
+        if _mentions(body, terms):
             findings.append(
                 _opaque(path.relative_to(REPO_ROOT).as_posix(), PRIVATE_IDENTIFIER)
             )
@@ -957,7 +973,7 @@ def test_wheelhouse_distributions_disclose_nothing():
     def _denied(text: str) -> str | None:
         """A supplied private term. A leak wherever it appears, prose included."""
         lowered = text.lower()
-        return PRIVATE_IDENTIFIER if any(term in lowered for term in terms) else None
+        return PRIVATE_IDENTIFIER if _mentions(lowered, terms) else None
 
     def _implementation_named(text: str) -> str | None:
         """An identifier shaped like an evidence implementation.
@@ -1054,7 +1070,7 @@ def test_built_wheel_discloses_nothing_supplied(built_wheel):
     offenders = [
         _opaque(f"built wheel {label}")
         for label, text in surfaces.items()
-        if any(term in text.lower() for term in terms)
+        if _mentions(text, terms)
     ]
     assert not offenders, f"the built wheel carries a prohibited term: {offenders}"
 
@@ -1070,8 +1086,9 @@ def test_package_contents_disclose_nothing_supplied():
         _opaque(f"package source #{index + 1}")
         for index, path in enumerate(sources)
         if any(
-            term in path.read_text(errors="ignore").lower() or term in path.name.lower()
-            for term in terms
+            _mentions(path.read_text(errors="ignore"), terms)
+            or _mentions(path.name, terms)
+            for _ in (0,)
         )
     ]
     assert not offenders, (
@@ -1092,7 +1109,7 @@ def test_installed_distributions_disclose_nothing_supplied():
     offenders = [
         _opaque(f"installed distribution #{index + 1}")
         for index, name in enumerate(installed)
-        if any(term in name.lower() for term in terms)
+        if _mentions(name, terms)
     ]
     assert not offenders, (
         f"an installed distribution name carries a prohibited term "
@@ -1422,14 +1439,14 @@ def test_every_markdown_file_is_name_audited():
     assert documents, "no markdown found to audit"
     offenders = []
     for name in documents:
-        if any(term in name.lower() for term in terms):
+        if _mentions(name, terms):
             # The filename is the disclosure. Reported like any other location:
             # the file is committed to a public repository, so the name is
             # already public and the fix is to rename it.
             offenders.append(_opaque(f"{name} (document name)"))
             continue
         body = (REPO_ROOT / name).read_text(errors="ignore").lower()
-        if any(term in body for term in terms):
+        if _mentions(body, terms):
             offenders.append(_opaque(f"{name} (document body)"))
     assert not offenders, (
         f"a document carries a prohibited term ({len(documents)} scanned): {offenders}"


### PR DESCRIPTION
## What does this PR do?

The release disclosure audit could not pass. It reported **44 documents** — `README.md`, `CONTRIBUTING.md`, `SECURITY.md`, `PULL_REQUEST_TEMPLATE.md` and every release note back to the first alpha — all unchanged files that shipped in v2.4.0.

None of it was a disclosure. Two causes:

### 1. The owner half of the repository secret became a denylist term

`ORI_EVIDENCE_ARTIFACT_REPOSITORY` is `owner/name`, and the assembly split the whole value on `/`:

```bash
for part in $(printf '%s' "${value}" | tr './,' ' '); do
```

So the **organisation name** was emitted as a term — and it appears in every install URL and compare link in this repository's own public documentation. The audit was flagging the project for naming itself, and no configuration could have made it pass.

Only the name half is private, and only it is emitted now. Verified against a realistic secret set:

```
before:  ori_verity,store,VerityStore,verity,ori-platform,ori-verity
after:   ori_verity,store,VerityStore,verity,ori-verity
```

The refusal when nothing is configured is unchanged — an audit that cannot know what to look for still must not report success.

### 2. Matching was plain substring

`if any(term in body for term in terms)` has no word boundary, so `verity` matched **"severity"**. Boundaries are now required, with `-`, `_`, `.` and `/` counting as separators so a repository path still matches the identifier inside it.

## Why nothing caught this earlier

These checks were added in `1b6d0b3`, **after v2.4.0 was tagged**, and they run only under the `disclosure_release` marker with a denylist supplied by the release workflow. No branch or pull request can reach them.

`v2.5.0-rc.1` was spent discovering that: signed, verified, preflight passed, all three interpreters green, then the build failed on this audit and no artifacts were produced. The tag is retained and not moved, per convention.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — a release-workflow assembly step and a test helper. No runtime code changes; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Testing notes

The audit still catches real disclosures. Each was planted in a document and the result checked:

| Planted | Result |
|---|---|
| the private identifier | flagged |
| its bare stem | flagged |
| an `owner/name` repository path | flagged |
| the identifier inside a GitHub URL | flagged |
| `severity` alone | **not** flagged |

And it passes against every realistic denylist shape — the identifier alone, with its bare stem, as a full repository path, and that path with the stem.

The assembly step was exercised directly, since it had never been tested: a full secret set, a repository-only set, and the empty case that must refuse.

Full suite 3994 passed, 27 skipped. mypy clean, ruff clean, `scripts/check_workflows.py` clean.

## Follow-up worth considering

The boundary logic still cannot run outside a release. The real terms should stay private, but exercising the matching in PR CI against a synthetic term would mean a defect in *how* it matches is found on a branch rather than by burning a tag. Not done here to keep this change to the defect.