### PR TITLE
chore(release): prepare v2.5.0-rc.2

### DIFF
--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -38,7 +38,22 @@ installed.
 
 | Tag | Reached | Outcome |
 |---|---|---|
-| `v2.5.0-rc.1` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
+| `v2.5.0-rc.1` | protection preflight, full test matrix | the release disclosure audit refused 44 unchanged public documents, so no bundle was built or signed |
+| `v2.5.0-rc.2` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
+
+`v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
+built, signed or published from it.
+
+Its cause was in the audit rather than the release. The audit derives its terms
+from the artifact repository secret, which is `owner/name`, and split the whole
+value — so the organisation name became a term it searched for. That name
+appears in every install URL and compare link in this repository's own public
+documentation, so the audit flagged the project for naming itself. Matching was
+also by substring, which made the private stem match `severity`.
+
+Both are fixed. The checks were added after v2.4.0 was tagged and run only
+under the release marker, so no branch or pull request could reach them, and
+`v2.5.0-rc.1` was the first execution of any kind.
 
 ## What this candidate is for
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc1"
+version = "2.5.0rc2"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Prepares the second v2.5.0 candidate. Same release content as `rc.1`, against an audit that can now pass. Version string and release notes only.

## Why rc.1 was spent

`v2.5.0-rc.1` is recorded in the candidate table and retained. It produced no artifacts and must not be installed.

The cause was in the audit, not the release. It derives its terms from the artifact repository secret — which is `owner/name` — and split the whole value, so the **organisation name** became a term it searched for. That name appears in every install URL and compare link in this repository's own public documentation, so the audit flagged the project for naming itself. Substring matching also made the private stem match `severity`.

Both fixed in #390.

## Confidence that rc.2 clears the same gate

The audit was reproduced locally under the exact terms the release workflow assembles, and the arithmetic accounts for rc.1 precisely:

| Denylist | Release-marker failures |
|---|---|
| `ori-platform` alone | 3 |
| the private identifier and its stem | **0** |

rc.1's CI reported `4 failed, 29 passed` — the three above plus the built-wheel check, which needs a wheel and is skipped locally. That matches only the organisation-name cause. A second bad term would have produced a visibly larger failure set, so there is not one hiding behind it.

## Type of change

- [x] `chore` — release preparation

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — a version string and release documentation. No runtime code changes; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Related issue

Continues #386.

## Testing notes

```
$ python scripts/check_release_identity.py --tag v2.5.0-rc.2
version=2.5.0-rc.2
```

Checked locally because that gate is the one `v2.4.0-rc.1` and `v2.4.0-rc.2` were spent proving.

Full suite 3994 passed, 27 skipped. The release-gated disclosure audit was run under the terms the workflow assembles, and passes.

## After merge

Tag signed and pushed separately. `release-signing` requires a second approver — the tagger cannot self-approve, so that deployment approval is the release approval.

What this candidate still has to prove, none of it established until it runs on a Raspberry Pi 4 on stock Trixie:

1. it installs against the system `python3.13`, with no hand-placed interpreter and no symlink;
2. the deployed environment resolves `LGPIOFactory`, not `NativeFactory`;
3. a wired relay physically actuates under a hardened profile.