### PR TITLE
fix(disclosure): scope the wheelhouse gate to what it is for

### DIFF
--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -38,6 +38,7 @@ import os
 import pathlib
 import re
 import subprocess
+import tomllib
 import zipfile
 from collections.abc import Sequence
 
@@ -634,6 +635,13 @@ def _mentions(haystack: str, terms: Sequence[str]) -> bool:
 # Only names the vendored-implementation pattern would otherwise flag. Listing
 # a name it does not match exempts nothing and reads as a judgement nobody made,
 # which the guard below refuses.
+#: The wheel this repository builds, as a wheel filename normalises it.
+#: Read from the packaging metadata so a rename cannot silently turn the
+#: first-party checks off.
+DISTRIBUTION_NAME = tomllib.loads(
+    (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+)["project"]["name"].replace("-", "_")
+
 FIRST_PARTY_EVIDENCE_MODULES = frozenset({"ori/security/evidence_chain.py"})
 
 
@@ -989,6 +997,12 @@ def test_wheelhouse_distributions_disclose_nothing():
         accurately. The sibling wheel test already draws this line; this audit
         did not, and a wheelhouse built from a real tag is what showed it.
         """
+        if text.strip() in FIRST_PARTY_EVIDENCE_MODULES:
+            # This runtime produces chain rows itself, so a module named for
+            # that work is what should ship. Without the registry the audit
+            # flags the package for containing the thing it exists to contain,
+            # as both a member name and a RECORD path.
+            return None
         if VENDORED_IMPLEMENTATION.search(text):
             return "evidence-implementation naming"
         return None
@@ -1010,9 +1024,17 @@ def test_wheelhouse_distributions_disclose_nothing():
         # WHEEL carries no long description; every line of it is structural.
         return [line.strip() for line in text.splitlines() if line.strip()]
 
+    def _is_first_party(wheel_name: str) -> bool:
+        """Whether this wheel is the one this repository builds.
+
+        Wheel names normalise the project name with underscores.
+        """
+        return wheel_name.startswith(f"{DISTRIBUTION_NAME}-")
+
     failures: list[str] = []
     inspected_binaries = 0
     for path in distributions:
+        first_party = _is_first_party(path.name)
         # Distribution names are printed only when they do not themselves
         # match; the location of an offending wheel is its index, not its name.
         location = f"distribution #{distributions.index(path) + 1}"
@@ -1022,7 +1044,14 @@ def test_wheelhouse_distributions_disclose_nothing():
         with zipfile.ZipFile(path) as archive:
             for index, name in enumerate(archive.namelist()):
                 member = f"{location} member #{index + 1}"
-                found = _category(name)
+                # The shape pattern asks whether *this project* is shipping an
+                # evidence implementation, so it reads our own members only. A
+                # third-party module that happens to be called something like
+                # `chain_store` is not our artifact, and flagging it would make
+                # any dependency bump able to fail a release. A private
+                # identifier is a leak wherever it appears, so that half reads
+                # every distribution.
+                found = _category(name) if first_party else _denied(name)
                 if found:
                     failures.append(_opaque(f"{member} (member name)", found))
                 if name.endswith((".so", ".dylib", ".pyd", ".dll")):
@@ -1030,6 +1059,13 @@ def test_wheelhouse_distributions_disclose_nothing():
                     found = _category(_printable_strings(archive.read(name)))
                     if found:
                         failures.append(_opaque(f"{member} (compiled strings)", found))
+                elif name.endswith((".py", ".pyi")):
+                    # A vendored implementation can be imported by name from
+                    # source without any filename revealing it. Names and
+                    # metadata alone missed that, in any distribution.
+                    found = _denied(archive.read(name).decode("utf-8", "ignore"))
+                    if found:
+                        failures.append(_opaque(f"{member} (source)", found))
                 if name.endswith(("METADATA", "RECORD", "WHEEL")):
                     text = archive.read(name).decode("utf-8", "ignore")
                     # A supplied private identifier is a leak anywhere in the
@@ -1039,6 +1075,8 @@ def test_wheelhouse_distributions_disclose_nothing():
                         failures.append(_opaque(f"{member} (wheel metadata)", found))
                     # The naming pattern reads declared fields only.
                     for field in _declared_fields(name, text):
+                        if not first_party:
+                            break
                         found = _implementation_named(field)
                         if found:
                             failures.append(


### PR DESCRIPTION
## What does this PR do?

The gate exists to stop **this project** shipping an evidence implementation. It was also applying that judgement to every vendored wheel, where it answers a different question badly.

Three faults, each one release away from being found.

### 1. It flagged our own registered module

The shape pattern never consulted `FIRST_PARTY_EVIDENCE_MODULES`. `ori/security/evidence_chain.py` — deliberately registered when this runtime became a chain-row producer — was refused twice: once as an archive member, once as the same path in `RECORD`, because the two call sites reach the matcher by different routes. The exemption now lives in the matcher, so both inherit it.

This is what spent `v2.5.0-rc.2`.

### 2. It judged third-party wheels by our naming rules

The same pattern ran over vendored members and metadata. A third-party module called `chain_store` is **not our artifact**, and flagging it would let any dependency bump fail a release on a name its author chose years ago.

The pattern now reads our own distribution only, identified from packaging metadata so a rename cannot quietly disable it.

A wheel *named* like an evidence store is still refused wherever it came from — that is a claim about the package, not about one module inside it.

### 3. Source members were never read for a leaked identifier

Names, metadata and compiled strings were scanned; `.py` content was not. A vendored implementation imported by name from source passed cleanly. This one is pre-existing — I confirmed it against `main` rather than assuming — and it is the hole that actually matters for the gate's purpose, so it is closed here.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — a release-time test only. No runtime code changes; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Testing notes

Verified against a real wheelhouse built by `scripts/build-wheelhouse.sh`, planting each case into a built wheel:

| Case | Flagged |
|---|---|
| our wheel gains an evidence-shaped module | yes |
| our wheel gains an `attest_impl` module | yes |
| third-party wheel has `chain_store.py` | **no** |
| third-party wheel has `ledger_db.py` | **no** |
| third-party wheel leaks the identifier in source | yes |
| our wheel leaks the identifier in source | yes |
| a wheel *named* like an evidence store | yes |

That is the gate as intended: it refuses us shipping an implementation, and it refuses a leaked identifier anywhere, without judging a third party's module naming.

All 33 release-marker checks pass against that wheelhouse. Full suite 3994 passed, 27 skipped.

## The pattern worth breaking

This is the second tag spent on a check that runs only under the release marker, after `v2.5.0-rc.1` went to the terms defect. Preflight and the full matrix pass, then the build fails on something no branch can reach.

The wheelhouse audit needs a built wheelhouse, not a secret. Running it on pull requests would have caught all three faults above on a branch. Worth doing next, and deliberately not folded in here.