### PR TITLE
ci: audit a built wheelhouse on pull requests, judging only our own naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,39 @@ jobs:
         if: matrix.python-version == '3.12'
         run: bash scripts/refresh-evidence-vectors.sh
 
+      # The wheelhouse audit runs only under the release marker, so defects in
+      # it reach tags before any branch can see them: v2.5.0-rc.1 and rc.2 were
+      # both spent that way. It needs a built wheelhouse rather than a secret,
+      # so it can run here on a synthetic term.
+      - name: Audit a built wheelhouse for disclosure
+        if: matrix.python-version == '3.12'
+        env:
+          ORI_WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
+          ORI_WHEELHOUSE_TARGET: generic
+        run: |
+          set -euo pipefail
+          bash scripts/build-wheelhouse.sh
+          # The real identifiers stay in the release environment. A synthetic
+          # term proves the machinery rather than the secret.
+          term="orisyntheticdisclosureprobe"
+          ORI_DISCLOSURE_DENYLIST="${term}" python -m pytest \
+            tests/test_evidence_disclosure.py -m disclosure_release -q
+          # Silence is only evidence if the audit would have spoken. Plant the
+          # term in a shipped wheel and require a refusal, so a wheelhouse that
+          # is never really read cannot report itself clean.
+          probe="${RUNNER_TEMP}/wheelhouse-probe"
+          rm -rf "${probe}"
+          cp -r "${ORI_WHEELHOUSE_OUT}" "${probe}"
+          printf 'LEAKED = "%s"\n' "${term}" > "${RUNNER_TEMP}/probe_leak.py"
+          (cd "${RUNNER_TEMP}" && zip -q "$(ls "${probe}"/*.whl | head -1)" probe_leak.py)
+          if ORI_WHEELHOUSE_OUT="${probe}" ORI_DISCLOSURE_DENYLIST="${term}" \
+             python -m pytest tests/test_evidence_disclosure.py \
+             -m disclosure_release -q >/dev/null 2>&1; then
+            echo "the audit accepted a wheelhouse carrying the probe term" >&2
+            exit 1
+          fi
+          rm -rf "${probe}" "${RUNNER_TEMP}/probe_leak.py"
+
       - name: Type check runtime contract boundaries
         run: bash scripts/typecheck-boundaries.sh
 

--- a/tests/test_evidence_disclosure.py
+++ b/tests/test_evidence_disclosure.py
@@ -1038,7 +1038,11 @@ def test_wheelhouse_distributions_disclose_nothing():
         # Distribution names are printed only when they do not themselves
         # match; the location of an offending wheel is its index, not its name.
         location = f"distribution #{distributions.index(path) + 1}"
-        found = _category(path.name)
+        # A package name is its author's choice as much as a module name is, so
+        # shape judges ours and the denylist judges everyone. A vendored
+        # implementation is caught by the identifiers it carries rather than by
+        # a name we would have to guess at.
+        found = _category(path.name) if first_party else _denied(path.name)
         if found:
             failures.append(_opaque(f"{location} (distribution name)", found))
         with zipfile.ZipFile(path) as archive:


### PR DESCRIPTION
## What does this PR do?

Two candidates were spent on a check no branch could reach. `v2.5.0-rc.1` went to the denylist terms defect, `v2.5.0-rc.2` to the first-party registry. In both, preflight and the full matrix passed and the build then failed on something that had never executed until a tag existed.

The wheelhouse audit needs a **built wheelhouse, not a secret**. So it can run on pull requests.

### Exercising it without the secret

The real identifiers stay in the release environment; a synthetic term runs here instead. That is sufficient because the defects were in the machinery, not in the terms. Confirmed by reintroducing the fault that spent rc.2:

```
with the rc.2 defect reintroduced:  1 failed, 32 passed
```

### Silence is only evidence if the audit would have spoken

The step also plants the term in a shipped wheel and requires a refusal:

```
clean wheelhouse:    33 passed
planted wheelhouse:  REFUSED
```

Without that control, a wheelhouse that is never really read would report itself clean — the same shape of mistake as the defects being guarded against. The audit counts what it inspected but asserts nothing about it.

### Third-party naming is not ours to legislate

Running on every pull request means a dependency bump now reaches this audit, and **a Dependabot PR must not be able to get stuck on a name someone else chose.**

The shape pattern now reads our own distribution alone — package name included, since a package name is its author's choice as much as a module name is. The denylist still reads every distribution: names, metadata, compiled strings, and source.

So a bump can fail this only by carrying something private, never by choosing a word we happen to match:

| Case | Flagged |
|---|---|
| third-party module named `chain_store` | **no** |
| third-party package named `attest_core` | **no** |
| third-party carries the private identifier | yes |
| our wheel gains an evidence-shaped module | yes |
| our wheel carries the private identifier | yes |

## Type of change

- [x] `ci` — continuous integration

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — a CI step and a release-time test scope. No runtime code changes; no capability changes state, posture or availability.

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Testing notes

The whole CI sequence was run locally against a real wheelhouse from `scripts/build-wheelhouse.sh`: clean pass, planted refusal, and the rc.2 regression check above. Full suite 3994 passed, 27 skipped. `scripts/check_workflows.py` clean.

Scoped to the 3.12 leg, like the vendored-vector check, since building a wheelhouse three times would buy nothing.

## What this does not do

It cannot anticipate a dependency that has not landed. What it changes is *when* we find out — and with the scoping above, a future dependency's naming is no longer something we can be stopped by at all. Only a genuine leak is.