### PR TITLE
chore(release): prepare v2.5.0-rc.3

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.5.0-rc.1` are collected here until the next
+Changes merged to `main` after `v2.5.0-rc.3` are collected here until the next
 candidate or release is cut.
 
 _No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.1` is the first candidate.
+Minor release, in progress. `v2.5.0-rc.3` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -39,7 +39,8 @@ installed.
 | Tag | Reached | Outcome |
 |---|---|---|
 | `v2.5.0-rc.1` | protection preflight, full test matrix | the release disclosure audit refused 44 unchanged public documents, so no bundle was built or signed |
-| `v2.5.0-rc.2` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
+| `v2.5.0-rc.2` | protection preflight, full test matrix, build | the wheelhouse audit refused the runtime's own evidence modules, so no bundle was built or signed |
+| `v2.5.0-rc.3` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.
@@ -55,9 +56,27 @@ Both are fixed. The checks were added after v2.4.0 was tagged and run only
 under the release marker, so no branch or pull request could reach them, and
 `v2.5.0-rc.1` was the first execution of any kind.
 
+`v2.5.0-rc.2` produced no artifacts either, and must not be installed. It
+cleared the audit that stopped `v2.5.0-rc.1` and failed one stage later, in the
+wheelhouse audit that inspects every wheel a bundle would ship.
+
+That audit judges a module by shape as well as by name, because a private
+implementation could arrive under any name. It was never told which modules are
+ours by design, so it refused the runtime's own evidence code for looking
+exactly like what it was written to look like.
+
+The rule is now stated once and applied everywhere: shape judges our own
+distribution, and the denylist judges every distribution. A dependency cannot
+fail this gate by choosing a name — only by carrying something private.
+
+Both audits now run on pull requests against a built wheelhouse, against a
+planted term as well as a clean one, so a release-only path is no longer the
+first execution. `v2.5.0-rc.3` is the first candidate whose gates have all run
+before the tag.
+
 ## What this candidate is for
 
-`v2.5.0-rc.1` exists to be installed on real hardware. Specifically:
+`v2.5.0-rc.3` exists to be installed on real hardware. Specifically:
 
 1. It must install on Raspberry Pi OS Trixie using the **system** `python3.13`,
    with no hand-placed interpreter and no symlink.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc2"
+version = "2.5.0rc3"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps the project to `2.5.0rc3` and records what stopped `v2.5.0-rc.2`.

`v2.5.0-rc.2` cleared the audit that stopped `v2.5.0-rc.1` and failed one stage later, in the wheelhouse audit that inspects every wheel a bundle would ship. That audit judges a module by shape as well as by name, because a private implementation could arrive under any name. It had never been told which modules are ours by design, so it refused the runtime's own evidence code for looking exactly like what it was written to look like.

The rule is now stated once and applied everywhere: shape judges our own distribution, and the denylist judges every distribution. A dependency cannot fail this gate by choosing a name — only by carrying something private.

Both audits now run on pull requests against a built wheelhouse, against a planted term as well as a clean one, so a release-only path is no longer the first execution. `v2.5.0-rc.3` is the first candidate whose gates have all run before the tag.

The unreleased note still pointed at `v2.5.0-rc.1` while carrying no changes, because the previous candidate did not move it. It now points at `v2.5.0-rc.3`.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

No capability behaviour changed — this is a version bump and the release note. `[skip-cap-matrix]`

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Part of the v2.5.0 release train.

## Testing notes

`python scripts/check_release_identity.py --tag v2.5.0-rc.3` resolves `version=2.5.0-rc.3`.

The disclosure suite runs green with the release marker and a supplied denylist, 79 passed. Full suite: 3994 passed, 27 skipped.