### PR TITLE
fix(installer): give a Pi release a pin factory it can actually import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,16 @@ jobs:
       # it reach tags before any branch can see them: v2.5.0-rc.1 and rc.2 were
       # both spent that way. It needs a built wheelhouse rather than a secret,
       # so it can run here on a synthetic term.
+      #
+      # The Pi target is audited rather than the generic one because it is a
+      # superset: the same runtime lock plus the Raspberry Pi hardware wheels
+      # that aarch64 bundles now ship. Auditing the smaller target would leave
+      # the wheels that actually reach a device uninspected.
       - name: Audit a built wheelhouse for disclosure
         if: matrix.python-version == '3.12'
         env:
           ORI_WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
-          ORI_WHEELHOUSE_TARGET: generic
+          ORI_WHEELHOUSE_TARGET: pi
         run: |
           set -euo pipefail
           bash scripts/build-wheelhouse.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,21 +188,27 @@ jobs:
       matrix:
         include:
           - target: linux-x86_64-python3.11
+            wheelhouse-target: generic
             runner: ubuntu-24.04
             python-version: "3.11"
           - target: linux-x86_64-python3.12
+            wheelhouse-target: generic
             runner: ubuntu-24.04
             python-version: "3.12"
           - target: linux-aarch64-python3.11
+            wheelhouse-target: pi
             runner: ubuntu-24.04-arm
             python-version: "3.11"
           - target: linux-aarch64-python3.12
+            wheelhouse-target: pi
             runner: ubuntu-24.04-arm
             python-version: "3.12"
           - target: linux-x86_64-python3.13
+            wheelhouse-target: generic
             runner: ubuntu-24.04
             python-version: "3.13"
           - target: linux-aarch64-python3.13
+            wheelhouse-target: pi
             runner: ubuntu-24.04-arm
             python-version: "3.13"
 
@@ -255,7 +261,7 @@ jobs:
       - name: Build offline wheelhouse and deterministic bundle
         env:
           ORI_WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
-          ORI_WHEELHOUSE_TARGET: generic
+          ORI_WHEELHOUSE_TARGET: ${{ matrix.wheelhouse-target }}
           ORI_RELEASE_BUNDLE_VERSION: ${{ steps.identity.outputs.version }}
           ORI_RELEASE_BUNDLE_TARGET: ${{ matrix.target }}
           ORI_RELEASE_BUNDLE_OUT: ${{ runner.temp }}/bundle

--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -84,10 +84,53 @@ Both are present on a stock Trixie image; the command is for a minimal one.
 
 ## The venv must be able to see it
 
-The installer creates an isolated virtual environment. An isolated venv cannot
-import apt packages, so a Pi install needs the system site directory visible for
-the GPIO layer — otherwise `gpiozero` is present but factory-less, which fails
-in exactly the silent way described above.
+An isolated venv cannot import apt packages, so a Pi install needs the pin
+factory reachable from inside it — otherwise `gpiozero` is present but
+factory-less, which fails in exactly the silent way described above.
+
+The venv stays isolated and the installer takes the module by name. The two
+files apt ships, `lgpio.py` and the extension built for this interpreter's ABI,
+are **copied** into the release's own `site-packages`.
+
+Copied rather than linked, for two reasons. The release permission transaction
+requires an external symlink target to be executable and apt ships both files
+`0644`, so a link is accepted where it is made and refused a seam later.
+Copying also freezes the reviewed bytes into the release instead of leaving
+live code attached to whatever a future apt upgrade puts at that path.
+
+Creating the venv with `--system-site-packages` would have been simpler and is
+the wrong trade. It puts every apt package on the runtime's import path, where
+an unpinned optional import — a transport, a hardware backend — could activate
+a capability from a package no release reviewed. It also lets pip treat a pinned
+dependency whose version matches a system one as already satisfied, leaving the
+runtime importing unhashed code.
+
+Before anything is copied, the source is checked: discovery runs the interpreter
+in isolated mode so no environment variable or working directory can steer it,
+the answer must land in an admitted system package directory, and each file must
+be a regular file, root-owned, and not writable beyond its owner. The extension
+is named from the interpreter's own `EXT_SUFFIX` rather than matched by pattern,
+so an extension left behind for another ABI cannot be taken.
+
+**Only Pi hardware stages it, and there it is required.** An install that
+cannot stage both halves fails with `prerequisite_install_failed` rather than
+finishing without the capability the bundle exists to deliver. On Linux that is
+not a Pi the same `aarch64` bundle installs without asking: nothing is copied
+even where the apt package happens to be present, because that host has no pins
+to drive and system code in a release that will never use it is exposure bought
+for nothing. `/proc/device-tree/model` is what decides.
+
+To check what a deployed venv can reach beyond its own tree:
+
+```bash
+sudo /opt/ori/current/venv/bin/python -c \
+  "import importlib.util as u; \
+   print([m for m in ('yaml','cryptography','requests','RPi','aiocoap') \
+          if (s := u.find_spec(m)) and 'dist-packages' in (s.origin or '')])"
+```
+
+An empty list is the expected answer. Anything else means the venv is reading
+the system path for something other than the pin factory.
 
 Check a deployed install:
 
@@ -99,6 +142,29 @@ sudo /opt/ori/current/venv/bin/python -c \
 `LGPIOFactory` means GPIO is live. **`NativeFactory` means it is not** -- the
 import succeeded, every availability check passes, and the pins are driven by an
 experimental fallback. Treat that result as a failed check, not a partial pass.
+
+## Upgrading off a hand-placed interpreter
+
+Upgrade first, then remove the old interpreter. The installer binds an existing
+installation to its release symlinks and refuses an install root it cannot
+validate, so deleting the interpreter a previous release points at leaves the
+upgrade blocked on `unsafe_install_root` with nothing installable in its place.
+
+The order that works:
+
+```bash
+# 1. Install the new release while the old interpreter is still present.
+sudo bash install-linux.sh --version <version> -- --unattended --scope system
+
+# 2. Confirm the new venv is on the system interpreter.
+sudo readlink -f /opt/ori/current/venv/bin/python   # expect /usr/bin/python3.13
+
+# 3. Only then remove the hand-placed interpreter and its symlink.
+sudo rm -rf /usr/local/ori-python /usr/local/bin/python3.12
+```
+
+Step 2 before step 3. A release whose venv still resolves through
+`/usr/local` will stop working the moment step 3 runs.
 
 ## Verifying a Pi before you rely on it
 
@@ -123,9 +189,10 @@ sudo /opt/ori/current/venv/bin/python -c \
 systemctl cat ori-runtime.service | grep ExecStart
 ```
 
-Step 3 is the one that matters, and read its output rather than its exit code:
-it prints `ok` for any factory at all, including the experimental fallback.
-Steps 1 and 2 can pass on a device whose Ori install still cannot drive a pin.
+Step 3 is the one that matters, and read the name it prints rather than its
+exit code: it succeeds for any factory at all, including the experimental
+fallback. Steps 1 and 2 can pass on a device whose Ori install still cannot
+drive a pin.
 
 ## Before a demo
 
@@ -133,7 +200,7 @@ Anything that must physically actuate has to be proven on the device, under a
 profile that refuses to pretend:
 
 1. Install from a release bundle carrying a `linux-aarch64-python3.13` target.
-2. Confirm step 3 above returns `ok`.
+2. Confirm step 3 above prints `LGPIOFactory`.
 3. Wire the relay to **normally closed** terminals and declare its `gpio_pin`.
 4. Move `deployment_profile` off `development`. A hardened profile fails
    startup when a configured GPIO path has no `gpiozero` behind it, which is

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -17,7 +17,7 @@ import time
 import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable, Literal, Sequence
+from typing import Callable, Literal, NoReturn, Sequence
 
 import yaml
 
@@ -1722,6 +1722,74 @@ def _set_owned_mode(change: _PermissionChange, uid: int, gid: int, mode: int) ->
         os.close(descriptor)
 
 
+_SYSTEM_PIN_FACTORY_MODULE = "lgpio"
+# Where a Raspberry Pi OS image puts apt's Python packages. Discovery is
+# constrained to this set so an interpreter answering from somewhere else
+# cannot decide what gets copied into a release.
+_SYSTEM_PACKAGE_DIRECTORIES = (Path("/usr/lib/python3/dist-packages"),)
+_DEVICE_MODEL = Path("/proc/device-tree/model")
+
+
+def _is_raspberry_pi() -> bool:
+    """Whether this host is Raspberry Pi hardware.
+
+    `aarch64` bundles carry the Pi wheels and also serve community `aarch64`
+    Linux, which has no apt pin factory and no pins to drive. The absent module
+    is a failed install on the first and a non-event on the second, so the
+    hardware decides rather than the bundle.
+    """
+    try:
+        model = _DEVICE_MODEL.read_bytes()
+    except OSError:
+        return False
+    return b"raspberry pi" in model.lower()
+
+
+def _staging_refusal(
+    venv: Path, base: str, purelib: str, suffix: str, origin: str
+) -> str | None:
+    """Why the pin factory cannot be staged from this system, or None."""
+    if not base:
+        return "the base interpreter could not be identified"
+    if not purelib or not Path(purelib).is_dir():
+        return "the release site directory is missing"
+    # The destination is named by a probe, and root is about to write there.
+    # Bind it to the environment being built, the way every other privileged
+    # write in this installer is bound to its intended path.
+    try:
+        destination = Path(purelib).resolve(strict=True)
+        environment = venv.resolve(strict=True)
+    except OSError:
+        return "the release site directory could not be resolved"
+    if not destination.is_relative_to(environment):
+        return "the release site directory lies outside the environment"
+    if not suffix:
+        return "the interpreter reports no extension suffix"
+    if not origin:
+        return (
+            f"{_SYSTEM_PIN_FACTORY_MODULE} is not installed; "
+            "install the system package that provides it"
+        )
+    if Path(origin).parent not in _SYSTEM_PACKAGE_DIRECTORIES:
+        return "it resolves outside the admitted system package directories"
+    return None
+
+
+def _system_file_failure(path: Path) -> str | None:
+    """Why a system file cannot be taken into a release, or None."""
+    try:
+        info = os.lstat(path)
+    except OSError:
+        return "is missing"
+    if not stat.S_ISREG(info.st_mode):
+        return "is not a regular file"
+    if info.st_uid != 0:
+        return "is not owned by root"
+    if info.st_mode & (stat.S_IWGRP | stat.S_IWOTH):
+        return "is writable beyond its owner"
+    return None
+
+
 class OfflineReleasePreparer:
     """Build an isolated release environment without package-index access."""
 
@@ -1746,6 +1814,7 @@ class OfflineReleasePreparer:
                 "offline_install_failed", "verified wheelhouse is incomplete"
             )
         venv = staging / "venv"
+        pi_requirements = wheelhouse / "requirements-pi.txt"
         self._run([self._bootstrap_python, "-m", "venv", str(venv)])
         python = str(venv / "bin" / "python")
         base = [
@@ -1758,10 +1827,11 @@ class OfflineReleasePreparer:
             str(wheelhouse),
         ]
         self._run([*base, "--require-hashes", "-r", str(requirements)])
-        pi_requirements = wheelhouse / "requirements-pi.txt"
         if pi_requirements.is_file():
             self._run([*base, "--require-hashes", "-r", str(pi_requirements)])
         self._run([*base, "--no-deps", str(wheels[0])])
+        if pi_requirements.is_file() and _is_raspberry_pi():
+            self._stage_system_pin_factory(venv)
 
     def validate(self, release: Path) -> None:
         python = release / "venv" / "bin" / "python"
@@ -1791,6 +1861,111 @@ class OfflineReleasePreparer:
                 "offline_install_failed", "release entrypoint is missing"
             )
         self._run([str(entrypoint), "--help"])
+
+    def _stage_system_pin_factory(self, venv: Path) -> None:
+        """Copy the operating system's pin factory into the isolated venv.
+
+        `lgpio` ships only from apt: PyPI's release carries an empty module, and
+        apt builds the extension per interpreter version. An isolated venv
+        cannot import it, so gpiozero falls back to NativeFactory, which drives
+        pins without claiming the line through the kernel.
+
+        The venv stays isolated and the module is taken by name. Creating it
+        with `--system-site-packages` would put every apt package on the
+        runtime's import path, where an unpinned optional import — a transport,
+        a hardware backend — could activate a capability no release reviewed.
+
+        The bytes are copied rather than linked, for two reasons. The release
+        permission transaction requires an external symlink target to be
+        executable and apt ships both files `0644`, so a link is refused at a
+        later seam than the one that created it. Copying also freezes the
+        reviewed bytes into the release instead of leaving live code attached to
+        whatever a future apt upgrade puts at that path.
+
+        Reached only on Pi hardware. Failing to stage both halves fails the
+        install: the device is expected to drive pins, and an install that
+        quietly finishes without that capability is the silent degradation this
+        path exists to remove. The same `aarch64` bundle installs elsewhere
+        without ever asking, because community Linux has no apt pin factory and
+        no pins to drive.
+        """
+        python = str(venv / "bin" / "python")
+        base = self._probe(python, "import sys; print(sys._base_executable or '')")
+        purelib = self._probe(
+            python, "import sysconfig; print(sysconfig.get_paths()['purelib'])"
+        )
+        # The extension is ABI-tagged, so asking the interpreter that will
+        # import it is the only way to name the one file it can load. A glob
+        # would also match extensions left behind for other ABIs.
+        suffix = (
+            self._probe(
+                base,
+                "import sysconfig; print(sysconfig.get_config_var('EXT_SUFFIX') or '')",
+            )
+            if base
+            else ""
+        )
+        # Discovery is constrained as well as isolated: the interpreter says
+        # where it would import from, and only an admitted system directory is
+        # accepted as that answer.
+        origin = (
+            self._probe(
+                base,
+                "import importlib.util as u;"
+                f"s = u.find_spec({_SYSTEM_PIN_FACTORY_MODULE!r});"
+                "print(s.origin or '' if s else '')",
+            )
+            if base
+            else ""
+        )
+        reason = _staging_refusal(venv, base, purelib, suffix, origin)
+        if reason is not None:
+            self._refuse_pin_factory(reason)
+
+        source = Path(origin).parent
+        members = [
+            source / f"{_SYSTEM_PIN_FACTORY_MODULE}.py",
+            source / f"_{_SYSTEM_PIN_FACTORY_MODULE}{suffix}",
+        ]
+        for member in members:
+            failure = _system_file_failure(member)
+            if failure is not None:
+                self._refuse_pin_factory(f"{member.name} {failure}")
+        destination = Path(purelib)
+        for member in members:
+            target = destination / member.name
+            # A fresh venv holds neither name. One already sitting there means
+            # the wheelhouse or the staging tree is not what it should be, and
+            # overwriting it would hide that.
+            if target.exists() or target.is_symlink():
+                self._refuse_pin_factory(
+                    f"{member.name} is already present in the release"
+                )
+        for member in members:
+            target = destination / member.name
+            shutil.copyfile(member, target)
+            os.chmod(target, 0o644)
+
+    def _refuse_pin_factory(self, reason: str) -> NoReturn:
+        raise LinuxInstallError(
+            "prerequisite_install_failed",
+            f"this device needs the system {_SYSTEM_PIN_FACTORY_MODULE} "
+            f"pin factory and {reason}",
+        )
+
+    def _probe(self, interpreter: str, source: str) -> str:
+        """Ask an interpreter one question, in isolated mode.
+
+        `-I` keeps the answer from depending on `PYTHON*` variables, a user site
+        directory, or the working directory the installer happens to run from.
+        """
+        try:
+            result = self._runner([interpreter, "-I", "-c", source])
+        except (OSError, subprocess.SubprocessError):
+            return ""
+        if result.returncode != 0:
+            return ""
+        return result.stdout.strip()
 
     def _run(
         self, command: Sequence[str], *, expected_stdout: str | None = None

--- a/scripts/install-linux.sh
+++ b/scripts/install-linux.sh
@@ -560,7 +560,9 @@ def bootstrap_install(
             except OSError as exc:
                 raise BootstrapError(
                     "config_validation_failed",
-                    "interactive install requires a terminal; use --unattended or download the script first",
+                    "interactive install requires a terminal; pass "
+                    "-- --unattended --scope system (or --scope user), "
+                    "or download the script and run it from a terminal",
                 ) from exc
     except (OSError, subprocess.SubprocessError) as exc:
         raise BootstrapError(

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -1451,6 +1451,329 @@ def test_offline_preparer_uses_only_verified_wheelhouse_and_exact_version(
     assert "--no-deps" in pip_commands[-1]
 
 
+_EXT_SUFFIX = ".cpython-313-aarch64-linux-gnu.so"
+_ADMITTED = Path("/usr/lib/python3/dist-packages")
+
+
+def _pi_preparer(
+    tmp_path: Path,
+    *,
+    source: Path | None,
+    monkeypatch: pytest.MonkeyPatch,
+    suffix: str = _EXT_SUFFIX,
+    on_pi: bool = True,
+    purelib: Path | None = None,
+    occupied: bool = False,
+) -> tuple[Path, list[Sequence[str]], Callable[[], None]]:
+    """A Pi bundle whose system probe answers with *source* as lgpio's home."""
+    root = tmp_path / "bundle"
+    wheelhouse = root / "wheelhouse"
+    wheelhouse.mkdir(parents=True)
+    (wheelhouse / "requirements.txt").write_text("locked", encoding="utf-8")
+    (wheelhouse / "requirements-pi.txt").write_text("locked", encoding="utf-8")
+    (wheelhouse / "ori_runtime-2.3.0-py3-none-any.whl").write_bytes(b"wheel")
+    bundle = ExtractedReleaseBundle(
+        root, "2.3.0", "linux-aarch64-python3.13", "3.13", 2
+    )
+
+    site_packages = purelib or tmp_path / "release" / "venv" / "site-packages"
+    commands: list[Sequence[str]] = []
+
+    def runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if "venv" in command:
+            venv = Path(command[-1])
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin" / "python").write_text("", encoding="utf-8")
+            for name in ENTRY_POINTS:
+                (venv / "bin" / name).write_text("", encoding="utf-8")
+            site_packages.mkdir(parents=True, exist_ok=True)
+            if occupied:
+                (site_packages / "lgpio.py").write_text("SQUATTER", encoding="utf-8")
+        body = command[-1]
+        stdout = ""
+        if "sys._base_executable" in body:
+            stdout = "/usr/bin/python3.13"
+        elif "EXT_SUFFIX" in body:
+            stdout = suffix
+        elif "find_spec" in body:
+            stdout = str(source / "lgpio.py") if source is not None else ""
+        elif "purelib" in body:
+            stdout = str(site_packages)
+        return subprocess.CompletedProcess(command, 0, stdout, "")
+
+    monkeypatch.setattr(installer_linux, "_is_raspberry_pi", lambda: on_pi)
+    release = tmp_path / "release"
+    release.mkdir()
+    preparer = OfflineReleasePreparer(
+        bundle=bundle, runner=runner, bootstrap_python="python3"
+    )
+    return site_packages, commands, lambda: preparer.prepare(release)
+
+
+def _plant(directory: Path, *, suffix: str = _EXT_SUFFIX) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    (directory / "lgpio.py").write_text("PIN_FACTORY", encoding="utf-8")
+    (directory / f"_lgpio{suffix}").write_bytes(b"\x7fELF")
+    (directory / "yaml.py").write_text("", encoding="utf-8")
+    # An extension left behind for a different interpreter ABI.
+    (directory / "_lgpio.cpython-311-aarch64-linux-gnu.so").write_bytes(b"stale")
+
+
+def _accept_system_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Treat planted fixtures as root-owned; tests do not run as root."""
+    monkeypatch.setattr(installer_linux, "_system_file_failure", lambda path: None)
+
+
+def test_offline_preparer_copies_the_pin_factory_into_a_pi_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """gpiozero without a backend silently falls back to NativeFactory.
+
+    The bytes are copied rather than linked: the release permission transaction
+    requires an external symlink target to be executable and apt ships these
+    `0644`, so a link is refused at a later seam than the one that made it.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch
+    )
+    run()
+    staged = sorted(entry.name for entry in purelib.iterdir())
+    assert staged == [f"_lgpio{_EXT_SUFFIX}", "lgpio.py"]
+    assert not any((purelib / name).is_symlink() for name in staged)
+    assert (purelib / "lgpio.py").read_text(encoding="utf-8") == "PIN_FACTORY"
+
+
+def test_offline_preparer_takes_only_the_current_abi_and_nothing_else(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A glob would admit an extension built for another interpreter ABI."""
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch
+    )
+    run()
+    staged = {entry.name for entry in purelib.iterdir()}
+    assert "yaml.py" not in staged
+    assert "_lgpio.cpython-311-aarch64-linux-gnu.so" not in staged
+
+
+def test_offline_preparer_probes_the_system_in_isolated_mode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Discovery must not depend on PYTHON* variables or the working directory."""
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    _, commands, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch
+    )
+    run()
+    probes = [command for command in commands if "-c" in command]
+    assert probes, "the preparer probed nothing"
+    assert all("-I" in command for command in probes)
+
+
+def test_offline_preparer_refuses_a_pin_factory_outside_admitted_directories(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The interpreter says where it would import from; only a known home counts."""
+    _plant(tmp_path / "elsewhere")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (_ADMITTED,))
+    _, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "elsewhere", monkeypatch=monkeypatch
+    )
+    with pytest.raises(LinuxInstallError, match="prerequisite_install_failed"):
+        run()
+
+
+def test_offline_preparer_refuses_a_pi_bundle_without_the_pin_factory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A Pi bundle carries GPIO wheels because the device is meant to drive pins.
+
+    Finishing the install without that capability is the silent degradation this
+    path exists to remove, and development posture would not catch it.
+    """
+    _, _, run = _pi_preparer(tmp_path, source=None, monkeypatch=monkeypatch)
+    with pytest.raises(LinuxInstallError, match="prerequisite_install_failed"):
+        run()
+
+
+def test_offline_preparer_refuses_a_pin_factory_it_cannot_trust(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ownership and mode are checked before any byte enters the release."""
+    _plant(tmp_path / "dist")
+    # World-writable rather than wrongly-owned: the suite runs as root in a
+    # container and as an ordinary user on a laptop, and only one of those can
+    # make a file fail an ownership check.
+    (tmp_path / "dist" / "lgpio.py").chmod(0o666)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    _, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch
+    )
+    with pytest.raises(LinuxInstallError, match="prerequisite_install_failed"):
+        run()
+
+
+def test_offline_preparer_stages_nothing_on_hardware_that_is_not_a_pi(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An `aarch64` bundle also serves Linux that is not a Pi.
+
+    The source here is present and valid, so an absent module cannot be what
+    makes this pass. Non-Pi hardware must not stage the factory even when it
+    could: the host has no pins to drive, and copying system code into a release
+    that will never use it is exposure bought for nothing. Nothing is copied and
+    the system is never probed at all.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, commands, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch, on_pi=False
+    )
+    run()
+    assert list(purelib.iterdir()) == []
+    assert not any("find_spec" in command[-1] for command in commands)
+
+
+def test_offline_preparer_reads_pi_hardware_rather_than_trusting_the_bundle(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The model file is the signal, and a missing one is not a Pi."""
+    monkeypatch.setattr(installer_linux, "_DEVICE_MODEL", tmp_path / "absent")
+    assert installer_linux._is_raspberry_pi() is False
+
+    model = tmp_path / "model"
+    model.write_bytes(b"Raspberry Pi 4 Model B Rev 1.5\x00")
+    monkeypatch.setattr(installer_linux, "_DEVICE_MODEL", model)
+    assert installer_linux._is_raspberry_pi() is True
+
+    model.write_bytes(b"Some Other ARM Board\x00")
+    assert installer_linux._is_raspberry_pi() is False
+
+
+def test_offline_preparer_binds_the_destination_to_the_venv(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Root is about to write where a probe pointed, so the path is bound.
+
+    Every other privileged write in this installer is tied to its intended
+    path; a destination named by a subprocess is no exception.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    _, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch, purelib=outside
+    )
+    with pytest.raises(LinuxInstallError, match="prerequisite_install_failed"):
+        run()
+    assert list(outside.iterdir()) == [], "a file was written outside the venv"
+
+
+def test_offline_preparer_refuses_to_overwrite_a_staged_pin_factory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A fresh venv holds neither name; one already there means something else."""
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, _, run = _pi_preparer(
+        tmp_path, source=tmp_path / "dist", monkeypatch=monkeypatch, occupied=True
+    )
+    with pytest.raises(LinuxInstallError, match="prerequisite_install_failed"):
+        run()
+    assert (purelib / "lgpio.py").read_text(encoding="utf-8") == "SQUATTER"
+
+
+def test_system_file_failure_names_each_way_a_file_is_untrusted(
+    tmp_path: Path,
+) -> None:
+    """The check the installer runs before copying anything out of the system."""
+    missing = tmp_path / "absent.py"
+    assert installer_linux._system_file_failure(missing) == "is missing"
+
+    directory = tmp_path / "adirectory"
+    directory.mkdir()
+    assert installer_linux._system_file_failure(directory) == "is not a regular file"
+
+    link = tmp_path / "alink.py"
+    real = tmp_path / "real.py"
+    real.write_text("", encoding="utf-8")
+    link.symlink_to(real)
+    assert installer_linux._system_file_failure(link) == "is not a regular file"
+
+    loose = tmp_path / "loose.py"
+    loose.write_text("", encoding="utf-8")
+    loose.chmod(0o666)
+    assert installer_linux._system_file_failure(loose) in {
+        # Which one is reported depends on whether the suite runs as root.
+        "is not owned by root",
+        "is writable beyond its owner",
+    }
+    tight = tmp_path / "tight.py"
+    tight.write_text("", encoding="utf-8")
+    tight.chmod(0o644)
+    expected = None if os.geteuid() == 0 else "is not owned by root"
+    assert installer_linux._system_file_failure(tight) == expected
+
+
+def test_offline_preparer_leaves_a_generic_venv_isolated(tmp_path: Path) -> None:
+    """A bundle carrying no Pi wheels never probes the system at all."""
+    root = tmp_path / "bundle"
+    wheelhouse = root / "wheelhouse"
+    wheelhouse.mkdir(parents=True)
+    (wheelhouse / "requirements.txt").write_text("locked", encoding="utf-8")
+    (wheelhouse / "ori_runtime-2.3.0-py3-none-any.whl").write_bytes(b"wheel")
+    bundle = ExtractedReleaseBundle(root, "2.3.0", "linux-x86_64-python3.13", "3.13", 2)
+    commands: list[Sequence[str]] = []
+
+    def runner(command: Sequence[str]) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        if "venv" in command:
+            venv = Path(command[-1])
+            (venv / "bin").mkdir(parents=True)
+            (venv / "bin" / "python").write_text("", encoding="utf-8")
+            for name in ENTRY_POINTS:
+                (venv / "bin" / name).write_text("", encoding="utf-8")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    release = tmp_path / "release"
+    release.mkdir()
+    OfflineReleasePreparer(
+        bundle=bundle, runner=runner, bootstrap_python="python3"
+    ).prepare(release)
+    assert not any("find_spec" in command[-1] for command in commands)
+    assert "--system-site-packages" not in next(
+        command for command in commands if "venv" in command
+    )
+
+
 def test_offline_preparer_rejects_missing_or_ambiguous_runtime_wheel(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_release_publication.py
+++ b/tests/test_release_publication.py
@@ -1319,3 +1319,26 @@ def test_installer_failure_codes_are_all_documented() -> None:
 
     undocumented = sorted(raised - documented)
     assert not undocumented, f"codes the guide does not explain: {undocumented}"
+
+
+def test_arm_bundles_carry_the_raspberry_pi_wheelhouse(
+    workflow: dict[str, Any],
+) -> None:
+    """Every published aarch64 bundle must ship the Pi hardware wheels.
+
+    The build matrix once pinned `ORI_WHEELHOUSE_TARGET: generic` for all six
+    targets, so no released bundle carried `gpiozero` at all and a Pi install
+    came up with no actuator. The target is a per-entry decision now, and the
+    architecture in the bundle name is what decides it.
+    """
+    entries = workflow["jobs"]["build"]["strategy"]["matrix"]["include"]
+    wheelhouse_targets = {
+        entry["target"]: entry["wheelhouse-target"] for entry in entries
+    }
+    assert wheelhouse_targets, "the build matrix declares no targets"
+    for target, wheelhouse_target in wheelhouse_targets.items():
+        expected = "pi" if "aarch64" in target else "generic"
+        assert wheelhouse_target == expected, (
+            f"{target} builds the {wheelhouse_target!r} wheelhouse; "
+            f"expected {expected!r}"
+        )


### PR DESCRIPTION
## What does this PR do?

No published bundle could drive a GPIO pin, for two independent reasons that stack. Found by installing `v2.5.0-rc.3` on the bench Pi.

The release matrix built the generic wheelhouse for every target, so no bundle carried `gpiozero` at all and the branch that installs `requirements-pi.txt` could never fire. Behind that, the release venv is isolated while the only working pin factory on Raspberry Pi OS ships from apt — PyPI's `lgpio` release carries an empty module, and apt builds the extension per interpreter version.

Shipping `gpiozero` alone would have been worse than the gap. It resolves `NativeFactory`, which drives pins without claiming the line through the kernel, so a second writer is refused nothing while every availability check passes.

`aarch64` targets now build the Pi wheelhouse, and the two files that make up the module are copied into the release's own site directory.

### Why copied, and why named rather than exposed

Creating the venv with `--system-site-packages` would put every apt package on the runtime's import path, where an unpinned optional import — a transport, a hardware backend — could activate a capability from a package no release reviewed. It would also let pip treat a pinned dependency whose version matches a system one as already satisfied, leaving the runtime importing unhashed code. Eight runtime dependencies overlap with system packages on a stock image, `cryptography` among them.

A symlink is accepted where it is made and refused a seam later: the release permission transaction requires an external target to be executable and apt ships both files `0644`. Verified on the device — `trust_failure("/usr/lib/python3/dist-packages/lgpio.py", require_executable=True)` returns `is not executable`. Copying also freezes the reviewed bytes instead of leaving live code attached to whatever a future apt upgrade puts at that path.

### What is checked before anything is copied

Discovery runs the interpreter isolated, so no environment variable or working directory can steer it. The answer must land in an admitted system package directory. Each file must be a root-owned regular file that nothing else can write. The extension is named from the interpreter's own `EXT_SUFFIX` rather than matched by pattern, so an extension left behind for another ABI cannot be taken. The destination is bound to the environment being built, and a member already sitting there is refused rather than overwritten.

### Where it applies

Raspberry Pi hardware requires this and fails the install with `prerequisite_install_failed` without it — a bundle that finishes without the capability it exists to deliver is the silent degradation this path removes. The same `aarch64` bundle also serves community Linux per `docs/linux-install.md`, which has no apt pin factory and no pins to drive, so nothing is staged there and the system is never probed.

The disclosure audit follows the wheels: CI now builds the Pi wheelhouse, a superset of the generic one, so the packages that reach a device are the ones inspected.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes shape or tier. This makes an already-declared physical capability reachable on hardware that could not reach it, and the hardened posture check that governs it is unchanged.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

`gpiozero` and `smbus2` are already pinned in `requirements/pi.txt`; this delivers them rather than adding them.

## Related issue

Part of #395. Its physical-actuation criterion stays open: that needs a signed candidate installed through the authenticated path, with a real relay on normally-closed terminals under a hardened profile.

## Testing notes

Full suite 4007 passed, 27 skipped. `pyright ori/` and `mypy ori/` clean. The two test files touched carry the same 97 pre-existing `reportArgumentType` diagnostics at the same nine lines as on `main`, measured against a merge-base worktree — the new tests add none.

**On the bench Pi (Raspberry Pi 4, Trixie, system 3.13)**, running the shipped staging code as root against the real apt files:

```
_is_raspberry_pi() -> True
staged
second stage refused: prerequisite_install_failed: ... lgpio.py is already present in the release
-rw-r--r-- root root _lgpio.cpython-313-aarch64-linux-gnu.so
-rw-r--r-- root root lgpio.py
factory: LGPIOFactory
modules resolving through dist-packages [yaml, cryptography, requests, RPi, aiocoap]: []
LOOPBACK OK   (BCM26 driven, BCM20 read)
```

**On Ubuntu 24.04 in Docker**, both `aarch64` and `x86_64`, a Pi bundle installs on non-Pi hardware with `gpiozero` present, `lgpio staged: []`, and no refusal. `test_owner_stripping_umask_is_rejected_stably_and_cleaned_up` fails there when the suite runs as root; it fails identically on `main` at `5a82b87` and is unrelated to this change.

Eleven mutations were checked against the new tests, each failing the intended assertion: staging skipped entirely, only the Python half linked, the whole source directory taken, the wrong ABI extension, probing without isolated mode, ownership validation skipped, symlink instead of copy, staging regardless of hardware, the destination unbound from the venv, a pre-existing member overwritten, and the release matrix reverted to the generic wheelhouse.