### PR TITLE
chore(release): prepare v2.5.0-rc.4

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.5.0-rc.3` are collected here until the next
+Changes merged to `main` after `v2.5.0-rc.4` are collected here until the next
 candidate or release is cut.
 
 _No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.3` is the current candidate.
+Minor release, in progress. `v2.5.0-rc.4` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -40,7 +40,8 @@ installed.
 |---|---|---|
 | `v2.5.0-rc.1` | protection preflight, full test matrix | the release disclosure audit refused 44 unchanged public documents, so no bundle was built or signed |
 | `v2.5.0-rc.2` | protection preflight, full test matrix, build | the wheelhouse audit refused the runtime's own evidence modules, so no bundle was built or signed |
-| `v2.5.0-rc.3` | — | published to carry the first Python 3.13 targets and be installed on a Raspberry Pi 4 running Trixie |
+| `v2.5.0-rc.3` | published | first candidate to build a bundle; installed on the bench Pi against the system `python3.13`, and found to carry no GPIO capability at all |
+| `v2.5.0-rc.4` | — | the GPIO packaging candidate: published to prove a Pi release can import its pin factory |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.
@@ -74,17 +75,36 @@ planted term as well as a clean one, so a release-only path is no longer the
 first execution. `v2.5.0-rc.3` is the first candidate whose gates have all run
 before the tag.
 
+`v2.5.0-rc.3` published and installed. It is the first candidate to produce
+artifacts, and the Python 3.13 target works: the bench Pi runs it against the
+stock system interpreter, with the hand-placed 3.12 build and its symlink
+deleted from the device.
+
+It has no GPIO capability whatsoever. No released bundle carried `gpiozero`,
+because the release matrix built the generic wheelhouse for every target, and
+the release venv is isolated while the only working pin factory on Raspberry Pi
+OS ships from apt. `v2.5.0-rc.4` carries the fix and exists to prove it.
+
 ## What this candidate is for
 
-`v2.5.0-rc.3` exists to be installed on real hardware. Specifically:
+`v2.5.0-rc.4` is **the GPIO packaging candidate**. It exists to answer one
+question on real hardware: can a Pi release import a pin factory that claims its
+lines through the kernel?
 
 1. It must install on Raspberry Pi OS Trixie using the **system** `python3.13`,
-   with no hand-placed interpreter and no symlink.
+   with no hand-placed interpreter and no symlink. Proven by `v2.5.0-rc.3`, and
+   re-proven here because the install path changed.
 2. The deployed environment must resolve `LGPIOFactory` rather than
    `NativeFactory` — see below for why that distinction is not cosmetic.
-3. A wired relay must physically actuate under a hardened deployment profile.
+3. No module outside the release tree may resolve through the system path.
 
-Nothing below is proven until those hold on a device.
+**It is not a Tier D candidate, and an actuation demonstration must not be
+claimed from it.** Three things stand between a working pin factory and a
+trustworthy safety cutoff, and all three are open: the relay has no commissioned
+controller-loss posture and its polarity setting is not plumbed through; the
+current path reports an uncalibrated instantaneous sample as amperes; and a
+Tier D condition selects a mutable skill action list, which for overcurrent
+dispatches alerts and never reaches an actuator. Those need a later candidate.
 
 ## Raspberry Pi
 
@@ -129,6 +149,27 @@ For a Tier D cutoff that is the property worth having. Hardened startup now
 asks which factory resolved and refuses the unarbitrated one, naming it, so a
 missing dependency and an unusable platform read differently.
 
+### A Pi release now carries a pin factory it can import
+
+Refusing the unarbitrated fallback was the right check against the wrong
+absence: no released bundle carried `gpiozero` at all. The release matrix built
+the generic wheelhouse for every target, so the installer branch that installs
+the Raspberry Pi requirements could never fire.
+
+`aarch64` targets now build the Pi wheelhouse. Behind that sat a second gap:
+the release venv is isolated, and the only working pin factory ships from apt —
+PyPI's `lgpio` carries an empty module, and apt builds the extension per
+interpreter version. The two files that make up the module are copied into the
+release's own site directory, after the source is checked to be root-owned,
+unwritable by anyone else, and resolved in isolated mode from an admitted
+system directory.
+
+Copied rather than linked, and named rather than exposed. Making the whole
+system path visible would put every apt package on the runtime's import path,
+where an unpinned optional import could activate a capability no release
+reviewed. Raspberry Pi hardware requires this and fails the install without it;
+the same bundle installs elsewhere without staging anything.
+
 ## Evidence
 
 The runtime produces its own signed, hash-chained rows per `evidence/v2`,
@@ -165,3 +206,11 @@ Nothing publishes an artifact outbound yet.
   evidence of connected sensors and loaded skills alone.
 - Release rollback remains described and unit-tested but unproven end to end on
   a systemd host.
+- **No Tier D electrical cutoff can be demonstrated.** The relay's polarity
+  setting is documented but never plumbed through, and controller loss
+  reconnects the load rather than opening it, with no commissioned posture
+  deciding which is correct for a given load. The `ads1115_current` path
+  discards its configured calibration and reports a single instantaneous sample
+  as amperes. And a Tier D condition selects a mutable skill action list, which
+  for overcurrent dispatches alerts and never reaches an actuator. A pin factory
+  that works is a prerequisite for fixing these, not evidence that they are.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc3"
+version = "2.5.0rc4"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps the project to `2.5.0rc4` and records what `v2.5.0-rc.3` proved and what it did not.

`v2.5.0-rc.3` is the first candidate to produce artifacts, and its Python 3.13 target works. The bench Pi runs it against the stock system interpreter, with the hand-placed 3.12 build and its symlink deleted from the device.

It carries no GPIO capability at all. No released bundle contained `gpiozero`, because the release matrix built the generic wheelhouse for every target, and the release venv is isolated while the only working pin factory on Raspberry Pi OS ships from apt. #396 fixed both; this candidate exists to prove that on hardware.

### Labelled as the GPIO packaging candidate

`v2.5.0-rc.4` answers one question: can a Pi release import a pin factory that claims its lines through the kernel? It is deliberately **not** a Tier D candidate, and an actuation demonstration must not be claimed from it.

Three defects stand between a working pin factory and a trustworthy safety cutoff, all found while bench-testing `v2.5.0-rc.3` and all now tracked:

- **#397** — `actions.relay.active_high` is documented but never reaches `RelayAction.connect()`, so an active-low board starts energised and the cutoff command releases it. Separately, controller loss de-energises the coil and reconnects the load, with no commissioned posture deciding whether that is correct for a given load.
- **#398** — `ads1115_current` discards its configured calibration between config and the adapter, and reports one instantaneous ADC sample as amperes with no bias removal and no RMS.
- **#324** — a Tier D condition selects a mutable skill action list. `dangerous_overcurrent` dispatches `[alert_whatsapp, log_to_dashboard]`, and the override the YAML comment tells operators to use does not exist as a configuration surface.

The release notes record these as known gaps so the candidate cannot be read as proving something it does not.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — version bump and release notes only.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Part of the v2.5.0 release train. Known gaps recorded against #397, #398 and #324.

## Testing notes

`python scripts/check_release_identity.py --tag v2.5.0-rc.4` resolves `version=2.5.0-rc.4`.

Full suite 4007 passed, 27 skipped. The disclosure suite runs green with the release marker and a supplied denylist, 79 passed.