### PR TITLE
fix(release): identify a wheel by its own metadata, not a vendored copy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,51 @@ jobs:
           fi
           rm -rf "${probe}" "${RUNNER_TEMP}/probe_leak.py"
 
+      # The bundle build is the last release-only step with no branch
+      # equivalent, and v2.5.0-rc.4 was spent proving it: the Pi wheelhouse is
+      # the first release target to carry setuptools, whose wheel vendors
+      # twelve dist-info directories, and the builder called it ambiguous. The
+      # wheelhouse above is reused rather than rebuilt.
+      - name: Assemble a release bundle from that wheelhouse
+        if: matrix.python-version == '3.12'
+        env:
+          ORI_WHEELHOUSE_OUT: ${{ runner.temp }}/wheelhouse
+        run: |
+          set -euo pipefail
+          # The bundle refuses a target whose Python does not match the build
+          # interpreter, so the target is derived here rather than written out.
+          target="$(python -c "
+          import platform, sys
+          arch = {'x86_64': 'x86_64', 'amd64': 'x86_64', 'aarch64': 'aarch64', 'arm64': 'aarch64'}[platform.machine()]
+          sys.stdout.write(f'linux-{arch}-python{sys.version_info.major}.{sys.version_info.minor}')
+          ")"
+          # The bundle names its version in SemVer and the wheel in PEP 440.
+          # check_release_identity.py is the authority on that pairing, so the
+          # tag derived here is handed to it rather than trusted.
+          tag="$(python -c "
+          import pathlib, re, sys
+          text = pathlib.Path('pyproject.toml').read_text(encoding='utf-8')
+          found = re.search(r'^version = \"([^\"]+)\"', text, re.M)
+          if not found:
+              sys.exit('pyproject declares no version')
+          packaged = found.group(1)
+          parts = re.fullmatch(r'(\d+\.\d+\.\d+)(?:(a|b|rc)(\d+))?', packaged)
+          if not parts:
+              sys.exit(f'unrecognised packaged version: {packaged}')
+          base, kind, number = parts.groups()
+          sys.stdout.write('v' + (base if kind is None else f'{base}-{kind}.{number}'))
+          ")"
+          version="$(python scripts/check_release_identity.py --tag "${tag}" | cut -d= -f2)"
+          echo "Assembling ${version} for ${target}"
+          python scripts/build_release_bundle.py \
+            --wheelhouse "${ORI_WHEELHOUSE_OUT}" \
+            --runtime-version "${version}" \
+            --target "${target}" \
+            --config-template ori.linux.yaml.example \
+            --service-template packaging/systemd/ori-runtime.service.in \
+            --output-dir "${RUNNER_TEMP}/bundle"
+          ls -l "${RUNNER_TEMP}/bundle"
+
       - name: Type check runtime contract boundaries
         run: bash scripts/typecheck-boundaries.sh
 

--- a/scripts/build-wheelhouse.sh
+++ b/scripts/build-wheelhouse.sh
@@ -222,14 +222,20 @@ wheelhouse = Path(sys.argv[1])
 package_name = sys.argv[2].lower().replace("_", "-")
 
 
+def _is_root_dist_info_metadata(name: str) -> bool:
+    # A wheel's own metadata sits at the archive root. Deeper matches are
+    # vendored payload, and taking the first suffix match would let
+    # namelist() order decide which package this wheel claims to be.
+    parts = name.split("/")
+    return len(parts) == 2 and parts[0].endswith(".dist-info") and parts[1] == "METADATA"
+
+
 def _metadata_for_wheel(path: Path) -> tuple[str, str]:
     with zipfile.ZipFile(path) as zf:
-        metadata_name = next(
-            (name for name in zf.namelist() if name.endswith(".dist-info/METADATA")),
-            "",
-        )
-        if not metadata_name:
-            raise SystemExit(f"ERROR: missing METADATA in wheel: {path.name}")
+        candidates = [n for n in zf.namelist() if _is_root_dist_info_metadata(n)]
+        if len(candidates) != 1:
+            raise SystemExit(f"ERROR: ambiguous METADATA in wheel: {path.name}")
+        metadata_name = candidates[0]
         metadata = zf.read(metadata_name).decode("utf-8")
 
     name = ""

--- a/scripts/build_release_bundle.py
+++ b/scripts/build_release_bundle.py
@@ -211,14 +211,25 @@ def _release_wheelhouse_files(wheelhouse: Path) -> list[Path]:
     return files
 
 
+def _is_root_dist_info_metadata(name: str) -> bool:
+    """Whether *name* is the wheel's own metadata rather than vendored payload."""
+    parts = name.split("/")
+    return (
+        len(parts) == 2 and parts[0].endswith(".dist-info") and parts[1] == "METADATA"
+    )
+
+
 def _wheel_identity(path: Path) -> tuple[str, str]:
     _require_regular_file(path, f"wheel {path.name!r}")
     try:
         with zipfile.ZipFile(path) as archive:
+            # A wheel's own metadata is the `*.dist-info/METADATA` at the
+            # archive root. Anything deeper is payload: setuptools vendors
+            # twelve packages and ships each one's dist-info inside the wheel,
+            # so matching the suffix anywhere finds thirteen and calls a
+            # perfectly ordinary wheel ambiguous.
             metadata_names = [
-                name
-                for name in archive.namelist()
-                if name.endswith(".dist-info/METADATA")
+                name for name in archive.namelist() if _is_root_dist_info_metadata(name)
             ]
             if len(metadata_names) != 1:
                 raise BundleBuildError(f"wheel {path.name!r} has ambiguous METADATA")

--- a/scripts/smoke-release-wheel.sh
+++ b/scripts/smoke-release-wheel.sh
@@ -62,14 +62,17 @@ from pathlib import Path
 import re
 
 wheel = Path(sys.argv[1])
-metadata_name = ""
+def _is_root_dist_info_metadata(name: str) -> bool:
+    # The wheel's own metadata, not a vendored package's copy of it.
+    parts = name.split("/")
+    return len(parts) == 2 and parts[0].endswith(".dist-info") and parts[1] == "METADATA"
+
+
 with zipfile.ZipFile(wheel) as zf:
-    for name in zf.namelist():
-        if name.endswith(".dist-info/METADATA"):
-            metadata_name = name
-            break
-    if not metadata_name:
-        raise AssertionError(f"missing METADATA in {wheel}")
+    candidates = [n for n in zf.namelist() if _is_root_dist_info_metadata(n)]
+    if len(candidates) != 1:
+        raise AssertionError(f"ambiguous METADATA in {wheel}")
+    metadata_name = candidates[0]
     metadata = zf.read(metadata_name).decode("utf-8")
 
 requires = [

--- a/tests/test_release_bundle_build.py
+++ b/tests/test_release_bundle_build.py
@@ -35,7 +35,11 @@ from ori.security.release_bundles import (
     verify_release_bundle,
     write_signature_envelope,
 )
-from scripts.build_release_bundle import BundleBuildError, build_release_bundle
+from scripts.build_release_bundle import (
+    BundleBuildError,
+    _wheel_identity,
+    build_release_bundle,
+)
 
 VERSION = "2.3.0"
 TARGET = f"linux-x86_64-python{sys.version_info.major}.{sys.version_info.minor}"
@@ -168,6 +172,76 @@ def _explain_difference(first: Path, second: Path) -> str:
             lines.append(f"  first  {member_a}")
             lines.append(f"  second {member_b}")
     return "\n".join(lines)
+
+
+# The shape of a real setuptools wheel: its own metadata at the archive root,
+# and every vendored package's dist-info carried inside the package directory.
+_VENDORED_DIST_INFO = (
+    "setuptools/_vendor/autocommand-2.2.2.dist-info/METADATA",
+    "setuptools/_vendor/packaging-26.0.dist-info/METADATA",
+    "setuptools/_vendor/zipp-3.23.0.dist-info/METADATA",
+)
+
+
+def _write_vendoring_wheel(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        _add_zip_entry(
+            archive,
+            "setuptools-83.0.0.dist-info/METADATA",
+            "Metadata-Version: 2.1\nName: setuptools\nVersion: 83.0.0\n",
+        )
+        for name in _VENDORED_DIST_INFO:
+            vendored = name.split("/")[-2].split("-")[0]
+            _add_zip_entry(
+                archive,
+                name,
+                f"Metadata-Version: 2.1\nName: {vendored}\nVersion: 1.0\n",
+            )
+
+
+def test_a_wheel_that_vendors_dist_info_is_identified_by_its_own_metadata(
+    tmp_path: Path,
+) -> None:
+    """setuptools ships twelve vendored dist-info directories inside the wheel.
+
+    Matching `.dist-info/METADATA` anywhere in the archive finds thirteen and
+    calls an ordinary wheel ambiguous, which is what stopped v2.5.0-rc.4: the
+    Raspberry Pi wheelhouse is the first release target to carry setuptools, so
+    no earlier bundle build had ever opened one.
+    """
+    wheel = tmp_path / "setuptools-83.0.0-py3-none-any.whl"
+    _write_vendoring_wheel(wheel)
+    assert _wheel_identity(wheel) == ("setuptools", "83.0.0")
+
+
+def test_a_wheel_with_no_root_metadata_is_still_refused(tmp_path: Path) -> None:
+    """Narrowing the match must not turn a real defect into a pass.
+
+    A wheel carrying only vendored metadata has no identity of its own, and
+    selecting the first suffix match would have let it claim a vendored one.
+    """
+    wheel = tmp_path / "broken-1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for name in _VENDORED_DIST_INFO:
+            _add_zip_entry(
+                archive, name, "Metadata-Version: 2.1\nName: vendored\nVersion: 1.0\n"
+            )
+    with pytest.raises(BundleBuildError, match="ambiguous METADATA"):
+        _wheel_identity(wheel)
+
+
+def test_two_root_metadata_members_remain_ambiguous(tmp_path: Path) -> None:
+    """Genuine ambiguity is two distributions at the root, not vendored payload."""
+    wheel = tmp_path / "confused-1.0-py3-none-any.whl"
+    with zipfile.ZipFile(wheel, "w") as archive:
+        for dist in ("one-1.0", "two-2.0"):
+            _add_zip_entry(
+                archive,
+                f"{dist}.dist-info/METADATA",
+                f"Metadata-Version: 2.1\nName: {dist}\nVersion: 1.0\n",
+            )
+    with pytest.raises(BundleBuildError, match="ambiguous METADATA"):
+        _wheel_identity(wheel)
 
 
 def test_build_is_deterministic_and_verifies_end_to_end(tmp_path: Path) -> None:


### PR DESCRIPTION
## What does this PR do?

`v2.5.0-rc.4` built no bundle. `Build linux-aarch64-python3.11` failed with:

```
bundle_build_failed: wheel 'setuptools-83.0.0-py3-none-any.whl' has ambiguous METADATA
```

The Raspberry Pi wheelhouse is the first release target to carry `setuptools`, and that wheel vendors twelve packages, shipping each one's `dist-info` inside the archive:

```
setuptools-83.0.0.dist-info/METADATA          ← the wheel's own
setuptools/_vendor/autocommand-2.2.2.dist-info/METADATA
setuptools/_vendor/packaging-26.0.dist-info/METADATA
… ten more
```

`_wheel_identity` counted every member ending in `.dist-info/METADATA`, found thirteen, and refused an ordinary wheel. The wheel is not ambiguous: a wheel's own metadata is the `*.dist-info/METADATA` at the archive root, and anything deeper is payload. The check asked *how many members end with this suffix* when it meant *which member is the distribution's own*.

Genuine ambiguity — two distributions at the root — is still refused, and a wheel carrying only vendored metadata still has no identity of its own.

### Two quieter instances of the same defect

`scripts/build-wheelhouse.sh` (phone requirements generator) and `scripts/smoke-release-wheel.sh` both took the **first** suffix match, so `namelist()` order decided which package a wheel claimed to be. That fails silently rather than loudly — the phone path would have written a vendored package's name and version into a hash-locked requirements file. Both now use the same rule.

### The reason a tag was spent finding this

The bundle build was the last release-only step with no branch equivalent. The wheelhouse audit added after rc.2 downloads this same `setuptools` wheel on every PR and never opens it as a bundle, so the fault was unreachable until a tag existed.

CI now assembles a bundle from the wheelhouse it has already built. The target is derived from the running interpreter — the builder refuses a target whose Python does not match, which I hit while testing this — and the version goes through `check_release_identity.py`, the same authority the release preflight uses, so a wrong derivation fails rather than being trusted.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — release tooling only; no runtime capability changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

None. Found by `v2.5.0-rc.4`'s release run.

## Testing notes

Reproduced and fixed against a real Pi wheelhouse containing the actual `setuptools-83.0.0` wheel:

```
with the rc.4 code:  bundle_build_failed: wheel 'setuptools-83.0.0-py3-none-any.whl' has ambiguous METADATA
with the fix:        ori-runtime-2.5.0-rc.4-linux-aarch64-python3.12.tar.gz + .sha256
```

Three regression tests, using a fixture shaped like the real `setuptools` wheel. Two mutations checked: reverting to suffix-anywhere fails the vendoring test, and accepting multiple root members fails the ambiguity test.

The CI step's version and target derivation was executed locally against this checkout: `packaged=2.5.0rc4 → tag=v2.5.0-rc.4 → check_release_identity → version=2.5.0-rc.4`.

Full suite 4010 passed, 27 skipped. `mypy ori/` clean. `tests/test_release_bundle_build.py` carries the same 2 pre-existing `reportArgumentType` diagnostics as on `main`, measured against a merge-base worktree — the new tests add none.