### PR TITLE
chore(release): prepare v2.5.0-rc.5

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.5.0-rc.4` are collected here until the next
+Changes merged to `main` after `v2.5.0-rc.5` are collected here until the next
 candidate or release is cut.
 
 _No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.4` is the current candidate.
+Minor release, in progress. `v2.5.0-rc.5` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -41,7 +41,8 @@ installed.
 | `v2.5.0-rc.1` | protection preflight, full test matrix | the release disclosure audit refused 44 unchanged public documents, so no bundle was built or signed |
 | `v2.5.0-rc.2` | protection preflight, full test matrix, build | the wheelhouse audit refused the runtime's own evidence modules, so no bundle was built or signed |
 | `v2.5.0-rc.3` | published | first candidate to build a bundle; installed on the bench Pi against the system `python3.13`, and found to carry no GPIO capability at all |
-| `v2.5.0-rc.4` | — | the GPIO packaging candidate: published to prove a Pi release can import its pin factory |
+| `v2.5.0-rc.4` | protection preflight, full test matrix, build | the bundle builder refused `setuptools` as ambiguous, so no bundle was built or signed |
+| `v2.5.0-rc.5` | — | the GPIO packaging candidate: published to prove a Pi release can import its pin factory |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.
@@ -83,11 +84,34 @@ deleted from the device.
 It has no GPIO capability whatsoever. No released bundle carried `gpiozero`,
 because the release matrix built the generic wheelhouse for every target, and
 the release venv is isolated while the only working pin factory on Raspberry Pi
-OS ships from apt. `v2.5.0-rc.4` carries the fix and exists to prove it.
+OS ships from apt. `v2.5.0-rc.5` carries the fix and exists to prove it.
+
+`v2.5.0-rc.4` produced no artifacts and must not be installed. It carried the
+GPIO fix and died one stage before delivering it.
+
+Its cause was the fix's own first consequence. The Raspberry Pi wheelhouse is
+the first release target to carry `setuptools`, and that wheel vendors twelve
+packages, shipping each one's `dist-info` inside the archive. The bundle builder
+counted every member ending in `.dist-info/METADATA`, found thirteen, and
+refused an ordinary wheel as ambiguous. A wheel's own metadata is the one at the
+archive root; anything deeper is payload.
+
+The bundle build was also the last release-only step with no branch equivalent,
+which is why a tag was spent finding it: the wheelhouse audit added after
+`v2.5.0-rc.2` downloads that same `setuptools` wheel on every pull request and
+never opens it as a bundle. Pull requests now assemble a bundle from the
+wheelhouse they already build.
+
+Four candidates have now been spent on release-only steps, each closing the
+particular hole that burned its predecessor rather than the class. What is
+different at `v2.5.0-rc.5` is coverage rather than intent: every stage a bundle
+passes through before signing now runs on a branch. Signing, publish and
+reverify cannot — they need a release credential — and no v2.5.0 candidate has
+reached them yet.
 
 ## What this candidate is for
 
-`v2.5.0-rc.4` is **the GPIO packaging candidate**. It exists to answer one
+`v2.5.0-rc.5` is **the GPIO packaging candidate**. It exists to answer one
 question on real hardware: can a Pi release import a pin factory that claims its
 lines through the kernel?
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc4"
+version = "2.5.0rc5"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps the project to `2.5.0rc5` and records what stopped `v2.5.0-rc.4`.

`v2.5.0-rc.4` carried the GPIO fix and died one stage before delivering it, on that fix's own first consequence. The Raspberry Pi wheelhouse is the first release target to carry `setuptools`, whose wheel vendors twelve packages and ships each one's `dist-info` inside the archive. The bundle builder counted every member ending in `.dist-info/METADATA`, found thirteen, and refused an ordinary wheel as ambiguous.

Fixed in #400, along with two quieter instances of the same defect that took the first suffix match rather than failing.

### Why a tag had to be spent on it

The bundle build was the last release-only step with no branch equivalent. The wheelhouse audit added after `v2.5.0-rc.2` downloads that same `setuptools` wheel on every pull request and never opens it as a bundle, so the fault was unreachable until a tag existed.

Pull requests now assemble a bundle from the wheelhouse they already build. Verified on #400's own run: a 16 MB `linux-x86_64-python3.12` bundle, from the Pi wheelhouse, with the target derived from the runner's interpreter and the version routed through `check_release_identity.py`.

### What is and is not covered now

Four candidates have been spent on release-only steps, each closing the particular hole that burned its predecessor rather than the class. What is different here is coverage rather than intent: preflight, tests, wheelhouse, disclosure audit and bundle assembly all run on a branch.

Signing, publish and reverify cannot — they need a release credential. No v2.5.0 candidate has reached them yet, since `v2.5.0-rc.4` died at build.

### Still not a Tier D candidate

`v2.5.0-rc.5` remains the GPIO packaging candidate. #397, #398 and #324 are open, and an actuation demonstration must not be claimed from it.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — version bump and release notes only.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Part of the v2.5.0 release train. Known gaps recorded against #397, #398 and #324.

## Testing notes

`python scripts/check_release_identity.py --tag v2.5.0-rc.5` resolves `version=2.5.0-rc.5`.

Full suite 4010 passed, 27 skipped. Disclosure suite green under the release marker with a supplied denylist, 79 passed.