### PR TITLE
fix(installer): scope release validation to what a transaction can reach

### DIFF
--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -145,12 +145,9 @@ experimental fallback. Treat that result as a failed check, not a partial pass.
 
 ## Upgrading off a hand-placed interpreter
 
-Upgrade first, then remove the old interpreter. The installer binds an existing
-installation to its release symlinks and refuses an install root it cannot
-validate, so deleting the interpreter a previous release points at leaves the
-upgrade blocked on `unsafe_install_root` with nothing installable in its place.
-
-The order that works:
+Upgrade first, then remove the old interpreter. A superseded release that
+nothing is using no longer blocks anything: an install inspects only the
+candidate and the release `current` points at, so inert history is left alone.
 
 ```bash
 # 1. Install the new release while the old interpreter is still present.
@@ -159,12 +156,46 @@ sudo bash install-linux.sh --version <version> -- --unattended --scope system
 # 2. Confirm the new venv is on the system interpreter.
 sudo readlink -f /opt/ori/current/venv/bin/python   # expect /usr/bin/python3.13
 
-# 3. Only then remove the hand-placed interpreter and its symlink.
+# 3. Remove the hand-placed interpreter and its symlink.
 sudo rm -rf /usr/local/ori-python /usr/local/bin/python3.12
 ```
 
-Step 2 before step 3. A release whose venv still resolves through
-`/usr/local` will stop working the moment step 3 runs.
+Step 2 before step 3. A release whose venv still resolves through `/usr/local`
+will stop working the moment step 3 runs.
+
+**Never remove the interpreter the active release is built on.** That release
+is what an upgrade rolls back to, so removing its interpreter leaves the
+installation with a rollback target that cannot start. An install refuses
+before interrupting the service rather than discovering it mid-rollback, so the
+symptom is a blocked upgrade rather than a failed one.
+
+That is why step 2 is a confirmation and not a formality. Once the new release
+is active, the old one is inert: nothing inspects it, and it does not block
+anything.
+
+### When retirement is useful
+
+Retirement is optional. It applies when you want to deliberately give up
+rollback and downgrade to an inactive release — not as a step in removing an
+interpreter, which the order above already handles.
+
+```bash
+sudo ori-install-linux release list --scope system
+sudo ori-install-linux release retire <version> --scope system
+```
+
+The active release cannot be retired, and the command refuses it. If the
+release you want to retire is still active, activate a different healthy
+release first.
+
+`release list` reports `has_interpreter` per release. It is named for what it
+checks — whether a file is there. Whether a release *starts* is only answered
+by starting it, which the installer does for the rollback candidate at install
+time. `has_interpreter` does not identify releases that block upgrades; only
+the active rollback candidate is load-bearing.
+
+Retiring moves a release into `/opt/ori/retired/` rather than deleting it, so
+it is reversible; deletion is a separate act.
 
 ## Verifying a Pi before you rely on it
 

--- a/ori/installer/cli.py
+++ b/ori/installer/cli.py
@@ -33,7 +33,9 @@ from ori.installer.linux import (
     collect_installer_config,
     ensure_service_account,
     install_composed_release,
+    list_releases,
     require_trusted_base_interpreter,
+    retire_release,
     uninstall_runtime,
 )
 from ori.security.release_bundles import (
@@ -107,6 +109,20 @@ def _profile(scope: str, service_user: str | None = None) -> SystemdServiceProfi
             f"renamed; drop --service-user, or pass --service-user {SERVICE_USER}",
         )
     return SystemdServiceProfile.system()
+
+
+def _release_layout(scope: str, root: Path | None) -> InstallLayout:
+    """The install root alone, for commands that never touch a systemd unit.
+
+    `_paths` also resolves unit and environment-file locations and validates
+    them. Listing and retiring releases have nothing to do with either, so
+    asking for them would make an unrelated path constraint decide whether a
+    release command runs.
+    """
+    default_root = (
+        Path.home() / ".local" / "ori" if scope == "user" else Path("/opt/ori")
+    )
+    return InstallLayout.resolve(root or default_root)
 
 
 def _paths(
@@ -367,6 +383,43 @@ def _uninstall(args: argparse.Namespace) -> dict[str, object]:
     }
 
 
+def _release_list(args: argparse.Namespace) -> dict[str, object]:
+    if args.scope is None:
+        raise LinuxInstallError(
+            "config_validation_failed",
+            "release list requires --scope system or --scope user",
+        )
+    layout = _release_layout(args.scope, args.root)
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "ok": True,
+        "releases": list_releases(layout),
+        "scope": args.scope,
+        "status": "listed",
+    }
+
+
+def _release_retire(args: argparse.Namespace) -> dict[str, object]:
+    if args.scope is None:
+        raise LinuxInstallError(
+            "config_validation_failed",
+            "release retire requires --scope system or --scope user",
+        )
+    layout = _release_layout(args.scope, args.root)
+    destination = retire_release(layout, args.version, scope=args.scope)
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "ok": True,
+        "version": args.version,
+        "retired_to": str(destination),
+        # Stated rather than implied: an operator retiring a release to unblock
+        # an interpreter removal has just given up the ability to go back to it.
+        "rollback_available": False,
+        "scope": args.scope,
+        "status": "retired",
+    }
+
+
 def _add_output_arguments(parser: argparse.ArgumentParser) -> None:
     """Machine output is requested explicitly, never inferred.
 
@@ -420,6 +473,24 @@ def build_parser() -> argparse.ArgumentParser:
     install.add_argument("--location")
     install.add_argument("--deployment-type", choices=("pi", "server"), default="pi")
     install.add_argument("--operator-contact")
+
+    release = commands.add_parser(
+        "release", help="inspect and retire installed releases", allow_abbrev=False
+    )
+    release_actions = release.add_subparsers(dest="release_command", required=True)
+    release_list = release_actions.add_parser(
+        "list", help="list installed releases", allow_abbrev=False
+    )
+    _add_scope_arguments(release_list)
+    _add_output_arguments(release_list)
+    release_retire = release_actions.add_parser(
+        "retire",
+        help="move a release out of the selectable set without deleting it",
+        allow_abbrev=False,
+    )
+    _add_scope_arguments(release_retire)
+    _add_output_arguments(release_retire)
+    release_retire.add_argument("version")
 
     uninstall = commands.add_parser(
         "uninstall", help="remove Runtime and its unit", allow_abbrev=False
@@ -556,8 +627,17 @@ def _exit_error(
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    handlers = {
+        "install": _install,
+        "uninstall": _uninstall,
+        "release": lambda parsed: (
+            _release_list(parsed)
+            if parsed.release_command == "list"
+            else _release_retire(parsed)
+        ),
+    }
     try:
-        result = _install(args) if args.command == "install" else _uninstall(args)
+        result = handlers[args.command](args)
     except (ReleaseBundleError, LinuxInstallError) as exc:
         _exit_error(exc, json_mode=bool(getattr(args, "json", False)))
     if getattr(args, "json", False) or args.command != "install":

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import json
 import os
 import pwd
@@ -17,7 +19,7 @@ import time
 import uuid
 from dataclasses import dataclass, replace
 from pathlib import Path
-from typing import Callable, Literal, NoReturn, Sequence
+from typing import Callable, Iterator, Literal, NoReturn, Sequence
 
 import yaml
 
@@ -1479,8 +1481,21 @@ def apply_system_service_permissions(
     profile: SystemdServiceProfile,
     *,
     allowed_data_sockets: Sequence[Path] = (),
+    releases: Sequence[Path] = (),
 ) -> None:
-    """Make verified code readable, and only data writable, by a system service."""
+    """Make verified code readable, and only data writable, by a system service.
+
+    *releases* names the release trees this installation may touch: the
+    candidate being installed, and the release `current` pointed at when it
+    began. Those are the only two a transaction can reach — a candidate to
+    activate, and a rollback target to restore.
+
+    Everything else under `releases/` is inert history. Walking it, as this
+    once did, gave any retained release a veto over every future install: one
+    whose interpreter had since been removed failed the external-symlink check
+    and left the installation permanently un-upgradeable, with nothing in the
+    transaction referring to it.
+    """
     if profile.scope != "system" or profile.service_user is None:
         raise LinuxInstallError(
             "service_start_failed", "system permissions require a system profile"
@@ -1522,18 +1537,31 @@ def apply_system_service_permissions(
             layout.root, root_stat, uid=0, gid=account.pw_gid, mode=0o750
         )
     ]
-    plan.extend(
-        _owned_tree_plan(
-            layout,
+    # The releases directory itself is still owned and mode-set. Its children
+    # are not searched: only the trees this transaction can reach are.
+    _assert_managed_path(layout, layout.releases)
+    plan.append(
+        _permission_change(
             layout.releases,
+            layout.releases.lstat(),
             uid=0,
             gid=account.pw_gid,
-            directory_mode=0o750,
-            regular_mode=0o440,
-            executable_mode=0o550,
-            allow_file_symlinks=True,
+            mode=0o750,
         )
     )
+    for release in _scoped_releases(layout, releases):
+        plan.extend(
+            _owned_tree_plan(
+                layout,
+                release,
+                uid=0,
+                gid=account.pw_gid,
+                directory_mode=0o750,
+                regular_mode=0o440,
+                executable_mode=0o550,
+                allow_file_symlinks=True,
+            )
+        )
     _assert_managed_path(layout, layout.data)
     plan.extend(
         _owned_tree_plan(
@@ -1549,6 +1577,228 @@ def apply_system_service_permissions(
         )
     )
     _apply_permission_plan(plan)
+
+
+RETIRED_DIRNAME = "retired"
+
+# A release that cannot import its own runtime within this is not one a
+# rollback could rely on.
+RELEASE_PROBE_TIMEOUT_S = 30.0
+
+
+@contextlib.contextmanager
+def release_lifecycle_lock(layout: InstallLayout) -> Iterator[None]:
+    """Serialise everything that can move a release under this root.
+
+    Install captures a rollback target and then activates. Retirement moves a
+    release out of the selectable set. Run concurrently, retirement can take
+    away the tree an in-progress install is holding as its way back — and no
+    argument passed between the two commands can prevent that, because neither
+    can see the other's state. The lock is the only thing that can.
+
+    It lives in the root's parent, not in the root. Two earlier placements were
+    both wrong in ways that only concurrency shows:
+
+    - A file inside the root is an artefact a failed first install cannot roll
+      back, leaving behind a root the transaction created and could not remove.
+    - The root's own directory descriptor cannot be locked before the root
+      exists, so a first install held nothing. The moment it created the root,
+      a second caller locked it and entered the same transaction.
+
+    The parent is where an install root is created, so it exists before any
+    install and outlives every one of them. Callers may share a parent —
+    `/opt` for a system root — so the lock is named for the root it guards.
+    """
+    parent = layout.root.parent
+    lock_path = parent / f".{layout.root.name}.lifecycle.lock"
+    try:
+        # The same preparation the transaction itself performs, for the same
+        # reason: the parent may be a host-owned directory such as `~/.local`
+        # that does not exist yet on a first install. Exclusion has to start
+        # before the root does, so it cannot wait for the transaction to make
+        # somewhere to put the lock.
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise LinuxInstallError(
+            "unsafe_install_root", "install root parent could not be prepared"
+        ) from exc
+    try:
+        descriptor = os.open(
+            lock_path,
+            os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+            0o600,
+        )
+    except OSError as exc:
+        raise LinuxInstallError(
+            "unsafe_install_root",
+            "the install root's parent does not admit a lifecycle lock",
+        ) from exc
+    try:
+        try:
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise LinuxInstallError(
+                "unsafe_install_root",
+                "another install or retirement is in progress for this root",
+            ) from exc
+        try:
+            yield
+        finally:
+            fcntl.flock(descriptor, fcntl.LOCK_UN)
+    finally:
+        os.close(descriptor)
+
+
+def list_releases(layout: InstallLayout) -> list[dict[str, object]]:
+    """Every installed release, and which one is active."""
+    if not layout.releases.is_dir():
+        return []
+    active = _inspect_current(layout)
+    entries: list[dict[str, object]] = []
+    for child in sorted(layout.releases.iterdir(), key=lambda item: item.name):
+        if child.is_symlink() or not child.is_dir() or child.name.startswith("."):
+            continue
+        interpreter = child / "venv" / "bin" / "python"
+        entries.append(
+            {
+                "version": child.name,
+                "active": child == active,
+                # Deliberately not called "runnable": this is a file check, and
+                # whether a release starts is only answered by starting it.
+                "has_interpreter": interpreter.is_file(),
+            }
+        )
+    return entries
+
+
+def retire_release(
+    layout: InstallLayout,
+    version: str,
+    *,
+    scope: str = "system",
+) -> Path:
+    """Move a release out of the selectable set, without deleting it.
+
+    Retiring is separated from deleting on purpose. An operator retiring a
+    release to unblock an interpreter removal is making a reversible decision;
+    losing the tree at the same moment turns a sequencing step into data loss.
+
+    Returns the quarantine path the release was moved to.
+    """
+    with release_lifecycle_lock(layout):
+        return _retire_release_locked(layout, version, scope=scope)
+
+
+def _retire_release_locked(layout: InstallLayout, version: str, *, scope: str) -> Path:
+    if scope != "system":
+        # Retirement moves a root-owned tree between root-owned directories.
+        # A user-scope implementation is a different ownership model, not a
+        # smaller version of this one, and half-implementing it raised an
+        # uncaught PermissionError rather than a stable installer error.
+        raise LinuxInstallError(
+            "config_validation_failed",
+            "release retirement is only supported for --scope system",
+        )
+    candidate = layout.release(version)
+    _assert_managed_path(layout, candidate)
+    if candidate.parent != layout.releases:
+        raise LinuxInstallError(
+            "unsafe_install_root", "a release must be a direct child of releases"
+        )
+    if candidate.is_symlink() or not candidate.is_dir():
+        raise LinuxInstallError(
+            "config_validation_failed", f"no installed release named {version!r}"
+        )
+    if candidate == _active_release(layout):
+        raise LinuxInstallError(
+            "config_validation_failed",
+            f"{version!r} is the active release; activate another before retiring it",
+        )
+    # Created and validated through the same no-follow primitive the install
+    # root uses. A plain mkdir would accept an existing symlink here, and the
+    # os.replace below would then move a release outside the managed tree.
+    quarantine = layout.root / RETIRED_DIRNAME
+    _ensure_private_directory(quarantine)
+    if quarantine.is_symlink() or not quarantine.is_dir():
+        raise LinuxInstallError(
+            "unsafe_install_root", "the retirement directory is not a managed directory"
+        )
+    destination = quarantine / version
+    if destination.exists() or destination.is_symlink():
+        raise LinuxInstallError(
+            "config_validation_failed", f"{version!r} has already been retired"
+        )
+    os.replace(candidate, destination)
+    return destination
+
+
+def _assert_release_starts(release: Path) -> None:
+    """Prove a release can start, by starting it.
+
+    An executable bit is not evidence. A file containing the text `not python`
+    satisfies `is_file()` and `X_OK` and fails the moment a rollback needs it —
+    which is the one moment there is no remaining fallback. The probe runs the
+    release's own interpreter and imports the runtime through it.
+    """
+    interpreter = release / "venv" / "bin" / "python"
+    # No `-I`. Isolated mode ignores the venv's prefix computation, so the
+    # release's own site-packages never load and the probe would be testing a
+    # different interpreter configuration than the unit runs. Isolation comes
+    # from scrubbing the environment instead: PYTHON* inherited from whoever
+    # invoked the installer could otherwise satisfy an import the service
+    # itself would not.
+    environment = {
+        key: value for key, value in os.environ.items() if not key.startswith("PYTHON")
+    }
+    try:
+        completed = subprocess.run(
+            [str(interpreter), "-c", "import ori.runtime"],
+            capture_output=True,
+            text=True,
+            timeout=RELEASE_PROBE_TIMEOUT_S,
+            check=False,
+            env=environment,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise LinuxInstallError(
+            "unsafe_install_root",
+            "the release that would be restored could not be executed",
+        ) from exc
+    if completed.returncode != 0:
+        # The reason is carried through. A refusal that says only "does not
+        # start" leaves an operator with a blocked upgrade and nothing to act
+        # on, and this runs while the service is still up.
+        detail = " ".join(completed.stderr.split())[-200:]
+        raise LinuxInstallError(
+            "unsafe_install_root",
+            f"the release that would be restored does not start: {detail}",
+        )
+
+
+def _scoped_releases(layout: InstallLayout, releases: Sequence[Path]) -> list[Path]:
+    """The release trees a transaction may touch, deduplicated and validated.
+
+    A caller naming nothing gets nothing: an empty scope permissions the
+    releases directory alone, which is the correct outcome for a call that
+    identifies no candidate and no rollback target.
+    """
+    scoped: list[Path] = []
+    seen: set[Path] = set()
+    for release in releases:
+        _assert_managed_path(layout, release)
+        if release.parent != layout.releases:
+            raise LinuxInstallError(
+                "unsafe_install_root", "scoped release is not a direct release"
+            )
+        if release.is_symlink() or not release.is_dir():
+            raise LinuxInstallError(
+                "unsafe_install_root", "scoped release is not a directory"
+            )
+        if release in seen:
+            continue
+        seen.add(release)
+        scoped.append(release)
+    return scoped
 
 
 def _owned_tree_plan(
@@ -2285,6 +2535,41 @@ def install_release(
     allowed_data_sockets: Sequence[Path] = (),
 ) -> InstallResult:
     """Prepare, activate, and health-gate one already-authenticated release."""
+    with release_lifecycle_lock(layout):
+        return _install_release_locked(
+            layout=layout,
+            version=version,
+            prepare=prepare,
+            validate=validate,
+            restart_service=restart_service,
+            stop_service=stop_service,
+            check_health=check_health,
+            allow_downgrade=allow_downgrade,
+            service_profile=service_profile,
+            prepare_activation=prepare_activation,
+            rollback_activation=rollback_activation,
+            commit_activation=commit_activation,
+            allowed_data_sockets=allowed_data_sockets,
+        )
+
+
+def _install_release_locked(
+    *,
+    layout: InstallLayout,
+    version: str,
+    prepare: Callable[[Path], None],
+    validate: Callable[[Path], None],
+    restart_service: Callable[[], None],
+    stop_service: Callable[[], None],
+    check_health: Callable[[Path], None],
+    allow_downgrade: bool,
+    service_profile: SystemdServiceProfile | None,
+    prepare_activation: Callable[[Path], None] | None,
+    rollback_activation: Callable[[], None] | None,
+    commit_activation: Callable[[Path], None] | None,
+    allowed_data_sockets: Sequence[Path],
+) -> InstallResult:
+    """The transaction itself, run while the lifecycle lock is held."""
     destination = layout.release(version)
     # Built inside the try, one directory at a time. A comprehension binds its
     # result only after the last element, so a root that exists while `data` is
@@ -2390,11 +2675,25 @@ def _install_release(
         validate(destination)
 
     if service_profile is not None and service_profile.scope == "system":
+        # `previous` as captured at the top of this transaction, not a fresh
+        # read of `current`. Re-resolving would probe whatever `current` points
+        # at now, which is not necessarily the release this transaction decided
+        # it would restore.
+        #
+        # It is probed by starting it rather than inspected: a live service
+        # proves the old release started once, not that it could start again if
+        # activation has to be undone.
+        if previous is not None:
+            _assert_release_starts(previous)
+        scope = [destination]
+        if previous is not None:
+            scope.append(previous)
         try:
             apply_system_service_permissions(
                 layout,
                 service_profile,
                 allowed_data_sockets=allowed_data_sockets,
+                releases=scope,
             )
         except Exception:
             if created and destination.exists():
@@ -2476,6 +2775,24 @@ def uninstall_runtime(
     if remove_data and layout.data.exists():
         _assert_managed_path(layout, layout.data)
         shutil.rmtree(layout.data)
+
+
+def _inspect_current(layout: InstallLayout) -> Path | None:
+    """Where `current` points, changing nothing.
+
+    `_active_release` unlinks a dangling `current` as part of resolving it,
+    which is right for an installer transaction and wrong for a listing. A
+    command that reports state must not alter it.
+    """
+    if not layout.current.is_symlink():
+        return None
+    try:
+        target = layout.current.resolve(strict=False)
+    except OSError:
+        return None
+    if target.parent != layout.releases or not target.is_dir():
+        return None
+    return target
 
 
 def _active_release(layout: InstallLayout) -> Path | None:

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -116,12 +116,21 @@ def _validate(path: Path) -> None:
     assert (path / "venv" / "installed.txt").read_text(encoding="utf-8") == "ok"
 
 
+def _real_interpreter(interpreter: Path) -> None:
+    """Give a fake release an interpreter that genuinely starts.
+
+    The rollback pre-check runs the release's own interpreter and imports the
+    runtime through it, because an executable bit is not evidence: a file
+    containing the text `python` satisfies every file-level check and fails at
+    the one moment a rollback needs it.
+    """
+    interpreter.parent.mkdir(parents=True, exist_ok=True)
+    interpreter.symlink_to(sys.executable)
+
+
 def _health_release(tmp_path: Path) -> Path:
     release = (tmp_path / "releases" / "2.3.0").resolve()
-    interpreter = release / "venv" / "bin" / "python"
-    interpreter.parent.mkdir(parents=True)
-    interpreter.write_bytes(b"python")
-    interpreter.chmod(0o700)
+    _real_interpreter(release / "venv" / "bin" / "python")
     return release
 
 
@@ -1996,7 +2005,11 @@ def test_system_permissions_keep_code_root_owned_and_data_service_owned(
         ),
     )
 
-    apply_system_service_permissions(layout, SystemdServiceProfile.system())
+    apply_system_service_permissions(
+        layout,
+        SystemdServiceProfile.system(),
+        releases=[layout.release("2.3.0")],
+    )
 
     assert ownership[layout.root] == (0, 1002)
     assert ownership[regular] == (0, 1002)
@@ -2017,6 +2030,8 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
     layout.data.mkdir(mode=0o700)
     monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 501)
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
+        # No scoped release: this covers permission application failing, not
+        # which trees are in scope.
         apply_system_service_permissions(layout, SystemdServiceProfile.system())
 
     monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
@@ -2027,7 +2042,11 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
     (layout.data / "escape").symlink_to(tmp_path / "outside")
     with pytest.raises(LinuxInstallError, match="unsafe_install_root"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+        apply_system_service_permissions(
+            layout,
+            SystemdServiceProfile.system(),
+            releases=[layout.release("2.3.0")],
+        )
     assert layout.root.stat().st_mode & 0o777 == 0o755
 
 
@@ -2112,6 +2131,493 @@ def test_system_upgrade_preserves_access_and_reapplies_permissions(
     assert observed_modes == [(0o750, 0o750)]
 
 
+def _release_with_interpreter(layout: InstallLayout, version: str) -> Path:
+    """A release for permission-plan tests, which do not run the probe.
+
+    The interpreter is a plain file rather than a symlink to the running
+    Python: an external symlink target is judged by the permission plan, and a
+    real interpreter lives outside the install root by definition.
+    """
+    release = layout.release(version)
+    interpreter = release / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_bytes(b"python")
+    interpreter.chmod(0o700)
+    return release
+
+
+def _startable_release(layout: InstallLayout, version: str) -> Path:
+    """A release for tests that cross the rollback pre-check."""
+    release = layout.release(version)
+    _real_interpreter(release / "venv" / "bin" / "python")
+    return release
+
+
+def _as_root(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+    monkeypatch.setattr("ori.installer.linux.os.fchmod", lambda *_args: None)
+
+
+def test_retiring_moves_a_release_out_of_the_selectable_set(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Retirement quarantines rather than deletes.
+
+    An operator retiring a release to unblock an interpreter removal is making
+    a sequencing decision. Losing the tree at the same moment would turn that
+    into data loss, so deletion stays a separate act.
+    """
+    from ori.installer.linux import RETIRED_DIRNAME, list_releases, retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    active = _release_with_interpreter(layout, "2.5.0")
+    old = _release_with_interpreter(layout, "2.4.0")
+    layout.current.symlink_to(active)
+    monkeypatch.setattr("ori.installer.linux.os.chown", lambda *_args: None)
+
+    destination = retire_release(layout, "2.4.0")
+
+    assert not old.exists()
+    assert destination == layout.root / RETIRED_DIRNAME / "2.4.0"
+    assert (destination / "venv" / "bin" / "python").is_file()
+    assert [entry["version"] for entry in list_releases(layout)] == ["2.5.0"]
+
+
+def test_retiring_the_active_release_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from ori.installer.linux import retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    active = _release_with_interpreter(layout, "2.5.0")
+    layout.current.symlink_to(active)
+    monkeypatch.setattr("ori.installer.linux.os.chown", lambda *_args: None)
+
+    with pytest.raises(LinuxInstallError, match="active release"):
+        retire_release(layout, "2.5.0")
+    assert active.is_dir()
+
+
+def test_retirement_cannot_run_while_an_install_holds_the_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No argument can protect an in-progress install's rollback target.
+
+    Neither command can see the other's state, so passing the target between
+    them is not possible in production — an earlier version of this test did
+    exactly that and proved nothing. Exclusion is the only mechanism that
+    works, and it is what production actually has.
+    """
+    from ori.installer.linux import release_lifecycle_lock, retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    _release_with_interpreter(layout, "2.4.0")
+
+    with release_lifecycle_lock(layout):
+        with pytest.raises(LinuxInstallError, match="already in progress|in progress"):
+            retire_release(layout, "2.4.0")
+
+
+def test_a_first_install_is_locked_before_the_root_exists(
+    tmp_path: Path,
+) -> None:
+    """The hole an earlier placement left open.
+
+    Locking the root's own descriptor cannot start before the root exists, so a
+    first install held nothing. The moment it created the root, a second caller
+    locked it and entered the same supposedly exclusive transaction.
+    """
+    from ori.installer.linux import release_lifecycle_lock
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    assert not layout.root.exists()
+
+    with release_lifecycle_lock(layout):
+        layout.root.mkdir(parents=True)
+        with pytest.raises(LinuxInstallError, match="in progress"):
+            with release_lifecycle_lock(layout):
+                pass
+
+
+def test_roots_sharing_a_parent_do_not_block_each_other(tmp_path: Path) -> None:
+    """`/opt` holds one install root today and could hold another.
+
+    The lock is named for the root it guards, so exclusion stays per-root
+    rather than becoming a lock on the directory installs happen to live in.
+    """
+    from ori.installer.linux import release_lifecycle_lock
+
+    first = InstallLayout.resolve(tmp_path / "ori")
+    second = InstallLayout.resolve(tmp_path / "ori-other")
+
+    with release_lifecycle_lock(first):
+        with release_lifecycle_lock(second):
+            pass
+
+
+def test_the_lock_is_released_so_a_later_command_can_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Exclusion that never lets go is an outage, not a safeguard."""
+    from ori.installer.linux import release_lifecycle_lock, retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    _release_with_interpreter(layout, "2.4.0")
+
+    with release_lifecycle_lock(layout):
+        pass
+    retire_release(layout, "2.4.0")
+    assert not layout.release("2.4.0").exists()
+
+
+def test_user_scope_retirement_is_refused_with_a_stable_error(
+    tmp_path: Path,
+) -> None:
+    """It moves a root-owned tree between root-owned directories.
+
+    A user-scope implementation is a different ownership model, not a smaller
+    version of this one. Half-implementing it raised an uncaught PermissionError
+    rather than an installer error the CLI can render.
+    """
+    from ori.installer.linux import retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    _release_with_interpreter(layout, "2.4.0")
+
+    with pytest.raises(LinuxInstallError, match="scope system"):
+        retire_release(layout, "2.4.0", scope="user")
+    assert layout.release("2.4.0").is_dir()
+
+
+def test_a_symlinked_quarantine_directory_is_refused(
+    tmp_path: Path,
+) -> None:
+    """os.replace through a symlinked quarantine would move a release outside.
+
+    A plain mkdir(exist_ok=True) accepts an existing symlink, so the retirement
+    destination could be anywhere the link points.
+    """
+    from ori.installer.linux import RETIRED_DIRNAME, retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    _release_with_interpreter(layout, "2.4.0")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (layout.root / RETIRED_DIRNAME).symlink_to(elsewhere)
+
+    with pytest.raises(LinuxInstallError):
+        retire_release(layout, "2.4.0")
+    assert layout.release("2.4.0").is_dir()
+    assert not any(elsewhere.iterdir())
+
+
+def test_retiring_something_that_is_not_a_release_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Only a canonical direct child of releases/ may be retired."""
+    from ori.installer.linux import retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    monkeypatch.setattr("ori.installer.linux.os.chown", lambda *_args: None)
+
+    with pytest.raises(LinuxInstallError):
+        retire_release(layout, "never-installed")
+    with pytest.raises(LinuxInstallError):
+        retire_release(layout, "../data")
+
+
+def test_retiring_the_same_release_twice_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A second retirement would overwrite the quarantined copy."""
+    from ori.installer.linux import retire_release
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    _release_with_interpreter(layout, "2.4.0")
+    monkeypatch.setattr("ori.installer.linux.os.chown", lambda *_args: None)
+    retire_release(layout, "2.4.0")
+
+    _release_with_interpreter(layout, "2.4.0")
+    with pytest.raises(LinuxInstallError, match="already been retired"):
+        retire_release(layout, "2.4.0")
+
+
+def test_listing_does_not_change_what_it_reports(tmp_path: Path) -> None:
+    """A read-only command must be read-only.
+
+    `_active_release` unlinks a dangling `current` as part of resolving it,
+    which is right inside an install transaction and wrong in a listing. On the
+    bench Pi, running the listing removed the symlink it was asked to report.
+    """
+    from ori.installer.linux import list_releases
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.current.symlink_to(layout.releases / "2.4.0")
+    assert layout.current.is_symlink()
+
+    list_releases(layout)
+
+    assert layout.current.is_symlink(), "listing removed the dangling current link"
+
+
+def test_listing_reports_which_release_is_active_and_has_an_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`has_interpreter` reports a file, and is named for that.
+
+    It does not identify releases that block an upgrade — only the active
+    rollback candidate is load-bearing, and whether that one starts is
+    established by starting it at install time. Calling this field `runnable`
+    would claim both things it does not check.
+    """
+    from ori.installer.linux import list_releases
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    active = _release_with_interpreter(layout, "2.5.0")
+    broken = layout.release("2.4.0")
+    (broken / "venv" / "bin").mkdir(parents=True)
+    (broken / "venv" / "bin" / "python").symlink_to(tmp_path / "gone" / "python")
+    layout.current.symlink_to(active)
+
+    entries = {entry["version"]: entry for entry in list_releases(layout)}
+    assert entries["2.5.0"]["active"] is True
+    assert entries["2.5.0"]["has_interpreter"] is True
+    assert entries["2.4.0"]["active"] is False
+    assert entries["2.4.0"]["has_interpreter"] is False
+
+
+def test_a_stale_retained_release_cannot_block_an_install(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The defect: any retained release held a veto over every future install.
+
+    A release whose interpreter lived outside the install root kept that
+    reference after being superseded. Removing the interpreter — the documented
+    order, after a later release is installed and healthy — then failed the
+    external-symlink check for a tree nothing in the transaction referred to,
+    and left the installation permanently un-upgradeable.
+    """
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    candidate = _release_with_interpreter(layout, "2.5.0")
+
+    # A superseded release pointing at an interpreter that no longer exists.
+    stale = layout.release("2.4.0")
+    (stale / "venv" / "bin").mkdir(parents=True)
+    (stale / "venv" / "bin" / "python").symlink_to(tmp_path / "removed" / "python")
+
+    _as_root(monkeypatch)
+    apply_system_service_permissions(
+        layout, SystemdServiceProfile.system(), releases=[candidate]
+    )
+
+
+def test_the_rollback_candidate_is_in_scope(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scoping to the candidate alone would leave the restore target unowned."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    candidate = _release_with_interpreter(layout, "2.5.0")
+    previous = _release_with_interpreter(layout, "2.4.0")
+
+    planned: list[Path] = []
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._apply_permission_plan",
+        lambda plan: planned.extend(change.path for change in plan),
+    )
+    apply_system_service_permissions(
+        layout, SystemdServiceProfile.system(), releases=[candidate, previous]
+    )
+    assert previous / "venv" / "bin" / "python" in planned
+    assert candidate / "venv" / "bin" / "python" in planned
+
+
+def test_history_outside_the_scope_is_never_walked(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Inert history must not be searched, not merely tolerated."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    candidate = _release_with_interpreter(layout, "2.5.0")
+    history = _release_with_interpreter(layout, "2.3.0")
+
+    planned: list[Path] = []
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._apply_permission_plan",
+        lambda plan: planned.extend(change.path for change in plan),
+    )
+    apply_system_service_permissions(
+        layout, SystemdServiceProfile.system(), releases=[candidate]
+    )
+    assert layout.releases in planned, "the releases directory itself is still owned"
+    assert not any(str(path).startswith(str(history)) for path in planned), (
+        "a release outside the transaction was walked"
+    )
+
+
+def test_reinstalling_the_active_version_does_not_plan_it_twice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The candidate and the rollback target are the same tree on a reinstall.
+
+    Planning it twice would apply two permission changes to every file, and
+    the second would record the first's result as the original to restore.
+    """
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    release = _release_with_interpreter(layout, "2.5.0")
+
+    planned: list[Path] = []
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._apply_permission_plan",
+        lambda plan: planned.extend(change.path for change in plan),
+    )
+    apply_system_service_permissions(
+        layout, SystemdServiceProfile.system(), releases=[release, release]
+    )
+    interpreter = release / "venv" / "bin" / "python"
+    assert planned.count(interpreter) == 1
+
+
+def test_a_rollback_candidate_that_cannot_start_is_refused(
+    tmp_path: Path,
+) -> None:
+    """An executable bit is not evidence that a release starts.
+
+    On the bench Pi a file containing the text `not python` was accepted as a
+    valid rollback candidate: it is a regular file, it has the executable bit,
+    and it is not an interpreter. That is only discovered during a rollback,
+    which is the one moment there is no remaining fallback.
+    """
+    from ori.installer.linux import _assert_release_starts
+
+    impostor = tmp_path / "2.4.0"
+    interpreter = impostor / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_text("not python\n", encoding="utf-8")
+    interpreter.chmod(0o755)
+    assert interpreter.is_file() and os.access(interpreter, os.X_OK)
+
+    with pytest.raises(LinuxInstallError, match="does not start|could not be executed"):
+        _assert_release_starts(impostor)
+
+
+def test_a_real_release_passes_the_start_probe(tmp_path: Path) -> None:
+    """The probe must not refuse a release that genuinely runs.
+
+    A real venv, because that is what the probe is judging. A bare symlink to
+    the running interpreter is not one — it has no `pyvenv.cfg`, so it cannot
+    see the packages the release would ship, and it would fail for a reason
+    the probe is not testing for.
+    """
+    from ori.installer.linux import _assert_release_starts
+
+    release = tmp_path / "2.5.0"
+    subprocess.run(
+        [sys.executable, "-m", "venv", "--system-site-packages", str(release / "venv")],
+        check=True,
+        capture_output=True,
+    )
+    version_dir = f"python{sys.version_info.major}.{sys.version_info.minor}"
+    site_packages = release / "venv" / "lib" / version_dir / "site-packages"
+    site_packages.mkdir(parents=True, exist_ok=True)
+    (site_packages / "ori-under-test.pth").write_text(
+        str(Path(sys.prefix) / "lib" / version_dir / "site-packages") + "\n",
+        encoding="utf-8",
+    )
+
+    _assert_release_starts(release)
+
+
+def test_the_probe_runs_the_release_captured_at_the_start(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Not a fresh read of `current`.
+
+    `current` is moved between capture and preflight. Without that the test
+    cannot tell a captured value from a re-read that happens to agree, which
+    is the whole difference being asserted.
+    """
+    probed: list[Path] = []
+    monkeypatch.setattr(
+        "ori.installer.linux._assert_release_starts",
+        lambda release: probed.append(release),
+    )
+
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.data.mkdir(parents=True)
+    captured = _release_with_interpreter(layout, "2.4.0")
+    decoy = _release_with_interpreter(layout, "2.3.0")
+    layout.current.symlink_to(captured)
+
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux._apply_permission_plan", lambda _plan: None
+    )
+
+    def prepare(staging: Path) -> None:
+        interpreter = staging / "venv" / "bin" / "python"
+        interpreter.parent.mkdir(parents=True)
+        interpreter.write_bytes(b"python")
+        interpreter.chmod(0o700)
+        # Repoint `current` after the transaction captured it.
+        layout.current.unlink()
+        layout.current.symlink_to(decoy)
+
+    # 2.5.0 is deliberately not pre-created: an existing destination skips
+    # staging entirely, and `prepare` would never run.
+    install_release(
+        layout=layout,
+        version="2.5.0",
+        prepare=prepare,
+        validate=lambda _path: None,
+        restart_service=lambda: None,
+        stop_service=lambda: None,
+        check_health=lambda _path: None,
+        service_profile=SystemdServiceProfile.system(),
+    )
+
+    assert layout.current.resolve() != captured, "the hook did not move `current`"
+    assert probed == [captured], (
+        f"probed {probed} rather than the release captured at the start"
+    )
+
+
 def test_permission_failure_is_stable_and_restores_current_owner(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -2134,6 +2640,8 @@ def test_permission_failure_is_stable_and_restores_current_owner(
         lambda *_args: (_ for _ in ()).throw(NotImplementedError("old glibc")),
     )
     with pytest.raises(LinuxInstallError, match="service_start_failed"):
+        # No scoped release: this covers permission application failing, not
+        # which trees are in scope.
         apply_system_service_permissions(layout, SystemdServiceProfile.system())
     assert ownership_calls == [(0, 1002), (original.st_uid, original.st_gid)]
 
@@ -2160,7 +2668,11 @@ def test_system_permissions_accept_internal_venv_directory_symlink(
     )
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
 
-    apply_system_service_permissions(layout, SystemdServiceProfile.system())
+    apply_system_service_permissions(
+        layout,
+        SystemdServiceProfile.system(),
+        releases=[layout.release("2.3.0")],
+    )
 
     assert (release / "lib64").resolve() == library
     assert (binary / "python").resolve() == interpreter
@@ -2186,7 +2698,11 @@ def test_system_permissions_reject_escaping_release_symlinks(
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
 
     with pytest.raises(LinuxInstallError, match="unsafe_install_root"):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+        apply_system_service_permissions(
+            layout,
+            SystemdServiceProfile.system(),
+            releases=[layout.release("2.3.0")],
+        )
 
     (release / "lib64").unlink()
     external_python = tmp_path / "python"
@@ -2198,7 +2714,11 @@ def test_system_permissions_reject_escaping_release_symlinks(
     with pytest.raises(
         LinuxInstallError, match="external release symlink target is not trusted"
     ):
-        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+        apply_system_service_permissions(
+            layout,
+            SystemdServiceProfile.system(),
+            releases=[layout.release("2.3.0")],
+        )
 
 
 def test_permission_failure_removes_new_release_before_activation(

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -2138,9 +2138,14 @@ def _release_with_interpreter(layout: InstallLayout, version: str) -> Path:
     Python: an external symlink target is judged by the permission plan, and a
     real interpreter lives outside the install root by definition.
     """
+    # Explicit modes rather than the ambient umask: on a private-user-group
+    # host, umask 0002 makes a default mkdir group-writable and the installer
+    # refuses such a tree. Fixtures must not depend on the umask the suite
+    # happens to run under.
+    layout.releases.mkdir(parents=True, mode=0o750, exist_ok=True)
     release = layout.release(version)
     interpreter = release / "venv" / "bin" / "python"
-    interpreter.parent.mkdir(parents=True)
+    interpreter.parent.mkdir(parents=True, mode=0o750)
     interpreter.write_bytes(b"python")
     interpreter.chmod(0o700)
     return release
@@ -2576,7 +2581,12 @@ def test_the_probe_runs_the_release_captured_at_the_start(
     )
 
     layout = InstallLayout.resolve(tmp_path / "ori")
-    layout.data.mkdir(parents=True)
+    # The root is created with an explicit private mode rather than inheriting
+    # the ambient umask. On a private-user-group host, umask 0002 makes a
+    # default mkdir group-writable, and the installer refuses such a root — as
+    # it should. That is a fixture detail, not what this test is about.
+    layout.root.mkdir(parents=True, mode=0o750)
+    layout.data.mkdir(mode=0o700)
     captured = _release_with_interpreter(layout, "2.4.0")
     decoy = _release_with_interpreter(layout, "2.3.0")
     layout.current.symlink_to(captured)

--- a/tests/test_linux_installer_cli.py
+++ b/tests/test_linux_installer_cli.py
@@ -1135,3 +1135,155 @@ def test_the_success_envelope_is_versioned(
     payload = json.loads(capsys.readouterr().out)
     assert payload["schema_version"] == 1
     assert payload["ok"] is True
+
+
+# ─── release lifecycle commands ──────────────────────────────────────────────
+
+
+def _installed_release(root: Path, version: str, *, active: bool = False) -> Path:
+    release = root / "releases" / version
+    interpreter = release / "venv" / "bin" / "python"
+    interpreter.parent.mkdir(parents=True)
+    interpreter.write_bytes(b"python")
+    interpreter.chmod(0o700)
+    if active:
+        (root / "current").symlink_to(release)
+    return release
+
+
+def test_release_list_reports_installed_releases_as_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    _installed_release(root, "2.4.0")
+    _installed_release(root, "2.5.0", active=True)
+
+    assert cli.main(["release", "list", "--scope", "system", "--root", str(root)]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    versions = {entry["version"]: entry for entry in payload["releases"]}
+    assert versions["2.5.0"]["active"] is True
+    assert versions["2.4.0"]["active"] is False
+    assert payload["status"] == "listed"
+
+
+def test_release_list_does_not_repair_a_dangling_current(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Through the command, not the helper.
+
+    The helper-level test proves the function; this proves the command wired to
+    it did not reintroduce the mutating resolver on the way through.
+    """
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    (root / "current").symlink_to(root / "releases" / "2.4.0")
+
+    assert cli.main(["release", "list", "--scope", "system", "--root", str(root)]) == 0
+    capsys.readouterr()
+    assert (root / "current").is_symlink()
+
+
+def test_release_retire_moves_a_release_and_says_rollback_is_gone(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    _installed_release(root, "2.4.0")
+    _installed_release(root, "2.5.0", active=True)
+
+    exit_code = cli.main(
+        ["release", "retire", "2.4.0", "--scope", "system", "--root", str(root)]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "retired"
+    # Stated, not implied: retiring gives up the ability to go back to it.
+    assert payload["rollback_available"] is False
+    assert not (root / "releases" / "2.4.0").exists()
+    assert (root / "retired" / "2.4.0" / "venv" / "bin" / "python").is_file()
+
+
+def test_release_retire_refuses_the_active_release_with_a_stable_error(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    _installed_release(root, "2.5.0", active=True)
+
+    with pytest.raises(SystemExit):
+        cli.main(
+            [
+                "release",
+                "retire",
+                "2.5.0",
+                "--scope",
+                "system",
+                "--root",
+                str(root),
+                "--json",
+            ]
+        )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "config_validation_failed"
+    assert (root / "releases" / "2.5.0").is_dir()
+
+
+def test_release_retire_refuses_user_scope_rather_than_crashing(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Retirement moves a root-owned tree between root-owned directories.
+
+    On the bench Pi the half-implemented version raised an uncaught
+    PermissionError. A CLI must fail with an error code it can render.
+    """
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    _installed_release(root, "2.4.0")
+
+    with pytest.raises(SystemExit):
+        cli.main(
+            [
+                "release",
+                "retire",
+                "2.4.0",
+                "--scope",
+                "user",
+                "--root",
+                str(root),
+                "--json",
+            ]
+        )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "config_validation_failed"
+    assert (root / "releases" / "2.4.0").is_dir()
+
+
+def test_release_retire_is_excluded_while_the_root_is_locked(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The production protection for an in-progress install's rollback target."""
+    from ori.installer.linux import InstallLayout, release_lifecycle_lock
+
+    root = tmp_path / "ori"
+    (root / "releases").mkdir(parents=True)
+    _installed_release(root, "2.4.0")
+    layout = InstallLayout.resolve(root)
+
+    with release_lifecycle_lock(layout):
+        with pytest.raises(SystemExit):
+            cli.main(
+                [
+                    "release",
+                    "retire",
+                    "2.4.0",
+                    "--scope",
+                    "system",
+                    "--root",
+                    str(root),
+                    "--json",
+                ]
+            )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["error"]["code"] == "unsafe_install_root"
+    assert (root / "releases" / "2.4.0").is_dir()


### PR DESCRIPTION
## What does this PR do?

A retained release held a veto over every future install.

Permission planning walked the whole releases tree, so a **superseded** release whose interpreter had since been removed failed the external-symlink check and left the installation permanently un-upgradeable — with nothing in the transaction referring to it:

```
unsafe_install_root: external release symlink target is not trusted:
/usr/local/ori-python does not exist
```

The documented upgrade order produced exactly that state. `docs/RASPBERRY_PI_SUPPORT.md` said to upgrade and then remove the old interpreter, which is right, but a superseded release keeps recording the interpreter it was built against.

Reproduced on the bench Pi against a live `/opt/ori` with three releases, one dangling:

```
main   (walks every release):  REFUSED -> /usr/local/ori-python does not exist
branch (scoped to candidate):  7009 paths planned | stale release: 0 | superseded rc.3: 0
```

## What changed

**Scoped validation.** Only two releases are inspected: the candidate, and the release `current` pointed at when the transaction began. Those are the only two a transaction can reach. The releases directory itself is still owned and mode-set; its other children are never searched.

**The rollback target is captured once and reused.** Re-reading `current` later would probe whatever it points at by then, which is not necessarily the release the transaction decided it would restore.

**It is probed by starting it.** An executable bit is not evidence — on the Pi, a file containing the text `not python` satisfied `is_file()` and `X_OK` and would have been discovered only *during* a rollback, the one moment there is no remaining fallback. The probe runs the release's own interpreter and imports the runtime through it.

The environment is scrubbed rather than passing `-I`: isolated mode ignores the venv's prefix computation, so `site-packages` never loads and the probe would test a configuration the unit never runs. Measured all three modes before choosing.

**One lifecycle lock covers install and retirement.** No argument passed between them can protect an in-progress install's rollback target, because neither command can see the other's state. The lock is anchored in the install root's **parent** — a file inside the root is an artefact a failed first install cannot roll back, and the root's own descriptor cannot be locked before the root exists, which left first installs unprotected. It is named per-root, so two roots under `/opt` do not block each other.

**Retirement becomes a guarded operation** rather than the manual `mv` it was. `ori-install-linux release list` and `release retire` refuse the active release, a non-canonical path, and a double retirement. The quarantine directory is created through the installer's existing no-follow primitive, so a symlinked `retired` cannot redirect the move outside the managed tree. User scope is refused with a stable error rather than raising `PermissionError` from an unconditional `chown`.

**Listing no longer mutates what it reports.** Resolving `current` through the installer's resolver unlinks a dangling link — right inside a transaction, wrong in a read-only command.

## Documentation

The upgrade procedure is corrected. Retirement is not a step in removing an interpreter: the rule is never to remove the interpreter the *active* release is built on, and once superseded a release is inert. Retirement is optional, for deliberately giving up rollback to an inactive release.

`release list` reports `has_interpreter`, named for what it checks. It does not identify releases that block an upgrade — only the active rollback candidate is load-bearing.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — installer transaction scope and a new lifecycle subcommand; no runtime capability changes shape or tier.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #402.

## Testing notes

Full suite **4083 passed, 27 skipped**. Installer and CLI: **218 passed, 3 skipped**. `mypy ori/` and `pyright ori/` clean.

Six CLI-level tests go through `cli.main` rather than the helpers, including the user-scope refusal and the lock excluding retirement — helper-level tests had concealed both.

Mutations checked, each failing its intended assertion: walking the whole releases directory, skipping the rollback probe, no deduplication of scoped releases, allowing user-scope retirement, unsafe quarantine creation, a mutating listing, no exclusion between install and retire, and re-reading `current` instead of using the captured release.

Three of those initially survived and each required a test to be fixed rather than the code: deduplication had no coverage, the read-only listing had no coverage, and the captured-release test was asserting against a scenario that never ran because the destination was pre-created and `prepare` was skipped.

Verified on the bench Pi against the live install root, read-only except for a deliberately restored stale release which was removed afterwards. `/opt/ori` remains on rc.5 and `ori doctor` reports 14 pass, 1 warn, 0 fail.