### PR TITLE
docs(relay): correct the fail-safe wiring and startup claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -855,11 +855,24 @@ Any other protocol in ori.yaml raises `ConfigValidationError` at
 startup before the event loop begins.
 
 **Relay wiring safety:**
-Always use Normally Closed (NC) relay terminals. NC wiring means the
-load is disconnected when the relay is de-energised. Power loss or
-an Ori crash defaults the system to the safe state without software
-intervention. Never use Normally Open (NO) terminals for any load
-that must be de-energised on failure.
+Never select NC or NO by convention. Contact type establishes nothing
+about the protected circuit — the downstream wiring decides whether a
+de-energised coil isolates or reconnects the load. Do not write code,
+config, or documentation that derives a coil state, or a circuit
+outcome, from a contact type.
+
+Losing the controller physically de-energises the coil. What that does
+to the protected circuit is established per channel by commissioning:
+de-energise the coil, observe what the load actually does, record it.
+That observation is the only thing that licenses calling any state safe.
+
+**The runtime's startup polarity is not trustworthy today.**
+`actions.relay.active_high` is documented in `ori.yaml` and never
+reaches `RelayAction`, so on an active-low board the logical inactive
+output energises the coil. The runtime also consumes no commissioned
+mapping. Until #397 lands, an installation is fail-safe only because its
+wiring was proven by test and its board polarity happens to match the
+default — the software guarantees neither.
 
 ---
 

--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -232,7 +232,12 @@ profile that refuses to pretend:
 
 1. Install from a release bundle carrying a `linux-aarch64-python3.13` target.
 2. Confirm step 3 above prints `LGPIOFactory`.
-3. Wire the relay to **normally closed** terminals and declare its `gpio_pin`.
+3. Wire the relay and declare its `gpio_pin`. Do not pick NC or NO by
+   convention — contact type establishes nothing about the protected circuit.
+   Commission the channel: de-energise the coil, observe what the load actually
+   does, and record it. Note that this release ignores `active_high`, so on an
+   active-low board the runtime's startup output energises the coil; verify the
+   resting state on the bench rather than assuming it.
 4. Move `deployment_profile` off `development`. A hardened profile fails
    startup when a configured GPIO path has no `gpiozero` behind it, which is
    the behaviour you want — it turns a silent simulation into a refusal.

--- a/ori/actions/relay.py
+++ b/ori/actions/relay.py
@@ -16,12 +16,19 @@ Used for Tier B (soft physical) and Tier D (safety-critical) actions.
     - Wiring must be inspected and approved by a qualified electrician.
     - Verify the relay's rated switching capacity (voltage, current) is
       not exceeded by the connected load.
-    - Confirm ``active_high`` matches the relay module's trigger logic
-      (most opto-isolated relay boards are ``active_low``).
-    - Wire to the Normally Closed (NC) terminal, not Normally Open
-      (NO).  NC wiring means power loss or an Ori crash defaults the
-      load to the safe state (disconnected) without software
-      intervention.
+    - Never select NC or NO by convention.  Contact type establishes
+      nothing about the protected circuit: the downstream wiring
+      decides whether a de-energised coil isolates or reconnects the
+      load.  Commission the channel instead — de-energise the coil,
+      observe what the load actually does, and record it.
+    - Losing the controller physically de-energises the coil.  What
+      that does to the protected circuit is whatever commissioning
+      observed, and nothing else.
+    - **Startup polarity is not trustworthy in this release.**
+      ``active_high`` is documented in ori.yaml and never reaches this
+      module, so on an active-low board the runtime's logical inactive
+      output energises the coil.  Do not rely on startup or crash state
+      to leave a load isolated until that is fixed (#397).
     - Test with the load de-energised before connecting live circuits.
     - Never operate a relay above its rated duty cycle.
 


### PR DESCRIPTION
## What does this PR do?

Three documents told an installer to wire a relay in a way that inverts the failure the instruction promises to protect against.

`ori/actions/relay.py`, `CLAUDE.md`, and the pre-demo checklist in `docs/RASPBERRY_PI_SUPPORT.md` each stated that normally-closed wiring means power loss or a runtime crash leaves the load disconnected without software intervention. That describes a normally-**open** contact. An NC contact is closed at rest, so a load wired through it is *connected* when the coil drops — the opposite of what the text promises, on precisely the failure it is written for.

**Prescribing NC in place of NO would not fix it.** Any rule that picks a contact type by convention keeps contact type as an input to a safety decision, and that is the part that is wrong. Whether a de-energised coil isolates or reconnects the load is a property of the downstream wiring, and only commissioning the channel establishes which: de-energise the coil, observe what the load actually does, record it. All three documents now say that and stop naming a required terminal.

## The second correction: startup state was also unearned

These documents could not honestly claim that de-energised is the state the runtime drives at startup or on failure.

[runtime.py:544](ori/runtime.py#L544) calls `RelayAction.connect()` with `gpio_pin` and `allow_simulation` only. `active_high` defaults to `True` in [relay.py:174](ori/actions/relay.py#L174), and `ori.yaml.example` documents an `active_high` key that nothing reads. On the active-low boards most opto-isolated modules use, the logical *inactive* output is a HIGH pin, which energises the coil — so the resting state is whatever the board does with that pin, not a state the runtime chose.

Losing the controller does physically de-energise the coil. What that does to the protected circuit is whatever commissioning observed, and nothing else. The documents now separate those two facts instead of asserting a safe outcome the software does not produce.

Each document now records what the runtime does and does not guarantee before #397 lands: no commissioned mapping, and untrustworthy startup polarity.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — the only `ori/` change is a docstring. No capability, tier, or executor behaviour is touched.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #397. Does not close it. Plumbing `active_high`, and giving the runtime a commissioned mapping to resolve outcomes through, both need the authenticated carrier and stay open there.

## Testing notes

Nothing executable changed. The checks that matter are that no document names a required contact type, and that the `active_high` claim matches the code: `connect()` is called without it at [runtime.py:544](ori/runtime.py#L544) and it defaults to `True`.
