### PR TITLE
chore(evidence): re-pin unchanged vectors to merged specs

### DIFF
--- a/tests/vectors/evidence_exchange/MANIFEST.json
+++ b/tests/vectors/evidence_exchange/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "37cdd9e700d5322d17beee1e1184e4a4aecef0b4",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-registration.json": "dd9f7f0cbf320abd5f5d594ab4e20e75b3fd7c3ff3cab4b6a1ed0749a7a72536",

--- a/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
+++ b/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors/receiver-state",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "37cdd9e700d5322d17beee1e1184e4a4aecef0b4",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-quarantine.json": "ec5922987116b8487d1f49cb29bb53cd0cb44ef6cc8872f4a7b9ada8e8714bbd",

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "37cdd9e700d5322d17beee1e1184e4a4aecef0b4",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",

--- a/tests/vectors/gateway_api/MANIFEST.json
+++ b/tests/vectors/gateway_api/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "gateway-api/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "37cdd9e700d5322d17beee1e1184e4a4aecef0b4",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "inbound-evidence.json": "cb18d5f6fad051f6ca1924b20ef1040d2d67185c41a9a9eccee6159db0eb0473",

--- a/tests/vectors/runtime_evidence_anchor/MANIFEST.json
+++ b/tests/vectors/runtime_evidence_anchor/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "runtime-evidence-anchor/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "37cdd9e700d5322d17beee1e1184e4a4aecef0b4",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "runtime-anchor.json": "bd8e46cdff590447213d99e892b7f67480188134163d0a207e9f396b94847190"


### PR DESCRIPTION
## What does this PR do?

Every pull request began failing on the Python 3.12 leg before its own tests
could run. `ori-specs` advanced from `d18d795` to `37cdd9e` when the
commissioned-safety-binding contract merged, while the five vector sets already
consumed by ori-runtime remained byte-for-byte unchanged. Their manifests still
pinned the previous repository commit, so the fail-closed provenance check
correctly refused them.

This uses the repository's existing reviewed apply path to re-pin those five
manifests to the merged ori-specs commit:

```text
ORI_VECTORS_APPLY=1 bash scripts/refresh-evidence-vectors.sh
```

The diff is deliberately only five `source_commit` replacements. No vector
file, digest, consumer, updater, workflow, runtime path, or capability changes.

### Why this is separate from the PR that encountered it

PR #406 happened to be the first pull request opened after ori-specs moved, but
the stale pin belongs to the repository rather than that runtime change. Mixing
the re-pin into #406 would make an unrelated startup-notification PR responsible
for reviewing cross-repository provenance. #348 and #380 established the
opposite convention: stale provenance is visible drift and is reconciled in a
dedicated, reviewable PR.

### What the new upstream contract does not mean here

`37cdd9e` adds `commissioned-safety-binding/v1` and its own vector corpus. This
PR neither vendors nor implements that new corpus. That work belongs to the
commissioned posture arc tracked by #324 and #397. The five existing source
paths were checked individually and their JSON bytes still match exactly.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures — focused corpus suite and host limitation documented below
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — provenance metadata for unchanged conformance fixtures
only. No runtime capability changes state, posture, availability, or action
tier.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable — nothing under `/ori/` changes.

## Related issue

Closes #407.

## Testing notes

The updater was first run in check mode against an immutable checkout of
ori-specs `37cdd9e700d5322d17beee1e1184e4a4aecef0b4`. Every set reported
`contents match`; there were no `NEW`, `CHANGED`, or `REMOVED` vector entries.
After apply, both the same pinned check and a fresh check against live ori-specs
`main` reported all five sets matching that commit.

Focused conformance and accounting suite:

```text
pytest -q \
  tests/test_evidence_v2_vectors.py \
  tests/test_evidence_exchange_graph.py \
  tests/test_evidence_delivery_ledger.py \
  tests/test_evidence_ingest.py

216 passed in 102.27s
```

File-level pre-commit hooks and `git diff --check` pass. The complete local suite
is not marked green: this Pop!_OS host intermittently exposes `/dev/i2c-1`
during collection without the Raspberry Pi sensor libraries or hardware, which
produces the two pre-existing `TestPiIntegration` failures documented on #406.
The GitHub Python 3.11/3.12/3.13 matrix is the full-suite merge gate for this
five-line metadata change.
