### PR TITLE
chore(vectors): re-pin vendored vectors to current ori-specs

### DIFF
--- a/tests/vectors/evidence_exchange/MANIFEST.json
+++ b/tests/vectors/evidence_exchange/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "af96339bd50dc9f04f826eb68d0fa7867f667eae",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-registration.json": "dd9f7f0cbf320abd5f5d594ab4e20e75b3fd7c3ff3cab4b6a1ed0749a7a72536",

--- a/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
+++ b/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors/receiver-state",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "af96339bd50dc9f04f826eb68d0fa7867f667eae",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-quarantine.json": "ec5922987116b8487d1f49cb29bb53cd0cb44ef6cc8872f4a7b9ada8e8714bbd",

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "af96339bd50dc9f04f826eb68d0fa7867f667eae",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",

--- a/tests/vectors/gateway_api/MANIFEST.json
+++ b/tests/vectors/gateway_api/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "gateway-api/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "af96339bd50dc9f04f826eb68d0fa7867f667eae",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "inbound-evidence.json": "cb18d5f6fad051f6ca1924b20ef1040d2d67185c41a9a9eccee6159db0eb0473",

--- a/tests/vectors/runtime_evidence_anchor/MANIFEST.json
+++ b/tests/vectors/runtime_evidence_anchor/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "runtime-evidence-anchor/vectors",
-  "source_commit": "d18d7955643c3c9fed6de5273a8c729417523765",
+  "source_commit": "af96339bd50dc9f04f826eb68d0fa7867f667eae",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "runtime-anchor.json": "bd8e46cdff590447213d99e892b7f67480188134163d0a207e9f396b94847190"


### PR DESCRIPTION
## What does this PR do?

Unblocks CI on every open pull request. The `Check vendored evidence vectors against ori-specs` step fails on the 3.12 leg of every branch, including PRs whose content has nothing to do with vectors — #406 is the current casualty.

Nothing is wrong with those branches. Two contract merges have landed in ori-specs since the manifests were pinned, neither touching a vendored file, so every set reports:

```text
contents match, but the manifest pins d18d7955…
  and ori-specs is now at af96339b…
```

**Pins only. No vendored bytes change.** The diff is five `source_commit` lines and nothing else.

That separation is deliberate and worth keeping: a squash merge rewrites the commit while leaving every byte identical, so a contents-only check would report a match while the manifest named a commit that no longer exists on main — provenance pointing at nothing, which is worse than no pin for looking authoritative.

## Type of change

- [x] `chore` — neither fixes a bug nor adds a feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no code changes at all; five provenance pins in test fixtures.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

None. Maintenance of the vendoring provenance trail.

## Testing notes

`bash scripts/refresh-evidence-vectors.sh` reports every set matching at `af96339b`. The vector suites pass unchanged, which is the point: if a byte had moved, they would not.