### PR TITLE
fix(hal): make baud_rate the canonical spelling, and stop dropping it silently

### DIFF
--- a/ori/config.py
+++ b/ori/config.py
@@ -15,6 +15,12 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import yaml
 
+from ori.hal.base import (
+    BAUD_RATE_KEY,
+    LEGACY_BAUD_RATE_KEY,
+    AdapterConnectionError,
+    resolve_baud_rate,
+)
 from ori.hal.protocol_registry import SUPPORTED_SENSOR_PROTOCOLS
 from ori.security.config_signatures import (
     CONFIG_REQUIRE_SIGNED_ENV,
@@ -32,6 +38,7 @@ from ori.utils.path_utils import path_is_relative_to
 logger = logging.getLogger(__name__)
 
 _VALID_ACTION_TIERS = {"A", "B", "C", "D"}
+_SERIAL_PROTOCOLS = {"serial", "usb_serial"}
 _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -672,6 +679,8 @@ def _parse_sensors(data: Any) -> list[SensorConfig]:
         metadata = {k: v for k, v in item.items() if k not in known}
         if protocol == "coap":
             _validate_coap_sensor_metadata(metadata, f"sensors[{i}]")
+        if protocol in _SERIAL_PROTOCOLS:
+            _normalise_serial_sensor_baud(metadata, f"sensors[{i}]")
 
         sensors.append(
             SensorConfig(
@@ -684,6 +693,35 @@ def _parse_sensors(data: Any) -> list[SensorConfig]:
             )
         )
     return sensors
+
+
+def _normalise_serial_sensor_baud(metadata: dict[str, Any], section: str) -> None:
+    """Refuse an ambiguous baud spelling, and rewrite the legacy one.
+
+    Refused here rather than only in the adapter because an adapter without
+    ``pyserial`` never reaches its own check, so on a developer machine the
+    ambiguity would load clean and surface on the Pi. Normalising to the
+    canonical key means the deprecation warning is emitted once, at load.
+    """
+    has_canonical = BAUD_RATE_KEY in metadata
+    has_legacy = LEGACY_BAUD_RATE_KEY in metadata
+    if not (has_canonical or has_legacy):
+        return
+
+    try:
+        resolved = resolve_baud_rate(
+            has_canonical=has_canonical,
+            canonical=metadata.get(BAUD_RATE_KEY),
+            has_legacy=has_legacy,
+            legacy=metadata.get(LEGACY_BAUD_RATE_KEY),
+            default=0,
+            adapter_name=section,
+        )
+    except AdapterConnectionError as exc:
+        raise ConfigValidationError(str(exc)) from exc
+
+    metadata.pop(LEGACY_BAUD_RATE_KEY, None)
+    metadata[BAUD_RATE_KEY] = resolved
 
 
 def _validate_coap_sensor_metadata(metadata: dict[str, Any], section: str) -> None:

--- a/ori/hal/base.py
+++ b/ori/hal/base.py
@@ -6,6 +6,7 @@ import enum
 import logging
 import time
 from abc import ABC, abstractmethod
+from typing import Any
 
 from ori.network.events import SensorReading
 
@@ -154,6 +155,83 @@ class HardwareCircuitBreaker:
             return True
 
         return False
+
+
+BAUD_RATE_KEY = "baud_rate"
+LEGACY_BAUD_RATE_KEY = "baudrate"
+
+
+def coerce_baud_rate(value: Any, key: str, adapter_name: str) -> int:
+    """A baud rate is a positive whole number, or it is a refusal.
+
+    Never a fallback to the default. A rate the runtime could not read is not
+    evidence that the operator wanted 9600.
+    """
+    rate: int | None = None
+    if isinstance(value, bool):
+        rate = None
+    elif isinstance(value, int):
+        rate = value
+    elif isinstance(value, float) and value.is_integer():
+        rate = int(value)
+    elif isinstance(value, str):
+        try:
+            rate = int(value.strip())
+        except ValueError:
+            rate = None
+
+    if rate is None or rate <= 0:
+        raise AdapterConnectionError(
+            f"{adapter_name}: '{key}' must be a positive whole number of bits "
+            f"per second, got {value!r}."
+        )
+    return rate
+
+
+def resolve_baud_rate(
+    *,
+    has_canonical: bool,
+    canonical: Any,
+    has_legacy: bool,
+    legacy: Any,
+    default: int,
+    adapter_name: str,
+) -> int:
+    """Resolve the canonical ``baud_rate``, bridging the legacy ``baudrate``.
+
+    One setting had two spellings across two adapters, so a serial sensor
+    configured with the wrong one ran at the default with nothing logged and
+    nothing refused.
+
+    Presence and value are passed in rather than the config dict, so each
+    adapter keeps a literal ``config.get("baud_rate")`` where a reader can see
+    it — and where the configuration-surface extractor can too. A helper that
+    swallowed the dict would make both adapters appear to read nothing, and an
+    inventory built from that would omit the key entirely.
+    """
+    if has_canonical and has_legacy:
+        raise AdapterConnectionError(
+            f"{adapter_name}: sensor config sets both '{BAUD_RATE_KEY}' and "
+            f"'{LEGACY_BAUD_RATE_KEY}'. Refused even when the values agree — "
+            f"ambiguity must not establish configuration. Keep "
+            f"'{BAUD_RATE_KEY}'."
+        )
+
+    if has_canonical:
+        return coerce_baud_rate(canonical, BAUD_RATE_KEY, adapter_name)
+
+    if has_legacy:
+        logger.warning(
+            "%s: '%s' is deprecated; the canonical spelling is '%s'. The alias "
+            "is accepted for this configuration generation and is removed when "
+            "runtime-config/v2 becomes the accepted surface. Rename it now.",
+            adapter_name,
+            LEGACY_BAUD_RATE_KEY,
+            BAUD_RATE_KEY,
+        )
+        return coerce_baud_rate(legacy, LEGACY_BAUD_RATE_KEY, adapter_name)
+
+    return default
 
 
 class BaseAdapter(ABC):

--- a/ori/hal/serial_adapter.py
+++ b/ori/hal/serial_adapter.py
@@ -12,6 +12,7 @@ from ori.hal.base import (
     AdapterTimeoutError,
     BaseAdapter,
     HardwareCircuitBreaker,
+    resolve_baud_rate,
 )
 from ori.network.events import SensorReading
 from ori.utils.time_utils import now_ms
@@ -166,7 +167,7 @@ class SerialAdapter(BaseAdapter):
             type: active_power
             protocol: serial
             port: /dev/ttyUSB0
-            baudrate: 9600
+            baud_rate: 9600
             slave_id: 1
     """
 
@@ -199,7 +200,8 @@ class SerialAdapter(BaseAdapter):
 
                 Optional keys:
 
-                - ``baudrate`` (int, default ``9600``)
+                - ``baud_rate`` (int, default ``9600``) — ``baudrate`` is
+                  accepted as a deprecated alias; setting both is refused
                 - ``bytesize`` (int, default ``8``)
                 - ``parity`` (str, default ``'N'``)
                 - ``stopbits`` (int, default ``1``)
@@ -230,7 +232,14 @@ class SerialAdapter(BaseAdapter):
                 "SerialAdapter: 'port' is required in sensor config (e.g. /dev/ttyUSB0)"
             )
 
-        self._baudrate = int(config.get("baudrate", _DEFAULT_BAUDRATE))
+        self._baudrate = resolve_baud_rate(
+            has_canonical="baud_rate" in config,
+            canonical=config.get("baud_rate"),
+            has_legacy="baudrate" in config,
+            legacy=config.get("baudrate"),
+            default=_DEFAULT_BAUDRATE,
+            adapter_name="SerialAdapter",
+        )
         self._bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
         self._parity = str(config.get("parity", _DEFAULT_PARITY))
         self._stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))

--- a/ori/hal/usb_serial_adapter.py
+++ b/ori/hal/usb_serial_adapter.py
@@ -15,6 +15,7 @@ from ori.hal.base import (
     AdapterTimeoutError,
     BaseAdapter,
     HardwareCircuitBreaker,
+    resolve_baud_rate,
 )
 from ori.network.events import SensorReading
 from ori.utils.time_utils import now_ms
@@ -142,10 +143,14 @@ class UsbSerialAdapter(BaseAdapter):
                 "UsbSerialAdapter: 'device_path' is required (e.g. /dev/ttyUSB0)"
             )
 
-        baud_from_cfg = config.get(
-            "baud_rate", config.get("baudrate", _DEFAULT_BAUD_RATE)
+        self._baud_rate = resolve_baud_rate(
+            has_canonical="baud_rate" in config,
+            canonical=config.get("baud_rate"),
+            has_legacy="baudrate" in config,
+            legacy=config.get("baudrate"),
+            default=_DEFAULT_BAUD_RATE,
+            adapter_name="UsbSerialAdapter",
         )
-        self._baud_rate = int(baud_from_cfg)
         self._bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
         self._parity = str(config.get("parity", _DEFAULT_PARITY))
         self._stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))

--- a/tests/test_config_surface_inventory.py
+++ b/tests/test_config_surface_inventory.py
@@ -287,17 +287,42 @@ def real_coverage() -> dict:
     return coverage(entries, example_paths())
 
 
-def test_real_coverage_maps_baud_rate_to_the_usb_adapter_only(
+def test_real_coverage_credits_baud_rate_to_both_serial_adapters(
     real_coverage: dict,
 ) -> None:
-    """The defect in ori-runtime #411, shown through the real adapters.
+    """ori-runtime #411, after the fix: one spelling, read by both adapters.
 
-    The shipped example sets `baud_rate` on a *serial* sensor, and only
-    `UsbSerialAdapter` reads that spelling.
+    The extractor sees a key only where an adapter reads it literally, so this
+    assertion is what keeps the shared resolver from hiding its own inputs. An
+    earlier version of the fix passed the whole config dict into the helper;
+    the extractor then reported that *neither* adapter read `baud_rate`, and a
+    schema built from `read_by_adapters` would have omitted the key outright.
+
+    An empty reader list is never the expected answer here. If this fails
+    because an adapter stopped reading the key explicitly, restore the read —
+    do not relax the assertion.
     """
     rows = {item["path"]: item for item in real_coverage["sensor_metadata"]}
     assert "sensors[].baud_rate" in rows
-    assert rows["sensors[].baud_rate"]["read_by_adapters"] == ["UsbSerialAdapter"]
+    assert rows["sensors[].baud_rate"]["read_by_adapters"] == [
+        "SerialAdapter",
+        "UsbSerialAdapter",
+    ]
+
+
+def test_the_deprecated_baud_alias_stays_discoverable() -> None:
+    """The migration window is only honest while the alias is visible.
+
+    `baudrate` is accepted until runtime-config/v2 lands. An operator's file may
+    still carry it, so an inventory that showed only the canonical spelling
+    would describe a surface narrower than the one the runtime accepts.
+    """
+    from tests.golden.build_config_surface_inventory import adapter_metadata
+
+    adapters = adapter_metadata()
+    for name in ("SerialAdapter", "UsbSerialAdapter"):
+        assert "baud_rate" in adapters[name]
+        assert "baudrate" in adapters[name], "the alias is still accepted"
 
 
 def test_real_coverage_credits_no_action_path_to_a_sensor_adapter(

--- a/tests/test_serial_adapter.py
+++ b/tests/test_serial_adapter.py
@@ -33,7 +33,7 @@ skip_if_no_serial = pytest.mark.skipif(
 def _config(
     sensor_type: str = "voltage",
     port: str = "/dev/ttyUSB0",
-    baudrate: int = 9600,
+    baud_rate: int = 9600,
     slave_id: int = 1,
     timeout: float = 1.0,
     register: int | None = None,
@@ -41,7 +41,7 @@ def _config(
     cfg: dict = {
         "sensor_type": sensor_type,
         "port": port,
-        "baudrate": baudrate,
+        "baud_rate": baud_rate,
         "slave_id": slave_id,
         "timeout": timeout,
     }
@@ -188,7 +188,7 @@ class TestConnect:
             patch("ori.hal.serial_adapter.serial", create=True) as mock_serial_mod,
         ):
             mock_serial_mod.Serial.return_value = MagicMock(is_open=True)
-            await adapter.connect(_config(sensor_type="voltage", baudrate=9600))
+            await adapter.connect(_config(sensor_type="voltage", baud_rate=9600))
 
         assert adapter.is_connected is True
         assert adapter._sensor_type == "voltage"
@@ -486,7 +486,7 @@ class TestSerialIntegration:
             {
                 "sensor_type": "voltage",
                 "port": "/dev/ttyUSB0",
-                "baudrate": 9600,
+                "baud_rate": 9600,
                 "slave_id": 1,
             }
         )

--- a/tests/test_serial_baud_rate.py
+++ b/tests/test_serial_baud_rate.py
@@ -1,0 +1,246 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the canonical `baud_rate` spelling and its legacy bridge.
+
+`ori.yaml.example` configured a serial sensor with `baud_rate`, and
+`SerialAdapter` read `baudrate`. The key was silently dropped and the port
+opened at the adapter's default, which looked correct only because the
+example's value happened to equal that default (ori-runtime #411).
+
+A key the runtime discards reads, to whoever wrote it, as a setting that took
+effect. So these tests assert on the rate the serial library was actually
+opened with, not on the attribute the adapter stored: an adapter that parses
+the value correctly and then opens the port at 9600 would pass the weaker
+check.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ori.config import ConfigValidationError, _parse_sensors
+from ori.hal.base import AdapterConnectionError
+from ori.hal.serial_adapter import SerialAdapter
+from ori.hal.usb_serial_adapter import UsbSerialAdapter
+
+
+def _serial_config(**overrides: Any) -> dict:
+    return {"sensor_type": "voltage", "port": "/dev/ttyUSB0", **overrides}
+
+
+def _usb_config(**overrides: Any) -> dict:
+    return {"sensor_type": "usb_power", "device_path": "/dev/ttyUSB0", **overrides}
+
+
+async def _open_serial(config: dict) -> tuple[SerialAdapter, dict]:
+    """Connect a SerialAdapter and return the kwargs pyserial was called with."""
+    adapter = SerialAdapter()
+    with (
+        patch("ori.hal.serial_adapter._SERIAL_AVAILABLE", True),
+        patch("ori.hal.serial_adapter.serial", create=True) as mod,
+    ):
+        mod.Serial.return_value = MagicMock(is_open=True)
+        await adapter.connect(config)
+        kwargs = mod.Serial.call_args.kwargs if mod.Serial.call_args else {}
+    return adapter, kwargs
+
+
+async def _open_usb(config: dict) -> tuple[UsbSerialAdapter, dict]:
+    adapter = UsbSerialAdapter()
+    with (
+        patch("ori.hal.usb_serial_adapter._PYSERIAL_AVAILABLE", True),
+        patch("ori.hal.usb_serial_adapter._serial_module", create=True) as mod,
+    ):
+        mod.Serial.return_value = MagicMock(is_open=True)
+        await adapter.connect(config)
+        kwargs = mod.Serial.call_args.kwargs if mod.Serial.call_args else {}
+    return adapter, kwargs
+
+
+# ── The canonical spelling reaches the port ──────────────────────────────────
+
+
+async def test_serial_adapter_opens_at_the_requested_baud_rate() -> None:
+    """The defect: this key was read as `baudrate` and dropped."""
+    adapter, kwargs = await _open_serial(_serial_config(baud_rate=19200))
+    assert adapter._baudrate == 19200
+    assert kwargs["baudrate"] == 19200
+
+
+async def test_usb_serial_adapter_opens_at_the_requested_baud_rate() -> None:
+    adapter, kwargs = await _open_usb(_usb_config(baud_rate=19200))
+    assert adapter._baud_rate == 19200
+    assert kwargs["baudrate"] == 19200
+
+
+async def test_a_default_is_used_only_when_the_key_is_absent() -> None:
+    adapter, kwargs = await _open_serial(_serial_config())
+    assert adapter._baudrate == 9600
+    assert kwargs["baudrate"] == 9600
+
+
+# ── The legacy alias works, and says so ──────────────────────────────────────
+
+
+async def test_legacy_spelling_still_opens_at_the_requested_rate(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        adapter, kwargs = await _open_serial(_serial_config(baudrate=19200))
+    assert adapter._baudrate == 19200
+    assert kwargs["baudrate"] == 19200
+    assert "baudrate" in caplog.text
+    assert "baud_rate" in caplog.text
+
+
+async def test_legacy_spelling_warns_on_the_usb_adapter_too(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The forgiving adapter is why the inconsistency survived unnoticed."""
+    with caplog.at_level(logging.WARNING):
+        adapter, kwargs = await _open_usb(_usb_config(baudrate=19200))
+    assert adapter._baud_rate == 19200
+    assert kwargs["baudrate"] == 19200
+    assert "deprecated" in caplog.text
+
+
+async def test_canonical_spelling_warns_about_nothing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    with caplog.at_level(logging.WARNING):
+        await _open_serial(_serial_config(baud_rate=19200))
+    assert "deprecated" not in caplog.text
+
+
+# ── Ambiguity is refused, not resolved ───────────────────────────────────────
+
+
+@pytest.mark.parametrize("values", [(9600, 19200), (9600, 9600)])
+async def test_both_spellings_are_refused(values: tuple[int, int]) -> None:
+    """Refused even when the two agree.
+
+    Picking a winner would mean the runtime decides which of two conflicting
+    declarations the operator meant. Agreement today is not agreement after
+    the next edit, and a precedence rule is invisible in the file that has it.
+    """
+    canonical, legacy = values
+    with pytest.raises(AdapterConnectionError, match="both"):
+        await _open_serial(_serial_config(baud_rate=canonical, baudrate=legacy))
+
+
+async def test_both_spellings_are_refused_on_the_usb_adapter() -> None:
+    with pytest.raises(AdapterConnectionError, match="both"):
+        await _open_usb(_usb_config(baud_rate=9600, baudrate=9600))
+
+
+# ── A value that cannot be read is a refusal, never the default ──────────────
+
+
+@pytest.mark.parametrize(
+    "bad", ["fast", "", 0, -1, 9600.5, True, False, None, [9600], {"rate": 9600}]
+)
+async def test_an_unreadable_rate_is_refused_rather_than_defaulted(bad: Any) -> None:
+    """9600 must never be the answer to a value the runtime could not parse.
+
+    `True` is here because Python makes it an instance of `int`, so a naive
+    check reads it as 1 baud.
+    """
+    with pytest.raises(AdapterConnectionError):
+        await _open_serial(_serial_config(baud_rate=bad))
+
+
+@pytest.mark.parametrize(
+    "good, expected", [(19200, 19200), ("19200", 19200), (9600.0, 9600)]
+)
+async def test_a_rate_that_reads_as_a_whole_number_is_accepted(
+    good: Any, expected: int
+) -> None:
+    """A quoted or float-typed rate is an existing YAML spelling, not an error."""
+    adapter, kwargs = await _open_serial(_serial_config(baud_rate=good))
+    assert adapter._baudrate == expected
+    assert kwargs["baudrate"] == expected
+
+
+# ── The config boundary refuses before any hardware is touched ───────────────
+#
+# The adapter check alone is not enough: without `pyserial`, `connect()` raises
+# before it ever resolves a baud rate, so an ambiguous config would load clean
+# on a developer machine and surface only on the Pi.
+
+
+def _sensor(protocol: str = "serial", **overrides: Any) -> list[dict]:
+    return [
+        {
+            "id": "meter",
+            "type": "voltage",
+            "protocol": protocol,
+            "port": "/dev/ttyUSB0",
+            **overrides,
+        }
+    ]
+
+
+def test_config_load_refuses_both_spellings() -> None:
+    with pytest.raises(ConfigValidationError, match="both"):
+        _parse_sensors(_sensor(baud_rate=9600, baudrate=9600))
+
+
+def test_config_load_refuses_an_unreadable_rate() -> None:
+    with pytest.raises(ConfigValidationError):
+        _parse_sensors(_sensor(baud_rate="fast"))
+
+
+def test_config_load_rewrites_the_legacy_key(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Normalised at the boundary, so the deprecation is logged once."""
+    with caplog.at_level(logging.WARNING):
+        sensors = _parse_sensors(_sensor(baudrate=19200))
+    assert sensors[0].metadata["baud_rate"] == 19200
+    assert "baudrate" not in sensors[0].metadata
+    assert "deprecated" in caplog.text
+
+
+def test_config_load_leaves_the_canonical_key_alone() -> None:
+    sensors = _parse_sensors(_sensor(baud_rate=19200))
+    assert sensors[0].metadata["baud_rate"] == 19200
+
+
+def test_config_load_covers_the_usb_serial_protocol() -> None:
+    with pytest.raises(ConfigValidationError, match="both"):
+        _parse_sensors(_sensor(protocol="usb_serial", baud_rate=9600, baudrate=9600))
+
+
+def test_config_load_does_not_invent_a_rate_where_none_was_set() -> None:
+    sensors = _parse_sensors(_sensor())
+    assert "baud_rate" not in sensors[0].metadata
+
+
+def test_a_non_serial_protocol_is_left_untouched() -> None:
+    """The bridge is scoped to the protocols whose adapters read a baud rate."""
+    sensors = _parse_sensors(
+        [{"id": "cpu", "type": "cpu_percent", "protocol": "psutil", "baudrate": 123}]
+    )
+    assert sensors[0].metadata["baudrate"] == 123
+
+
+# ── The shipped examples ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "example", ["ori.yaml.example", "ori.yaml.phone.example", "ori.linux.yaml.example"]
+)
+def test_shipped_examples_use_only_the_canonical_spelling(example: str) -> None:
+    """The example is what operators copy, so it is the surface that teaches."""
+    import pathlib
+
+    path = pathlib.Path(__file__).resolve().parents[1] / example
+    if not path.exists():
+        pytest.skip(f"{example} is not shipped")
+    text = path.read_text()
+    assert "baudrate" not in text


### PR DESCRIPTION
## What does this PR do?

`ori.yaml.example` configures a serial sensor with `baud_rate`. `SerialAdapter` read `baudrate`.

The key was accepted by the loader, forwarded into metadata, and dropped by the adapter that never asked for it. **Setting `baud_rate: 19200` ran the device at 9600** — nothing logged, nothing refused. It looked correct only because the example's value equalled the adapter's default.

`UsbSerialAdapter` read *both* spellings, which is how this survived: one adapter was forgiving, the other was not, and the shipped example used the spelling only the forgiving one accepted.

**Why it is not cosmetic.** `_parse_sensors` keeps five keys and routes everything else into unvalidated metadata, which `runtime.py` merges into the dict passed to `connect()`. Any misspelled sensor key is accepted, forwarded, and discarded. A key the runtime discards reads, to whoever wrote it, as a setting that took effect.

## The rule

`baud_rate` is canonical, honoured by both adapters. `baudrate` is accepted for this configuration generation with a deprecation warning naming its replacement, and is removed when `runtime-config/v2` becomes the accepted surface.

**Both spellings together are refused, even when the values agree.** Agreement today is not agreement after the next edit, and a precedence rule is invisible in the file that has it. Ambiguity must not establish configuration.

**A value that cannot be read is a refusal, never the default.** A rate the runtime could not parse is not evidence that the operator wanted 9600. Booleans are refused explicitly — Python makes `True` an instance of `int`, so a naive check reads it as 1 baud. Quoted and float-typed whole numbers stay accepted; they are existing YAML spellings, not errors.

## Two things worth reviewing closely

**Refused at config load, not only in the adapter.** Without `pyserial`, an adapter raises before it ever resolves a baud rate — so an ambiguous file would load clean on a developer machine and surface only on the Pi. The loader refuses for `serial` and `usb_serial`, and normalises the legacy key so the deprecation warns once at startup. The adapter check stays an independent boundary, not a formality that holds only because the loader held.

**The shared resolver takes presence and values, not the config dict.** An earlier version passed the dict, which left no `config.get("baud_rate")` in either adapter — and the configuration-surface extractor then reported that **nothing** reads the key. That output is false, and a schema derived from it would omit the setting outright. Each adapter now keeps its own literal reads while shared code still owns ambiguity, warning and coercion.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability gains, loses, or changes availability. A serial sensor that worked still works; one configured with a non-default rate now runs at the rate it asked for. Nothing in the capability matrix describes baud selection.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #411
- [x] Every new Tier D code path has test coverage — no Tier D path is touched
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #411

## Testing notes

**4295 passed, 27 skipped.** 32 new tests, no hardware required.

Tests assert **the rate pyserial was actually opened with**, not the attribute the adapter stored — an adapter that parses the value correctly and then opens the port at 9600 would pass the weaker check.

Six mutations, each failing a distinct set:

| Mutation | Failures |
|---|---|
| Original defect restored | 16 |
| Value coercion removed | 11 |
| Ambiguity refusal removed | 5 |
| Config-load boundary removed | 4 |
| Deprecation warning downgraded to `debug` | 3 |
| Either adapter loses its explicit read | both production-seam tests |

Invalid values covered: `"fast"`, `""`, `0`, `-1`, `9600.5`, `True`, `False`, `None`, list, dict. Accepted: `19200`, `"19200"`, `9600.0`.

**One stale artifact, not fixed here.** The configuration surface inventory published at ori-specs#112 records `sensors[].baud_rate` as read by `UsbSerialAdapter` only. It is pinned to the pre-fix commit and is non-normative, so it is left alone; the correct reading after this change is both adapters, and the production-seam test asserts exactly that.
