### PR TITLE
docs(agents): require self-review before handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -789,3 +789,18 @@ these rules can compromise the runtime that controls physical hardware.
 | Add a bundled skill                   | `skills/`                            |
 | Understand a design decision          | `CLAUDE.md`                          |
 | Understand the business context       | `CONTRIBUTING.md`                    |
+
+## Review before handoff
+
+Self-review before handing off work is **required, and is never sufficient
+proof.** State plainly what remains unverified: what was simulated, deferred,
+tested on the host only, or left dependent on another repository or on hardware.
+A handoff that lists only successes misrepresents its own coverage.
+
+It does not replace independent review for shared contracts, Tier D or
+physical-authority changes, release and install work, or any claim of HIL proof.
+
+The method is the `ori-rigorous-review` skill, kept in the `ori-specs`
+repository under `agent-skills/` and installed with
+`scripts/install-agent-skills`. Read it before reviewing; do not reimplement it
+here.

--- a/tests/vectors/commissioned_safety_binding/MANIFEST.json
+++ b/tests/vectors/commissioned_safety_binding/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "commissioned-safety-binding",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "binding-vectors-v1.json": "c1d6f25aaa399897065bccf0041743edaebfcecf52d660cb70940cf88e5b980a"

--- a/tests/vectors/evidence_exchange/MANIFEST.json
+++ b/tests/vectors/evidence_exchange/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-registration.json": "dd9f7f0cbf320abd5f5d594ab4e20e75b3fd7c3ff3cab4b6a1ed0749a7a72536",

--- a/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
+++ b/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors/receiver-state",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-quarantine.json": "ec5922987116b8487d1f49cb29bb53cd0cb44ef6cc8872f4a7b9ada8e8714bbd",

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",

--- a/tests/vectors/gateway_api/MANIFEST.json
+++ b/tests/vectors/gateway_api/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "gateway-api/vectors",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "inbound-evidence.json": "cb18d5f6fad051f6ca1924b20ef1040d2d67185c41a9a9eccee6159db0eb0473",

--- a/tests/vectors/runtime_evidence_anchor/MANIFEST.json
+++ b/tests/vectors/runtime_evidence_anchor/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "runtime-evidence-anchor/vectors",
-  "source_commit": "aeef770a782bfe1e2603863e796bfb43858e84c1",
+  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "runtime-anchor.json": "bd8e46cdff590447213d99e892b7f67480188134163d0a207e9f396b94847190"


### PR DESCRIPTION
## What does this PR do?

Adds one always-loaded rule: self-review before handoff is required, and is never sufficient proof.

The method itself is not restated here. It lives in the `ori-rigorous-review` skill, added to `ori-specs` in ori-platform/ori-specs#115, so there is one copy to review and correct rather than fourteen that drift. This file carries only the trigger, because a skill cannot invoke itself and the decision to review has to be in always-loaded context.

The rule is deliberately bounded: self-review does not replace independent review for shared contracts, Tier D or physical-authority changes, release and install work, or any claim of HIL proof. Stated as "always self-review before handing off", the rule invites reading self-review as sufficient, which would be worse than having no rule at all.

Documentation only. No code, tests, build, or CI surface is touched.

<!-- Describe the change. Focus on WHY, not just what. -->

## Type of change

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [ ] `pytest tests/ -v` passes with 0 failures
- [ ] `ruff check --fix ori/ tests/ skills/` is clean
- [ ] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [ ] PR description explains **why**, not just what

### If you used AI assistance

- [ ] I can explain every line of AI-generated code in this PR
- [ ] I have read and understood all files I am modifying
- [ ] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [ ] I opened an issue and discussed this change before writing code
- [ ] Every new Tier D code path has test coverage
- [ ] No new dependencies added without prior issue discussion

### If this adds or modifies a bundled skill (`/skills/`)

> **Community skills go to [ori-platform/ori-skills](https://github.com/ori-platform/ori-skills) — not here.**
> PRs to `/skills/` in this repo are for first-party bundled skills only.

- [ ] I opened an issue and got maintainer approval before writing this skill
- [ ] `action_tier` is declared on every trigger
- [ ] `bypass_llm: true` is only paired with `action_tier: D`
- [ ] Tier C triggers declare `safe_default_action`, and it is a non-actuating action
- [ ] Every action is declared at or above its minimum tier in `ori/reasoning/action_registry.py`
- [ ] Any new executable action has a matching registry entry (registration is refused without one)
- [ ] The skill is within the workload budgets — triggers, sensors, the trigger × sensor product, and default actions per trigger
- [ ] `hooks.py` is clean and minimal
- [ ] No `subprocess` calls in hooks

> **Packaged skills run with the runtime's own authority.** Their `hooks.py` is
> imported directly into the runtime interpreter, and only packaged skills may
> declare `action_tier: D`. There is no sandbox standing between a bundled hook
> and the process — the previous in-process one was removed in v2.4.0 because it
> could be escaped. Review bundled hooks as runtime code, not as skill content.

## Related issue

<!-- Closes #<issue-number> -->

## Testing notes

<!-- Anything unusual about how this was tested? Hardware-specific? -->

---

Checklist items above are left for the reviewer: this is a documentation-only change and no test, build, or CI surface was exercised in this repository.
