### PR TITLE
fix(config): stop a sensor entry displacing what the runtime supplies

### DIFF
--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -225,6 +225,34 @@ Nothing publishes an artifact outbound yet.
   no safety cutoff is commissioned. Its fixed disclaimer cannot be removed by
   a long operator-configured location.
 
+## Breaking configuration change
+
+**A sensor entry may no longer set `sensor_id`, `sensor_type` or
+`circuit_breaker`.** Startup refuses the configuration and names the offending
+keys.
+
+These are supplied by the runtime when it builds an adapter's connection
+config, and sensor metadata was spread over them, so they took effect. A sensor
+could disable hardware recovery for its own adapter while `hal.circuit_breaker`
+still read as configured, or reach its adapter declaring a type it was not
+configured as — so the reading was produced under an identity nobody declared.
+
+Neither did what whoever wrote it intended, so no working deployment is losing
+behaviour. A device that carries one of these keys will refuse to start until
+it is removed, which is deliberate: on a runtime that can act physically, a
+setting that never applied should stop the device rather than continue to look
+applied.
+
+Sensor identity comes from `id` and `type`; breaker settings come from
+`hal.circuit_breaker`.
+
+Per-sensor breaker tuning is a legitimate need this refusal does not serve, and
+a bounded mechanism for it is open as #419. It is not a simple relaxation:
+opening a breaker blocks reads, so on a sensor feeding a Tier D condition an
+over-eager breaker removes the input the protection path depends on. Neither
+tripping sooner nor later is unambiguously the safe direction, which is why the
+key is refused rather than bounded by a guess.
+
 ## Known gaps in this candidate
 
 - WhatsApp alerts cannot be delivered outside a sandbox: the provider models a

--- a/ori/config.py
+++ b/ori/config.py
@@ -39,6 +39,13 @@ logger = logging.getLogger(__name__)
 
 _VALID_ACTION_TIERS = {"A", "B", "C", "D"}
 _SERIAL_PROTOCOLS = {"serial", "usb_serial"}
+
+# Supplied by runtime.py when it assembles an adapter's connect() config, and
+# therefore not settable on a sensor. `calibration` is absent because it is
+# already a first-class sensor key and never reaches metadata.
+RESERVED_SENSOR_METADATA_KEYS = frozenset(
+    {"sensor_id", "sensor_type", "circuit_breaker"}
+)
 _ENV_VAR_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -677,6 +684,7 @@ def _parse_sensors(data: Any) -> list[SensorConfig]:
         # Fields not in the first-class set go into metadata
         known = {"id", "type", "protocol", "poll_interval_ms", "calibration"}
         metadata = {k: v for k, v in item.items() if k not in known}
+        _refuse_reserved_sensor_metadata(metadata, f"sensors[{i}]", sensor_id)
         if protocol == "coap":
             _validate_coap_sensor_metadata(metadata, f"sensors[{i}]")
         if protocol in _SERIAL_PROTOCOLS:
@@ -693,6 +701,36 @@ def _parse_sensors(data: Any) -> list[SensorConfig]:
             )
         )
     return sensors
+
+
+def _refuse_reserved_sensor_metadata(
+    metadata: dict[str, Any], section: str, sensor_id: str
+) -> None:
+    """Refuse a sensor key that would displace a value the runtime supplies.
+
+    `runtime.py` builds the adapter's config by injecting the sensor's identity
+    and the HAL circuit-breaker settings, then spreading metadata over the top.
+    Metadata therefore wins, and these three names are not in the first-class
+    set, so a sensor entry could set them.
+
+    Both consequences are severe enough to refuse rather than resolve by
+    precedence. `circuit_breaker` makes hardware recovery configurable per
+    sensor, which is the bypass the HAL rules forbid. `sensor_type` decides what
+    the adapter reads and in what unit, so a sensor declared one way reaches its
+    adapter as another, and the reading is produced under an identity the
+    operator did not declare.
+
+    An operator who wrote one of these meant something by it, and silently
+    preferring the runtime's value would be the same defect one level down.
+    """
+    reserved = sorted(RESERVED_SENSOR_METADATA_KEYS & set(metadata))
+    if reserved:
+        raise ConfigValidationError(
+            f"{section} (id={sensor_id!r}): {', '.join(repr(k) for k in reserved)} "
+            f"{'is' if len(reserved) == 1 else 'are'} supplied by the runtime and "
+            f"cannot be set on a sensor. Use 'id' and 'type' for sensor identity, "
+            f"and 'hal.circuit_breaker' for breaker settings."
+        )
 
 
 def _normalise_serial_sensor_baud(metadata: dict[str, Any], section: str) -> None:

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -964,7 +964,14 @@ class OriRuntime:
                 adapter = make_adapter(sensor_cfg.protocol)
             except UnknownProtocolError as exc:
                 raise ConfigValidationError(str(exc)) from exc
+            # Metadata is spread first and the runtime's own values are applied
+            # over it, never the reverse. Config load already refuses a sensor
+            # that names one of these, and this ordering means the boundary does
+            # not depend on that check having run: a metadata key reaching here
+            # cannot displace the sensor's declared identity or the circuit
+            # breaker, which would make hardware recovery settable per sensor.
             connect_cfg = {
+                **sensor_cfg.metadata,
                 "sensor_id": sensor_cfg.id,
                 "sensor_type": sensor_cfg.type,
                 "circuit_breaker": config.hal.circuit_breaker,
@@ -972,7 +979,6 @@ class OriRuntime:
                 # into the same namespace. Flattening is what let a documented
                 # `sensitivity` sit unread beside the adapter's own default.
                 "calibration": dict(sensor_cfg.calibration),
-                **sensor_cfg.metadata,
             }
             if sensor_cfg.protocol == "coap":
                 coap_cfg = (

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -41,7 +41,12 @@ from ori.actions.relay import (
 from ori.actions.sms import SMSAction
 from ori.actions.system_control import SystemControlAction
 from ori.actions.whatsapp import TwilioProvider, WhatsAppAction
-from ori.config import Config, ConfigValidationError, requires_production_posture
+from ori.config import (
+    Config,
+    ConfigValidationError,
+    SensorConfig,
+    requires_production_posture,
+)
 from ori.firmware_mqtt_operator import (
     FirmwareMqttOperatorController,
     FirmwareMqttOperatorServer,
@@ -223,6 +228,39 @@ def _resolve_dispatcher_approval_timeout(
         if candidate > resolved:
             resolved = candidate
     return max(1, resolved)
+
+
+def adapter_connect_config(sensor_cfg: SensorConfig, config: Config) -> dict[str, Any]:
+    """Build the dict handed to an adapter's ``connect()``.
+
+    Metadata is spread first and the runtime's own values are applied over it,
+    never the reverse. Config load already refuses a sensor that names one of
+    these, and this ordering means the boundary does not depend on that check
+    having run: a metadata key reaching here cannot displace the sensor's
+    declared identity or the circuit breaker, which would make hardware
+    recovery settable per sensor.
+
+    Extracted from ``start()`` so the boundary is a unit a test can drive with
+    a real adapter, rather than ten lines inside an eight-hundred-line method.
+    """
+    connect_cfg: dict[str, Any] = {
+        **sensor_cfg.metadata,
+        "sensor_id": sensor_cfg.id,
+        "sensor_type": sensor_cfg.type,
+        "circuit_breaker": config.hal.circuit_breaker,
+        # Calibration is passed as its own block rather than flattened into the
+        # same namespace. Flattening is what let a documented `sensitivity` sit
+        # unread beside the adapter's own default.
+        "calibration": dict(sensor_cfg.calibration),
+    }
+    if sensor_cfg.protocol == "coap":
+        coap_cfg = config.actions.coap if isinstance(config.actions.coap, dict) else {}
+        # setdefault, so a sensor may narrow its own host allowlist. It cannot
+        # widen it: the uri host is validated against actions.coap.allowed_hosts
+        # at config load, in a section sensor metadata cannot reach.
+        connect_cfg.setdefault("allowed_hosts", coap_cfg.get("allowed_hosts", []))
+        connect_cfg.setdefault("timeout_s", coap_cfg.get("timeout_s", 2.0))
+    return connect_cfg
 
 
 class OriRuntime:
@@ -964,30 +1002,7 @@ class OriRuntime:
                 adapter = make_adapter(sensor_cfg.protocol)
             except UnknownProtocolError as exc:
                 raise ConfigValidationError(str(exc)) from exc
-            # Metadata is spread first and the runtime's own values are applied
-            # over it, never the reverse. Config load already refuses a sensor
-            # that names one of these, and this ordering means the boundary does
-            # not depend on that check having run: a metadata key reaching here
-            # cannot displace the sensor's declared identity or the circuit
-            # breaker, which would make hardware recovery settable per sensor.
-            connect_cfg = {
-                **sensor_cfg.metadata,
-                "sensor_id": sensor_cfg.id,
-                "sensor_type": sensor_cfg.type,
-                "circuit_breaker": config.hal.circuit_breaker,
-                # Calibration is passed as its own block rather than flattened
-                # into the same namespace. Flattening is what let a documented
-                # `sensitivity` sit unread beside the adapter's own default.
-                "calibration": dict(sensor_cfg.calibration),
-            }
-            if sensor_cfg.protocol == "coap":
-                coap_cfg = (
-                    config.actions.coap if isinstance(config.actions.coap, dict) else {}
-                )
-                connect_cfg.setdefault(
-                    "allowed_hosts", coap_cfg.get("allowed_hosts", [])
-                )
-                connect_cfg.setdefault("timeout_s", coap_cfg.get("timeout_s", 2.0))
+            connect_cfg = adapter_connect_config(sensor_cfg, config)
             try:
                 await adapter.connect(connect_cfg)
                 self._adapters.append(adapter)

--- a/tests/test_sensor_metadata_reserved_keys.py
+++ b/tests/test_sensor_metadata_reserved_keys.py
@@ -22,6 +22,7 @@ boundary.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -29,8 +30,12 @@ import pytest
 from ori.config import (
     RESERVED_SENSOR_METADATA_KEYS,
     ConfigValidationError,
+    SensorConfig,
     _parse_sensors,
 )
+from ori.hal.base import CircuitState
+from ori.hal.psutil_adapter import PsutilAdapter
+from ori.runtime import adapter_connect_config
 
 
 def _sensor(**overrides: Any) -> list[dict]:
@@ -81,59 +86,156 @@ def test_an_ordinary_sensor_still_loads() -> None:
 # ── Layer 2: the runtime's assembly cannot be displaced ──────────────────────
 
 
-def _assemble(metadata: dict[str, Any]) -> dict[str, Any]:
-    """Reproduce runtime.py's connect_cfg assembly for a sensor.
+def _config(circuit_breaker: dict[str, Any] | None = None) -> Any:
+    """A Config stub carrying only what the assembly reads."""
+    return SimpleNamespace(
+        hal=SimpleNamespace(
+            circuit_breaker=circuit_breaker
+            or {
+                "failure_threshold": 5,
+                "recovery_timeout_s": 300,
+                "success_threshold": 2,
+            }
+        ),
+        actions=SimpleNamespace(coap={}),
+    )
 
-    Built from the real source rather than restated, so a change to the
-    ordering in runtime.py fails here instead of passing against a copy that
-    drifted.
+
+def _poisoned(**metadata: Any) -> SensorConfig:
+    """A sensor whose metadata names runtime-supplied keys.
+
+    Built directly rather than through the loader, because the loader now
+    refuses exactly this. That is the point: the assembly must hold on its own,
+    for a value that reached it by any route the loader did not see.
+    """
+    return SensorConfig(
+        id="load-current",
+        type="cpu_percent",
+        protocol="psutil",
+        poll_interval_ms=1000,
+        metadata=metadata,
+        calibration={},
+    )
+
+
+@pytest.mark.parametrize(
+    "key, poison",
+    [
+        ("sensor_id", "spoofed"),
+        ("sensor_type", "temperature"),
+        ("circuit_breaker", {"failure_threshold": 999}),
+    ],
+)
+def test_metadata_cannot_displace_a_runtime_supplied_key(key: str, poison: Any) -> None:
+    cfg = adapter_connect_config(_poisoned(**{key: poison}), _config())
+    assert cfg[key] != poison
+
+
+def test_metadata_that_names_nothing_reserved_survives_assembly() -> None:
+    cfg = adapter_connect_config(_poisoned(port="/dev/ttyUSB0"), _config())
+    assert cfg["port"] == "/dev/ttyUSB0"
+
+
+def test_every_reserved_key_is_actually_supplied_by_the_assembly() -> None:
+    """The reserved set and what the runtime supplies must not drift apart.
+
+    A name reserved at load but no longer supplied would refuse a key for a
+    reason that stopped being true; one supplied but not reserved is #416 again.
+    """
+    assert RESERVED_SENSOR_METADATA_KEYS <= set(
+        adapter_connect_config(_poisoned(), _config())
+    )
+
+
+# ── Behavioural: a real adapter, connected, keeps the runtime's breaker ──────
+#
+# Everything above inspects a dict. This drives a real HAL adapter through the
+# real assembly and asserts the breaker it built, because an assembly that
+# produces the right dict and an adapter that ignores it would pass the
+# structural check and still be wrong on a device.
+
+
+async def test_a_connected_adapter_uses_the_runtime_breaker_not_the_sensor_one() -> (
+    None
+):
+    global_cb = {
+        "failure_threshold": 5,
+        "recovery_timeout_s": 300,
+        "success_threshold": 2,
+    }
+    sensor = _poisoned(
+        circuit_breaker={"failure_threshold": 999, "recovery_timeout_s": 1}
+    )
+
+    adapter = PsutilAdapter()
+    await adapter.connect(adapter_connect_config(sensor, _config(global_cb)))
+
+    breaker = adapter._breaker
+    assert breaker is not None
+    assert breaker.failure_threshold == 5, "the sensor's 999 must not reach the breaker"
+    assert breaker.recovery_timeout_s == 300
+
+
+async def test_a_connected_adapter_keeps_the_declared_sensor_identity() -> None:
+    # Both types are ones PsutilAdapter supports, so a win by the poison would
+    # silently read the wrong metric rather than raising.
+    sensor = _poisoned(sensor_type="memory_percent", sensor_id="spoofed")
+
+    adapter = PsutilAdapter()
+    await adapter.connect(adapter_connect_config(sensor, _config()))
+
+    # `read()` takes the sensor id from its caller, so the identity that comes
+    # from config -- and therefore the one at risk here -- is the type.
+    reading = await adapter.read("load-current")
+    assert adapter._sensor_type == "cpu_percent"
+    assert reading.sensor_type == "cpu_percent"
+    assert reading.unit == "percent"
+
+
+async def test_the_breaker_still_opens_at_the_configured_threshold() -> None:
+    """A boundary that produced an unusable breaker would also pass the above."""
+    adapter = PsutilAdapter()
+    await adapter.connect(
+        adapter_connect_config(_poisoned(), _config({"failure_threshold": 2}))
+    )
+    breaker = adapter._breaker
+    assert breaker is not None
+    assert breaker.state is CircuitState.CLOSED
+    for _ in range(2):
+        breaker._record_failure()
+    assert breaker.state is CircuitState.OPEN
+
+
+def test_start_uses_the_shared_assembly_rather_than_its_own_dict() -> None:
+    """The join, not the unit.
+
+    Everything above drives `adapter_connect_config` directly. All of it would
+    still pass if `start()` went back to building its own `connect_cfg` literal,
+    which is precisely how the defect existed in the first place. This asserts
+    the call site, so the unit and its caller cannot drift apart.
     """
     import ast
     import pathlib
 
-    source = pathlib.Path("ori/runtime.py").read_text()
-    tree = ast.parse(source)
+    tree = ast.parse(pathlib.Path("ori/runtime.py").read_text())
+    calls, literals = 0, 0
     for node in ast.walk(tree):
-        if (
-            isinstance(node, ast.Assign)
-            and any(
-                isinstance(t, ast.Name) and t.id == "connect_cfg" for t in node.targets
-            )
-            and isinstance(node.value, ast.Dict)
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(t, ast.Name) and t.id == "connect_cfg" for t in node.targets
         ):
-            keys: list[str | None] = [
-                k.value
-                if isinstance(k, ast.Constant) and isinstance(k.value, str)
-                else None
-                for k in node.value.keys
-            ]
-            # None marks the ** spread of metadata.
-            spread_at = keys.index(None)
-            injected_after = [k for k in keys[spread_at + 1 :] if k is not None]
-            result: dict[str, Any] = dict(metadata)
-            for name in injected_after:
-                result[name] = f"<runtime:{name}>"
-            return result
-    raise AssertionError("connect_cfg assignment not found in ori/runtime.py")
+            continue
+        if isinstance(node.value, ast.Dict):
+            literals += 1
+        elif (
+            isinstance(node.value, ast.Call)
+            and isinstance(node.value.func, ast.Name)
+            and node.value.func.id == "adapter_connect_config"
+        ):
+            calls += 1
 
-
-@pytest.mark.parametrize("key", ["sensor_id", "sensor_type", "circuit_breaker"])
-def test_metadata_cannot_displace_a_runtime_supplied_key(key: str) -> None:
-    """The spread comes first; the runtime's values are applied over it."""
-    assembled = _assemble({key: "spoofed"})
-    assert assembled[key] == f"<runtime:{key}>"
-
-
-def test_metadata_that_names_nothing_reserved_survives_assembly() -> None:
-    assembled = _assemble({"port": "/dev/ttyUSB0"})
-    assert assembled["port"] == "/dev/ttyUSB0"
-
-
-def test_every_reserved_key_is_actually_injected_by_the_runtime() -> None:
-    """The reserved set and the runtime's injection must not drift apart.
-
-    A name reserved at load but no longer injected would refuse a key for a
-    reason that stopped being true; one injected but not reserved is #416 again.
-    """
-    injected = set(_assemble({}))
-    assert RESERVED_SENSOR_METADATA_KEYS <= injected
+    assert calls == 1, (
+        "start() must build the adapter config through the shared assembly"
+    )
+    assert literals == 0, "no dict literal may rebuild connect_cfg alongside it"

--- a/tests/test_sensor_metadata_reserved_keys.py
+++ b/tests/test_sensor_metadata_reserved_keys.py
@@ -1,0 +1,139 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""A sensor entry must not displace what the runtime supplies to an adapter.
+
+`runtime.py` injects the sensor's identity and the HAL circuit-breaker settings
+into the dict handed to `adapter.connect()`. Those names were not in the
+first-class set `_parse_sensors` withholds, and metadata was spread last, so a
+sensor entry could overwrite them (ori-runtime #416).
+
+Two consequences made this a safety defect rather than an untidiness. A sensor
+could raise `failure_threshold` to a value its adapter would never reach,
+disabling breaker recovery for that adapter while `hal.circuit_breaker` still
+read as configured. And a sensor declared one type could reach its adapter as
+another, so the reading was produced under an identity nobody declared.
+
+Both layers are tested separately on purpose. Config load refuses the entry;
+the runtime's assembly order refuses to be displaced even if something reaches
+it anyway. A check that holds only because an earlier check held is not a
+boundary.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ori.config import (
+    RESERVED_SENSOR_METADATA_KEYS,
+    ConfigValidationError,
+    _parse_sensors,
+)
+
+
+def _sensor(**overrides: Any) -> list[dict]:
+    return [
+        {"id": "load-current", "type": "current", "protocol": "psutil", **overrides}
+    ]
+
+
+# ── Layer 1: config load refuses the entry ───────────────────────────────────
+
+
+@pytest.mark.parametrize("key", sorted(RESERVED_SENSOR_METADATA_KEYS))
+def test_a_reserved_key_on_a_sensor_is_refused(key: str) -> None:
+    with pytest.raises(ConfigValidationError, match="supplied by the runtime"):
+        _parse_sensors(_sensor(**{key: "anything"}))
+
+
+def test_the_refusal_names_every_offending_key() -> None:
+    """One error listing all of them, not one error per run of the loader."""
+    with pytest.raises(ConfigValidationError) as excinfo:
+        _parse_sensors(_sensor(sensor_type="temperature", circuit_breaker={}))
+    message = str(excinfo.value)
+    assert "'circuit_breaker'" in message
+    assert "'sensor_type'" in message
+
+
+def test_the_refusal_says_where_the_setting_belongs() -> None:
+    """A refusal that does not say what to do instead invites a workaround."""
+    with pytest.raises(ConfigValidationError) as excinfo:
+        _parse_sensors(_sensor(circuit_breaker={"failure_threshold": 999}))
+    assert "hal.circuit_breaker" in str(excinfo.value)
+
+
+def test_calibration_is_not_in_the_reserved_set() -> None:
+    """It is a first-class sensor key, so it never reaches metadata at all.
+
+    Reserving it would refuse `calibration:` on every sensor that uses it.
+    """
+    assert "calibration" not in RESERVED_SENSOR_METADATA_KEYS
+    assert _parse_sensors(_sensor(calibration={"sensitivity": 0.066}))[0].calibration
+
+
+def test_an_ordinary_sensor_still_loads() -> None:
+    sensors = _parse_sensors(_sensor(port="/dev/ttyUSB0"))
+    assert sensors[0].metadata == {"port": "/dev/ttyUSB0"}
+
+
+# ── Layer 2: the runtime's assembly cannot be displaced ──────────────────────
+
+
+def _assemble(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Reproduce runtime.py's connect_cfg assembly for a sensor.
+
+    Built from the real source rather than restated, so a change to the
+    ordering in runtime.py fails here instead of passing against a copy that
+    drifted.
+    """
+    import ast
+    import pathlib
+
+    source = pathlib.Path("ori/runtime.py").read_text()
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Assign)
+            and any(
+                isinstance(t, ast.Name) and t.id == "connect_cfg" for t in node.targets
+            )
+            and isinstance(node.value, ast.Dict)
+        ):
+            keys: list[str | None] = [
+                k.value
+                if isinstance(k, ast.Constant) and isinstance(k.value, str)
+                else None
+                for k in node.value.keys
+            ]
+            # None marks the ** spread of metadata.
+            spread_at = keys.index(None)
+            injected_after = [k for k in keys[spread_at + 1 :] if k is not None]
+            result: dict[str, Any] = dict(metadata)
+            for name in injected_after:
+                result[name] = f"<runtime:{name}>"
+            return result
+    raise AssertionError("connect_cfg assignment not found in ori/runtime.py")
+
+
+@pytest.mark.parametrize("key", ["sensor_id", "sensor_type", "circuit_breaker"])
+def test_metadata_cannot_displace_a_runtime_supplied_key(key: str) -> None:
+    """The spread comes first; the runtime's values are applied over it."""
+    assembled = _assemble({key: "spoofed"})
+    assert assembled[key] == f"<runtime:{key}>"
+
+
+def test_metadata_that_names_nothing_reserved_survives_assembly() -> None:
+    assembled = _assemble({"port": "/dev/ttyUSB0"})
+    assert assembled["port"] == "/dev/ttyUSB0"
+
+
+def test_every_reserved_key_is_actually_injected_by_the_runtime() -> None:
+    """The reserved set and the runtime's injection must not drift apart.
+
+    A name reserved at load but no longer injected would refuse a key for a
+    reason that stopped being true; one injected but not reserved is #416 again.
+    """
+    injected = set(_assemble({}))
+    assert RESERVED_SENSOR_METADATA_KEYS <= injected

--- a/tests/vectors/commissioned_safety_binding/MANIFEST.json
+++ b/tests/vectors/commissioned_safety_binding/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "commissioned-safety-binding",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "binding-vectors-v1.json": "c1d6f25aaa399897065bccf0041743edaebfcecf52d660cb70940cf88e5b980a"

--- a/tests/vectors/evidence_exchange/MANIFEST.json
+++ b/tests/vectors/evidence_exchange/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-registration.json": "dd9f7f0cbf320abd5f5d594ab4e20e75b3fd7c3ff3cab4b6a1ed0749a7a72536",

--- a/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
+++ b/tests/vectors/evidence_exchange_receiver_state/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence-exchange/vectors/receiver-state",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "anchor-quarantine.json": "ec5922987116b8487d1f49cb29bb53cd0cb44ef6cc8872f4a7b9ada8e8714bbd",

--- a/tests/vectors/evidence_v2/MANIFEST.json
+++ b/tests/vectors/evidence_v2/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "evidence/vectors",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "canonical-form.json": "80018fc74b3f59de5a9e24b2c738cdba29c6e9ca2614f006d4b5deab83ff898a",

--- a/tests/vectors/gateway_api/MANIFEST.json
+++ b/tests/vectors/gateway_api/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "gateway-api/vectors",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "inbound-evidence.json": "cb18d5f6fad051f6ca1924b20ef1040d2d67185c41a9a9eccee6159db0eb0473",

--- a/tests/vectors/runtime_evidence_anchor/MANIFEST.json
+++ b/tests/vectors/runtime_evidence_anchor/MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "source_repository": "ori-platform/ori-specs",
   "source_path": "runtime-evidence-anchor/vectors",
-  "source_commit": "3a2732a1baa53cbad53eec0fb1f76b0e40862692",
+  "source_commit": "3da7a7a9e4b80382cc45b14098424e51c402b57f",
   "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
   "files": {
     "runtime-anchor.json": "bd8e46cdff590447213d99e892b7f67480188134163d0a207e9f396b94847190"


### PR DESCRIPTION
## What does this PR do?

`runtime.py` injects the sensor's identity and the HAL circuit-breaker settings into the dict handed to `adapter.connect()` — then spread `sensor_cfg.metadata` **over the top**.

`_parse_sensors` withholds only `id`, `type`, `protocol`, `poll_interval_ms` and `calibration`. So `sensor_id`, `sensor_type` and `circuit_breaker` reached metadata, and metadata won.

Reproduced through the real loader, no mocks:

```
declared type : current
metadata      : {'sensor_type': 'temperature', 'sensor_id': 'spoofed', 'circuit_breaker': {'failure_threshold': 999}}

what the adapter actually receives:
   sensor_id        spoofed
   sensor_type      temperature
   circuit_breaker  {'failure_threshold': 999}
```

## Why this is safety work, not tidiness

**The circuit breaker became configurable per sensor.** A sensor entry could raise `failure_threshold` to a value its adapter never reaches, disabling hardware recovery for that adapter while `hal.circuit_breaker` still read as configured. `CLAUDE.md` states "No circuit breaker bypass" as a rule every adapter must honour; this was a bypass reachable from an unvalidated pass-through, with nothing refused, warned, or logged.

**A sensor could present a type it was not declared as.** A sensor declared `type: current` reached its adapter as `sensor_type: temperature`. The rule engine assigns the reserved reading names unconditionally, so rule conditions are not fooled — but the adapter decides *what it reads and in what unit* from `sensor_type`, so the reading is produced under the wrong identity before the rule engine ever sees it.

## Two boundaries, not one

**Config load refuses the entry.** The three names are reserved sensor metadata. The refusal lists every offending key and says where the setting belongs (`hal.circuit_breaker`) — a refusal that doesn't invites a workaround.

Refusal rather than precedence, deliberately: an operator who wrote `circuit_breaker` on a sensor meant something by it, and silently preferring the runtime's value is the same defect one level down.

**The assembly cannot be displaced.** `**metadata` now spreads *first*, with the runtime's values applied over it. This does not depend on the loader having run — a check that holds only because an earlier check held is not a boundary.

`calibration` is **not** reserved: it is a first-class sensor key that never reaches metadata, and reserving it would refuse `calibration:` on every sensor that legitimately uses one.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability gains, loses, or changes availability. A configuration that never worked as written is now refused instead of silently taking effect; nothing in the capability matrix describes sensor metadata precedence.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #416
- [x] Every new Tier D code path has test coverage — no Tier D path is added; this closes a bypass of an existing hardware-recovery boundary
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #416

## Testing notes

**4311 passed, 27 skipped** (+16 in the new file), `ruff` clean, `pyright` 0 errors. No hardware required.

All five shipped examples still parse — 3/3/1/3/3 sensors. **None relied on the old behaviour**, checked before the refusal was written rather than after.

### What is proven, and at what level

**Behavioural — a real adapter.** Three tests connect a real `PsutilAdapter` through the real `adapter_connect_config()` and assert what it did: the breaker it built carries the runtime's thresholds rather than the sensor's `999`, the metric it reads is the declared `cpu_percent` rather than the poisoned `memory_percent`, and the breaker still opens at the configured threshold. The identity case poisons with a second *supported* psutil type, so a win by the override reads the wrong metric silently instead of raising.

**Structural — the join.** `OriRuntime.start()` calling that helper is guarded by AST inspection only: the test asserts the call site exists and that no dict literal rebuilds `connect_cfg` beside it. Nothing here boots a runtime, so the join is checked by reading the source, not by observing a start-up.

**Not covered at all.** No test runs on device hardware, and no adapter other than `PsutilAdapter` is exercised through the assembly.

That split is deliberate. `adapter_connect_config()` was extracted from `start()` — ten lines inside an eight-hundred-line method — precisely so the boundary could be driven behaviourally at all. The join guard exists because without it every behavioural test above would still pass against a `start()` that went back to building its own literal, which is exactly how the defect existed.

### Mutation

| Mutation | Failures |
|---|---|
| Config-load refusal removed | 5 |
| Assembly order reverted to metadata-last | 5, including both adapter tests |
| `start()` rebuilds its own `connect_cfg` literal | 1 — the join guard alone |

The sets differ, so no boundary is propped up by another.

## Also in this PR

**Release note** for the breaking configuration change: a device setting `sensor_id`, `sensor_type` or `circuit_breaker` on a sensor now refuses to start. Nothing working is losing behaviour — none of the three did what whoever wrote it intended — but a startup refusal should not arrive unannounced.

**#419** records what this refusal does *not* serve. Per-sensor circuit-breaker tuning is a legitimate need: one global `hal.circuit_breaker` across a flaky LoRaWAN sensor and a local I2C sensor is a poor fit. It is refused here rather than bounded because the obvious bound does not survive scrutiny — opening a breaker blocks reads, so on a sensor feeding a Tier D condition an over-eager breaker removes the input the protection path depends on. Neither tripping sooner nor later is unambiguously the safe direction, and that decision belongs in ori-specs#110 with the rest of the sensor schema.

**A vendored-vector re-pin** to ori-specs `3da7a7a`. Only `source_commit` moves — no digests, no vector content. That is the third documentation-only specs merge to stale these pins.
