### PR TITLE
test(config): pin the reason allowed_hosts is not a reserved sensor key

### DIFF
--- a/tests/test_sensor_metadata_reserved_keys.py
+++ b/tests/test_sensor_metadata_reserved_keys.py
@@ -239,3 +239,66 @@ def test_start_uses_the_shared_assembly_rather_than_its_own_dict() -> None:
         "start() must build the adapter config through the shared assembly"
     )
     assert literals == 0, "no dict literal may rebuild connect_cfg alongside it"
+
+
+# ── Why `allowed_hosts` is deliberately not reserved ─────────────────────────
+#
+# A sensor may still set `allowed_hosts`, and `adapter_connect_config` uses
+# setdefault, so the sensor's list wins at the adapter. That looks like the same
+# defect this file exists to close, and it is not: the uri host is validated at
+# config load against `actions.coap.allowed_hosts`, a section sensor metadata
+# cannot reach. A sensor can therefore narrow its own allowlist but never widen
+# it. Reserving the key would refuse a legitimate narrowing.
+#
+# That argument was used to justify leaving the key unreserved, so it is pinned
+# here rather than left as reasoning in a review comment.
+
+
+@pytest.mark.parametrize(
+    "sensor_allow",
+    [
+        None,
+        ["evil.example"],
+        ["evil.example", "allowed.example"],
+    ],
+)
+def test_a_sensor_cannot_widen_the_coap_host_allowlist(
+    sensor_allow: list[str] | None,
+) -> None:
+    from ori.config import _validate_coap_sensor_allowlist
+
+    entry: dict[str, Any] = {
+        "id": "s1",
+        "type": "temperature",
+        "protocol": "coap",
+        "uri": "coap://evil.example/r",
+        "json_path": "v",
+    }
+    if sensor_allow is not None:
+        entry["allowed_hosts"] = sensor_allow
+
+    parsed = _parse_sensors([entry])
+    with pytest.raises(ConfigValidationError, match="not listed in actions.coap"):
+        _validate_coap_sensor_allowlist(parsed, {"allowed_hosts": ["allowed.example"]})
+
+
+def test_a_sensor_may_narrow_its_own_coap_allowlist() -> None:
+    """The reason the key is not reserved: narrowing is legitimate."""
+    from ori.config import _validate_coap_sensor_allowlist
+
+    parsed = _parse_sensors(
+        [
+            {
+                "id": "s1",
+                "type": "temperature",
+                "protocol": "coap",
+                "uri": "coap://allowed.example/r",
+                "json_path": "v",
+                "allowed_hosts": ["allowed.example"],
+            }
+        ]
+    )
+    _validate_coap_sensor_allowlist(
+        parsed, {"allowed_hosts": ["allowed.example", "other.example"]}
+    )
+    assert parsed[0].metadata["allowed_hosts"] == ["allowed.example"]


### PR DESCRIPTION
## Why

#418 reserved `sensor_id`, `sensor_type` and `circuit_breaker` on a sensor because metadata displaced what the runtime supplies. It deliberately left `allowed_hosts` unreserved — and **the justification for that existed only as a review argument.**

The argument: a sensor may set `allowed_hosts`, and `adapter_connect_config` uses `setdefault`, so the sensor's list wins at the adapter. That is safe because the uri host is validated at config load against `actions.coap.allowed_hosts` — a section sensor metadata cannot reach. A sensor can therefore **narrow** its own allowlist but never **widen** it, and narrowing is legitimate, so reserving the key would refuse something useful.

The reasoning is correct. Nothing pinned it. The property held only through `_validate_coap_sensor_allowlist` comparing against the global set, and pointing that comparison at the sensor's own list would have broken it silently — a load-bearing security property with no test naming it.

## What this adds

Four cases. A uri outside the global allowlist is refused when the sensor supplies:

- no allowlist of its own
- a wider one (`["evil.example"]`)
- one containing both hosts

and a sensor narrowing to a subset of the global list is **accepted**, which is the behaviour that makes reserving the key the wrong fix.

## Evidence

Mutation: changing `_validate_coap_sensor_allowlist` to consult the sensor's list instead of the global one fails **exactly the two widening cases** and leaves the rest green — so the tests catch the specific regression rather than passing incidentally.

Tests only. No production code changes.

## Type of change

- [x] `test` — tests only

## Checklist

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — tests only; no behaviour changes.

## Related issue

Follows #418. No issue is closed by this.