### PR TITLE
fix(vectors): make the pin provenance, not equality with main's tip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,14 @@ jobs:
 
       # Vendored contract vectors are hermetic, which is why the suite works
       # offline — and also how they could go stale invisibly. This notices.
+      # The provenance rule decides when a consumer must re-vendor, so a defect
+      # in it costs either false failures on every unrelated specs merge or a
+      # pin naming a commit nobody can find. It runs against throwaway git
+      # fixtures and needs no network.
+      - name: Test the vendored-vector provenance rule
+        if: matrix.python-version == '3.12'
+        run: bash scripts/test-refresh-evidence-vectors.sh
+
       - name: Check vendored evidence vectors against ori-specs
         if: matrix.python-version == '3.12'
         run: bash scripts/refresh-evidence-vectors.sh

--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -54,7 +54,10 @@ if [ -n "${ORI_SPECS_DIR:-}" ]; then
 else
   SPECS="$(mktemp -d)"
   CLEANUP="${SPECS}"
-  git clone --quiet --depth 1 https://github.com/ori-platform/ori-specs.git "${SPECS}"
+  # Full history, blobs fetched on demand. --depth 1 makes ancestry
+  # unanswerable, and ancestry is what the pin means.
+  git clone --quiet --filter=blob:none \
+    https://github.com/ori-platform/ori-specs.git "${SPECS}"
 fi
 trap '[ -n "${CLEANUP}" ] && rm -rf "${CLEANUP}"' EXIT
 
@@ -102,25 +105,44 @@ for entry in "${SETS[@]}"; do
   # Contents matching is not the whole story. The manifest also records which
   # ori-specs commit the vectors came from, and that pin is the cross-repository
   # provenance trail. A squash merge rewrites the commit while leaving every
-  # byte identical, so a contents-only check reports "match" and leaves the
-  # manifest naming a commit that no longer exists on main — provenance
-  # pointing at nothing, which is worse than no pin because it looks
-  # authoritative.
+  # byte identical, so a contents-only check cannot tell a live pin from one
+  # naming a commit that never landed — provenance pointing at nothing, which
+  # is worse than no pin because it looks authoritative.
+  #
+  # What the pin asserts is "these bytes came from that commit", and that stays
+  # true as main advances. So the test is reachability, not equality with the
+  # tip. Requiring equality made every ori-specs merge stale every consumer,
+  # including documentation-only merges that touched no vector, and a check
+  # that fires when nothing relevant changed trains people to re-pin without
+  # reading the diff.
   PINNED=""
   if [ -f "${DEST}/MANIFEST.json" ]; then
     PINNED="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_commit"])' \
       "${DEST}/MANIFEST.json" 2>/dev/null || echo "")"
   fi
 
-  if [ "${drift}" -eq 0 ] && [ "${PINNED}" = "${COMMIT}" ]; then
-    echo "${label}: vectors match ori-specs at ${COMMIT}"
+  # A pin is live when the commit it names is an ancestor of main. An unknown
+  # commit is not an ancestor, so a rewritten or never-merged SHA fails here.
+  reachable=0
+  if [ -n "${PINNED}" ] && git -C "${SPECS}" merge-base --is-ancestor \
+      "${PINNED}" HEAD 2>/dev/null; then
+    reachable=1
+  fi
+
+  if [ "${drift}" -eq 0 ] && [ "${reachable}" -eq 1 ]; then
+    if [ "${PINNED}" = "${COMMIT}" ]; then
+      echo "${label}: vectors match ori-specs at ${COMMIT}"
+    else
+      echo "${label}: vectors match; pinned at ${PINNED} (an ancestor of ${COMMIT})"
+    fi
     continue
   fi
 
   if [ "${APPLY}" != "1" ]; then
     if [ "${drift}" -eq 0 ]; then
-      echo "${label}: contents match, but the manifest pins ${PINNED:-<none>}" >&2
-      echo "  and ori-specs is now at ${COMMIT}." >&2
+      echo "${label}: contents match, but the manifest pins ${PINNED:-<none>}," >&2
+      echo "  which is not an ancestor of ori-specs main at ${COMMIT}." >&2
+      echo "  That commit never landed on main, so the pin names nothing." >&2
     fi
     overall_drift=1
     continue

--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -92,8 +92,23 @@ if [ -n "${ORI_SPECS_DIR:-}" ]; then
     echo "unmerged branch would pin a commit that is not on main." >&2
     exit 1
   fi
+  # Refused, not warned. The vectors are copied from the working tree while the
+  # manifest is pinned to the committed main SHA, so a dirty checkout writes a
+  # pin that names a commit which did not produce the bytes beside it -- false
+  # provenance without ever leaving main, and a second run over the same dirty
+  # tree reports success. A warning cannot prevent that; only refusing can.
+  #
+  # The stronger form is to read the vectors from the resolved main commit
+  # rather than from the working tree, which removes the class instead of
+  # guarding it. That is a larger change than this rule needs.
   if [ -n "$(git -C "${SPECS}" status --porcelain 2>/dev/null)" ]; then
-    echo "note: ${SPECS} has uncommitted changes; vendoring from the working tree." >&2
+    echo "ORI_SPECS_DIR has uncommitted changes." >&2
+    git -C "${SPECS}" status --porcelain 2>/dev/null | sed 's/^/  /' >&2
+    echo "Vectors are copied from the working tree while the pin records the" >&2
+    echo "committed ${MAIN_REF}, so a dirty checkout would record provenance" >&2
+    echo "those bytes do not have. Commit or stash, or unset ORI_SPECS_DIR to" >&2
+    echo "vendor from a fresh clone of main." >&2
+    exit 1
   fi
 fi
 overall_drift=0

--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -61,7 +61,41 @@ else
 fi
 trap '[ -n "${CLEANUP}" ] && rm -rf "${CLEANUP}"' EXIT
 
-COMMIT="$(git -C "${SPECS}" rev-parse HEAD)"
+# Provenance is defined against ori-specs main, so main is what the pin is
+# resolved and compared against -- never HEAD. A local checkout supplied
+# through ORI_SPECS_DIR can be on any branch, and an unmerged one would
+# otherwise let --apply vendor its vectors and pin its commit, which every
+# later ancestry check would then accept.
+MAIN_REF=""
+for candidate in refs/remotes/origin/main refs/heads/main refs/heads/master; do
+  if git -C "${SPECS}" rev-parse --verify --quiet "${candidate}" >/dev/null; then
+    MAIN_REF="${candidate}"
+    break
+  fi
+done
+if [ -z "${MAIN_REF}" ]; then
+  echo "no main branch found in ${SPECS}; cannot establish provenance" >&2
+  exit 1
+fi
+COMMIT="$(git -C "${SPECS}" rev-parse "${MAIN_REF}")"
+
+# Vectors are copied from the working tree, so the tree itself has to be main.
+# Comparing the pin against main while copying bytes from somewhere else would
+# record a provenance those files do not have.
+if [ -n "${ORI_SPECS_DIR:-}" ]; then
+  head_commit="$(git -C "${SPECS}" rev-parse HEAD)"
+  if [ "${head_commit}" != "${COMMIT}" ]; then
+    echo "ORI_SPECS_DIR is not on ${MAIN_REF}." >&2
+    echo "  checkout is at ${head_commit}" >&2
+    echo "  ${MAIN_REF} is at ${COMMIT}" >&2
+    echo "Vectors are copied from the working tree, so vendoring from an" >&2
+    echo "unmerged branch would pin a commit that is not on main." >&2
+    exit 1
+  fi
+  if [ -n "$(git -C "${SPECS}" status --porcelain 2>/dev/null)" ]; then
+    echo "note: ${SPECS} has uncommitted changes; vendoring from the working tree." >&2
+  fi
+fi
 overall_drift=0
 
 write_manifest() {
@@ -125,7 +159,7 @@ for entry in "${SETS[@]}"; do
   # commit is not an ancestor, so a rewritten or never-merged SHA fails here.
   reachable=0
   if [ -n "${PINNED}" ] && git -C "${SPECS}" merge-base --is-ancestor \
-      "${PINNED}" HEAD 2>/dev/null; then
+      "${PINNED}" "${COMMIT}" 2>/dev/null; then
     reachable=1
   fi
 

--- a/scripts/test-refresh-evidence-vectors.sh
+++ b/scripts/test-refresh-evidence-vectors.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for the vendored-vector provenance rule in refresh-evidence-vectors.sh.
+#
+# The rule decides when a consumer must re-vendor, so getting it wrong costs
+# either false CI failures on every unrelated specs merge, or a pin that names
+# a commit nobody can find. Both were reachable from the previous version, and
+# neither is visible by reading the script.
+#
+# Each case builds a real throwaway ori-specs git repository, points the script
+# at it with ORI_SPECS_DIR, and drives the real script.
+#
+#   bash scripts/test-refresh-evidence-vectors.sh
+
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="${REPO}/scripts/refresh-evidence-vectors.sh"
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
+
+# A minimal ori-specs with one vendored set, plus a consumer that vendors it.
+# The script iterates a fixed SETS list, so the fixture provides every path it
+# looks for; only commissioned-safety-binding carries content that matters here.
+new_fixture() {
+  local box="${WORK}/$1"
+  local specs="${box}/specs" consumer="${box}/consumer"
+  mkdir -p "${specs}" "${consumer}/scripts" "${consumer}/tests/vectors"
+
+  git -C "${specs}" init -q
+  git -C "${specs}" config user.email t@example.com
+  git -C "${specs}" config user.name t
+  for d in evidence/vectors evidence-exchange/vectors evidence-exchange/vectors/receiver-state \
+           runtime-evidence-anchor/vectors gateway-api/vectors commissioned-safety-binding; do
+    mkdir -p "${specs}/${d}"
+    printf '{"set":"%s","v":1}\n' "${d}" > "${specs}/${d}/vectors.json"
+  done
+  git -C "${specs}" add -A >/dev/null
+  git -C "${specs}" commit -qm "initial vectors"
+
+  cp "${SCRIPT}" "${consumer}/scripts/"
+  chmod +x "${consumer}/scripts/refresh-evidence-vectors.sh"
+  echo "${box}"
+}
+
+vendor() {  # vendor the current specs state into the consumer
+  local box="$1"
+  ORI_SPECS_DIR="${box}/specs" ORI_VECTORS_APPLY=1 \
+    bash "${box}/consumer/scripts/refresh-evidence-vectors.sh" >/dev/null 2>&1
+}
+
+check() {   # run the drift check; echo output, return its exit code
+  local box="$1"
+  ORI_SPECS_DIR="${box}/specs" bash "${box}/consumer/scripts/refresh-evidence-vectors.sh" 2>&1
+}
+
+pinned_commit() {
+  python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["source_commit"])' \
+    "$1/consumer/tests/vectors/commissioned_safety_binding/MANIFEST.json"
+}
+
+# ── 1. a later documentation-only specs commit must pass ─────────────────────
+#
+# This is the case that made the previous rule unusable: main moves, no vector
+# changes, and every consumer fails CI.
+
+box="$(new_fixture docs-only)"
+vendor "${box}"
+before="$(pinned_commit "${box}")"
+echo "notes" > "${box}/specs/README.md"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "docs: unrelated to any vector"
+after_head="$(git -C "${box}/specs" rev-parse HEAD)"
+
+out="$(check "${box}")"; code=$?
+if [ "${code}" -eq 0 ]; then
+  ok "a later docs-only specs commit passes"
+else
+  bad "a later docs-only specs commit passes" "exit ${code}: ${out}"
+fi
+if [ "${before}" != "${after_head}" ]; then
+  ok "the pin is genuinely behind main, not equal to it"
+else
+  bad "the pin is genuinely behind main, not equal to it" "fixture did not advance main"
+fi
+if grep -q "an ancestor of" <<< "${out}"; then
+  ok "the report says the pin is an ancestor rather than claiming equality"
+else
+  bad "the report says the pin is an ancestor rather than claiming equality" "${out}"
+fi
+
+# ── 2. a pin not reachable from main must fail ───────────────────────────────
+#
+# A commit that never landed: the shape a squash merge leaves behind, and the
+# reason a contents-only check is not enough.
+
+box="$(new_fixture unreachable)"
+vendor "${box}"
+git -C "${box}/specs" checkout -q -b sidebranch
+echo "side" > "${box}/specs/side.md"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "never merged"
+orphan="$(git -C "${box}/specs" rev-parse HEAD)"
+git -C "${box}/specs" checkout -q -
+python3 - "${box}" "${orphan}" <<'PY'
+import json, pathlib, sys
+p = pathlib.Path(sys.argv[1]) / "consumer/tests/vectors/commissioned_safety_binding/MANIFEST.json"
+d = json.loads(p.read_text()); d["source_commit"] = sys.argv[2]
+p.write_text(json.dumps(d, indent=2) + "\n")
+PY
+
+out="$(check "${box}")"; code=$?
+if [ "${code}" -ne 0 ] && grep -q "not an ancestor" <<< "${out}"; then
+  ok "a pin that never landed on main fails"
+else
+  bad "a pin that never landed on main fails" "exit ${code}: ${out}"
+fi
+
+# ── 3. changed vector bytes must fail even when the pin is reachable ─────────
+#
+# Reachability must not become a way to ignore content drift.
+
+box="$(new_fixture bytes-changed)"
+vendor "${box}"
+reachable_pin="$(pinned_commit "${box}")"
+printf '{"set":"commissioned-safety-binding","v":2}\n' \
+  > "${box}/specs/commissioned-safety-binding/vectors.json"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "vectors: a real contract change"
+
+out="$(check "${box}")"; code=$?
+if [ "${code}" -ne 0 ] && grep -q "CHANGED" <<< "${out}"; then
+  ok "a vector byte change fails even though the pin is reachable"
+else
+  bad "a vector byte change fails even though the pin is reachable" "exit ${code}: ${out}"
+fi
+if git -C "${box}/specs" merge-base --is-ancestor "${reachable_pin}" HEAD; then
+  ok "precondition: that pin really was reachable"
+else
+  bad "precondition: that pin really was reachable" "fixture is wrong"
+fi
+
+# ── 4. the pin moves only when the bytes move ────────────────────────────────
+#
+# Re-pinning a set whose contents did not change would claim those bytes came
+# from a commit that did not produce them. Provenance is about where the bytes
+# came from, so a live pin is left alone even under --apply.
+
+box="$(new_fixture apply-noop)"
+vendor "${box}"
+original="$(pinned_commit "${box}")"
+echo "more" > "${box}/specs/README.md"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "docs again"
+vendor "${box}"
+if [ "$(pinned_commit "${box}")" = "${original}" ]; then
+  ok "--apply leaves a reachable, content-matching pin alone"
+else
+  bad "--apply leaves a reachable, content-matching pin alone" \
+      "pin advanced to a commit that did not produce these bytes"
+fi
+
+box="$(new_fixture apply-moves)"
+vendor "${box}"
+printf '{"set":"commissioned-safety-binding","v":3}\n' \
+  > "${box}/specs/commissioned-safety-binding/vectors.json"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "vectors: real change"
+vendor "${box}"
+if [ "$(pinned_commit "${box}")" = "$(git -C "${box}/specs" rev-parse HEAD)" ]; then
+  ok "--apply re-pins when the vectors actually changed"
+else
+  bad "--apply re-pins when the vectors actually changed" "pin did not advance"
+fi
+if grep -q '"v":3' "${box}/consumer/tests/vectors/commissioned_safety_binding/vectors.json"; then
+  ok "the new bytes were copied, not just the pin"
+else
+  bad "the new bytes were copied, not just the pin" "vendored content is stale"
+fi
+
+
+echo
+printf '%d passed, %d failed\n' "${PASS}" "${FAIL}"
+[ "${FAIL}" -eq 0 ]

--- a/scripts/test-refresh-evidence-vectors.sh
+++ b/scripts/test-refresh-evidence-vectors.sh
@@ -35,7 +35,7 @@ new_fixture() {
   local specs="${box}/specs" consumer="${box}/consumer"
   mkdir -p "${specs}" "${consumer}/scripts" "${consumer}/tests/vectors"
 
-  git -C "${specs}" init -q
+  git -C "${specs}" init -q -b main
   git -C "${specs}" config user.email t@example.com
   git -C "${specs}" config user.name t
   for d in evidence/vectors evidence-exchange/vectors evidence-exchange/vectors/receiver-state \
@@ -184,6 +184,51 @@ if grep -q '"v":3' "${box}/consumer/tests/vectors/commissioned_safety_binding/ve
   ok "the new bytes were copied, not just the pin"
 else
   bad "the new bytes were copied, not just the pin" "vendored content is stale"
+fi
+
+
+# ── 5. a supplied checkout that is not main must be refused ──────────────────
+#
+# ORI_SPECS_DIR points at a working tree, and the vectors are copied from it.
+# On an unmerged branch, --apply would vendor that branch's bytes and pin its
+# commit; every later run would then find the pin reachable and report success.
+# Case 2 does not cover this -- it puts an orphan pin in the manifest while the
+# checkout is back on main, so the copy path is never exercised off-main.
+
+box="$(new_fixture unmerged-branch)"
+vendor "${box}"
+git -C "${box}/specs" checkout -q -b feature/new-vectors
+printf '{"set":"commissioned-safety-binding","v":99}\n' \
+  > "${box}/specs/commissioned-safety-binding/vectors.json"
+git -C "${box}/specs" add -A >/dev/null
+git -C "${box}/specs" commit -qm "vectors: not merged to main"
+branch_commit="$(git -C "${box}/specs" rev-parse HEAD)"
+
+out="$(check "${box}")"; code=$?
+if [ "${code}" -ne 0 ] && grep -q "is not on refs/heads/main" <<< "${out}"; then
+  ok "check refuses a supplied checkout that is not on main"
+else
+  bad "check refuses a supplied checkout that is not on main" "exit ${code}: ${out}"
+fi
+
+vendor "${box}"
+if [ "$(pinned_commit "${box}")" = "${branch_commit}" ]; then
+  bad "apply refuses to vendor from an unmerged branch" "it pinned the branch commit"
+else
+  ok "apply refuses to vendor from an unmerged branch"
+fi
+if grep -q '"v":99' "${box}/consumer/tests/vectors/commissioned_safety_binding/vectors.json"; then
+  bad "apply did not copy the unmerged branch bytes" "branch bytes were vendored"
+else
+  ok "apply did not copy the unmerged branch bytes"
+fi
+
+git -C "${box}/specs" checkout -q main
+out="$(check "${box}")"; code=$?
+if [ "${code}" -eq 0 ]; then
+  ok "the same checkout passes once it is back on main"
+else
+  bad "the same checkout passes once it is back on main" "exit ${code}: ${out}"
 fi
 
 

--- a/scripts/test-refresh-evidence-vectors.sh
+++ b/scripts/test-refresh-evidence-vectors.sh
@@ -232,6 +232,59 @@ else
 fi
 
 
+# ── 6. a dirty supplied checkout must be refused ─────────────────────────────
+#
+# The branch gate is not enough on its own. On a clean main with an uncommitted
+# vector edit, the script would copy the dirty working-tree bytes while pinning
+# the committed main SHA -- false provenance without ever leaving main, and a
+# second run over the same tree reports success because contents now match.
+
+box="$(new_fixture dirty-tree)"
+vendor "${box}"
+clean_pin="$(pinned_commit "${box}")"
+printf '{"set":"commissioned-safety-binding","v":66}\n' \
+  > "${box}/specs/commissioned-safety-binding/vectors.json"
+
+out="$(check "${box}")"; code=$?
+if [ "${code}" -ne 0 ] && grep -q "uncommitted changes" <<< "${out}"; then
+  ok "check refuses a dirty supplied checkout"
+else
+  bad "check refuses a dirty supplied checkout" "exit ${code}: ${out}"
+fi
+
+vendor "${box}"
+if grep -q '"v":66' "${box}/consumer/tests/vectors/commissioned_safety_binding/vectors.json"; then
+  bad "apply does not copy uncommitted vector bytes" "dirty bytes were vendored"
+else
+  ok "apply does not copy uncommitted vector bytes"
+fi
+if [ "$(pinned_commit "${box}")" = "${clean_pin}" ]; then
+  ok "apply leaves the pin untouched for a dirty checkout"
+else
+  bad "apply leaves the pin untouched for a dirty checkout" "the pin moved"
+fi
+
+# An untracked file in a vendored directory is copied by the glob, so it counts
+# as dirt even though nothing tracked changed.
+box="$(new_fixture untracked-file)"
+vendor "${box}"
+printf '{"stray":true}\n' > "${box}/specs/commissioned-safety-binding/stray.json"
+out="$(check "${box}")"; code=$?
+if [ "${code}" -ne 0 ] && grep -q "uncommitted changes" <<< "${out}"; then
+  ok "an untracked file in a vendored directory is refused"
+else
+  bad "an untracked file in a vendored directory is refused" "exit ${code}: ${out}"
+fi
+
+git -C "${box}/specs" clean -qfd
+out="$(check "${box}")"; code=$?
+if [ "${code}" -eq 0 ]; then
+  ok "the same checkout passes once it is clean"
+else
+  bad "the same checkout passes once it is clean" "exit ${code}: ${out}"
+fi
+
+
 echo
 printf '%d passed, %d failed\n' "${PASS}" "${FAIL}"
 [ "${FAIL}" -eq 0 ]


### PR DESCRIPTION
## The problem

The drift check required the pinned `source_commit` to **equal ori-specs main's current tip**. So every merge to ori-specs staled every consumer — including merges that touched no vector at all.

**Three documentation-only specs merges broke this check in a single day.** Each time, the vendored bytes were byte-identical and the only fix was a re-pin that changed nothing but a commit id.

A check that fires when nothing relevant changed trains people to re-pin without reading the diff. That is worse than no check, because the one time it fires for a real reason it looks the same as the noise.

## The rule

A pin asserts *these bytes came from that commit*, and that stays true as main advances. So the test is **reachability**:

```bash
git merge-base --is-ancestor "$PINNED" "$MAIN_COMMIT"
```

where `$MAIN_COMMIT` is resolved from `refs/remotes/origin/main` — never from `HEAD`, for the reasons in the review section below.

The case the equality rule existed to catch still fails: a squash-rewritten or never-merged commit is **not** an ancestor, so provenance naming a commit that never landed is refused exactly as before. The byte-for-byte comparison is untouched and still fails on its own.

The clone drops `--depth 1` for `--filter=blob:none`. Ancestry is unanswerable in a shallow clone, and ancestry is now what the pin means; blobs are fetched on demand so the clone stays cheap.

## One consequence, found by writing the test

Under `--apply`, a set whose contents match and whose pin is reachable is now **left alone**. My first test asserted the opposite and failed — correctly. Advancing the pin would claim those bytes came from a commit that did not produce them.

**The pin moves when the bytes move.** That is a better semantic than the one I set out to write.

## Evidence

`scripts/test-refresh-evidence-vectors.sh` — **9 assertions, 0 failures**. It drives the real script against throwaway git repositories, so it needs no network and does not depend on ori-specs' current state.

Covering the three cases specified, plus what they imply:

- a later docs-only specs commit **passes**, and is reported as an ancestor rather than as equal
- a pin that **never landed** on main fails, naming why
- changed vector bytes **fail even when the pin is reachable**
- `--apply` leaves a live pin alone, and re-pins *and copies* when the vectors genuinely changed

Mutation separates all three rules — no assertion is propped up by another:

| Mutation | Failures |
|---|---|
| Revert to tip equality | 2 — docs-only, and apply-noop |
| Reachability always true | 1 — the unlanded pin |
| Content comparison ignored | 3 — every byte-change case |

Also verified against the **real** ori-specs over the network: all six sets report match at `3da7a7a`, exit 0.

The harness runs in CI on the 3.12 leg, immediately before the check it guards.

## Scope

`ori-runtime` only. Other repositories vendor these vectors too, but I have not located their equivalent scripts and am not assuming they are identical tooling.

## Type of change

- [x] `fix` — bug fix

## Checklist

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime capability is touched; this changes a CI provenance check and its test harness.

## Related issue

No issue; this follows the re-vendor failures seen across #413, #415 and #418.

## Blocker fixed in review: `ORI_SPECS_DIR` validated the wrong ref

The rule said *an ancestor of main* and the implementation tested `merge-base --is-ancestor "$PINNED" HEAD`. With `ORI_SPECS_DIR` pointing at a local checkout, `HEAD` is whatever branch that checkout is on — so `--apply` could vendor an **unmerged branch's** vectors, pin its commit, and every later run would find that pin reachable and report success.

The commit is now resolved from `refs/remotes/origin/main` (falling back to a local `main`/`master`), and ancestry is tested against that. With no main branch at all the script refuses rather than guessing.

Resolving the commit correctly is not sufficient on its own, because the vectors are copied from the **working tree**, not from a ref. Comparing the pin against main while copying bytes from another branch would record a provenance those files do not have. So a supplied checkout that is not on main is refused outright, naming both commits; an uncommitted tree is reported.

The original "never landed" case did not cover this — it writes an orphan commit into the manifest while the checkout is back on main, so the copy path is never exercised off-main.

**Four assertions added** (13 total, 0 failures): check refuses an off-main checkout; apply neither pins the branch commit nor copies its bytes; the same checkout passes once it returns to main. Restoring the bypass fails **exactly those four**.

Fixtures now init with `-b main` so the branch name does not depend on the local git default.

## Second blocker fixed in review: a dirty `ORI_SPECS_DIR`

The off-main gate closed one route and left another beside it. On a **clean main with an uncommitted vector edit**, the script copied the dirty working-tree bytes and pinned the committed main SHA — a pin naming a commit that did not produce the bytes next to it, without ever leaving main. A second run then reported success, because by then the contents matched.

The code warned about this and proceeded. That is the same error as treating a drift detector as an authorization boundary: the message appeared and the write happened anyway.

A supplied checkout with **any** uncommitted change is now refused before check or apply, listing what is dirty. Untracked files count — the copy step globs `*.json` out of each source directory, so an untracked file there is vendored even though nothing tracked changed.

**Five assertions added, 18 total.** Downgrading the refusal back to a message fails the assertion that dirty bytes are not vendored.

The stronger design — reading vectors from the resolved main commit rather than the working tree — removes the class instead of guarding it. It is recorded in the script; this is the smaller safe fix.

## Coverage note

Every `--apply` in the harness goes through `ORI_SPECS_DIR`, which is the path carrying these gates. The clone path skips them because a fresh clone is clean and on the default branch — and that path is now exercised end to end over the network **with apply**, not only with check: it reports match for all six sets and leaves the vendored files and pins untouched.
