### PR TITLE
fix(runtime): supply poll_interval_ms to the adapters that poll on it

### DIFF
--- a/ori/hal/smart_adapter.py
+++ b/ori/hal/smart_adapter.py
@@ -216,7 +216,6 @@ class SmartAdapter(BaseAdapter):
         self._connected = False
         self._sensor_type: str = ""
         self._device: str = ""
-        self._poll_interval_ms: int = 0
         self._breaker: HardwareCircuitBreaker | None = None
 
     async def connect(self, config: dict) -> None:
@@ -235,7 +234,6 @@ class SmartAdapter(BaseAdapter):
 
         self._sensor_type = sensor_type
         self._device = device
-        self._poll_interval_ms = int(config.get("poll_interval_ms", 0))
         self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
         self._connected = True
 

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -248,6 +248,11 @@ def adapter_connect_config(sensor_cfg: SensorConfig, config: Config) -> dict[str
         "sensor_id": sensor_cfg.id,
         "sensor_type": sensor_cfg.type,
         "circuit_breaker": config.hal.circuit_breaker,
+        # Adapters that run their own poll loop refresh a cache the runtime then
+        # reads on the same schedule. Without this the cache refreshed at the
+        # adapter's default while the runtime read at the operator's rate,
+        # serving one stale reading repeatedly as though it were fresh.
+        "poll_interval_ms": sensor_cfg.poll_interval_ms,
         # Calibration is passed as its own block rather than flattened into the
         # same namespace. Flattening is what let a documented `sensitivity` sit
         # unread beside the adapter's own default.

--- a/tests/test_adapter_poll_interval.py
+++ b/tests/test_adapter_poll_interval.py
@@ -21,7 +21,6 @@ the other side.
 
 from __future__ import annotations
 
-import contextlib
 import pathlib
 from types import SimpleNamespace
 from typing import Any
@@ -77,10 +76,13 @@ def test_metadata_cannot_displace_the_interval() -> None:
 
 
 async def test_the_http_adapter_receives_the_configured_interval() -> None:
-    """Asserted on the adapter's own state, not on the dict it was handed.
+    """Asserted on the adapter's own state after a connection that succeeded.
 
     An assembly that supplied the key beside an adapter that ignored it would
-    pass a dict-only check and still poll at ten seconds on a device.
+    pass a dict-only check and still poll at ten seconds on a device. The
+    connection is required to succeed rather than suppressed: an adapter that
+    refused before reaching the assignment would otherwise leave the default in
+    place and the assertion would read it as proof.
     """
     from ori.hal.http_adapter import HttpAdapter
 
@@ -88,9 +90,12 @@ async def test_the_http_adapter_receives_the_configured_interval() -> None:
     cfg = adapter_connect_config(
         _sensor("http", 1500, url="https://host/r", json_path="v"), _config()
     )
-    with contextlib.suppress(Exception):
+    try:
         await adapter.connect(cfg)
-    assert adapter._poll_interval_ms == 1500
+        assert adapter.is_connected
+        assert adapter._poll_interval_ms == 1500
+    finally:
+        await adapter.close()
 
 
 async def test_the_coap_adapter_receives_the_configured_interval() -> None:
@@ -98,24 +103,36 @@ async def test_the_coap_adapter_receives_the_configured_interval() -> None:
 
     `aiocoap` ships in neither requirements file, so a test that needs the real
     library skips in CI as well as locally — proving nothing while looking
-    covered. The adapter's availability flag and module are patched instead,
-    which is how tests/test_coap_adapter.py already exercises this adapter.
+    covered. The availability flag and module are patched instead, which is how
+    tests/test_coap_adapter.py already exercises this adapter.
+
+    `create_client_context` is awaited by production code, so the fake returns
+    an awaitable. A synchronous fake raises `TypeError` inside `connect()`,
+    which a suppressed exception would hide — and `_poll_interval_ms` is
+    assigned before that point, so the assertion would still pass over an
+    adapter that never connected.
     """
     from ori.hal.coap_adapter import CoapAdapter
+
+    class _FakeContext:
+        async def shutdown(self) -> None:
+            return None
+
+    async def _create_client_context() -> _FakeContext:
+        return _FakeContext()
 
     fake_aiocoap = SimpleNamespace(
         GET="GET",
         Message=lambda code, uri, payload: SimpleNamespace(code=code),
-        Context=SimpleNamespace(create_client_context=staticmethod(lambda: None)),
+        Context=SimpleNamespace(
+            create_client_context=staticmethod(_create_client_context)
+        ),
     )
+
     adapter = CoapAdapter()
     cfg = adapter_connect_config(
         _sensor(
-            "coap",
-            1500,
-            uri="coap://host/r",
-            json_path="v",
-            allowed_hosts=["host"],
+            "coap", 1500, uri="coap://host/r", json_path="v", allowed_hosts=["host"]
         ),
         _config(),
     )
@@ -123,9 +140,12 @@ async def test_the_coap_adapter_receives_the_configured_interval() -> None:
         patch("ori.hal.coap_adapter._AIOCOAP_AVAILABLE", True),
         patch("ori.hal.coap_adapter._aiocoap", fake_aiocoap),
     ):
-        with contextlib.suppress(Exception):
+        try:
             await adapter.connect(cfg)
-    assert adapter._poll_interval_ms == 1500
+            assert adapter.is_connected
+            assert adapter._poll_interval_ms == 1500
+        finally:
+            await adapter.close()
 
 
 @pytest.mark.parametrize("protocol", ["coap", "http"])
@@ -155,12 +175,24 @@ def test_smart_adapter_no_longer_reads_an_interval_it_ignores() -> None:
     assert "poll_interval_ms" not in source
 
 
-def test_no_adapter_reads_a_key_the_assembly_never_supplies() -> None:
-    """The general form of #417, so the next instance fails here.
+def test_no_adapter_directly_reads_a_key_the_assembly_never_supplies() -> None:
+    """The general form of #417, for reads this can actually see.
 
     Every key an adapter reads must be one an operator can set in sensor
     metadata, or one the runtime supplies. A key in neither set resolves to the
     adapter's default no matter what the operator writes.
+
+    **This does not close the class.** `adapter_metadata()` finds literal
+    `config.get(...)` calls inside adapter classes and nothing else, so a
+    setting an adapter resolves through a shared helper is invisible to it.
+    That limitation is not hypothetical: it appeared during #411, when moving
+    baud resolution into a helper made both serial adapters look as though they
+    read nothing, and it is why those adapters pass presence and values into
+    the resolver explicitly rather than handing it the config dict.
+
+    So this catches the next *direct* instance. A helper-resolved one needs
+    either a stronger extractor or the same explicit-read discipline #411
+    adopted.
     """
     from tests.golden.build_config_surface_inventory import adapter_metadata
 
@@ -174,5 +206,5 @@ def test_no_adapter_reads_a_key_the_assembly_never_supplies() -> None:
             unreachable[name] = dead
 
     assert not unreachable, (
-        f"adapters read keys the runtime never supplies: {unreachable}"
+        f"adapters directly read keys the runtime never supplies: {unreachable}"
     )

--- a/tests/test_adapter_poll_interval.py
+++ b/tests/test_adapter_poll_interval.py
@@ -208,3 +208,121 @@ def test_no_adapter_directly_reads_a_key_the_assembly_never_supplies() -> None:
     assert not unreachable, (
         f"adapters directly read keys the runtime never supplies: {unreachable}"
     )
+
+
+# ── The cadence itself, not the value handed to it ───────────────────────────
+#
+# Everything above asserts the interval the adapter stored. That is the input to
+# its sleep, not the rate anything actually refreshes at. The defect this PR
+# fixes is a cache refreshing on the adapter's default while the runtime read on
+# the operator's, so the claim worth proving is the sleep the loop performs.
+
+
+async def test_the_coap_poll_loop_sleeps_for_the_configured_interval() -> None:
+    """Capture the loop's own sleep rather than the attribute feeding it."""
+    import asyncio as _asyncio
+
+    from ori.hal import coap_adapter
+    from ori.hal.coap_adapter import CoapAdapter
+
+    class _FakeContext:
+        async def shutdown(self) -> None:
+            return None
+
+    async def _create_client_context() -> _FakeContext:
+        return _FakeContext()
+
+    fake_aiocoap = SimpleNamespace(
+        GET="GET",
+        Message=lambda code, uri, payload: SimpleNamespace(code=code),
+        Context=SimpleNamespace(
+            create_client_context=staticmethod(_create_client_context)
+        ),
+    )
+
+    slept: list[float] = []
+    failures: list[BaseException] = []
+    first_sleep = _asyncio.Event()
+
+    # Bind the real sleep before patching. `asyncio.sleep` is the same module
+    # attribute being replaced, so a fake that calls it recurses into itself --
+    # the delay is recorded first, so the assertion still passed while the poll
+    # loop died behind it.
+    real_sleep = _asyncio.sleep
+
+    async def _record_sleep(delay: float) -> None:
+        slept.append(delay)
+        first_sleep.set()
+        await real_sleep(0)
+
+    adapter = CoapAdapter()
+    cfg = adapter_connect_config(
+        _sensor(
+            "coap", 1500, uri="coap://host/r", json_path="v", allowed_hosts=["host"]
+        ),
+        _config(),
+    )
+    with (
+        patch("ori.hal.coap_adapter._AIOCOAP_AVAILABLE", True),
+        patch("ori.hal.coap_adapter._aiocoap", fake_aiocoap),
+        patch.object(coap_adapter.asyncio, "sleep", _record_sleep),
+    ):
+        try:
+            await adapter.connect(cfg)
+            assert adapter._poll_task is not None, "connect() must start the loop"
+            await _asyncio.wait_for(first_sleep.wait(), timeout=2.0)
+            task = adapter._poll_task
+        finally:
+            await adapter.close()
+        if task is not None and task.done() and not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                failures.append(exc)
+
+    assert slept, "the poll loop never slept, so nothing governs its cadence"
+    assert slept[0] == 1.5, f"loop slept {slept[0]}s, not the configured 1.5s"
+    assert not failures, f"the poll loop raised while being observed: {failures}"
+
+
+async def test_the_http_poll_loop_sleeps_for_the_configured_interval() -> None:
+    """Both adapters carried the defect, so both cadences are asserted."""
+    import asyncio as _asyncio
+
+    from ori.hal import http_adapter
+    from ori.hal.http_adapter import HttpAdapter
+
+    slept: list[float] = []
+    failures: list[BaseException] = []
+    first_sleep = _asyncio.Event()
+
+    # Bind the real sleep before patching. `asyncio.sleep` is the same module
+    # attribute being replaced, so a fake that calls it recurses into itself --
+    # the delay is recorded first, so the assertion still passed while the poll
+    # loop died behind it.
+    real_sleep = _asyncio.sleep
+
+    async def _record_sleep(delay: float) -> None:
+        slept.append(delay)
+        first_sleep.set()
+        await real_sleep(0)
+
+    adapter = HttpAdapter()
+    cfg = adapter_connect_config(
+        _sensor("http", 1500, url="https://host/r", json_path="v"), _config()
+    )
+    with patch.object(http_adapter.asyncio, "sleep", _record_sleep):
+        try:
+            await adapter.connect(cfg)
+            assert adapter._poll_task is not None, "connect() must start the loop"
+            await _asyncio.wait_for(first_sleep.wait(), timeout=2.0)
+            task = adapter._poll_task
+        finally:
+            await adapter.close()
+        if task is not None and task.done() and not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                failures.append(exc)
+
+    assert slept, "the poll loop never slept, so nothing governs its cadence"
+    assert slept[0] == 1.5, f"loop slept {slept[0]}s, not the configured 1.5s"
+    assert not failures, f"the poll loop raised while being observed: {failures}"

--- a/tests/test_adapter_poll_interval.py
+++ b/tests/test_adapter_poll_interval.py
@@ -1,0 +1,178 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""`poll_interval_ms` must reach the adapters that poll on it.
+
+`_parse_sensors` lifts `poll_interval_ms` out of metadata into `SensorConfig`,
+and the runtime did not put it back when assembling an adapter's connection
+config. `CoapAdapter` and `HttpAdapter` read it anyway, so the read always
+returned their own default (ori-runtime #417).
+
+That is not only a setting that failed to apply. Both adapters run a background
+loop that refreshes a cache, and `read()` serves that cache. The runtime polls
+on the operator's interval while the cache refreshed on the adapter's default of
+ten seconds, so a sensor configured at one second served the same reading ten
+times over as though each were fresh.
+
+`SmartAdapter` read the same key and never used the value. That read is gone
+rather than fed: a read whose result nothing consumes is the same defect from
+the other side.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import pathlib
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ori.config import SensorConfig
+from ori.runtime import adapter_connect_config
+
+
+def _config() -> Any:
+    return SimpleNamespace(
+        hal=SimpleNamespace(circuit_breaker={}),
+        actions=SimpleNamespace(coap={}),
+    )
+
+
+def _sensor(protocol: str, poll_interval_ms: int, **metadata: Any) -> SensorConfig:
+    return SensorConfig(
+        id="s1",
+        type="temperature",
+        protocol=protocol,
+        poll_interval_ms=poll_interval_ms,
+        metadata=metadata,
+        calibration={},
+    )
+
+
+def test_the_assembly_supplies_the_configured_interval() -> None:
+    cfg = adapter_connect_config(_sensor("coap", 1500), _config())
+    assert cfg["poll_interval_ms"] == 1500
+
+
+def test_metadata_cannot_displace_the_interval() -> None:
+    """It is supplied after the spread, like the other runtime-owned keys.
+
+    `_parse_sensors` already keeps this name out of metadata, so this asserts
+    the assembly does not depend on that having happened.
+    """
+    poisoned = SensorConfig(
+        id="s1",
+        type="temperature",
+        protocol="coap",
+        poll_interval_ms=1500,
+        metadata={"poll_interval_ms": 99999},
+        calibration={},
+    )
+    assert adapter_connect_config(poisoned, _config())["poll_interval_ms"] == 1500
+
+
+# ── The adapters that poll on it ─────────────────────────────────────────────
+
+
+async def test_the_http_adapter_receives_the_configured_interval() -> None:
+    """Asserted on the adapter's own state, not on the dict it was handed.
+
+    An assembly that supplied the key beside an adapter that ignored it would
+    pass a dict-only check and still poll at ten seconds on a device.
+    """
+    from ori.hal.http_adapter import HttpAdapter
+
+    adapter = HttpAdapter()
+    cfg = adapter_connect_config(
+        _sensor("http", 1500, url="https://host/r", json_path="v"), _config()
+    )
+    with contextlib.suppress(Exception):
+        await adapter.connect(cfg)
+    assert adapter._poll_interval_ms == 1500
+
+
+async def test_the_coap_adapter_receives_the_configured_interval() -> None:
+    """Same assertion for CoAP, without depending on aiocoap being installed.
+
+    `aiocoap` ships in neither requirements file, so a test that needs the real
+    library skips in CI as well as locally — proving nothing while looking
+    covered. The adapter's availability flag and module are patched instead,
+    which is how tests/test_coap_adapter.py already exercises this adapter.
+    """
+    from ori.hal.coap_adapter import CoapAdapter
+
+    fake_aiocoap = SimpleNamespace(
+        GET="GET",
+        Message=lambda code, uri, payload: SimpleNamespace(code=code),
+        Context=SimpleNamespace(create_client_context=staticmethod(lambda: None)),
+    )
+    adapter = CoapAdapter()
+    cfg = adapter_connect_config(
+        _sensor(
+            "coap",
+            1500,
+            uri="coap://host/r",
+            json_path="v",
+            allowed_hosts=["host"],
+        ),
+        _config(),
+    )
+    with (
+        patch("ori.hal.coap_adapter._AIOCOAP_AVAILABLE", True),
+        patch("ori.hal.coap_adapter._aiocoap", fake_aiocoap),
+    ):
+        with contextlib.suppress(Exception):
+            await adapter.connect(cfg)
+    assert adapter._poll_interval_ms == 1500
+
+
+@pytest.mark.parametrize("protocol", ["coap", "http"])
+async def test_the_adapter_default_is_no_longer_what_an_operator_gets(
+    protocol: str,
+) -> None:
+    """The defect, stated as the thing that must not recur."""
+    if protocol == "coap":
+        from ori.hal import coap_adapter as module
+    else:
+        from ori.hal import http_adapter as module
+
+    cfg = adapter_connect_config(_sensor(protocol, 1000), _config())
+    assert cfg["poll_interval_ms"] != module._DEFAULT_POLL_INTERVAL_MS
+
+
+# ── The adapter that never used it ───────────────────────────────────────────
+
+
+def test_smart_adapter_no_longer_reads_an_interval_it_ignores() -> None:
+    """It assigned the value and read it back nowhere.
+
+    Feeding it would have been the wrong fix: the correct answer to a read
+    nothing consumes is to remove the read.
+    """
+    source = pathlib.Path("ori/hal/smart_adapter.py").read_text()
+    assert "poll_interval_ms" not in source
+
+
+def test_no_adapter_reads_a_key_the_assembly_never_supplies() -> None:
+    """The general form of #417, so the next instance fails here.
+
+    Every key an adapter reads must be one an operator can set in sensor
+    metadata, or one the runtime supplies. A key in neither set resolves to the
+    adapter's default no matter what the operator writes.
+    """
+    from tests.golden.build_config_surface_inventory import adapter_metadata
+
+    supplied = set(adapter_connect_config(_sensor("psutil", 1000), _config()))
+    withheld = {"id", "type", "protocol", "poll_interval_ms", "calibration"}
+
+    unreachable: dict[str, list[str]] = {}
+    for name, keys in adapter_metadata().items():
+        dead = sorted(k for k in keys if k in withheld and k not in supplied)
+        if dead:
+            unreachable[name] = dead
+
+    assert not unreachable, (
+        f"adapters read keys the runtime never supplies: {unreachable}"
+    )


### PR DESCRIPTION
## What does this PR do?

`_parse_sensors` lifts `poll_interval_ms` out of metadata into `SensorConfig`, and the adapter connection config never put it back. `CoapAdapter` and `HttpAdapter` read it anyway, so the read **always returned their own default of ten seconds**, whatever the operator configured.

## Why it is worse than a setting that failed to apply

Both adapters run a background loop that refreshes a cache, and `read()` serves that cache.

The runtime polls on the **operator's** interval while the cache refreshed on the **adapter's** default. A sensor configured at one second served the same reading **ten times over, each as though it were fresh**. A stale reading presented as current is worse than a slow one — nothing downstream can tell the difference.

`SmartAdapter` read the same key and used the value nowhere. That read is **removed rather than fed**: the correct answer to a read nothing consumes is to delete it.

The value is injected after the metadata spread, like the other runtime-supplied keys, so a metadata key reaching the assembly cannot displace it.

## A guard for direct reads — not the whole class

`test_no_adapter_directly_reads_a_key_the_assembly_never_supplies` asserts that no adapter **directly** reads a key which `_parse_sensors` withholds and the assembly does not supply.

**It does not close the class, and the test says so.** `adapter_metadata()` finds literal `config.get(...)` calls inside adapter classes and nothing else, so a setting resolved through a shared helper is invisible to it. That limitation surfaced in #411: moving baud resolution into a helper made both serial adapters look as though they read nothing, which is why they now pass presence and values into the resolver explicitly rather than handing it the config dict.

So this catches the next *direct* instance. A helper-resolved one needs either a stronger extractor or that same explicit-read discipline.

## Two harness defects found and fixed

Worth naming, because both would have produced a green test that proved nothing:

**`importorskip` proved nothing.** The CoAP assertion originally required `aiocoap`, which ships in **neither** requirements file — so it skipped locally *and* in CI while looking covered. It now patches the adapter's availability flag and injects a fake module, exactly as `tests/test_coap_adapter.py` already does. Installing `aiocoap` locally would have been worse than the skip: green on my machine, still skipped in CI.

**A blanket `try/except` masked an early refusal.** It hid the adapter raising before it ever reached the assignment, so the assertion ran against an untouched default. Also, a helper taking `**metadata` collided with its own `poll_interval_ms` parameter.

**And it happened again, in the fix for it.** Review caught that the CoAP test still wrapped `connect()` in `contextlib.suppress`, with a *synchronous* fake `create_client_context` where production awaits one. `connect()` raised `TypeError`, suppression hid it, and `_poll_interval_ms` is assigned before that point — so the assertion passed over an adapter that never connected and never started its poll loop.

Both adapter tests now require `connect()` to succeed and `is_connected` to be true, with `close()` in `finally` so the poll task does not outlive the test. Reinstating the synchronous fake fails with `object NoneType can't be used in 'await' expression` rather than passing quietly.

## Type of change

- [x] `fix` — bug fix

## Checklist

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability gains, loses, or changes availability. A configured interval that never reached two adapters now does; nothing in the matrix describes adapter poll scheduling.

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code — #417
- [x] Every new Tier D code path has test coverage — no Tier D path is touched
- [x] No new dependencies added without prior issue discussion — **none added**, deliberately

## Related issue

Closes #417

## Testing notes

**4323 passed, 27 skipped**, `pyright` 0 errors, vendored-vector drift clean. No hardware and no new dependency required.

8 assertions in the new file, **0 skipped**, and the CoAP case now genuinely connects rather than skipping or suppressing.

| Mutation | Failures |
|---|---|
| Remove the supply from the assembly | 7 |
| Restore `SmartAdapter`'s read | 1 |

Before the `importorskip` was replaced, removing the supply left the CoAP assertion *skipped* rather than failing. That is the difference between the two versions of this test.
