### PR TITLE
test(hal): stop the poll-cadence tests reading somebody else's sleep

### DIFF
--- a/tests/test_adapter_poll_interval.py
+++ b/tests/test_adapter_poll_interval.py
@@ -225,6 +225,8 @@ async def test_the_coap_poll_loop_sleeps_for_the_configured_interval() -> None:
     from ori.hal import coap_adapter
     from ori.hal.coap_adapter import CoapAdapter
 
+    poll_task_prefix = "coap-poll:"
+
     class _FakeContext:
         async def shutdown(self) -> None:
             return None
@@ -251,9 +253,22 @@ async def test_the_coap_poll_loop_sleeps_for_the_configured_interval() -> None:
     real_sleep = _asyncio.sleep
 
     async def _record_sleep(delay: float) -> None:
-        slept.append(delay)
-        first_sleep.set()
-        await real_sleep(0)
+        # Patching `asyncio.sleep` patches it for the whole loop, not just this
+        # adapter, so any concurrent task's sleep lands here too. Attribute each
+        # one to its task and keep only the adapter's: without this the first
+        # recorded delay could belong to somebody else, which is exactly how
+        # this test failed intermittently in a full-suite run while passing in
+        # isolation.
+        task = _asyncio.current_task()
+        if task is not None and (task.get_name() or "").startswith(poll_task_prefix):
+            slept.append(delay)
+            first_sleep.set()
+            await real_sleep(0)
+            return
+        # Any other task keeps its own timing. Collapsing every sleep to zero
+        # turns a concurrent sleeper into a busy loop that can starve the poll
+        # task this test is waiting on.
+        await real_sleep(delay)
 
     adapter = CoapAdapter()
     cfg = adapter_connect_config(
@@ -262,10 +277,15 @@ async def test_the_coap_poll_loop_sleeps_for_the_configured_interval() -> None:
         ),
         _config(),
     )
+
+    async def _no_network(self: object) -> None:
+        return None
+
     with (
         patch("ori.hal.coap_adapter._AIOCOAP_AVAILABLE", True),
         patch("ori.hal.coap_adapter._aiocoap", fake_aiocoap),
         patch.object(coap_adapter.asyncio, "sleep", _record_sleep),
+        patch.object(CoapAdapter, "_poll_once", _no_network),
     ):
         try:
             await adapter.connect(cfg)
@@ -280,7 +300,7 @@ async def test_the_coap_poll_loop_sleeps_for_the_configured_interval() -> None:
                 failures.append(exc)
 
     assert slept, "the poll loop never slept, so nothing governs its cadence"
-    assert slept[0] == 1.5, f"loop slept {slept[0]}s, not the configured 1.5s"
+    assert set(slept) == {1.5}, f"the poll loop slept {slept}, not 1.5s"
     assert not failures, f"the poll loop raised while being observed: {failures}"
 
 
@@ -290,6 +310,8 @@ async def test_the_http_poll_loop_sleeps_for_the_configured_interval() -> None:
 
     from ori.hal import http_adapter
     from ori.hal.http_adapter import HttpAdapter
+
+    poll_task_prefix = "http-poll:"
 
     slept: list[float] = []
     failures: list[BaseException] = []
@@ -302,15 +324,41 @@ async def test_the_http_poll_loop_sleeps_for_the_configured_interval() -> None:
     real_sleep = _asyncio.sleep
 
     async def _record_sleep(delay: float) -> None:
-        slept.append(delay)
-        first_sleep.set()
-        await real_sleep(0)
+        # Patching `asyncio.sleep` patches it for the whole loop, not just this
+        # adapter, so any concurrent task's sleep lands here too. Attribute each
+        # one to its task and keep only the adapter's: without this the first
+        # recorded delay could belong to somebody else, which is exactly how
+        # this test failed intermittently in a full-suite run while passing in
+        # isolation.
+        task = _asyncio.current_task()
+        if task is not None and (task.get_name() or "").startswith(poll_task_prefix):
+            slept.append(delay)
+            first_sleep.set()
+            await real_sleep(0)
+            return
+        # Any other task keeps its own timing. Collapsing every sleep to zero
+        # turns a concurrent sleeper into a busy loop that can starve the poll
+        # task this test is waiting on.
+        await real_sleep(delay)
 
     adapter = HttpAdapter()
     cfg = adapter_connect_config(
         _sensor("http", 1500, url="https://host/r", json_path="v"), _config()
     )
-    with patch.object(http_adapter.asyncio, "sleep", _record_sleep):
+
+    # The loop polls before it sleeps, and `_poll_once` makes a real request.
+    # Waiting on the first sleep therefore waited on DNS: fast here, but
+    # environment-dependent, and slow enough under load to exceed the timeout.
+    # That is what made this test fail intermittently in a full-suite run while
+    # passing in isolation — no patching race, an unmocked network call. The
+    # subject is the cadence, not the poll.
+    async def _no_network(self: object) -> None:
+        return None
+
+    with (
+        patch.object(http_adapter.asyncio, "sleep", _record_sleep),
+        patch.object(HttpAdapter, "_poll_once", _no_network),
+    ):
         try:
             await adapter.connect(cfg)
             assert adapter._poll_task is not None, "connect() must start the loop"
@@ -324,5 +372,69 @@ async def test_the_http_poll_loop_sleeps_for_the_configured_interval() -> None:
                 failures.append(exc)
 
     assert slept, "the poll loop never slept, so nothing governs its cadence"
-    assert slept[0] == 1.5, f"loop slept {slept[0]}s, not the configured 1.5s"
+    assert set(slept) == {1.5}, f"the poll loop slept {slept}, not 1.5s"
     assert not failures, f"the poll loop raised while being observed: {failures}"
+
+
+async def test_a_concurrent_task_sleeping_does_not_pollute_the_cadence_reading() -> (
+    None
+):
+    """The interference the task attribution exists to exclude.
+
+    Patching `asyncio.sleep` patches it for the whole event loop, so any other
+    task sleeping during the window is recorded too. That is how the HTTP
+    cadence test failed intermittently in a full-suite run while passing in
+    isolation: the first recorded delay belonged to somebody else.
+
+    Without a foreign sleeper, removing the attribution changes nothing and the
+    fix would be unproven — so this test supplies one.
+    """
+    import asyncio as _asyncio
+
+    from ori.hal import http_adapter
+    from ori.hal.http_adapter import HttpAdapter
+
+    recorded: list[float] = []
+    first_sleep = _asyncio.Event()
+    real_sleep = _asyncio.sleep
+    foreign_delay = 0.037
+
+    async def _record_sleep(delay: float) -> None:
+        task = _asyncio.current_task()
+        if task is not None and (task.get_name() or "").startswith("http-poll:"):
+            recorded.append(delay)
+            first_sleep.set()
+            await real_sleep(0)
+            return
+        await real_sleep(delay)
+
+    async def _foreign() -> None:
+        while True:
+            await _asyncio.sleep(foreign_delay)
+
+    adapter = HttpAdapter()
+    cfg = adapter_connect_config(
+        _sensor("http", 1500, url="https://host/r", json_path="v"), _config()
+    )
+
+    async def _no_network(self: object) -> None:
+        return None
+
+    with (
+        patch.object(http_adapter.asyncio, "sleep", _record_sleep),
+        patch.object(HttpAdapter, "_poll_once", _no_network),
+    ):
+        noise = _asyncio.create_task(_foreign(), name="foreign-sleeper")
+        try:
+            await adapter.connect(cfg)
+            await _asyncio.wait_for(first_sleep.wait(), timeout=2.0)
+        finally:
+            noise.cancel()
+            await _asyncio.gather(noise, return_exceptions=True)
+            await adapter.close()
+
+    assert recorded, "the adapter's own poll loop never slept"
+    assert foreign_delay not in recorded, (
+        f"a concurrent task's sleep was attributed to the adapter: {recorded}"
+    )
+    assert set(recorded) == {1.5}


### PR DESCRIPTION
## The symptom

`test_the_http_poll_loop_sleeps_for_the_configured_interval` failed intermittently in full-suite runs while passing in isolation — including 20 consecutive clean runs of its own file.

**Two independent causes, both in the test.** No production code changes.

## Why the test can see sleeps that are not its own

Both cadence tests patch `asyncio.sleep` to capture the delay the poll loop asks for. That patch is on the **asyncio module**, so it applies to the whole event loop, not to one adapter. Every sleep taken while it is active arrives at the fake.

### Cause 1 — a concurrent task

Any other task sleeping during the window was recorded, so the first captured delay could belong to something else.

Sleeps are now attributed by task name; only the adapter's own `http-poll:` / `coap-poll:` task counts. Foreign tasks keep their own timing — an earlier version collapsed every sleep to zero, which turned a concurrent sleeper into a **busy loop that starved the poll task the test was waiting on**, producing a fresh flake of its own.

### Cause 2 — the poll itself

The loop calls `_poll_once` **before** it sleeps, `_poll_once` makes a real HTTP request, and any sleep taken inside that request belongs to the **same task** — so it passes the attribution check and lands in the capture beside the cadence sleep.

Injecting a 0.25s sleep into `_poll_once` reproduces it exactly:

```
recorded: [0.25, 1.5, 0.25, 1.5, 0.25, 1.5, ...]
set(slept) == {1.5}?  False
```

Real `httpx` takes such a path only sometimes, which is why the failure was intermittent and confined to the HTTP adapter — the CoAP test already used a fake client, and has never failed.

Both cadence tests now control `_poll_once`, so the only sleep in the capture is the loop's own. The subject is the cadence, not the poll.

## Evidence, and its limits

A new test supplies a concurrent sleeper at 0.037s and asserts its delay never reaches the adapter's reading. Removing the attribution rule fails it, so **cause 1 is covered rather than assumed**.

**Cause 2 cannot be mutation-tested**, and I want to be plain about that rather than imply otherwise. Its trigger is nondeterministic: a test that reproduces it on demand would have to inject the sleep itself, which is the controlled reproduction above, not a regression test. The evidence for that half is the injection result, not a green run count.

For the same reason, repeated clean runs are weak evidence here — 20 of them preceded a failure. What justifies this fix is the identified mechanism, not the tally.

## A correction worth recording

My first explanation was that DNS resolution inside `_poll_once` exceeded the 2s `wait_for`. **I tested that and it was wrong** — a deliberately slow poll still reached the sleep, because the patch intercepted the poll's own sleep and satisfied the wait early. That result is what led to the real cause.

## Type of change

- [x] `test` — tests only

## Checklist

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — tests only; no behaviour changes.

## Related issue

Follows #422, which introduced these tests. No issue is closed by this.