### PR TITLE
fix(hal): make `mqtt.tls` the one place broker TLS is configured

### DIFF
--- a/ori/hal/mqtt_base.py
+++ b/ori/hal/mqtt_base.py
@@ -27,6 +27,17 @@ except ImportError:
     _AIOMQTT_AVAILABLE = False
 
 
+# Deprecated spellings of each `mqtt.tls.*` setting, kept for migration.
+_TLS_ALIASES: dict[str, tuple[str, ...]] = {
+    "enabled": ("mqtt_tls_enabled",),
+    "ca_certfile": ("mqtt_tls_ca_certfile", "tls_ca_certfile"),
+    "certfile": ("mqtt_tls_certfile", "tls_certfile"),
+    "keyfile": ("mqtt_tls_keyfile", "tls_keyfile"),
+    "keyfile_password": ("mqtt_tls_keyfile_password", "tls_keyfile_password"),
+    "insecure": ("mqtt_tls_insecure", "tls_insecure"),
+}
+
+
 class MqttCachedAdapter(BaseAdapter):
     """Reusable base for MQTT adapters that subscribe and cache latest values."""
 
@@ -108,22 +119,34 @@ class MqttCachedAdapter(BaseAdapter):
         if not isinstance(tls_cfg, dict):
             tls_cfg = {}
 
-        tls_enabled = self._as_bool(
-            _first("mqtt_tls_enabled")
-            if _first("mqtt_tls_enabled") is not None
-            else tls_cfg.get("enabled"),
-            default=False,
-        )
+        def _tls_setting(canonical: str) -> Any:
+            """Resolve one `mqtt.tls.*` setting, refusing a second spelling of it."""
+            # Presence is membership: a spelling written as `null` was written.
+            supplied: list[tuple[str, Any]] = []
+            if canonical in tls_cfg:
+                supplied.append((f"mqtt.tls.{canonical}", tls_cfg[canonical]))
+            for alias in _TLS_ALIASES[canonical]:
+                if alias in config:
+                    supplied.append((alias, config[alias]))
+                if alias in mqtt_cfg:
+                    supplied.append((f"mqtt.{alias}", mqtt_cfg[alias]))
 
-        tls_ca_certfile = _first("mqtt_tls_ca_certfile", "tls_ca_certfile")
-        tls_certfile = _first("mqtt_tls_certfile", "tls_certfile")
-        tls_keyfile = _first("mqtt_tls_keyfile", "tls_keyfile")
-        tls_keyfile_password = _first(
-            "mqtt_tls_keyfile_password", "tls_keyfile_password"
-        )
-        tls_insecure = _first("mqtt_tls_insecure", "tls_insecure")
-        if tls_insecure is None:
-            tls_insecure = tls_cfg.get("insecure")
+            if len(supplied) > 1:
+                names = ", ".join(repr(name) for name, _ in supplied)
+                raise AdapterConnectionError(
+                    f"{self.adapter_name}: {names} all supply the TLS setting "
+                    f"'mqtt.tls.{canonical}'. Refused rather than resolved by "
+                    f"precedence, even where the values agree. Keep "
+                    f"'mqtt.tls.{canonical}' and remove the others."
+                )
+            return supplied[0][1] if supplied else None
+
+        tls_enabled = self._as_bool(_tls_setting("enabled"), default=False)
+        tls_ca_certfile = _tls_setting("ca_certfile")
+        tls_certfile = _tls_setting("certfile")
+        tls_keyfile = _tls_setting("keyfile")
+        tls_keyfile_password = _tls_setting("keyfile_password")
+        tls_insecure = _tls_setting("insecure")
 
         needs_tls_context = tls_enabled or any(
             v not in (None, "")

--- a/tests/test_mqtt_tls_config.py
+++ b/tests/test_mqtt_tls_config.py
@@ -1,0 +1,271 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""TLS material resolution for the MQTT adapter family.
+
+Every spelling the runtime documents must reach `ssl`. A path that resolves to
+nothing does not fail: the context falls back to the system trust store, so the
+broker is verified against public CAs while the operator believes their private
+one is in force.
+"""
+
+from __future__ import annotations
+
+import ssl
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
+
+from ori.hal.base import AdapterConnectionError
+from ori.hal.mqtt_adapter import MqttAdapter
+
+NOW = datetime(2026, 7, 23, 12, 0, tzinfo=UTC)
+CA_COMMON_NAME = "Ori Site Broker CA"
+
+
+def _self_signed(common_name: str, *, is_ca: bool) -> tuple[bytes, bytes]:
+    key = ec.generate_private_key(ec.SECP256R1())
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, common_name)])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(NOW - timedelta(days=1))
+        .not_valid_after(NOW + timedelta(days=365))
+        .add_extension(x509.BasicConstraints(ca=is_ca, path_length=None), True)
+        .sign(key, hashes.SHA256())
+    )
+    return (
+        certificate.public_bytes(serialization.Encoding.PEM),
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.PKCS8,
+            serialization.NoEncryption(),
+        ),
+    )
+
+
+@pytest.fixture
+def ca_certfile(tmp_path: Path) -> Path:
+    certificate, _ = _self_signed(CA_COMMON_NAME, is_ca=True)
+    path = tmp_path / "site-ca.crt"
+    path.write_bytes(certificate)
+    return path
+
+
+@pytest.fixture
+def client_material(tmp_path: Path) -> tuple[Path, Path]:
+    certificate, key = _self_signed("ori-runtime-01", is_ca=False)
+    certfile = tmp_path / "client.crt"
+    keyfile = tmp_path / "client.key"
+    certfile.write_bytes(certificate)
+    keyfile.write_bytes(key)
+    return certfile, keyfile
+
+
+def _trusted_common_names(context: ssl.SSLContext) -> list[str]:
+    names = []
+    for entry in context.get_ca_certs():
+        for rdn in entry.get("subject", ()):
+            for attribute, value in rdn:
+                if attribute == "commonName":
+                    names.append(value)
+    return names
+
+
+def _kwargs(config: dict) -> dict:
+    return MqttAdapter()._build_mqtt_client_kwargs(config)
+
+
+def _ca_configs(ca: str) -> dict[str, dict]:
+    """Every spelling `ori.yaml.example` and the adapters accept for one CA."""
+    return {
+        "nested-under-mqtt-tls": {
+            "mqtt": {"tls": {"enabled": True, "ca_certfile": ca}}
+        },
+        "flat-under-mqtt": {"mqtt": {"tls": {"enabled": True}, "tls_ca_certfile": ca}},
+        "flat-on-the-sensor": {"mqtt_tls_enabled": True, "mqtt_tls_ca_certfile": ca},
+        "short-flat-on-the-sensor": {"mqtt_tls_enabled": True, "tls_ca_certfile": ca},
+    }
+
+
+@pytest.mark.parametrize("spelling", list(_ca_configs("/unused").keys()))
+def test_every_documented_ca_spelling_reaches_the_trust_store(
+    spelling: str, ca_certfile: Path
+) -> None:
+    """The operator's CA is loaded, and it is the only one trusted."""
+    context = _kwargs(_ca_configs(str(ca_certfile))[spelling])["tls_context"]
+
+    assert _trusted_common_names(context) == [CA_COMMON_NAME]
+
+
+def test_a_nested_client_certificate_path_is_read(
+    tmp_path: Path, client_material: tuple[Path, Path]
+) -> None:
+    """Driven by absence: `ssl` exposes no way to read back a loaded chain."""
+    _, keyfile = client_material
+
+    with pytest.raises(AdapterConnectionError, match="invalid MQTT TLS configuration"):
+        _kwargs(
+            {
+                "mqtt": {
+                    "tls": {
+                        "enabled": True,
+                        "certfile": str(tmp_path / "absent.crt"),
+                        "keyfile": str(keyfile),
+                    }
+                }
+            }
+        )
+
+
+def test_a_nested_keyfile_that_does_not_match_its_certificate_is_refused(
+    tmp_path: Path, client_material: tuple[Path, Path]
+) -> None:
+    certfile, _ = client_material
+    _, other_key = _self_signed("someone-else", is_ca=False)
+    mismatched = tmp_path / "other.key"
+    mismatched.write_bytes(other_key)
+
+    with pytest.raises(AdapterConnectionError, match="invalid MQTT TLS configuration"):
+        _kwargs(
+            {
+                "mqtt": {
+                    "tls": {
+                        "enabled": True,
+                        "certfile": str(certfile),
+                        "keyfile": str(mismatched),
+                    }
+                }
+            }
+        )
+
+
+def test_a_nested_ca_path_that_does_not_exist_is_refused(tmp_path: Path) -> None:
+    with pytest.raises(AdapterConnectionError, match="invalid MQTT TLS configuration"):
+        _kwargs(
+            {"mqtt": {"tls": {"enabled": True, "ca_certfile": str(tmp_path / "nope")}}}
+        )
+
+
+def test_two_spellings_of_one_trust_anchor_are_refused(
+    ca_certfile: Path, tmp_path: Path
+) -> None:
+    """Choosing between two declared trust anchors decides which broker is believed."""
+    other = tmp_path / "other-ca.crt"
+    other.write_bytes(_self_signed("Other CA", is_ca=True)[0])
+
+    with pytest.raises(AdapterConnectionError, match="mqtt.tls.ca_certfile"):
+        _kwargs(
+            {
+                "mqtt_tls_enabled": True,
+                "mqtt_tls_ca_certfile": str(ca_certfile),
+                "mqtt": {"tls": {"ca_certfile": str(other)}},
+            }
+        )
+
+
+def test_agreeing_spellings_are_refused_too(ca_certfile: Path) -> None:
+    """Agreement today is not agreement after the next edit."""
+    with pytest.raises(AdapterConnectionError, match="mqtt.tls.ca_certfile"):
+        _kwargs(
+            {
+                "mqtt_tls_enabled": True,
+                "mqtt_tls_ca_certfile": str(ca_certfile),
+                "mqtt": {"tls": {"ca_certfile": str(ca_certfile)}},
+            }
+        )
+
+
+def test_the_refusal_names_every_spelling_that_supplied_the_setting(
+    ca_certfile: Path,
+) -> None:
+    with pytest.raises(AdapterConnectionError) as excinfo:
+        _kwargs(
+            {
+                "mqtt_tls_enabled": True,
+                "mqtt_tls_ca_certfile": str(ca_certfile),
+                "tls_ca_certfile": str(ca_certfile),
+                "mqtt": {"tls": {"ca_certfile": str(ca_certfile)}},
+            }
+        )
+
+    message = str(excinfo.value)
+    for spelling in ("mqtt.tls.ca_certfile", "mqtt_tls_ca_certfile", "tls_ca_certfile"):
+        assert spelling in message
+
+
+def test_an_alias_inside_the_mqtt_block_conflicts_with_the_canonical_one(
+    ca_certfile: Path,
+) -> None:
+    """`mqtt.tls_ca_certfile` and `mqtt.tls.ca_certfile` are two spellings."""
+    with pytest.raises(AdapterConnectionError, match="mqtt.tls.ca_certfile"):
+        _kwargs(
+            {
+                "mqtt": {
+                    "tls_ca_certfile": str(ca_certfile),
+                    "tls": {"enabled": True, "ca_certfile": str(ca_certfile)},
+                }
+            }
+        )
+
+
+def test_an_alias_written_as_null_still_conflicts(ca_certfile: Path) -> None:
+    """Presence is judged on the document as written."""
+    with pytest.raises(AdapterConnectionError, match="mqtt.tls.ca_certfile"):
+        _kwargs(
+            {
+                "mqtt_tls_ca_certfile": None,
+                "mqtt": {"tls": {"enabled": True, "ca_certfile": str(ca_certfile)}},
+            }
+        )
+
+
+def test_a_null_written_alone_is_left_to_value_handling(ca_certfile: Path) -> None:
+    """One spelling is never a conflict; the schema layer refuses the null."""
+    assert "tls_context" not in _kwargs({"mqtt_tls_ca_certfile": None})
+
+
+def test_different_settings_in_different_spellings_do_not_conflict(
+    ca_certfile: Path,
+) -> None:
+    """Only one setting written twice is a conflict, not two settings."""
+    context = _kwargs(
+        {
+            "mqtt_tls_enabled": True,
+            "mqtt": {"tls": {"ca_certfile": str(ca_certfile)}},
+        }
+    )["tls_context"]
+
+    assert _trusted_common_names(context) == [CA_COMMON_NAME]
+
+
+def test_nested_insecure_still_disables_verification() -> None:
+    context = _kwargs({"mqtt": {"tls": {"enabled": True, "insecure": True}}})[
+        "tls_context"
+    ]
+
+    assert context.check_hostname is False
+    assert context.verify_mode == ssl.CERT_NONE
+
+
+def test_material_declared_without_enabled_still_builds_a_context(
+    ca_certfile: Path,
+) -> None:
+    """Declaring a CA is asking for TLS, whether or not `enabled` is written."""
+    context = _kwargs({"mqtt": {"tls": {"ca_certfile": str(ca_certfile)}}})[
+        "tls_context"
+    ]
+
+    assert _trusted_common_names(context) == [CA_COMMON_NAME]
+
+
+def test_no_tls_configuration_builds_no_context() -> None:
+    assert "tls_context" not in _kwargs({"broker_host": "192.168.1.50"})


### PR DESCRIPTION
## What does this PR do?

`ori.yaml.example` documents a sensor's broker TLS as `mqtt.tls.enabled`, `mqtt.tls.insecure`, `mqtt.tls.ca_certfile`, `mqtt.tls.certfile` and `mqtt.tls.keyfile`. Only the first two were ever read. The resolver searched the sensor entry and the `mqtt` block, never `mqtt.tls`, so the three path settings resolved to nothing.

Nothing failed. `ssl.create_default_context(cafile=None)` succeeds and loads the system trust store, so a runtime configured against a private site CA verified its broker against the public ones instead, and presented no client certificate while appearing to be configured for mutual TLS. A wrong path would have raised; an unread one is silent, and the operator's evidence that TLS is configured is the file they wrote.

**Every documented spelling now resolves, and `mqtt.tls` is the only canonical home.** The flat names are aliases rather than winners: supplying a setting in more than one spelling is refused, naming every place it was written, even where the values agree. A precedence rule is invisible in the file that carries it, and choosing silently between two declared trust anchors decides which broker the runtime believes.

**Presence is membership, not a non-null value.** A spelling written as `null` was still written, and reading it as absent would let a second spelling take effect beside it — the same precedence rule, reached by a value instead of by an order. What a lone null means is left to the value: the schema layer refuses it against a declared string, and this check exists only to establish which spelling governs.

**One behaviour change beyond the fix.** TLS material written without `enabled` now builds a context where it previously built none, so a deployment whose material was being ignored will start attempting TLS. That is what the configuration asked for, and it is still a change worth stating before it is met in the field.

**Deliberately not in scope.** The non-TLS client settings — username, password, client id, keepalive, transport, timeouts — keep the existing precedence chain. Closing that belongs with the loader-level alias resolution in ori-specs#110, where the schema declares which spelling is canonical rather than each adapter deciding. Fixing it here would be a second implementation of a rule about to be declared, and half a class closed reads as the whole class handled.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — the matrix guard passes on this diff. No capability appears or disappears: MQTT sensor adapters could already be configured with broker TLS, and this makes the documented configuration reach `ssl` rather than adding a capability.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `cryptography` is already a runtime dependency and is used by the tests only.

## Related issue

Closes #427

The surface inventory that found it belongs to ori-specs#110, and the alias model this follows is settled in that contract.

## Testing notes

Seventeen tests in `tests/test_mqtt_tls_config.py`. They build a real self-signed CA and assert the resulting context trusts **that CA alone**, because a context that merely exists is exactly what the defect already produced — asserting its presence would have passed against the broken code.

The client-certificate path is driven by absence: `ssl` exposes no way to read back a chain a context is holding, so a path that is never read cannot be missing. A nonexistent certfile and a keyfile that does not match its certificate both have to raise.

Two mutations were checked and each restore verified byte-identical. Stubbing the conflict branch fails the four refusal tests and nothing else. Restoring `.get(...) is not None` presence fails only the null-alias conflict test, which is the case that separates membership from truth.

Full suite: 4493 passed, 27 skipped. `ruff` and `pyright` clean on both changed files.