### PR TITLE
feat(hal): consume sensor configuration vectors

### DIFF
--- a/ori/hal/config_schema.py
+++ b/ori/hal/config_schema.py
@@ -59,6 +59,7 @@ _DESCRIPTOR_KEYS = {
     "description",
 }
 _SCHEMA_CONSTRAINTS = {"exactly_one_of", "at_least_one_of"}
+_ALIAS_DESCRIPTOR_KEYS = {"type", "deprecated", "supersedes", "description"}
 
 
 class SchemaError(Exception):
@@ -221,6 +222,36 @@ def _validate_descriptor(descriptor: Any, where: str) -> None:
             f"got {_show(kind)}"
         )
 
+    for prop, expected in (
+        ("required", bool),
+        ("deprecated", bool),
+        ("supersedes", str),
+        ("required_unless", dict),
+        ("description", str),
+    ):
+        if prop in descriptor and not isinstance(descriptor[prop], expected):
+            raise SchemaError(
+                f"{where}: '{prop}' must be {expected.__name__}, got "
+                f"{type(descriptor[prop]).__name__}"
+            )
+
+    if descriptor.get("deprecated") and not descriptor.get("supersedes"):
+        raise SchemaError(f"{where}: 'deprecated' requires 'supersedes'")
+    if descriptor.get("supersedes") and not descriptor.get("deprecated"):
+        raise SchemaError(f"{where}: 'supersedes' is only valid on a deprecated field")
+
+    if descriptor.get("deprecated") is True:
+        competing = sorted(set(descriptor) - _ALIAS_DESCRIPTOR_KEYS)
+        if competing:
+            raise SchemaError(
+                f"{where}: a deprecated alias may declare only "
+                f"{sorted(_ALIAS_DESCRIPTOR_KEYS)}, not {competing}"
+            )
+        # The target owns recursive closure and every value constraint. An
+        # alias holds no value after resolution, so an array/object alias must
+        # not duplicate the target's contents declaration.
+        return
+
     if descriptor.get("required") and "default" in descriptor:
         raise SchemaError(
             f"{where}: 'default' and 'required: true' are mutually exclusive — "
@@ -246,19 +277,6 @@ def _validate_descriptor(descriptor: Any, where: str) -> None:
         _validate_descriptor(items, f"{where}[]")
     elif "items" in descriptor:
         raise SchemaError(f"{where}: 'items' is only valid on 'type: array'")
-
-    for prop, expected in (
-        ("required", bool),
-        ("deprecated", bool),
-        ("supersedes", str),
-        ("required_unless", dict),
-        ("description", str),
-    ):
-        if prop in descriptor and not isinstance(descriptor[prop], expected):
-            raise SchemaError(
-                f"{where}: '{prop}' must be {expected.__name__}, got "
-                f"{type(descriptor[prop]).__name__}"
-            )
 
     for bound in ("minimum", "maximum"):
         if bound not in descriptor:
@@ -303,13 +321,6 @@ def _validate_descriptor(descriptor: Any, where: str) -> None:
             raise SchemaError(f"{where}: 'enum' must be a non-empty list")
         for value in values:
             _check_value(value, descriptor, f"{where} enum", schema_phase=True)
-
-    if descriptor.get("deprecated") and not descriptor.get("supersedes"):
-        raise SchemaError(f"{where}: 'deprecated' requires 'supersedes'")
-    if descriptor.get("supersedes") and not descriptor.get("deprecated"):
-        raise SchemaError(f"{where}: 'supersedes' is only valid on a deprecated field")
-    if descriptor.get("deprecated") and descriptor.get("required"):
-        raise SchemaError(f"{where}: a deprecated field must not be required")
 
     # A default the schema would reject is a defect that otherwise appears only
     # for the operator who omits the key.
@@ -424,14 +435,14 @@ def _validate_references_in(fields: dict[str, Any], where: str) -> None:
     `required_unless` or `supersedes` names a key in *that* mapping, and
     validating only the top level let a nested alias point at nothing.
     """
-    names = set(fields)
     _validate_conditional_cycles(fields, where)
     for key, descriptor in fields.items():
-        _validate_references(descriptor, names, _join(where, key), fields)
-        if descriptor.get("type") == "object":
+        _validate_references(descriptor, fields, _join(where, key))
+        if descriptor.get("type") == "object" and not descriptor.get("deprecated"):
             _validate_references_in(descriptor["properties"], _join(where, key))
         elif (
             descriptor.get("type") == "array"
+            and not descriptor.get("deprecated")
             and descriptor["items"].get("type") == "object"
         ):
             _validate_references_in(
@@ -439,16 +450,20 @@ def _validate_references_in(fields: dict[str, Any], where: str) -> None:
             )
 
 
-def _validate_references(
-    descriptor: dict, fields: set[str], where: str, fields_by_name: dict[str, Any]
-) -> None:
+def _validate_references(descriptor: dict, fields: dict[str, Any], where: str) -> None:
     replacement = descriptor.get("supersedes")
-    if replacement is not None and replacement not in fields:
-        raise SchemaError(
-            f"{where}: 'supersedes' names {_show(replacement)}, which the schema does not "
-            f"declare. An alias for a key that does not exist warns an operator "
-            f"towards nothing."
-        )
+    if replacement is not None:
+        target = _schema_path(fields, replacement, where)
+        if target.get("deprecated"):
+            raise SchemaError(
+                f"{where}: 'supersedes' names {replacement!r}, which is itself "
+                "deprecated. An alias of an alias has no canonical spelling."
+            )
+        if descriptor["type"] != target["type"]:
+            raise SchemaError(
+                f"{where}: alias type {descriptor['type']!r} differs from its target "
+                f"{replacement!r} ({target['type']!r})"
+            )
 
     condition = descriptor.get("required_unless")
     if condition is None:
@@ -468,6 +483,29 @@ def _validate_references(
             f"{where}: 'required_unless' names {key!r}, which the schema does not declare — "
             f"the condition could never fire"
         )
+
+
+def _schema_path(fields: dict[str, Any], path: str, where: str) -> dict[str, Any]:
+    """Resolve an alias target without permitting an unstable array path."""
+    node = fields
+    segments = path.split(".")
+    for index, segment in enumerate(segments):
+        if segment not in node:
+            raise SchemaError(
+                f"{where}: 'supersedes' names {path!r}, which the schema does not "
+                "declare. An alias for a key that does not exist warns an operator "
+                "towards nothing."
+            )
+        descriptor = node[segment]
+        if index == len(segments) - 1:
+            return descriptor
+        if descriptor.get("deprecated") or descriptor["type"] != "object":
+            raise SchemaError(
+                f"{where}: 'supersedes' names {path!r}, but {segment!r} is not an "
+                "object with properties"
+            )
+        node = descriptor["properties"]
+    raise AssertionError("a non-empty supersedes path always returns")
 
 
 # ── Value checking, shared by both phases ────────────────────────────────────
@@ -595,8 +633,9 @@ def validate_document(
         )
 
     _require_external(schema, context, external)
-    _check_groups(document, schema.groups, context)
-    return _resolve_mapping(document, schema.fields, context, external)
+    document = _resolve_aliases(document, schema.fields, context)
+    inactive = _check_groups(document, schema.groups, context)
+    return _resolve_mapping(document, schema.fields, context, external, inactive)
 
 
 def _require_external(
@@ -622,6 +661,7 @@ def _resolve_mapping(
     fields: dict[str, Any],
     context: str,
     external: dict | None,
+    inactive: frozenset[str] = frozenset(),
 ) -> dict:
     """Resolve one mapping level: unknown keys, conditionals, defaults, recursion.
 
@@ -642,10 +682,6 @@ def _resolve_mapping(
                 f"Declared keys: {sorted(fields)}"
             )
 
-    # Deprecation is checked at every level: a nested alias and its nested
-    # replacement together is the same ambiguity as at the top.
-    _check_deprecations(document, fields, context)
-
     # Pass one: resolve everything that can be resolved without knowing whether
     # a dependent field is required. Conditionals are evaluated afterwards
     # against these values, not against the raw document — otherwise a
@@ -653,6 +689,8 @@ def _resolve_mapping(
     # document that is in fact complete.
     resolved: dict[str, Any] = {}
     for key, descriptor in fields.items():
+        if key in inactive:
+            continue
         where = _join(context, key)
 
         if key in document:
@@ -677,6 +715,8 @@ def _resolve_mapping(
 
     # Pass two: requirements, now that every sibling has its effective value.
     for key, descriptor in fields.items():
+        if key in inactive:
+            continue
         if key in resolved:
             continue
         _check_conditional_requirement(key, descriptor, resolved, context)
@@ -684,6 +724,8 @@ def _resolve_mapping(
             raise DocumentError(f"{_join(context, key)}: required and missing")
 
     for key, descriptor in fields.items():
+        if key in inactive:
+            continue
         if "must_be_subset_of" in descriptor and key in resolved:
             _check_subset(
                 resolved[key],
@@ -701,23 +743,41 @@ def _resolve_value(
     """Check a value and return its resolved form, recursing into objects."""
     _check_value(value, descriptor, where, schema_phase=False)
     if descriptor["type"] == "object":
+        value = _resolve_aliases(value, descriptor["properties"], where)
         return _resolve_mapping(value, descriptor["properties"], where, external)
     if descriptor["type"] == "array" and descriptor["items"]["type"] == "object":
         return [
             _resolve_mapping(
-                item, descriptor["items"]["properties"], f"{where}[{i}]", external
+                _resolve_aliases(
+                    item, descriptor["items"]["properties"], f"{where}[{i}]"
+                ),
+                descriptor["items"]["properties"],
+                f"{where}[{i}]",
+                external,
             )
             for i, item in enumerate(value)
         ]
     return value
 
 
-def _check_deprecations(document: dict, fields: dict, context: str) -> None:
+def _resolve_aliases(document: dict, fields: dict, context: str) -> dict:
+    """Move written aliases into their canonical positions before resolution."""
+    resolved = dict(document)
+    alias_origins: dict[str, str] = {}
     for key, descriptor in fields.items():
         if not descriptor.get("deprecated") or key not in document:
             continue
         replacement = descriptor["supersedes"]
-        if replacement in document:
+        exists, _ = _path_value(resolved, replacement)
+        if exists:
+            first_alias = alias_origins.get(replacement)
+            if first_alias is not None:
+                raise DocumentError(
+                    f"{context}: sets both deprecated aliases {first_alias!r} and "
+                    f"{key!r} for {replacement!r}. Refused even when the values agree "
+                    "— a precedence rule is invisible in the file that carries it. "
+                    f"Keep {replacement!r}."
+                )
             raise DocumentError(
                 f"{context}: sets both {replacement!r} and its deprecated alias {key!r}. "
                 f"Refused even when the values agree — agreement today is not agreement "
@@ -730,6 +790,39 @@ def _check_deprecations(document: dict, fields: dict, context: str) -> None:
             key,
             replacement,
         )
+        _set_path(resolved, replacement, document[key], context)
+        alias_origins[replacement] = key
+        del resolved[key]
+    return resolved
+
+
+def _path_value(document: dict, path: str) -> tuple[bool, Any]:
+    node: Any = document
+    for segment in path.split("."):
+        if not isinstance(node, dict) or segment not in node:
+            return False, None
+        node = node[segment]
+    return True, node
+
+
+def _set_path(document: dict, path: str, value: Any, context: str) -> None:
+    node = document
+    segments = path.split(".")
+    for segment in segments[:-1]:
+        if segment not in node:
+            node[segment] = {}
+        elif not isinstance(node[segment], dict):
+            raise DocumentError(
+                f"{context}: cannot resolve deprecated alias into {path!r}; "
+                f"{segment!r} is not an object"
+            )
+        # `resolved` starts as a shallow top-level copy. Copy every existing
+        # intermediate mapping before writing through it, otherwise an alias
+        # leaks a canonical key into the caller's document and a second
+        # validation rejects the runtime's own previous write.
+        node[segment] = dict(node[segment])
+        node = node[segment]
+    node[segments[-1]] = value
 
 
 def _check_conditional_requirement(
@@ -746,15 +839,19 @@ def _check_conditional_requirement(
         )
 
 
-def _check_groups(document: dict, groups: dict[str, Any], context: str) -> None:
+def _check_groups(
+    document: dict, groups: dict[str, Any], context: str
+) -> frozenset[str]:
     present = set(document)
+    inactive: frozenset[str] = frozenset()
 
     if "exactly_one_of" in groups:
         alternatives = groups["exactly_one_of"]
         satisfied = [g for g in alternatives if set(g) <= present]
         if len(satisfied) != 1:
             raise DocumentError(
-                f"{context}: exactly one of {alternatives} must be fully present, "
+                f"{context}: 'exactly_one_of' requires exactly one of {alternatives} "
+                "to be fully present, "
                 f"{len(satisfied)} are"
             )
         # Naming a group is choosing it. A key from a rejected alternative
@@ -767,13 +864,18 @@ def _check_groups(document: dict, groups: dict[str, Any], context: str) -> None:
                 f"{context}: {strays} belong to an alternative that was not chosen. "
                 f"Configured ambiguously rather than twice."
             )
+        inactive = frozenset(
+            {field for group in alternatives for field in group} - chosen
+        )
 
     if "at_least_one_of" in groups:
         alternatives = groups["at_least_one_of"]
         if not any(set(g) <= present for g in alternatives):
             raise DocumentError(
-                f"{context}: at least one of {alternatives} must be fully present"
+                f"{context}: 'at_least_one_of' requires at least one of {alternatives} "
+                "to be fully present"
             )
+    return inactive
 
 
 def _resolve_path(path: str, external: dict | None, where: str, prop: str) -> Any:

--- a/ori/hal/config_schema.py
+++ b/ori/hal/config_schema.py
@@ -770,7 +770,7 @@ def _resolve_aliases(document: dict, fields: dict, context: str) -> dict:
         replacement = descriptor["supersedes"]
         exists, _ = _path_value(resolved, replacement)
         if exists:
-            first_alias = alias_origins.get(replacement)
+            first_alias = _alias_origin_for_path(alias_origins, replacement)
             if first_alias is not None:
                 raise DocumentError(
                     f"{context}: sets both deprecated aliases {first_alias!r} and "
@@ -794,6 +794,16 @@ def _resolve_aliases(document: dict, fields: dict, context: str) -> dict:
         alias_origins[replacement] = key
         del resolved[key]
     return resolved
+
+
+def _alias_origin_for_path(alias_origins: dict[str, str], path: str) -> str | None:
+    """Return the alias that already supplied ``path`` or one of its parents."""
+    segments = path.split(".")
+    for length in range(len(segments), 0, -1):
+        origin = alias_origins.get(".".join(segments[:length]))
+        if origin is not None:
+            return origin
+    return None
 
 
 def _path_value(document: dict, path: str) -> tuple[bool, Any]:

--- a/scripts/refresh-evidence-vectors.sh
+++ b/scripts/refresh-evidence-vectors.sh
@@ -47,6 +47,10 @@ SETS=(
   # evidence carriage. It pins independently because it has no reason to move
   # when the evidence contracts do.
   "commissioned-safety-binding:tests/vectors/commissioned_safety_binding"
+  # Sensor configuration is its own contract and changes independently of the
+  # evidence sets. Its consumer is the loader, not the evidence subsystem, so
+  # it needs an independent provenance pin as well.
+  "sensor-configuration/vectors:tests/vectors/sensor_configuration"
 )
 
 if [ -n "${ORI_SPECS_DIR:-}" ]; then

--- a/scripts/test-refresh-evidence-vectors.sh
+++ b/scripts/test-refresh-evidence-vectors.sh
@@ -27,7 +27,7 @@ trap 'rm -rf "${WORK}"' EXIT
 ok()  { PASS=$((PASS + 1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
 bad() { FAIL=$((FAIL + 1)); printf '  \033[31mFAIL\033[0m  %s\n' "$1"; [ -n "${2:-}" ] && printf '        %s\n' "$2"; }
 
-# A minimal ori-specs with one vendored set, plus a consumer that vendors it.
+# A minimal ori-specs with every vendored set, plus a consumer that vendors it.
 # The script iterates a fixed SETS list, so the fixture provides every path it
 # looks for; only commissioned-safety-binding carries content that matters here.
 new_fixture() {
@@ -39,7 +39,8 @@ new_fixture() {
   git -C "${specs}" config user.email t@example.com
   git -C "${specs}" config user.name t
   for d in evidence/vectors evidence-exchange/vectors evidence-exchange/vectors/receiver-state \
-           runtime-evidence-anchor/vectors gateway-api/vectors commissioned-safety-binding; do
+           runtime-evidence-anchor/vectors gateway-api/vectors commissioned-safety-binding \
+           sensor-configuration/vectors; do
     mkdir -p "${specs}/${d}"
     printf '{"set":"%s","v":1}\n' "${d}" > "${specs}/${d}/vectors.json"
   done

--- a/tests/test_evidence_exchange_graph.py
+++ b/tests/test_evidence_exchange_graph.py
@@ -433,6 +433,14 @@ VECTOR_CONSUMERS = {
     ("runtime_evidence_anchor", "runtime-anchor"): (
         "test_evidence_anchor.py::test_derivations_match_the_contract_vectors",
     ),
+    ("sensor_configuration", "schema-load"): (
+        "test_sensor_config_schema.py"
+        "::test_schema_load_conforms_to_the_vendored_contract_vectors",
+    ),
+    ("sensor_configuration", "protocol-config"): (
+        "test_sensor_config_schema.py"
+        "::test_protocol_config_conforms_to_the_vendored_contract_vectors",
+    ),
 }
 
 #: Vendored vectors this runtime cannot exercise yet.
@@ -483,6 +491,37 @@ VECTOR_EXEMPTIONS = {
             "would hand one over are still open. Vendored now so the drift "
             "check covers the bytes the producer must match, and exempt until a "
             "publisher exists to assert against them."
+        ),
+    },
+    ("sensor_configuration", "sensor-entry"): {
+        "owner": "the runtime",
+        "status": "proof_pending",
+        "tracking": "ori-specs#110",
+        "reason": (
+            "The canonical sensor envelope has no production consumer until "
+            "the atomic schema activation adds loader enforcement. The vector "
+            "is vendored and drift-checked now, but no runtime parser reads it."
+        ),
+    },
+    ("sensor_configuration", "calibration"): {
+        "owner": "the runtime",
+        "status": "proof_pending",
+        "tracking": "ori-specs#110",
+        "reason": (
+            "Calibration selection depends on adapter declarations and loader "
+            "enforcement, neither of which is activated yet. The vector is "
+            "vendored for drift checking but does not claim runtime conformance."
+        ),
+    },
+    ("sensor_configuration", "protocol-definition"): {
+        "owner": "the runtime",
+        "status": "proof_pending",
+        "tracking": "ori-specs#110",
+        "reason": (
+            "The registry still uses its pre-activation factory chain, so it "
+            "cannot exercise module declaration resolution without constructing "
+            "adapters. The vector remains explicitly unconsumed until that seam "
+            "is replaced."
         ),
     },
 }

--- a/tests/test_sensor_config_schema.py
+++ b/tests/test_sensor_config_schema.py
@@ -514,6 +514,36 @@ def test_two_aliases_for_one_target_are_refused_without_schema_order_precedence(
     assert "mqtt.client_id" in message
 
 
+def test_an_object_alias_and_leaf_alias_name_the_written_aliases_on_conflict() -> None:
+    schema = _ok(
+        {
+            "mqtt": {
+                "type": "object",
+                "properties": {"username": {"type": "string"}},
+            },
+            "legacy_broker": {
+                "type": "object",
+                "deprecated": True,
+                "supersedes": "mqtt",
+            },
+            "mqtt_username": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.username",
+            },
+        }
+    )
+    with pytest.raises(DocumentError) as excinfo:
+        validate_document(
+            {"legacy_broker": {"username": "first"}, "mqtt_username": "second"},
+            schema,
+            context="s",
+        )
+    message = str(excinfo.value)
+    assert "legacy_broker" in message
+    assert "mqtt_username" in message
+
+
 def test_alias_resolution_does_not_mutate_or_change_the_callers_document() -> None:
     schema = _ok(
         {

--- a/tests/test_sensor_config_schema.py
+++ b/tests/test_sensor_config_schema.py
@@ -18,8 +18,10 @@ about which exists.
 from __future__ import annotations
 
 import contextlib
+import json
 import logging
 import random
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -32,6 +34,12 @@ from ori.hal.config_schema import (
     validate_schema,
 )
 
+VECTORS = Path(__file__).parent / "vectors" / "sensor_configuration"
+SCHEMA_LOAD_VECTORS = json.loads((VECTORS / "schema-load.json").read_text())["cases"]
+PROTOCOL_CONFIG_VECTORS = json.loads((VECTORS / "protocol-config.json").read_text())[
+    "cases"
+]
+
 
 def _ok(schema: dict) -> Any:
     """Validate a declaration and return the validated form.
@@ -39,6 +47,56 @@ def _ok(schema: dict) -> Any:
     `validate_document` accepts only that, never a raw mapping.
     """
     return validate_schema(schema, name="test")
+
+
+@pytest.mark.parametrize("case", SCHEMA_LOAD_VECTORS, ids=lambda case: case["name"])
+def test_schema_load_conforms_to_the_vendored_contract_vectors(case: dict) -> None:
+    """The hand-authored corpus, rather than a parallel runtime fixture, is authority."""
+    schema = case.get("schema")
+    if schema is None:
+        schema = json.loads(case["schema_text"])
+    if case["expect"] == "accepted":
+        assert isinstance(validate_schema(schema, name="vector"), ValidatedSchema)
+        return
+
+    with pytest.raises(SchemaError) as excinfo:
+        validate_schema(schema, name="vector")
+    message = str(excinfo.value)
+    for name in case["must_name"]:
+        assert name in message
+
+
+@pytest.mark.parametrize("case", PROTOCOL_CONFIG_VECTORS, ids=lambda case: case["name"])
+def test_protocol_config_conforms_to_the_vendored_contract_vectors(
+    case: dict, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Accepted vectors also prove the exact mapping an adapter would receive."""
+    schema = validate_schema(case["schema"], name=case["protocol"])
+    with caplog.at_level(logging.WARNING):
+        if case["expect"] == "accepted":
+            assert (
+                validate_document(
+                    case["document"],
+                    schema,
+                    context=case["protocol"],
+                    external=case.get("external"),
+                )
+                == case["resolved"]
+            )
+            for name in case.get("warns", []):
+                assert name in caplog.text
+            return
+
+        with pytest.raises(DocumentError) as excinfo:
+            validate_document(
+                case["document"],
+                schema,
+                context=case["protocol"],
+                external=case.get("external"),
+            )
+    message = str(excinfo.value)
+    for name in case["must_name"]:
+        assert name in message
 
 
 # ── Schema load: the declaration is refused on its own terms ────────────────
@@ -319,6 +377,20 @@ def test_exactly_one_of_refuses_a_stray_from_the_unchosen_group() -> None:
         )
 
 
+def test_exactly_one_of_does_not_apply_defaults_from_the_unselected_group() -> None:
+    schema = _ok(
+        {
+            "host": {"type": "string"},
+            "port": {"type": "integer", "default": 8899},
+            "serial": {"type": "string"},
+            "exactly_one_of": [["host", "port"], ["serial"]],
+        }
+    )
+    assert validate_document({"serial": "/dev/ttyUSB0"}, schema, context="s") == {
+        "serial": "/dev/ttyUSB0"
+    }
+
+
 def test_at_least_one_of_permits_more_than_one() -> None:
     """It is the mechanism for 'any of these will do'."""
     schema = _ok(
@@ -357,7 +429,7 @@ def test_a_deprecated_alias_is_accepted_with_a_warning(
 ) -> None:
     with caplog.at_level(logging.WARNING):
         resolved = validate_document({"baudrate": 19200}, _with_alias(), context="s")
-    assert resolved["baudrate"] == 19200
+    assert resolved == {"baud_rate": 19200}
     assert "deprecated" in caplog.text
     assert "baud_rate" in caplog.text
 
@@ -367,6 +439,196 @@ def test_an_alias_and_its_replacement_together_are_refused() -> None:
     with pytest.raises(DocumentError, match="deprecated alias"):
         validate_document(
             {"baud_rate": 9600, "baudrate": 9600}, _with_alias(), context="s"
+        )
+
+
+def test_an_alias_resolves_across_an_object_boundary() -> None:
+    schema = _ok(
+        {
+            "mqtt": {
+                "type": "object",
+                "properties": {"username": {"type": "string"}},
+            },
+            "mqtt_username": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.username",
+            },
+        }
+    )
+    assert validate_document({"mqtt_username": "operator"}, schema, context="s") == {
+        "mqtt": {"username": "operator"}
+    }
+
+
+def test_a_cross_path_alias_conflicts_with_a_written_canonical_value() -> None:
+    schema = _ok(
+        {
+            "mqtt": {
+                "type": "object",
+                "properties": {"username": {"type": "string"}},
+            },
+            "mqtt_username": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.username",
+            },
+        }
+    )
+    with pytest.raises(DocumentError, match=r"mqtt\.username"):
+        validate_document(
+            {"mqtt": {"username": "canonical"}, "mqtt_username": "legacy"},
+            schema,
+            context="s",
+        )
+
+
+def test_two_aliases_for_one_target_are_refused_without_schema_order_precedence() -> (
+    None
+):
+    schema = _ok(
+        {
+            "mqtt": {
+                "type": "object",
+                "properties": {"client_id": {"type": "string"}},
+            },
+            "mqtt_client_id": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.client_id",
+            },
+            "client_id": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.client_id",
+            },
+        }
+    )
+    with pytest.raises(DocumentError) as excinfo:
+        validate_document(
+            {"mqtt_client_id": "first", "client_id": "second"}, schema, context="s"
+        )
+    message = str(excinfo.value)
+    assert "mqtt_client_id" in message
+    assert "client_id" in message
+    assert "mqtt.client_id" in message
+
+
+def test_alias_resolution_does_not_mutate_or_change_the_callers_document() -> None:
+    schema = _ok(
+        {
+            "mqtt": {
+                "type": "object",
+                "properties": {
+                    "username": {"type": "string"},
+                    "keepalive": {"type": "integer"},
+                },
+            },
+            "mqtt_username": {
+                "type": "string",
+                "deprecated": True,
+                "supersedes": "mqtt.username",
+            },
+        }
+    )
+    document = {"mqtt_username": "operator", "mqtt": {"keepalive": 90}}
+    expected = {"mqtt": {"username": "operator", "keepalive": 90}}
+    assert validate_document(document, schema, context="s") == expected
+    assert document == {"mqtt_username": "operator", "mqtt": {"keepalive": 90}}
+    assert validate_document(document, schema, context="s") == expected
+
+
+def test_an_alias_path_cannot_descend_through_a_deprecated_object() -> None:
+    with pytest.raises(SchemaError, match="not an object"):
+        validate_schema(
+            {
+                "mqtt": {
+                    "type": "object",
+                    "properties": {"username": {"type": "string"}},
+                },
+                "broker": {
+                    "type": "object",
+                    "deprecated": True,
+                    "supersedes": "mqtt",
+                },
+                "legacy_username": {
+                    "type": "string",
+                    "deprecated": True,
+                    "supersedes": "broker.username",
+                },
+            },
+            name="test",
+        )
+
+
+@pytest.mark.parametrize(
+    "alias, target, fragment",
+    [
+        ("mqtt.username", {"type": "string"}, "not an object"),
+        (
+            "brokers.username",
+            {"type": "array", "items": {"type": "string"}},
+            "not an object",
+        ),
+    ],
+)
+def test_an_alias_path_must_descend_only_through_objects(
+    alias: str, target: dict, fragment: str
+) -> None:
+    with pytest.raises(SchemaError, match=fragment):
+        validate_schema(
+            {
+                alias.split(".")[0]: target,
+                "legacy": {"type": "string", "deprecated": True, "supersedes": alias},
+            },
+            name="test",
+        )
+
+
+@pytest.mark.parametrize("kind", ["array", "object"])
+def test_a_structural_alias_needs_no_duplicate_contents_declaration(kind: str) -> None:
+    target: dict[str, Any] = {"type": kind}
+    if kind == "array":
+        target["items"] = {"type": "string"}
+    else:
+        target["properties"] = {"value": {"type": "string"}}
+    assert isinstance(
+        validate_schema(
+            {
+                "canonical": target,
+                "legacy": {"type": kind, "deprecated": True, "supersedes": "canonical"},
+            },
+            name="test",
+        ),
+        ValidatedSchema,
+    )
+
+
+@pytest.mark.parametrize(
+    "property_name, value",
+    [
+        ("default", 1),
+        ("minimum", 1),
+        ("enum", [1]),
+        ("required", True),
+        ("fallback_from", "x"),
+    ],
+)
+def test_an_alias_cannot_declare_competing_value_semantics(
+    property_name: str, value: Any
+) -> None:
+    with pytest.raises(SchemaError, match=property_name):
+        validate_schema(
+            {
+                "canonical": {"type": "integer"},
+                "legacy": {
+                    "type": "integer",
+                    "deprecated": True,
+                    "supersedes": "canonical",
+                    property_name: value,
+                },
+            },
+            name="test",
         )
 
 

--- a/tests/vectors/sensor_configuration/MANIFEST.json
+++ b/tests/vectors/sensor_configuration/MANIFEST.json
@@ -1,0 +1,13 @@
+{
+  "source_repository": "ori-platform/ori-specs",
+  "source_path": "sensor-configuration/vectors",
+  "source_commit": "b92eaf0a85c504e2b7eec7744320583d9be79470",
+  "note": "Vendored copies of the normative vectors. The runtime must produce and accept the bytes they describe, so they are its conformance fixtures. Digests detect a local edit; the source commit is the provenance trail.",
+  "files": {
+    "calibration.json": "70ecdfcfdc26ca84570af8e89208c9e77a46b7d98db1d1bea013cbedf966e343",
+    "protocol-config.json": "d2634a9b3c080091c94fcd907f48c225865c37ec79a474c36d0033612e2bf0ed",
+    "protocol-definition.json": "6ed690eaca05cb113e5d24cebd6becf0426cd41ec23bbc108ba9c3ca5760711a",
+    "schema-load.json": "72601b71f2c636ec23ae9a37bbbbe2f3b34462d89c3b107baaa40f399b5b2d63",
+    "sensor-entry.json": "7b3773e3dd5c70ebc1466008868f6470cac7386e3d7646ac35887d6a5358c108"
+  }
+}

--- a/tests/vectors/sensor_configuration/calibration.json
+++ b/tests/vectors/sensor_configuration/calibration.json
@@ -1,0 +1,228 @@
+{
+  "contract": "sensor-configuration/v1 — calibration",
+  "phase": "configuration_load",
+  "note": "Selected by the pair (protocol, type), never by type alone. The same quantity over a different transport needs different calibration, or none: current through an ADS1115 needs the clamp's sensitivity, while current from a Modbus meter reporting amperes needs nothing.",
+  "refusal_note": "`calibration_schemas` is the adapter module's CALIBRATION_SCHEMAS for the case's protocol. An absent key means the pair has no schema.",
+  "cases": [
+    {
+      "name": "no_schema_for_the_pair_and_no_calibration_accepted",
+      "protocol": "serial",
+      "type": "current",
+      "calibration_schemas": {},
+      "calibration": {},
+      "expect": "accepted",
+      "resolved": {}
+    },
+    {
+      "name": "no_schema_for_the_pair_with_calibration_refused",
+      "protocol": "serial",
+      "type": "current",
+      "calibration_schemas": {},
+      "calibration": {
+        "sensitivity": 0.066
+      },
+      "expect": "refused",
+      "must_name": [
+        "serial",
+        "current"
+      ],
+      "why": "A calibration block nobody declared is the unknown-key defect where the consequence is a wrong measurement rather than a missing feature. A sensitivity that does not reach the adapter produces readings that look plausible and are wrong by a constant factor."
+    },
+    {
+      "name": "empty_calibration_schemas_is_a_statement_not_an_omission",
+      "protocol": "serial",
+      "type": "voltage",
+      "calibration_schemas": {},
+      "calibration": {},
+      "expect": "accepted",
+      "resolved": {},
+      "why": "An empty mapping states that the protocol calibrates nothing; an absent one states nothing at all."
+    },
+    {
+      "name": "declared_pair_accepted_with_defaults_applied",
+      "protocol": "i2c",
+      "type": "ads1115_current",
+      "calibration_schemas": {
+        "ads1115_current": {
+          "sensitivity": {
+            "type": "number",
+            "required": true,
+            "minimum": 0
+          },
+          "frequency_hz": {
+            "type": "integer",
+            "default": 50,
+            "enum": [
+              50,
+              60
+            ]
+          },
+          "gain": {
+            "type": "number",
+            "default": 1.0
+          }
+        }
+      },
+      "calibration": {
+        "sensitivity": 0.066
+      },
+      "expect": "accepted",
+      "resolved": {
+        "sensitivity": 0.066,
+        "frequency_hz": 50,
+        "gain": 1.0
+      }
+    },
+    {
+      "name": "undeclared_calibration_key_refused",
+      "protocol": "i2c",
+      "type": "ads1115_current",
+      "calibration_schemas": {
+        "ads1115_current": {
+          "sensitivity": {
+            "type": "number",
+            "required": true,
+            "minimum": 0
+          },
+          "frequency_hz": {
+            "type": "integer",
+            "default": 50,
+            "enum": [
+              50,
+              60
+            ]
+          },
+          "gain": {
+            "type": "number",
+            "default": 1.0
+          }
+        }
+      },
+      "calibration": {
+        "sensitivity": 0.066,
+        "sensitivty": 0.1
+      },
+      "expect": "refused",
+      "must_name": [
+        "sensitivty"
+      ],
+      "why": "The misspelling that made this contract necessary, one level down."
+    },
+    {
+      "name": "required_calibration_field_omitted_refused",
+      "protocol": "i2c",
+      "type": "ads1115_current",
+      "calibration_schemas": {
+        "ads1115_current": {
+          "sensitivity": {
+            "type": "number",
+            "required": true,
+            "minimum": 0
+          },
+          "frequency_hz": {
+            "type": "integer",
+            "default": 50,
+            "enum": [
+              50,
+              60
+            ]
+          },
+          "gain": {
+            "type": "number",
+            "default": 1.0
+          }
+        }
+      },
+      "calibration": {
+        "gain": 2.0
+      },
+      "expect": "refused",
+      "must_name": [
+        "sensitivity"
+      ]
+    },
+    {
+      "name": "calibration_value_out_of_bounds_refused",
+      "protocol": "i2c",
+      "type": "ads1115_current",
+      "calibration_schemas": {
+        "ads1115_current": {
+          "sensitivity": {
+            "type": "number",
+            "required": true,
+            "minimum": 0
+          },
+          "frequency_hz": {
+            "type": "integer",
+            "default": 50,
+            "enum": [
+              50,
+              60
+            ]
+          },
+          "gain": {
+            "type": "number",
+            "default": 1.0
+          }
+        }
+      },
+      "calibration": {
+        "sensitivity": -0.066
+      },
+      "expect": "refused",
+      "must_name": [
+        "sensitivity"
+      ]
+    },
+    {
+      "name": "calibration_is_selected_by_pair_not_by_type",
+      "protocol": "serial",
+      "type": "ads1115_current",
+      "calibration_schemas": {},
+      "calibration": {
+        "sensitivity": 0.066
+      },
+      "expect": "refused",
+      "must_name": [
+        "serial",
+        "ads1115_current"
+      ],
+      "why": "The same type over a transport that does not declare it has no schema, and inheriting one from another protocol is how a calibration reaches an adapter that ignores it."
+    },
+    {
+      "name": "calibration_is_not_flattened_into_protocol_configuration",
+      "protocol": "i2c",
+      "type": "ads1115_current",
+      "calibration_schemas": {
+        "ads1115_current": {
+          "sensitivity": {
+            "type": "number",
+            "required": true,
+            "minimum": 0
+          },
+          "frequency_hz": {
+            "type": "integer",
+            "default": 50,
+            "enum": [
+              50,
+              60
+            ]
+          },
+          "gain": {
+            "type": "number",
+            "default": 1.0
+          }
+        }
+      },
+      "calibration": {
+        "sensitivity": 0.066,
+        "address": 72
+      },
+      "expect": "refused",
+      "must_name": [
+        "address"
+      ],
+      "why": "`address` is protocol configuration. Flattening the two namespaces is what let a documented sensitivity sit unread beside an adapter's own default."
+    }
+  ]
+}

--- a/tests/vectors/sensor_configuration/protocol-config.json
+++ b/tests/vectors/sensor_configuration/protocol-config.json
@@ -1,0 +1,1637 @@
+{
+  "contract": "sensor-configuration/v1 — protocol configuration documents",
+  "phase": "configuration_load",
+  "note": "Each case carries its own schema, so a verifier needs no adapter. The schemas are shaped after real adapters but are not the runtime's declarations: `one accepted sensor per protocol` is a conformance check an implementation runs against its own fifteen, and cannot live in a corpus that ships beside the contract rather than beside the adapters.",
+  "refusal_note": "`must_name` lists identifiers a conforming refusal must contain — keys, paths, protocols and schema keywords, never English wording. `must_name_at_load` lists identifiers the surrounding configuration loader must add, which a validator checking a document against one schema cannot know: requiring them of the wrong layer makes a conforming implementation look otherwise. `warns` lists identifiers a deprecation warning must contain. `resolved` is the exact mapping the adapter must receive, with defaults, fallbacks and aliases applied.",
+  "external_note": "`external` is the rest of the device configuration, against which `fallback_from` and `must_be_subset_of` resolve.",
+  "cases": [
+    {
+      "name": "undeclared_key_refused_naming_key_and_protocol",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "timout_s": 2.0
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "timout_s"
+      ],
+      "why": "A key the runtime accepts and discards reads, to whoever wrote it, as a setting that took effect.",
+      "must_name_at_load": [
+        "coap"
+      ]
+    },
+    {
+      "name": "undeclared_key_nested_in_a_declared_object_refused_by_full_path",
+      "protocol": "mqtt",
+      "schema": {
+        "broker_host": {
+          "type": "string",
+          "required": true
+        },
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ca_certfile": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "document": {
+        "broker_host": "192.168.1.50",
+        "mqtt": {
+          "tls": {
+            "enabled": true,
+            "verify": false
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt.tls.verify"
+      ],
+      "why": "Naming the leaf alone does not say which of several objects carries it."
+    },
+    {
+      "name": "reserved_sensor_id_refused",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "sensor_id": "impostor"
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "sensor_id"
+      ],
+      "why": "Refusal, not precedence: the operator meant something by it."
+    },
+    {
+      "name": "reserved_sensor_type_refused",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "sensor_type": "temperature"
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "sensor_type"
+      ]
+    },
+    {
+      "name": "reserved_circuit_breaker_refused",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "circuit_breaker": {
+          "failure_threshold": 99
+        }
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "circuit_breaker"
+      ],
+      "why": "Would make hardware recovery settable per sensor, and on a sensor feeding a safety condition that removes the input the protection path depends on."
+    },
+    {
+      "name": "missing_required_field",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "method": "GET"
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "uri"
+      ]
+    },
+    {
+      "name": "required_unless_unsatisfied",
+      "protocol": "usb_serial",
+      "schema": {
+        "auto_detect_device_path": {
+          "type": "boolean",
+          "default": false
+        },
+        "device_path": {
+          "type": "string",
+          "required_unless": {
+            "auto_detect_device_path": true
+          }
+        }
+      },
+      "document": {},
+      "expect": "refused",
+      "must_name": [
+        "device_path",
+        "auto_detect_device_path"
+      ],
+      "why": "`auto_detect_device_path` resolves to its declared default of false, so a path is required."
+    },
+    {
+      "name": "required_unless_satisfied_by_the_siblings_written_value",
+      "protocol": "usb_serial",
+      "schema": {
+        "auto_detect_device_path": {
+          "type": "boolean",
+          "default": false
+        },
+        "device_path": {
+          "type": "string",
+          "required_unless": {
+            "auto_detect_device_path": true
+          }
+        }
+      },
+      "document": {
+        "auto_detect_device_path": true
+      },
+      "expect": "accepted",
+      "resolved": {
+        "auto_detect_device_path": true
+      }
+    },
+    {
+      "name": "required_unless_satisfied_by_a_written_path",
+      "protocol": "usb_serial",
+      "schema": {
+        "auto_detect_device_path": {
+          "type": "boolean",
+          "default": false
+        },
+        "device_path": {
+          "type": "string",
+          "required_unless": {
+            "auto_detect_device_path": true
+          }
+        }
+      },
+      "document": {
+        "device_path": "/dev/ttyUSB0"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "auto_detect_device_path": false,
+        "device_path": "/dev/ttyUSB0"
+      }
+    },
+    {
+      "name": "required_unless_satisfied_by_the_siblings_default",
+      "protocol": "coap",
+      "schema": {
+        "mode": {
+          "type": "string",
+          "default": "auto"
+        },
+        "path": {
+          "type": "string",
+          "required_unless": {
+            "mode": "auto"
+          }
+        }
+      },
+      "document": {},
+      "expect": "accepted",
+      "resolved": {
+        "mode": "auto"
+      },
+      "why": "A condition reading the raw entry would see nothing where `mode` should be and refuse a complete document."
+    },
+    {
+      "name": "required_unless_satisfied_by_a_fallback",
+      "protocol": "coap",
+      "schema": {
+        "mode": {
+          "type": "string",
+          "fallback_from": "actions.coap.mode"
+        },
+        "path": {
+          "type": "string",
+          "required_unless": {
+            "mode": "auto"
+          }
+        }
+      },
+      "document": {},
+      "expect": "accepted",
+      "external": {
+        "actions": {
+          "coap": {
+            "mode": "auto"
+          }
+        }
+      },
+      "resolved": {
+        "mode": "auto"
+      },
+      "why": "A condition reads the sibling's settled value, inherited as much as defaulted."
+    },
+    {
+      "name": "required_unless_in_a_nested_object_resolves_in_its_own_scope",
+      "protocol": "coap",
+      "schema": {
+        "tls": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "default": "auto"
+            },
+            "certfile": {
+              "type": "string",
+              "required_unless": {
+                "mode": "auto"
+              }
+            }
+          }
+        },
+        "mode": {
+          "type": "string",
+          "default": "manual"
+        }
+      },
+      "document": {
+        "mode": "manual",
+        "tls": {}
+      },
+      "expect": "accepted",
+      "resolved": {
+        "mode": "manual",
+        "tls": {
+          "mode": "auto"
+        }
+      },
+      "why": "The nested `mode` defaults to `auto` and satisfies the nested condition. Reading the parent's `mode` of `manual` would refuse a complete document; scopes do not see each other."
+    },
+    {
+      "name": "nested_required_unless_unsatisfied_in_its_own_scope",
+      "protocol": "coap",
+      "schema": {
+        "tls": {
+          "type": "object",
+          "properties": {
+            "mode": {
+              "type": "string",
+              "default": "auto"
+            },
+            "certfile": {
+              "type": "string",
+              "required_unless": {
+                "mode": "auto"
+              }
+            }
+          }
+        },
+        "mode": {
+          "type": "string",
+          "default": "manual"
+        }
+      },
+      "document": {
+        "tls": {
+          "mode": "manual"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "tls.certfile",
+        "mode"
+      ]
+    },
+    {
+      "name": "exactly_one_of_none_present",
+      "protocol": "solarman_modbus",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 8899
+        },
+        "serial": {
+          "type": "string"
+        },
+        "exactly_one_of": [
+          [
+            "host",
+            "port"
+          ],
+          [
+            "serial"
+          ]
+        ]
+      },
+      "document": {},
+      "expect": "refused",
+      "must_name": [
+        "exactly_one_of"
+      ]
+    },
+    {
+      "name": "exactly_one_of_group_selected",
+      "protocol": "solarman_modbus",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 8899
+        },
+        "serial": {
+          "type": "string"
+        },
+        "exactly_one_of": [
+          [
+            "host",
+            "port"
+          ],
+          [
+            "serial"
+          ]
+        ]
+      },
+      "document": {
+        "serial": "1234567890"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "serial": "1234567890"
+      },
+      "why": "`port` has a default but belongs to the group that was not selected, so it is not applied."
+    },
+    {
+      "name": "exactly_one_of_stray_member_of_an_unselected_group",
+      "protocol": "solarman_modbus",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer",
+          "default": 8899
+        },
+        "serial": {
+          "type": "string"
+        },
+        "exactly_one_of": [
+          [
+            "host",
+            "port"
+          ],
+          [
+            "serial"
+          ]
+        ]
+      },
+      "document": {
+        "serial": "1234567890",
+        "host": "192.168.1.70"
+      },
+      "expect": "refused",
+      "must_name": [
+        "host"
+      ],
+      "why": "A sensor declaring both is not configured twice; it is configured ambiguously."
+    },
+    {
+      "name": "at_least_one_of_none_present",
+      "protocol": "coap",
+      "schema": {
+        "topic": {
+          "type": "string"
+        },
+        "node_id": {
+          "type": "string"
+        },
+        "at_least_one_of": [
+          [
+            "topic"
+          ],
+          [
+            "node_id"
+          ]
+        ]
+      },
+      "document": {},
+      "expect": "refused",
+      "must_name": [
+        "at_least_one_of"
+      ]
+    },
+    {
+      "name": "at_least_one_of_extra_group_is_not_refused",
+      "protocol": "coap",
+      "schema": {
+        "topic": {
+          "type": "string"
+        },
+        "node_id": {
+          "type": "string"
+        },
+        "at_least_one_of": [
+          [
+            "topic"
+          ],
+          [
+            "node_id"
+          ]
+        ]
+      },
+      "document": {
+        "topic": "t",
+        "node_id": "n"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "topic": "t",
+        "node_id": "n"
+      },
+      "why": "`at_least_one_of` is the mechanism for `any of these will do`."
+    },
+    {
+      "name": "same_scope_alias_accepted_with_a_warning",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "baudrate": 19200
+      },
+      "expect": "accepted",
+      "resolved": {
+        "port": "/dev/ttyS0",
+        "baud_rate": 19200,
+        "parity": "N",
+        "slave_id": 1
+      },
+      "warns": [
+        "baudrate",
+        "baud_rate"
+      ]
+    },
+    {
+      "name": "alias_and_replacement_together_refused",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "baud_rate": 9600,
+        "baudrate": 9600
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "baud_rate"
+      ],
+      "why": "Refused even though the values agree: agreement today is not agreement after the next edit."
+    },
+    {
+      "name": "cross_path_alias_resolves_into_the_targets_position",
+      "protocol": "mqtt",
+      "schema": {
+        "broker_host": {
+          "type": "string",
+          "required": true
+        },
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "keepalive": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ca_certfile": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "document": {
+        "broker_host": "192.168.1.50",
+        "mqtt_username": "operator"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "broker_host": "192.168.1.50",
+        "mqtt": {
+          "username": "operator"
+        }
+      },
+      "warns": [
+        "mqtt_username",
+        "mqtt.username"
+      ],
+      "why": "What reaches the adapter is the canonical shape, whichever spelling was written."
+    },
+    {
+      "name": "cross_path_alias_and_its_nested_target_together_refused",
+      "protocol": "mqtt",
+      "schema": {
+        "broker_host": {
+          "type": "string",
+          "required": true
+        },
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "keepalive": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ca_certfile": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "document": {
+        "broker_host": "192.168.1.50",
+        "mqtt_username": "operator",
+        "mqtt": {
+          "username": "operator"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt_username",
+        "mqtt.username"
+      ],
+      "why": "The refusal names the full path: `username` does not say which of three places to write it."
+    },
+    {
+      "name": "cross_path_alias_beside_an_unrelated_sibling_accepted",
+      "protocol": "mqtt",
+      "schema": {
+        "broker_host": {
+          "type": "string",
+          "required": true
+        },
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            },
+            "keepalive": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "tls": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "ca_certfile": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "document": {
+        "broker_host": "192.168.1.50",
+        "mqtt_username": "operator",
+        "mqtt": {
+          "keepalive": 90
+        }
+      },
+      "expect": "accepted",
+      "resolved": {
+        "broker_host": "192.168.1.50",
+        "mqtt": {
+          "username": "operator",
+          "keepalive": 90
+        }
+      },
+      "warns": [
+        "mqtt_username",
+        "mqtt.username"
+      ],
+      "why": "Presence is judged on the target itself, not on the object that contains it."
+    },
+    {
+      "name": "protocol_default_applied_where_the_sensor_is_silent",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "port": "/dev/ttyS0",
+        "baud_rate": 9600,
+        "parity": "N",
+        "slave_id": 1
+      }
+    },
+    {
+      "name": "protocol_default_not_applied_where_the_sensor_speaks",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "parity": "E"
+      },
+      "expect": "accepted",
+      "resolved": {
+        "port": "/dev/ttyS0",
+        "baud_rate": 9600,
+        "parity": "E",
+        "slave_id": 1
+      }
+    },
+    {
+      "name": "fallback_applied_where_the_sensor_is_silent",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s"
+      },
+      "expect": "accepted",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "resolved": {
+        "uri": "coap://a.example/s",
+        "method": "GET",
+        "unit": "",
+        "timeout_s": 2.0,
+        "allowed_hosts": [
+          "a.example",
+          "b.example"
+        ]
+      }
+    },
+    {
+      "name": "allowlist_narrowing_accepted",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "allowed_hosts": [
+          "a.example"
+        ]
+      },
+      "expect": "accepted",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "resolved": {
+        "uri": "coap://a.example/s",
+        "method": "GET",
+        "unit": "",
+        "timeout_s": 2.0,
+        "allowed_hosts": [
+          "a.example"
+        ]
+      },
+      "why": "The operator's value wins where they wrote one."
+    },
+    {
+      "name": "allowlist_widening_refused",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "allowed_hosts": [
+          "a.example",
+          "evil.example"
+        ]
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example",
+              "b.example"
+            ],
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "allowed_hosts",
+        "evil.example"
+      ],
+      "why": "Refusing the widening is what makes the fallback safe to offer at all."
+    },
+    {
+      "name": "fallback_naming_a_field_the_configuration_does_not_contain",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s"
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example"
+            ]
+          }
+        }
+      },
+      "must_name": [
+        "timeout_s",
+        "actions.coap.timeout_s"
+      ],
+      "why": "Refused, not treated as absent."
+    },
+    {
+      "name": "inherited_value_the_fields_own_descriptor_rejects",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s"
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": [
+              "a.example"
+            ],
+            "timeout_s": -1
+          }
+        }
+      },
+      "must_name": [
+        "timeout_s"
+      ],
+      "why": "A value must not reach an adapter unchecked because it arrived by inheritance."
+    },
+    {
+      "name": "must_be_subset_of_resolving_to_a_non_array",
+      "protocol": "coap",
+      "schema": {
+        "uri": {
+          "type": "string",
+          "required": true
+        },
+        "method": {
+          "type": "string",
+          "default": "GET",
+          "enum": [
+            "GET",
+            "POST",
+            "PUT"
+          ]
+        },
+        "unit": {
+          "type": "string",
+          "default": ""
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        },
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "document": {
+        "uri": "coap://a.example/s",
+        "allowed_hosts": [
+          "a.example"
+        ]
+      },
+      "expect": "refused",
+      "external": {
+        "actions": {
+          "coap": {
+            "allowed_hosts": "a.example",
+            "timeout_s": 2.0
+          }
+        }
+      },
+      "must_name": [
+        "allowed_hosts"
+      ]
+    },
+    {
+      "name": "value_out_of_bounds",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "slave_id": 999
+      },
+      "expect": "refused",
+      "must_name": [
+        "slave_id"
+      ]
+    },
+    {
+      "name": "value_outside_the_enumeration",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "parity": "X"
+      },
+      "expect": "refused",
+      "must_name": [
+        "parity"
+      ]
+    },
+    {
+      "name": "wrong_type",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": 9600,
+        "baud_rate": 9600
+      },
+      "expect": "refused",
+      "must_name": [
+        "port"
+      ]
+    },
+    {
+      "name": "float_where_an_integer_is_declared",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "baud_rate": 9600.0
+      },
+      "expect": "refused",
+      "must_name": [
+        "baud_rate"
+      ],
+      "why": "7.0 is not 7. A coerced value turns a malformed document into a working one whose author believes something else."
+    },
+    {
+      "name": "boolean_where_an_integer_is_declared",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": {
+        "port": "/dev/ttyS0",
+        "baud_rate": true
+      },
+      "expect": "refused",
+      "must_name": [
+        "baud_rate"
+      ],
+      "why": "A boolean is not an integer whatever the host language says."
+    },
+    {
+      "name": "non_object_document",
+      "protocol": "serial",
+      "schema": {
+        "port": {
+          "type": "string",
+          "required": true
+        },
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        },
+        "parity": {
+          "type": "string",
+          "default": "N",
+          "enum": [
+            "N",
+            "E",
+            "O"
+          ]
+        },
+        "slave_id": {
+          "type": "integer",
+          "default": 1,
+          "minimum": 0,
+          "maximum": 247
+        }
+      },
+      "document": "port=/dev/ttyS0",
+      "expect": "refused",
+      "must_name": [],
+      "why": "Checked at the boundary: a string iterated into a group verdict blames the operator for a missing field rather than for the shape of the document.",
+      "expect_names_nothing": true
+    }
+  ]
+}

--- a/tests/vectors/sensor_configuration/protocol-definition.json
+++ b/tests/vectors/sensor_configuration/protocol-definition.json
@@ -1,0 +1,112 @@
+{
+  "contract": "sensor-configuration/v1 — protocol definitions",
+  "phase": "schema_load",
+  "note": "A definition names the module that implements a protocol. The module owns the schemas, so these cases describe what a module exposes rather than a document. `module_exports` lists the module-level names present.",
+  "refusal_note": "A definition whose module is missing either mapping is refused at configuration load, naming the protocol, the module and which mapping is absent. Not warned, and not defaulted to an open schema: an adapter registered without a declaration is one whose accepted surface is unknown.",
+  "cases": [
+    {
+      "name": "both_mappings_present",
+      "protocol": "serial",
+      "module": "ori.hal.serial_adapter",
+      "module_exports": [
+        "SerialAdapter",
+        "CONFIG_SCHEMA",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "expect": "accepted"
+    },
+    {
+      "name": "empty_calibration_schemas_accepted",
+      "protocol": "opcua",
+      "module": "ori.hal.opcua_adapter",
+      "module_exports": [
+        "OpcUaAdapter",
+        "CONFIG_SCHEMA",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "calibration_schemas": {},
+      "expect": "accepted",
+      "why": "An empty mapping states that the protocol calibrates nothing."
+    },
+    {
+      "name": "config_schema_absent",
+      "protocol": "serial",
+      "module": "ori.hal.serial_adapter",
+      "module_exports": [
+        "SerialAdapter",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "expect": "refused",
+      "must_name": [
+        "serial",
+        "ori.hal.serial_adapter",
+        "CONFIG_SCHEMA"
+      ]
+    },
+    {
+      "name": "calibration_schemas_absent",
+      "protocol": "serial",
+      "module": "ori.hal.serial_adapter",
+      "module_exports": [
+        "SerialAdapter",
+        "CONFIG_SCHEMA"
+      ],
+      "expect": "refused",
+      "must_name": [
+        "serial",
+        "ori.hal.serial_adapter",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "why": "An absent mapping cannot be told apart from an adapter whose author never considered the question."
+    },
+    {
+      "name": "both_mappings_absent",
+      "protocol": "serial",
+      "module": "ori.hal.serial_adapter",
+      "module_exports": [
+        "SerialAdapter"
+      ],
+      "expect": "refused",
+      "must_name": [
+        "CONFIG_SCHEMA",
+        "CALIBRATION_SCHEMAS"
+      ]
+    },
+    {
+      "name": "calibration_schemas_is_not_a_mapping",
+      "protocol": "serial",
+      "module": "ori.hal.serial_adapter",
+      "module_exports": [
+        "SerialAdapter",
+        "CONFIG_SCHEMA",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "calibration_schemas": [
+        "ads1115_current"
+      ],
+      "expect": "refused",
+      "must_name": [
+        "CALIBRATION_SCHEMAS"
+      ]
+    },
+    {
+      "name": "resolution_must_not_instantiate_an_adapter",
+      "protocol": "i2c",
+      "module": "ori.hal.i2c_adapter",
+      "module_exports": [
+        "I2CAdapter",
+        "CONFIG_SCHEMA",
+        "CALIBRATION_SCHEMAS"
+      ],
+      "expect": "accepted",
+      "assert": "adapter_not_instantiated",
+      "why": "Configuration is validated before any hardware is touched, so the path that answers `what does this protocol accept?` cannot be one that constructs adapters. Importing the module is permitted; construction is not."
+    },
+    {
+      "name": "supported_protocols_derive_from_the_definitions",
+      "expect": "accepted",
+      "assert": "supported_set_equals_definition_keys",
+      "why": "Two lists that must agree by hand are a defect waiting for the edit that updates one."
+    }
+  ]
+}

--- a/tests/vectors/sensor_configuration/schema-load.json
+++ b/tests/vectors/sensor_configuration/schema-load.json
@@ -1,0 +1,797 @@
+{
+  "contract": "sensor-configuration/v1 — schema load",
+  "phase": "schema_load",
+  "note": "Checked with no document in hand. A schema that has not itself been validated cannot be used to validate anything, so every case here is a defect in a declaration an adapter ships, not in anything an operator wrote.",
+  "refusal_note": "`must_name` lists identifiers a conforming refusal must contain — keys, paths, protocols and schema keywords, never English wording.",
+  "cases": [
+    {
+      "name": "object_without_properties",
+      "schema": {
+        "tls": {
+          "type": "object"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "tls",
+        "properties"
+      ],
+      "why": "An object that never says what may sit inside it admits anything."
+    },
+    {
+      "name": "array_without_items",
+      "schema": {
+        "allowed_hosts": {
+          "type": "array"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "allowed_hosts",
+        "items"
+      ]
+    },
+    {
+      "name": "default_its_own_descriptor_rejects",
+      "schema": {
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "default": 0
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "port",
+        "default"
+      ]
+    },
+    {
+      "name": "default_of_the_wrong_type",
+      "schema": {
+        "port": {
+          "type": "integer",
+          "default": "1883"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "port",
+        "default"
+      ],
+      "why": "Checked, never coerced, at declaration time as much as at use."
+    },
+    {
+      "name": "fractional_bound_on_an_integer_field",
+      "schema": {
+        "port": {
+          "type": "integer",
+          "minimum": 1.5
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "port",
+        "minimum"
+      ]
+    },
+    {
+      "name": "infinite_bound",
+      "schema_text": "{\"timeout_s\": {\"type\": \"number\", \"maximum\": 1e999}}",
+      "expect": "refused",
+      "must_name": [
+        "timeout_s",
+        "maximum"
+      ],
+      "why": "A bound must be finite. An infinity admits every value while reading as a limit.",
+      "note": "Carried as source text, not as a value: `Infinity` is not JSON, and embedding it would make this file unparseable for a strict reader and take every other case down with it. A verifier whose parser refuses the literal satisfies this case at its own boundary; one that yields an infinity must refuse it at the bound check."
+    },
+    {
+      "name": "boolean_bound",
+      "schema": {
+        "port": {
+          "type": "integer",
+          "minimum": true
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "port",
+        "minimum"
+      ],
+      "why": "A boolean is an integer in some host languages and is not a bound in any of them."
+    },
+    {
+      "name": "minimum_above_maximum",
+      "schema": {
+        "port": {
+          "type": "integer",
+          "minimum": 9000,
+          "maximum": 80
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "port"
+      ]
+    },
+    {
+      "name": "group_naming_an_undeclared_field",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "exactly_one_of": [
+          [
+            "host"
+          ],
+          [
+            "serial"
+          ]
+        ]
+      },
+      "expect": "refused",
+      "must_name": [
+        "serial",
+        "exactly_one_of"
+      ]
+    },
+    {
+      "name": "empty_group",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "exactly_one_of": [
+          [
+            "host"
+          ],
+          []
+        ]
+      },
+      "expect": "refused",
+      "must_name": [
+        "exactly_one_of"
+      ],
+      "why": "Always satisfied or never satisfiable; neither is what anyone meant."
+    },
+    {
+      "name": "field_in_two_groups_of_one_constraint",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "port": {
+          "type": "integer"
+        },
+        "exactly_one_of": [
+          [
+            "host",
+            "port"
+          ],
+          [
+            "host"
+          ]
+        ]
+      },
+      "expect": "refused",
+      "must_name": [
+        "host",
+        "exactly_one_of"
+      ],
+      "why": "Makes `exactly one group` undecidable."
+    },
+    {
+      "name": "two_identical_groups",
+      "schema": {
+        "host": {
+          "type": "string"
+        },
+        "at_least_one_of": [
+          [
+            "host"
+          ],
+          [
+            "host"
+          ]
+        ]
+      },
+      "expect": "refused",
+      "must_name": [
+        "at_least_one_of"
+      ]
+    },
+    {
+      "name": "required_unless_naming_an_undeclared_field",
+      "schema": {
+        "device_path": {
+          "type": "string",
+          "required_unless": {
+            "auto_detect": true
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "device_path",
+        "auto_detect"
+      ],
+      "why": "An unenforceable condition fails silently: it simply never fires."
+    },
+    {
+      "name": "direct_conditional_cycle",
+      "schema": {
+        "a": {
+          "type": "string",
+          "required_unless": {
+            "b": true
+          }
+        },
+        "b": {
+          "type": "boolean",
+          "required_unless": {
+            "a": "x"
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "a",
+        "b"
+      ],
+      "why": "Each would need the other settled first, so there is no evaluation order."
+    },
+    {
+      "name": "indirect_conditional_cycle",
+      "schema": {
+        "a": {
+          "type": "string",
+          "required_unless": {
+            "b": true
+          }
+        },
+        "b": {
+          "type": "boolean",
+          "required_unless": {
+            "c": 1
+          }
+        },
+        "c": {
+          "type": "integer",
+          "required_unless": {
+            "a": "x"
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "a",
+        "b",
+        "c"
+      ],
+      "why": "Cycles are refused at any length, and the refusal names the cycle."
+    },
+    {
+      "name": "cycle_is_named_from_its_lowest_sorting_member",
+      "schema": {
+        "c": {
+          "type": "string",
+          "required_unless": {
+            "a": true
+          }
+        },
+        "a": {
+          "type": "boolean",
+          "required_unless": {
+            "b": 1
+          }
+        },
+        "b": {
+          "type": "integer",
+          "required_unless": {
+            "c": "x"
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "a",
+        "b",
+        "c"
+      ],
+      "why": "One defect must read the same way however the walk enters it."
+    },
+    {
+      "name": "deprecated_without_supersedes",
+      "schema": {
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "supersedes"
+      ]
+    },
+    {
+      "name": "supersedes_naming_a_key_absent_from_the_schema",
+      "schema": {
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "baud_rate"
+      ]
+    },
+    {
+      "name": "deprecated_key_declared_required",
+      "schema": {
+        "baud_rate": {
+          "type": "integer"
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate",
+          "required": true
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "required"
+      ]
+    },
+    {
+      "name": "same_scope_alias_accepted",
+      "schema": {
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate"
+        }
+      },
+      "expect": "accepted"
+    },
+    {
+      "name": "alias_carrying_its_own_default",
+      "schema": {
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate",
+          "default": 19200
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "default"
+      ],
+      "why": "The value moves to the target, so the alias's default would apply to a position no longer holding anything. Apply it, ignore it, or apply it after the target's — three readings of one declaration."
+    },
+    {
+      "name": "alias_carrying_its_own_bound",
+      "schema": {
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate",
+          "minimum": 1200
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "minimum"
+      ],
+      "why": "A bound on the alias would let it admit what its target refuses."
+    },
+    {
+      "name": "alias_carrying_its_own_enum",
+      "schema": {
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate",
+          "enum": [
+            9600,
+            19200
+          ]
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "baudrate",
+        "enum"
+      ]
+    },
+    {
+      "name": "alias_carrying_a_nested_schema",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            }
+          }
+        },
+        "legacy_mqtt": {
+          "type": "object",
+          "deprecated": true,
+          "supersedes": "mqtt",
+          "properties": {
+            "username": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "legacy_mqtt",
+        "properties"
+      ],
+      "why": "Two declarations of one object's contents, and the one a value is checked against stops being the one the adapter obeys."
+    },
+    {
+      "name": "alias_carrying_a_conditional",
+      "schema": {
+        "auto_detect_device_path": {
+          "type": "boolean",
+          "default": false
+        },
+        "device_path": {
+          "type": "string"
+        },
+        "path": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "device_path",
+          "required_unless": {
+            "auto_detect_device_path": true
+          }
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "path",
+        "required_unless"
+      ],
+      "why": "A key being removed would become the thing another field's requirement is evaluated against."
+    },
+    {
+      "name": "alias_carrying_a_fallback",
+      "schema": {
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0
+        },
+        "timeout": {
+          "type": "number",
+          "deprecated": true,
+          "supersedes": "timeout_s",
+          "fallback_from": "actions.coap.timeout_s"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "timeout",
+        "fallback_from"
+      ]
+    },
+    {
+      "name": "alias_carrying_a_bound_on_another_section",
+      "schema": {
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hosts": {
+          "type": "array",
+          "deprecated": true,
+          "supersedes": "allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "hosts",
+        "must_be_subset_of"
+      ],
+      "why": "The security bound belongs to the canonical field, or it is escapable by writing the alias.",
+      "note": "The alias declares no `items`, which the exemption permits. Refusing it for that instead would report coverage of the alias rule that does not exist."
+    },
+    {
+      "name": "alias_carrying_only_structural_metadata_accepted",
+      "schema": {
+        "baud_rate": {
+          "type": "integer",
+          "default": 9600,
+          "minimum": 1
+        },
+        "baudrate": {
+          "type": "integer",
+          "deprecated": true,
+          "supersedes": "baud_rate",
+          "description": "Renamed to baud_rate in this generation."
+        }
+      },
+      "expect": "accepted",
+      "why": "`type` and `description` are not competing semantics: the type must already match the target's, and stating it keeps a declaration readable on its own."
+    },
+    {
+      "name": "an_array_alias_declares_no_items_and_is_accepted",
+      "schema": {
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "hosts": {
+          "type": "array",
+          "deprecated": true,
+          "supersedes": "allowed_hosts"
+        }
+      },
+      "expect": "accepted",
+      "why": "`items` is required of an array by the core and forbidden on an alias by this contract. Without the exemption an array alias could not be written at all."
+    },
+    {
+      "name": "an_object_alias_declares_no_properties_and_is_accepted",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            }
+          }
+        },
+        "broker": {
+          "type": "object",
+          "deprecated": true,
+          "supersedes": "mqtt"
+        }
+      },
+      "expect": "accepted"
+    },
+    {
+      "name": "cross_path_alias_accepted",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "expect": "accepted",
+      "why": "A rename that moves a setting into a nested object is the same migration as one within a scope."
+    },
+    {
+      "name": "alias_path_through_a_non_object",
+      "schema": {
+        "mqtt": {
+          "type": "string"
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt_username",
+        "mqtt.username"
+      ]
+    },
+    {
+      "name": "alias_path_descending_through_items",
+      "schema": {
+        "brokers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "username": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "brokers.username"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt_username",
+        "brokers.username"
+      ],
+      "why": "An array element has no stable identity for an alias to name."
+    },
+    {
+      "name": "alias_target_absent_from_the_nested_object",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "password": {
+              "type": "string"
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt_username",
+        "mqtt.username"
+      ]
+    },
+    {
+      "name": "alias_of_an_alias",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "username": {
+              "type": "string"
+            }
+          }
+        },
+        "mqtt_username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.username"
+        },
+        "username": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt_username"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "username",
+        "mqtt_username"
+      ],
+      "why": "An alias of an alias has no single canonical spelling."
+    },
+    {
+      "name": "alias_type_differs_from_its_target",
+      "schema": {
+        "mqtt": {
+          "type": "object",
+          "properties": {
+            "keepalive": {
+              "type": "integer"
+            }
+          }
+        },
+        "mqtt_keepalive_s": {
+          "type": "string",
+          "deprecated": true,
+          "supersedes": "mqtt.keepalive"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "mqtt_keepalive_s",
+        "mqtt.keepalive"
+      ],
+      "why": "Two descriptors for one setting are two things to edit."
+    },
+    {
+      "name": "fallback_from_naming_a_path_inside_sensors",
+      "schema": {
+        "timeout_s": {
+          "type": "number",
+          "fallback_from": "sensors.0.timeout_s"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "timeout_s",
+        "sensors"
+      ],
+      "why": "A fallback a sensor could write is not a bound."
+    },
+    {
+      "name": "must_be_subset_of_naming_a_path_inside_sensors",
+      "schema": {
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "must_be_subset_of": "sensors.0.allowed_hosts"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "allowed_hosts",
+        "sensors"
+      ]
+    },
+    {
+      "name": "must_be_subset_of_on_a_non_array_field",
+      "schema": {
+        "host": {
+          "type": "string",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        }
+      },
+      "expect": "refused",
+      "must_name": [
+        "host",
+        "must_be_subset_of"
+      ]
+    },
+    {
+      "name": "bounded_fallback_accepted",
+      "schema": {
+        "allowed_hosts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "fallback_from": "actions.coap.allowed_hosts",
+          "must_be_subset_of": "actions.coap.allowed_hosts"
+        },
+        "timeout_s": {
+          "type": "number",
+          "minimum": 0,
+          "fallback_from": "actions.coap.timeout_s"
+        }
+      },
+      "expect": "accepted"
+    }
+  ]
+}

--- a/tests/vectors/sensor_configuration/sensor-entry.json
+++ b/tests/vectors/sensor_configuration/sensor-entry.json
@@ -1,0 +1,277 @@
+{
+  "contract": "sensor-configuration/v1 — the sensor entry envelope",
+  "phase": "configuration_load",
+  "note": "The canonical fields every protocol schema sits inside. Stricter than the loader these vectors were written against, deliberately: an empty id, a duplicate id and a coerced typed field are all accepted today, and those are the defects this envelope closes.",
+  "refusal_note": "`must_name` lists identifiers a conforming refusal must contain — keys, paths, protocols and schema keywords, never English wording.",
+  "canonical_defaults": {
+    "poll_interval_ms": 1000,
+    "calibration": {}
+  },
+  "cases": [
+    {
+      "name": "minimal_entry_accepted",
+      "sensors": [
+        {
+          "id": "load-current",
+          "type": "current",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "accepted",
+      "resolved": [
+        {
+          "id": "load-current",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 1000,
+          "calibration": {}
+        }
+      ]
+    },
+    {
+      "name": "duplicate_id_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil"
+        },
+        {
+          "id": "load",
+          "type": "voltage",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "load"
+      ],
+      "why": "Per-sensor state is keyed by id, so duplicates do not produce two sensors. They produce one, silently, with readings from both arriving under a single identity."
+    },
+    {
+      "name": "empty_id_refused",
+      "sensors": [
+        {
+          "id": "",
+          "type": "current",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "id"
+      ]
+    },
+    {
+      "name": "whitespace_only_id_refused",
+      "sensors": [
+        {
+          "id": "   ",
+          "type": "current",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "id"
+      ],
+      "why": "Non-empty after trimming: a whitespace id is an empty one that survived a strip."
+    },
+    {
+      "name": "whitespace_only_type_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": " ",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "type"
+      ]
+    },
+    {
+      "name": "numeric_id_refused_rather_than_coerced",
+      "sensors": [
+        {
+          "id": 123,
+          "type": "current",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "id"
+      ],
+      "why": "A number where a string is declared. Coercing it would key state by a value the operator did not write."
+    },
+    {
+      "name": "string_poll_interval_refused_rather_than_coerced",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": "1500"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "poll_interval_ms"
+      ]
+    },
+    {
+      "name": "float_poll_interval_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 1500.0
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "poll_interval_ms"
+      ]
+    },
+    {
+      "name": "poll_interval_below_range_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 99
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "poll_interval_ms"
+      ]
+    },
+    {
+      "name": "poll_interval_above_range_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 60001
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "poll_interval_ms"
+      ]
+    },
+    {
+      "name": "poll_interval_at_the_bounds_accepted",
+      "sensors": [
+        {
+          "id": "fast",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 100
+        },
+        {
+          "id": "slow",
+          "type": "voltage",
+          "protocol": "psutil",
+          "poll_interval_ms": 60000
+        }
+      ],
+      "expect": "accepted",
+      "resolved": [
+        {
+          "id": "fast",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 100,
+          "calibration": {}
+        },
+        {
+          "id": "slow",
+          "type": "voltage",
+          "protocol": "psutil",
+          "poll_interval_ms": 60000,
+          "calibration": {}
+        }
+      ],
+      "why": "The range is inclusive at both ends."
+    },
+    {
+      "name": "canonical_fields_are_not_reserved_names",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 2000,
+          "calibration": {}
+        }
+      ],
+      "expect": "accepted",
+      "resolved": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "psutil",
+          "poll_interval_ms": 2000,
+          "calibration": {}
+        }
+      ],
+      "why": "An operator writes these and the runtime carries them across. Only the three names the runtime introduces are reserved."
+    },
+    {
+      "name": "missing_id_refused",
+      "sensors": [
+        {
+          "type": "current",
+          "protocol": "psutil"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "id"
+      ]
+    },
+    {
+      "name": "missing_protocol_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "protocol"
+      ]
+    },
+    {
+      "name": "undefined_protocol_refused",
+      "sensors": [
+        {
+          "id": "load",
+          "type": "current",
+          "protocol": "modbus_tcp"
+        }
+      ],
+      "expect": "refused",
+      "must_name": [
+        "modbus_tcp"
+      ],
+      "why": "`protocol` must name a defined protocol, and the refusal must say which are defined."
+    },
+    {
+      "name": "entry_is_not_a_mapping",
+      "sensors": [
+        "load-current"
+      ],
+      "expect": "refused",
+      "must_name": []
+    }
+  ]
+}


### PR DESCRIPTION
## What does this PR do?

Vendors the normative sensor-configuration corpus and makes the schema validator consume the schema-load and protocol-config cases. It corrects alias migration semantics before activation: aliases resolve into canonical paths, competing aliases refuse without declaration-order precedence, alias resolution is non-mutating, and unselected exactly_one_of alternatives do not receive defaults.

The runtime remains deliberately unactivated: sensor-entry, calibration, and protocol-definition vectors are explicitly tracked as proof pending until the atomic adapter/loader activation work.

[skip-cap-matrix] No runtime capability or physical-authority behavior changes: the validator remains unwired by the load-bearing activation guard.

## Type of change

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `test` — tests only
- [ ] `refactor` — neither fixes a bug nor adds a feature
- [ ] `skill` — new or updated bundled skill
- [ ] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Related: ori-platform/ori-specs#110.
Preparatory work for ori-runtime#423; closes no runtime issue.

## Testing notes

- Independent review re-ran the full suite: 4585 passed, 27 skipped.
- 77/77 applicable vendored corpus cases are collected and pass.
- Drift check confirms byte-identical vectors from ori-specs at b92eaf0.
- This is pre-activation only; no hardware or HIL claim is made.
