### PR TITLE
fix(tests): stop the suite from driving real GPIO

### DIFF
--- a/ori/actions/relay.py
+++ b/ori/actions/relay.py
@@ -173,7 +173,7 @@ class RelayAction:
         gpio_pin: int,
         active_high: bool = True,
         *,
-        allow_simulation: bool = False,
+        tolerate_missing_backend: bool = False,
     ) -> None:
         """Initialise *gpio_pin* as a relay output.
 
@@ -185,13 +185,15 @@ class RelayAction:
             active_high: ``True`` if the relay activates on a HIGH signal
                 (default).  Set ``False`` for opto-isolated relay boards
                 that trigger on LOW — verify the relay datasheet.
-            allow_simulation: Permit a no-op relay when gpiozero is unavailable.
-                This is fail-closed by default; runtime startup opts in only for
-                development posture.
+            tolerate_missing_backend: Permit a no-op relay when gpiozero cannot
+                be imported. Fail-closed by default; runtime startup opts in
+                only for development posture. It does **not** select simulation:
+                where gpiozero is importable a real device is built and a pin
+                moves, whatever this argument says.
 
         Note:
             When gpiozero is unavailable, simulation occurs only if
-            ``allow_simulation`` is explicitly true. Otherwise connection
+            ``tolerate_missing_backend`` is explicitly true. Otherwise connection
             raises and no hardware capability is reported.
         """
         if gpio_pin not in _VALID_BCM_PINS:
@@ -223,7 +225,7 @@ class RelayAction:
                 active_high,
             )
         except ImportError as exc:
-            if not allow_simulation:
+            if not tolerate_missing_backend:
                 self._device = None
                 self._simulated = False
                 self._connected = False

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -580,7 +580,7 @@ class OriRuntime:
             try:
                 await relay_action.connect(
                     gpio_pin=gpio_pin,
-                    allow_simulation=not requires_production_posture(
+                    tolerate_missing_backend=not requires_production_posture(
                         device=config.device,
                         security=config.security,
                     ),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test-wide guards.
+
+The suite must not be able to move a physical output. On a developer machine
+that is true by accident — gpiozero is absent, so every GPIO path falls back to
+simulation. On a Pi it was not true at all: `RelayAction.connect` builds a real
+`OutputDevice` whenever gpiozero is importable, so running the suite claimed
+BCM 26 and toggled it, and a bench with a relay wired would have actuated.
+
+Safety that depends on a dependency being missing is not safety. The guard here
+substitutes gpiozero's output classes with recording fakes, so the tests keep
+exercising the real code paths and reach no pin.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+#: Set to run against real hardware. Deliberately awkward: an operator who wants
+#: a bench test opts in for that run, and nothing acquires the ability by
+#: default because a dependency happened to be installed.
+ALLOW_GPIO_ENV = "ORI_TEST_ALLOW_REAL_GPIO"
+
+#: Every gpiozero name the runtime constructs. `Device` is absent on purpose:
+#: `resolved_pin_factory_name` calls `Device.ensure_pin_factory()` to learn
+#: which backend would drive a pin, which opens the chip and claims no line.
+#: That answer is what the hardened-posture check needs, and faking it would
+#: report a capability the host does not have.
+_OUTPUT_CLASSES = ("OutputDevice", "DigitalOutputDevice", "LED", "Buzzer", "PWMLED")
+
+
+class FakeGPIODevice:
+    """Stands in for a gpiozero output, recording instead of driving."""
+
+    def __init__(self, pin: int | str, *args: Any, **kwargs: Any) -> None:
+        self.pin = pin
+        self.active_high = bool(kwargs.get("active_high", True))
+        self.value = float(bool(kwargs.get("initial_value", False)))
+        self.closed = False
+        self.history: list[str] = []
+
+    def on(self) -> None:
+        self.value = 1.0
+        self.history.append("on")
+
+    def off(self) -> None:
+        self.value = 0.0
+        self.history.append("off")
+
+    def toggle(self) -> None:
+        self.value = 0.0 if self.value else 1.0
+        self.history.append("toggle")
+
+    def close(self) -> None:
+        self.closed = True
+        self.history.append("close")
+
+    def __repr__(self) -> str:
+        return f"FakeGPIODevice(pin={self.pin!r}, value={self.value})"
+
+
+def _real_gpio_allowed() -> bool:
+    return os.environ.get(ALLOW_GPIO_ENV, "").strip().lower() in {"1", "true", "yes"}
+
+
+@pytest.fixture(autouse=True)
+def no_real_gpio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refuse real GPIO for the whole suite unless a run opts in.
+
+    Autouse rather than a marker each hardware test remembers to apply: the
+    failure mode is a test that forgets, and a guard you can forget is the one
+    already in place — a module-level skip that fires when gpiozero is *absent*,
+    which is exactly backwards.
+    """
+    if _real_gpio_allowed():
+        return
+    try:
+        import gpiozero  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        return  # Nothing here can reach a pin.
+
+    for name in _OUTPUT_CLASSES:
+        if hasattr(gpiozero, name):
+            monkeypatch.setattr(gpiozero, name, FakeGPIODevice)

--- a/tests/test_gpio_actuation_guard.py
+++ b/tests/test_gpio_actuation_guard.py
@@ -1,0 +1,72 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The suite must not be able to move a physical output.
+
+These assertions only mean something where gpiozero is importable, which is the
+platform the runtime ships to and the one where the guard is load-bearing. On a
+developer machine they skip, and that is the honest outcome: nothing there can
+reach a pin, so nothing there can prove a guard against reaching one.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ori.actions.relay import RelayAction
+from tests.conftest import ALLOW_GPIO_ENV, FakeGPIODevice, _real_gpio_allowed
+
+gpiozero = pytest.importorskip(
+    "gpiozero", reason="guard is a no-op without gpiozero; nothing here reaches a pin"
+)
+
+
+def test_output_classes_are_substituted() -> None:
+    assert gpiozero.OutputDevice is FakeGPIODevice
+    assert gpiozero.DigitalOutputDevice is FakeGPIODevice
+
+
+def test_the_pin_factory_probe_is_left_alone() -> None:
+    """`Device` is deliberately not faked.
+
+    `resolved_pin_factory_name()` asks it which backend would drive a pin, which
+    opens the chip and claims no line. Faking it would make the hardened-posture
+    check report a capability the host does not have — the opposite defect.
+    """
+    assert not isinstance(gpiozero.Device, FakeGPIODevice)
+
+
+@pytest.mark.asyncio
+async def test_connecting_a_relay_reaches_no_pin() -> None:
+    relay = RelayAction()
+    await relay.connect(gpio_pin=26, tolerate_missing_backend=False)
+
+    assert isinstance(relay._device, FakeGPIODevice)
+    assert relay._simulated is False, (
+        "the relay must still report a real backend: the guard replaces the "
+        "device, not the runtime's belief about whether one exists"
+    )
+    assert relay._device.pin == 26
+
+
+@pytest.mark.asyncio
+async def test_actuating_a_relay_records_instead_of_driving() -> None:
+    relay = RelayAction()
+    await relay.connect(gpio_pin=26, tolerate_missing_backend=False)
+
+    await relay.trigger()
+    assert relay.is_active is True
+    await relay.release()
+    assert relay.is_active is False
+    assert relay._device.history == ["on", "off"]
+
+
+def test_the_opt_in_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv(ALLOW_GPIO_ENV, raising=False)
+    assert _real_gpio_allowed() is False
+    for value in ("1", "true", "YES"):
+        monkeypatch.setenv(ALLOW_GPIO_ENV, value)
+        assert _real_gpio_allowed() is True
+    for value in ("", "0", "no", "maybe"):
+        monkeypatch.setenv(ALLOW_GPIO_ENV, value)
+        assert _real_gpio_allowed() is False

--- a/tests/test_led_indicator.py
+++ b/tests/test_led_indicator.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import sys
 
 import pytest
 
@@ -79,7 +80,14 @@ async def test_pattern_collision_fault_vs_policy_states():
 
 
 @pytest.mark.asyncio
-async def test_non_pi_noop_mode():
+async def test_noop_mode_without_gpiozero(monkeypatch):
+    """No-op is a consequence of gpiozero being absent, not of the host.
+
+    This was `test_non_pi_noop_mode` and asserted the host was not a Pi. On a Pi
+    it reached for real GPIO and failed on a busy pin, so the one platform the
+    behaviour matters on was the one platform it could not run.
+    """
+    monkeypatch.setitem(sys.modules, "gpiozero", None)
     indicator = LEDIndicator(StatusSignalingConfig())
     await indicator.connect()
     assert indicator.available is False

--- a/tests/test_relay.py
+++ b/tests/test_relay.py
@@ -32,7 +32,7 @@ def skip_if_no_pi():
 async def relay() -> RelayAction:
     """A RelayAction already connected in simulation mode."""
     r = RelayAction()
-    await r.connect(gpio_pin=26, allow_simulation=True)
+    await r.connect(gpio_pin=26, tolerate_missing_backend=True)
     return r
 
 
@@ -43,7 +43,7 @@ async def relay() -> RelayAction:
 async def test_connect_sets_connected():
     r = RelayAction()
     assert not r._connected
-    await r.connect(gpio_pin=26, allow_simulation=True)
+    await r.connect(gpio_pin=26, tolerate_missing_backend=True)
     assert r._connected
 
 
@@ -52,7 +52,7 @@ async def test_connect_enters_simulation_mode_without_gpiozero(monkeypatch):
     """Remove gpiozero from sys.modules to force simulation mode."""
     monkeypatch.setitem(sys.modules, "gpiozero", None)
     r = RelayAction()
-    await r.connect(gpio_pin=26, allow_simulation=True)
+    await r.connect(gpio_pin=26, tolerate_missing_backend=True)
     assert r._simulated is True
     assert r._device is None
 
@@ -73,7 +73,7 @@ async def test_connect_is_fail_closed_by_default(monkeypatch):
 @pytest.mark.asyncio
 async def test_connect_stores_pin_and_active_high():
     r = RelayAction()
-    await r.connect(gpio_pin=17, active_high=False, allow_simulation=True)
+    await r.connect(gpio_pin=17, active_high=False, tolerate_missing_backend=True)
     assert r._pin == 17
     assert r._active_high is False
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -965,7 +965,7 @@ class TestRequiredRuntimeCapabilities:
         finally:
             await runtime.stop()
 
-        connect.assert_awaited_once_with(gpio_pin=26, allow_simulation=False)
+        connect.assert_awaited_once_with(gpio_pin=26, tolerate_missing_backend=False)
 
 
 class TestLocalSLMWiring:
@@ -1481,7 +1481,7 @@ class TestLifecycle:
 
         await close_gas_valve("close_gas_valve", SimpleNamespace())
 
-        connect.assert_awaited_once_with(gpio_pin=26, allow_simulation=True)
+        connect.assert_awaited_once_with(gpio_pin=26, tolerate_missing_backend=True)
         trigger.assert_awaited_once_with(duration_seconds=None)
 
 


### PR DESCRIPTION
## What does this PR do?

Running `pytest tests/` on a Raspberry Pi claimed **BCM 26** — physical pin 37 — and toggled it. `test_relay.py` connects a relay there in five places, nine tests use the connected fixture, and thirteen call sites actuate. On a bench with a coil wired, the suite moved it. This was found by running the suite on the bench during an unrelated review, not in theory.

**The tests read as though they were simulated.** `RelayAction.connect()` builds a real `OutputDevice` whenever gpiozero is importable, and the argument every one of those tests passed — `allow_simulation=True` — is consulted only inside the `except ImportError` branch. It permits a no-op when the dependency is missing; it does not ask for one. The name said otherwise and was believed, so it is now `tolerate_missing_backend`.

**The guard is autouse in a new `tests/conftest.py`**, substituting gpiozero's output classes with recording fakes unless `ORI_TEST_ALLOW_REAL_GPIO` is set. It sits there rather than as a marker each hardware test remembers to apply, because the failure mode is a test that forgets — which is precisely what the existing protection already was. `test_relay.py` skips when gpiozero is **absent**, so it guarded only the machines that were never at risk and left the one platform that was.

**`Device` is deliberately left real.** `resolved_pin_factory_name()` asks it which backend would drive a pin, which opens the chip and claims no line. Faking it would make the hardened-posture check report a capability the host does not have — the opposite defect, and a worse one.

**`RelayAction` gains no injection seam.** That was the first shape of this fix, mirroring `LEDIndicator`'s `device_factory`. It is the wrong shape here: a relay is the Tier D actuator, and a way to substitute its device is a way to substitute the physical path in production. Replacing the library's constructors reaches every caller without widening the runtime's own surface at all — the only change to `relay.py` is the rename and its docstring.

**One test was testing the wrong thing.** `test_non_pi_noop_mode` asserted the *host* was not a Pi, so on the one platform where no-op behaviour matters it reached for real GPIO and failed on a busy pin. It is now `test_noop_mode_without_gpiozero`, patches gpiozero away, and tests the behaviour it is named for on every platform.

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests only
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability appears, disappears or changes. `relay.py` changes a keyword argument's name and its docstring; the runtime's behaviour at every posture is identical.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D code path is added or altered. The rename is keyword-only and `ori/runtime.py` is its sole caller in this repository; an out-of-tree caller passing `allow_simulation=` would need updating, which is the point of renaming it rather than aliasing it.

## Related issue

Closes #430.

Two of the nineteen Pi failures tracked in #431 are fixed here as a consequence: `test_relay.py::test_connect_stores_pin_and_active_high` and `test_led_indicator.py`.

## Testing notes

**Verified on a Pi 4 by watching the pin, not by reading the code.** `pinctrl get 26` polled at 30ms throughout the run: **zero output samples across 900**, against an earlier unguarded run on the same bench that claimed and toggled the same pin. Both GPIO 20 and 26 were inputs before and after. 34 tests pass there, including the new guard tests.

The guard tests use `importorskip("gpiozero")`, so they skip on a developer machine — deliberately, and stated in the module docstring. Nothing there can reach a pin, so nothing there can prove a guard against reaching one. That is also why the local suite count moves from 4632/27 to **4632 passed, 28 skipped**: one added skip, no pass-count change.

`ruff`, `ruff format`, `mypy ori/` (144 files) and the runtime type boundary are clean.
