### PR TITLE
fix(config): name both entries when a sensor id is duplicated

### DIFF
--- a/ori/config.py
+++ b/ori/config.py
@@ -680,7 +680,7 @@ def _parse_sensors(
         raise ConfigValidationError("'sensors' must be a list.")
 
     sensors = []
-    seen_ids: set[str] = set()
+    seen_ids: dict[str, int] = {}
     for i, item in enumerate(data):
         if not isinstance(item, dict):
             raise ConfigValidationError(f"sensors[{i}] must be a mapping.")
@@ -721,9 +721,11 @@ def _parse_sensors(
             )
         if sensor_id in seen_ids:
             raise ConfigValidationError(
-                f"{section}.id: {sensor_id!r} duplicates an earlier sensor id."
+                f"{section}.id: {sensor_id!r} is already used by "
+                f"sensors[{seen_ids[sensor_id]}]. Per-sensor state is keyed by "
+                f"id, so two entries sharing one do not produce two sensors."
             )
-        seen_ids.add(sensor_id)
+        seen_ids[sensor_id] = i
 
         # Everything outside the canonical envelope is protocol configuration.
         # It is closed by the declaration selected above; forwarding a key that


### PR DESCRIPTION
## What does this PR do?

#423 asked that a duplicate sensor id be refused *"naming both offending entries."* The refusal that shipped names one:

```
sensors[1].id: 'dup' duplicates an earlier sensor id.
```

The operator is told which entry was rejected and has to find the other by searching the file for the id. Both indices are known at the point of refusal, so both are now named, along with the reason the constraint exists at all:

```
sensors[2].id: 'a' is already used by sensors[0]. Per-sensor state is keyed by
id, so two entries sharing one do not produce two sensors.
```

A refusal that does not say what to do invites a workaround, and "duplicates an earlier one" in a file with forty sensors is a search, not an instruction.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — the set of accepted and refused configurations is unchanged. The same documents are refused; the message names one more thing.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is touched. `seen_ids` becomes a `dict[str, int]` from a `set[str]`; nothing else changes.

## Related issue

Completes the last acceptance bullet of #423, which merged as part of #432 with the other bullets satisfied. The corpus case `duplicate_id_refused` requires the refusal to name the id, which both the old and new message do, so no vendored vector changes.

## Testing notes

`pytest tests/` — **4632 passed, 27 skipped**, unchanged from main. `ruff`, `ruff format` and `mypy ori/` (144 files) clean.

Verified by hand that the index reported is the *first* occurrence rather than the previous one, using three entries where the duplicate is not adjacent to its original:

```
_parse_sensors([{id: a}, {id: b}, {id: a}])
-> sensors[2].id: 'a' is already used by sensors[0].
```