### PR TITLE
fix(tests): make the watchdog's no-gpiozero test exercise its name

### DIFF
--- a/tests/test_external_watchdog.py
+++ b/tests/test_external_watchdog.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
-import builtins
+import importlib
 import sys
 import textwrap
 import types
@@ -145,14 +145,26 @@ async def test_enabled_starts_loop(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_no_gpiozero_silent(monkeypatch):
+    """The loop returns rather than pulsing when gpiozero cannot be imported.
+
+    Patching `builtins.__import__` did not exercise this: the loop resolves the
+    module through `importlib.import_module`, which does not consult it. Where
+    gpiozero was genuinely absent the test passed for that reason instead, and
+    where it was present the loop ran until a shutdown event this test never
+    sets — so on a Pi it hung the whole suite. Absence is now injected through
+    the mechanism the loop actually uses.
+    """
     runtime = OriRuntime(config_path="ori.yaml")
 
-    real_import = builtins.__import__
+    real_import_module = importlib.import_module
 
-    def _import(name, *args, **kwargs):
+    def _import_module(name, *args, **kwargs):
         if name == "gpiozero":
             raise ImportError("gpiozero not installed")
-        return real_import(name, *args, **kwargs)
+        return real_import_module(name, *args, **kwargs)
 
-    monkeypatch.setattr(builtins, "__import__", _import)
-    await runtime._external_watchdog_loop(gpio_pin=17, ping_interval_s=0.01)
+    monkeypatch.setattr(importlib, "import_module", _import_module)
+    await asyncio.wait_for(
+        runtime._external_watchdog_loop(gpio_pin=17, ping_interval_s=0.01),
+        timeout=5.0,
+    )


### PR DESCRIPTION
## What does this PR do?

`test_no_gpiozero_silent` does not fail on a Raspberry Pi. It **hangs forever**, taking the whole run with it at roughly a third of the way through, which is why a suite run on the target platform cannot currently be completed at all.

The test injects the absence of gpiozero like this:

```python
monkeypatch.setattr(builtins, "__import__", _import)
await runtime._external_watchdog_loop(gpio_pin=17, ping_interval_s=0.01)
```

`_external_watchdog_loop` does not use the `import` statement. It resolves the module through `importlib.import_module("gpiozero")`, which does not consult `builtins.__import__`. The patch has no effect at all.

Where gpiozero is genuinely absent — every developer laptop, and CI — the import fails anyway, the loop returns, and the test passes **for a reason it did not arrange**. Where gpiozero is present, the import succeeds and the loop enters:

```python
while not self._shutdown_event.is_set():
```

The test awaits the loop directly and never sets that event, because it believed it had made the import fail. So on the one platform where "silent without gpiozero" is a claim worth checking, the test cannot check it, and hangs instead.

Absence is now injected through the mechanism the loop actually uses, and the await is bounded so a future regression fails rather than hangs.

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — tests only; no runtime file changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

Nothing under `ori/` changes. The external watchdog is optional hardware and not a Tier D path; the loop's behaviour is untouched.

## Related issue

Part of #431. Recorded there in detail, because it blocks every other item in that issue: nothing else can be diagnosed while the suite cannot reach the end.

Deliberately **not** fixing the loop itself. `importlib.import_module` is a reasonable way to resolve an optional dependency, and the defect is in how the test claimed to remove it. If the loop should also refuse to spin when no shutdown event will ever arrive, that is a separate argument and a separate change.

## Testing notes

**On a Pi 4:** `tests/test_external_watchdog.py` runs in **2 seconds, 3 passed**, where it previously never returned. Confirmed the hang first on `96f5752`, `d1c1680` and `main`, with and without the actuation guard from #430, so it is independent of both.

**On macOS:** 4632 passed, 28 skipped — unchanged, as expected, since the test passed there before for the accidental reason and passes now for the arranged one.

`ruff`, `ruff format` and `mypy ori/` (144 files) clean. A full Pi suite run is in progress; it is the first that has a chance of finishing, and the resulting failure list will be posted to #431.