### PR TITLE
fix(tests): say what the i2c bench tests need instead of failing without it

### DIFF
--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -15,14 +15,35 @@ from ori.hal.base import (
     AdapterTimeoutError,
     HardwareCircuitBreaker,
 )
-from ori.hal.i2c_adapter import I2CAdapter, _window_spec
+from ori.hal.i2c_adapter import (
+    _ADS1115_AVAILABLE,
+    _BME280_AVAILABLE,
+    I2CAdapter,
+    _window_spec,
+)
 
 # ─── Pi guard ─────────────────────────────────────────────────────────────────
 
-skip_if_no_pi = pytest.mark.skipif(
-    not os.path.exists("/dev/i2c-1"),
-    reason="No I2C bus — not running on Pi",
-)
+_HAS_I2C_BUS = os.path.exists("/dev/i2c-1")
+
+
+def _needs_hardware(
+    available: bool, package: str, part: str, address: int, article: str = "a"
+):
+    """Skip naming what is absent, rather than failing as though broken.
+
+    An I2C bus node proves the host is a Pi. It does not prove a driver is
+    installed or that anything answers at the address, and these tests need
+    both. Reporting a missing driver as a failure reads as a defect in the
+    adapter, so a Pi run showed two red tests that said nothing about the code.
+    """
+    return pytest.mark.skipif(
+        not (_HAS_I2C_BUS and available),
+        reason=(
+            f"needs {article} {part} at I2C address 0x{address:02X} on bus 1 and the "
+            f"{package} package; install it on the bench to run this for real"
+        ),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -753,8 +774,10 @@ class TestReadTimeout:
 # ─── Pi-only integration tests ────────────────────────────────────────────────
 
 
-@skip_if_no_pi
 class TestPiIntegration:
+    """Real hardware. Skipped, with the reason named, when it is not present."""
+
+    @_needs_hardware(_BME280_AVAILABLE, "bme280", "BME280", 0x76)
     async def test_bme280_connect_and_read(self):
         adapter = I2CAdapter()
         await adapter.connect(
@@ -772,6 +795,13 @@ class TestPiIntegration:
         await adapter.close()
         assert not adapter.is_connected
 
+    @_needs_hardware(
+        _ADS1115_AVAILABLE,
+        "adafruit-circuitpython-ads1x15",
+        "ADS1115",
+        0x48,
+        article="an",
+    )
     async def test_ads1115_current_connect_and_read(self):
         adapter = I2CAdapter()
         await adapter.connect(


### PR DESCRIPTION
## What does this PR do?

`TestPiIntegration` was gated on `/dev/i2c-1` existing. That proves the host is a Pi. It does not prove a sensor driver is installed, or that anything answers at the address — and these tests need both.

So on a Pi they failed, before reaching the bus at all:

```
AdapterConnectionError: I2CAdapter: Adafruit ADS1x15 library is not installed.
Run: pip install adafruit-circuitpython-ads1x15
```

A missing driver reported as a failure reads as a defect in the adapter. A full Pi run showed two red tests that said nothing about the code, and that pair was a third of what an earlier triage counted as evidence the platform was broken.

Each test now names the part, the address and the package it needs:

```
SKIPPED: needs an ADS1115 at I2C address 0x48 on bus 1 and the
adafruit-circuitpython-ads1x15 package; install it on the bench to run
this for real
```

**The gate is driver *and* bus**, so installing the package on a wired bench makes these execute for real without a further change. That distinction matters: these assertions have never run anywhere, and a skip that hides why is how they stayed that way. This one states the exact conditions that would make them run.

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — tests only; no runtime file changes.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

Nothing under `ori/` changes.

## Related issue

Closes the code half of #431. The hardware half — whether the bench carries an ADS1115 so those assertions actually execute — stays open there, because it is a hardware decision and not a code one.

## Testing notes

`pytest tests/` — **4632 passed, 28 skipped** on macOS; `mypy ori/` clean across 144 files. On a Pi the two tests skip with the messages above instead of failing, which takes a full Pi run to **0 failures** in a correctly provisioned environment.

Note the reason strings are asserted by nothing. They are operator-facing text on a path that only executes on hardware, and writing a test that asserts its own skip message would prove only that the string exists.