### PR TITLE
chore(release): prepare v2.5.0-rc.6

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,6 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.5.0-rc.5` are collected here until the next
+Changes merged to `main` after `v2.5.0-rc.6` are collected here until the next
 candidate or release is cut.
 
 _No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.5` is the current candidate.
+Minor release, in progress. `v2.5.0-rc.6` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -28,8 +28,10 @@ Raspberry Pi wheelhouse buildable for the first time, and stops the runtime
 certifying a GPIO backend it does not exclusively own.
 
 It also carries the runtime half of the evidence exchange: signed chain rows
-produced here rather than imported, sealed into a delivery ledger, with a
-destination for the artifacts an authority returns.
+produced here rather than imported, sealed into a delivery ledger, carried to
+the gateway courier with checkpoints, and a destination for the artifacts an
+authority returns — with what came back refused retained, and why evidence
+trust is not established reported rather than hidden.
 
 ## Release candidates
 
@@ -42,7 +44,8 @@ installed.
 | `v2.5.0-rc.2` | protection preflight, full test matrix, build | the wheelhouse audit refused the runtime's own evidence modules, so no bundle was built or signed |
 | `v2.5.0-rc.3` | published | first candidate to build a bundle; installed on the bench Pi against the system `python3.13`, and found to carry no GPIO capability at all |
 | `v2.5.0-rc.4` | protection preflight, full test matrix, build | the bundle builder refused `setuptools` as ambiguous, so no bundle was built or signed |
-| `v2.5.0-rc.5` | — | the GPIO packaging candidate: published to prove a Pi release can import its pin factory |
+| `v2.5.0-rc.5` | published | the GPIO packaging candidate; installed on the bench Pi against the system `python3.13`, where the release venv resolves `LGPIOFactory` by default from `lgpio` staged inside the release tree, with nothing resolving from outside it |
+| `v2.5.0-rc.6` | — | the evidence exchange candidate: published to exercise runtime-to-gateway carriage, custody and checkpoints on hardware |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.
@@ -111,24 +114,35 @@ reached them yet.
 
 ## What this candidate is for
 
-`v2.5.0-rc.5` is **the GPIO packaging candidate**. It exists to answer one
-question on real hardware: can a Pi release import a pin factory that claims its
-lines through the kernel?
+`v2.5.0-rc.6` is **the evidence exchange candidate**. `v2.5.0-rc.5` answered
+the GPIO packaging question: on the bench Pi, against the system `python3.13`,
+the release venv resolves `LGPIOFactory` by default from the `lgpio` module
+staged inside the release tree, and nothing resolves from outside it. That
+result stands and this candidate re-carries it unchanged.
 
-1. It must install on Raspberry Pi OS Trixie using the **system** `python3.13`,
-   with no hand-placed interpreter and no symlink. Proven by `v2.5.0-rc.3`, and
-   re-proven here because the install path changed.
-2. The deployed environment must resolve `LGPIOFactory` rather than
-   `NativeFactory` — see below for why that distinction is not cosmetic.
-3. No module outside the release tree may resolve through the system path.
+What `v2.5.0-rc.6` exists to exercise on hardware is the runtime's side of
+`evidence-exchange/v1` against a real gateway:
 
-**It is not a Tier D candidate, and an actuation demonstration must not be
-claimed from it.** Three things stand between a working pin factory and a
-trustworthy safety cutoff, and all three are open: the relay has no commissioned
-controller-loss posture and its polarity setting is not plumbed through; the
-current path reports an uncalibrated instantaneous sample as amperes; and a
-Tier D condition selects a mutable skill action list, which for overcurrent
-dispatches alerts and never reaches an actuator. Those need a later candidate.
+1. Sealed envelopes and checkpoints leave on the outbound carriage as exact
+   signed bytes, and are released only by the courier's authenticated
+   acknowledgement or, for envelopes, by the custody acknowledgement that
+   returns through the inbound route.
+2. A refused authority artifact is retained and visible after a restart, and
+   `evidence.posture_problems` says why evidence trust is not established.
+3. Nothing about evidence ever gates the safety path: the runtime starts,
+   reports `authority_keys_missing` and `degraded`, and keeps recording.
+
+It pairs with `ori-gateway` at `5bf34c6` or later, which carries custody
+through its durable return queue and signs every acknowledgement from a
+persisted clock. Proven so far on a loopback broker between the two; the bench
+Pi is where this candidate earns its row.
+
+**It is still not a Tier D candidate, and an actuation demonstration must not
+be claimed from it.** The relay has no commissioned controller-loss posture and
+its polarity setting is not plumbed through, and a Tier D condition selects a
+mutable skill action list, which for overcurrent dispatches alerts and never
+reaches an actuator. The current path now refuses to report an uncalibrated
+sample as amperes rather than doing so silently. Those need a later candidate.
 
 ## Raspberry Pi
 
@@ -201,15 +215,43 @@ replacing the previously imported artifact and its loader. Rows are sealed into
 a delivery ledger that allocates `local_seq` gaplessly, and checkpoints are
 separately signed.
 
-Inbound authority artifacts now have a destination. Custody acknowledgements,
+Inbound authority artifacts have a destination. Custody acknowledgements,
 delivery receipts and epoch confirmations are verified against the published
 vectors and applied on the evidence worker thread. Custody uses key material
 dedicated to it, selected by a derived identifier rather than by trial
 verification.
 
-**Still partial.** No release ships an authority-key registry, so receipts and
-epoch confirmations are refused as unknown-key — fail-closed and correct.
-Nothing publishes an artifact outbound yet.
+Outbound carriage exists. Sealed envelopes awaiting custody and checkpoints
+held in a durable outbox are published to the gateway courier as exact signed
+bytes over a persistent session, republished under per-artifact backoff, and
+released only by an authenticated acknowledgement: a queued checkpoint is
+retired because the gateway's durable queue now owns retry, while an envelope
+stays awaiting custody until the custody acknowledgement arrives inbound.
+PUBACK retires nothing. Checkpoints are issued on a release-owned interval and
+at clean shutdown, retained before anything is sent.
+
+What ingest refuses is retained by the ledger — the newest 200, immutable —
+and surfaces in health as `ingest_refusal_count` and `last_ingest_refusal`, so
+a refused receipt is distinguishable from one that never arrived. Receipts and
+custody arriving after a restart are matched to their sealed envelopes because
+the ledger, not the process, holds them.
+
+Evidence trust that cannot be established locally — the ledger or key did not
+open, the release ships no authority-key registry, or a gateway is configured
+without a custody secret — is reported as `evidence.posture_problems` with the
+runtime `status` degraded, at ERROR under a hardened profile. It never prevents
+startup: evidence records what happened and must not decide whether the
+runtime may run, and Tier D is never gated on evidence availability.
+
+**Still partial.** No release ships an authority-key registry, so every
+runtime reports `authority_keys_missing` and refuses receipts and epoch
+confirmations as unknown-key — fail-closed and correct, and the reason a device
+cannot yet be represented as authority-confirmed. Anchor registration reports
+`pending_authorisation` until a commissioning reference has a path to the
+device.
+
+The security package is now `ori/security/evidence/`, `ori/security/firmware/`
+and `ori/security/remote_commands/`; no behaviour changed with the move.
 
 ## Installer and platform
 
@@ -263,8 +305,12 @@ key is refused rather than bounded by a guess.
 - **No Tier D electrical cutoff can be demonstrated.** The relay's polarity
   setting is documented but never plumbed through, and controller loss
   reconnects the load rather than opening it, with no commissioned posture
-  deciding which is correct for a given load. The `ads1115_current` path
-  discards its configured calibration and reports a single instantaneous sample
-  as amperes. And a Tier D condition selects a mutable skill action list, which
-  for overcurrent dispatches alerts and never reaches an actuator. A pin factory
-  that works is a prerequisite for fixing these, not evidence that they are.
+  deciding which is correct for a given load. And a Tier D condition selects a
+  mutable skill action list, which for overcurrent dispatches alerts and never
+  reaches an actuator. A pin factory that works is a prerequisite for fixing
+  these, not evidence that they are.
+- **No evidence exchange is proven end to end.** The carriage, custody and
+  checkpoint round-trip has run on a loopback broker between this runtime and
+  the gateway; no authority has received an artifact from a deployed gateway,
+  and no release carries the authority-key registry that would let this
+  runtime verify what one returns.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc5"
+version = "2.5.0rc6"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Bumps the project to `2.5.0rc6` and records what `v2.5.0-rc.5` established.

`v2.5.0-rc.5` published, and on the bench Pi — Raspberry Pi OS Trixie, system Python 3.13.5 — the release venv resolves `LGPIOFactory` by default from the `lgpio` module staged inside the release tree, with nothing resolving from outside it. That closes the GPIO packaging question the candidate was cut for.

`v2.5.0-rc.6` is the evidence exchange candidate. Since rc.5, main gained the runtime's outbound carriage (sealed envelopes and retained checkpoints to the gateway courier, released only by authenticated acknowledgement or custody), durable retention of refused authority artifacts with health projection, evidence trust posture reported as `evidence.posture_problems` and never used as a startup gate, the restart proofs for receipt and custody matching, the `security/` subpackages, and the sensor configuration and calibration fixes already merged. It pairs with `ori-gateway` at `5bf34c6` or later. The notes say what the loopback bench proved and what the Pi still has to.

### Still not a Tier D candidate

The relay's polarity and controller-loss posture and the release-owned safety registry remain open; an actuation demonstration must not be claimed from this candidate. No evidence exchange is proven end to end through an authority, and no release carries the authority-key registry.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #326, #442

## Testing notes

`scripts/check_release_identity.py --tag v2.5.0-rc.6` resolves the packaged version. Full suite on macOS and, as a normal user in a Debian Trixie arm64 container against Python 3.13.5: 4715 passed, 26 skipped. The disclosure audit passes over the amended notes.