### PR TITLE
fix(tests): wait for the runtime to come up before observing evidence posture

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -3772,6 +3772,18 @@ class TestRemoteDevicePolicy:
             await runtime._state_store.close()
 
 
+async def _until_started(runtime: OriRuntime, timeout_s: float = 30.0) -> None:
+    """Wait for start() to have built the action path and the evidence stack.
+
+    A fixed sleep raced start() on a loaded, coverage-instrumented CI runner.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout_s
+    while runtime._dispatcher is None or runtime._evidence_attestor is None:
+        if asyncio.get_running_loop().time() > deadline:
+            raise AssertionError("the runtime did not come up in time")
+        await asyncio.sleep(0.05)
+
+
 class TestEvidencePostureNeverGatesStartup:
     """Tier D is never gated on evidence, not by availability and not by trust.
 
@@ -3804,7 +3816,7 @@ class TestEvidencePostureNeverGatesStartup:
         observed: dict[str, Any] = {}
 
         async def _observe_then_stop():
-            await asyncio.sleep(0.2)
+            await _until_started(runtime)
             observed["dispatcher"] = runtime._dispatcher
             attestor = runtime._evidence_attestor
             observed["signing_available"] = attestor is not None and attestor.available
@@ -3846,7 +3858,7 @@ class TestEvidencePostureNeverGatesStartup:
         observed: dict[str, Any] = {}
 
         async def _observe_then_stop():
-            await asyncio.sleep(0.2)
+            await _until_started(runtime)
             observed["health"] = await runtime._build_health_snapshot()
             await runtime.stop()
 


### PR DESCRIPTION
## What does this PR do?

`TestEvidencePostureNeverGatesStartup` observed the runtime after a fixed 200 ms sleep, which raced `start()` on the coverage-instrumented Python 3.12 job and failed main at `78c3edb` with "the action path did not come up". The two tests now wait for `start()` to have built the dispatcher and the evidence attestor, bounded at 30 s, before observing health and stopping. What they assert is unchanged.

## Type of change

- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: tests only
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #326

## Testing notes

The two tests run three times plain and once under `--cov=ori` locally, all green.