### PR TITLE
test(gateway): verify the gateway's signed reasoning responses with the runtime verifier

### DIFF
--- a/tests/fixtures/gateway_signed_reasoning_responses.json
+++ b/tests/fixtures/gateway_signed_reasoning_responses.json
@@ -1,0 +1,141 @@
+{
+  "secret": "published-test-reasoning-envelope-secret",
+  "signed_at_ms": 1700000000000,
+  "device_id": "site-a",
+  "cases": [
+    {
+      "name": "below_agreement_zone_rounds_to_zero",
+      "request_id": "interop-1",
+      "provider_confidence": 0.000042,
+      "emitted_confidence": 0,
+      "response": {
+        "request_id": "interop-1",
+        "device_id": "site-a",
+        "text": "Ikẹjà ✓ 電力 — below_agreement_zone_rounds_to_zero",
+        "model": "fake-model",
+        "tokens_used": 3,
+        "latency_ms": 4,
+        "confidence": 0,
+        "action_tier": "C",
+        "proposed_action": null,
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:7c3469e2b055ef86a45c0d40eed42be92798961373db33f8c11585b75017fb22"
+        }
+      }
+    },
+    {
+      "name": "half_unit_rounds_up",
+      "request_id": "interop-2",
+      "provider_confidence": 0.00005,
+      "emitted_confidence": 0.0001,
+      "response": {
+        "request_id": "interop-2",
+        "device_id": "site-a",
+        "text": "Ikẹjà ✓ 電力 — half_unit_rounds_up",
+        "model": "fake-model",
+        "tokens_used": 3,
+        "latency_ms": 4,
+        "confidence": 0.0001,
+        "action_tier": "C",
+        "proposed_action": null,
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:ba3598a7e072583af0c99fdee29a511e4c9eab1369e893e857f6bc65ad5fb1ac"
+        }
+      }
+    },
+    {
+      "name": "ordinary_confidence",
+      "request_id": "interop-3",
+      "provider_confidence": 0.93,
+      "emitted_confidence": 0.93,
+      "response": {
+        "request_id": "interop-3",
+        "device_id": "site-a",
+        "text": "Ikẹjà ✓ 電力 — ordinary_confidence",
+        "model": "fake-model",
+        "tokens_used": 3,
+        "latency_ms": 4,
+        "confidence": 0.93,
+        "action_tier": "C",
+        "proposed_action": null,
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:8c2bbf54cf366a2bbee6c76b7b719981210638f69f625da1b4bdeccb3db02b3c"
+        }
+      }
+    },
+    {
+      "name": "five_decimals_round_to_four",
+      "request_id": "interop-4",
+      "provider_confidence": 0.123456,
+      "emitted_confidence": 0.1235,
+      "response": {
+        "request_id": "interop-4",
+        "device_id": "site-a",
+        "text": "Ikẹjà ✓ 電力 — five_decimals_round_to_four",
+        "model": "fake-model",
+        "tokens_used": 3,
+        "latency_ms": 4,
+        "confidence": 0.1235,
+        "action_tier": "C",
+        "proposed_action": null,
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:7d2282d2e0e392194784639062298833e67adaeb04e71297091795458a55e08c"
+        }
+      }
+    },
+    {
+      "name": "unit_confidence",
+      "request_id": "interop-5",
+      "provider_confidence": 1,
+      "emitted_confidence": 1,
+      "response": {
+        "request_id": "interop-5",
+        "device_id": "site-a",
+        "text": "Ikẹjà ✓ 電力 — unit_confidence",
+        "model": "fake-model",
+        "tokens_used": 3,
+        "latency_ms": 4,
+        "confidence": 1,
+        "action_tier": "C",
+        "proposed_action": null,
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:4f9a0c2d2e4abf200c37c06f9ca2ae436e9a95c30d77b6678bac8eac385fb8ef"
+        }
+      }
+    },
+    {
+      "name": "error_response",
+      "request_id": "interop-6",
+      "provider_confidence": 0,
+      "emitted_confidence": 0,
+      "provider_error": "provider unavailable",
+      "response": {
+        "request_id": "interop-6",
+        "device_id": "site-a",
+        "text": "",
+        "model": "gateway",
+        "tokens_used": 0,
+        "latency_ms": 0,
+        "confidence": 0,
+        "action_tier": "C",
+        "proposed_action": null,
+        "error": "provider error",
+        "auth": {
+          "scheme": "hmac-sha256",
+          "signed_at_ms": 1700000000000,
+          "signature": "hmac-sha256:3c153b54325603ba82f71f66b423ecb78486163dfd6321bace5b79f0e31eb492"
+        }
+      }
+    }
+  ]
+}

--- a/tests/test_gateway_reasoning_interop.py
+++ b/tests/test_gateway_reasoning_interop.py
@@ -1,0 +1,96 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Gateway-signed reasoning responses verified by this runtime's own verifier.
+
+The fixture is what `ori-gateway`'s dispatcher emitted for a fixed clock and a
+published test secret, including confidences on either side of the `1e-4`
+boundary where Go and CPython spell a float differently. Verifying each one
+here proves the bytes the gateway signs are the bytes this runtime
+re-serialises — the inverse of the runtime-signed request fixture the gateway
+carries.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import pytest
+
+from ori.security.gateway_messages import (
+    GatewayMessageAuthConfig,
+    GatewayMessageAuthenticator,
+    GatewayMessageAuthError,
+)
+
+FIXTURE = (
+    pathlib.Path(__file__).parent
+    / "fixtures"
+    / "gateway_signed_reasoning_responses.json"
+)
+
+
+@pytest.fixture(scope="module")
+def corpus() -> dict:
+    return json.loads(FIXTURE.read_text(encoding="utf-8"))
+
+
+def _verifier(corpus: dict) -> GatewayMessageAuthenticator:
+    return GatewayMessageAuthenticator(
+        GatewayMessageAuthConfig(shared_secret=corpus["secret"])
+    )
+
+
+def test_every_gateway_signed_response_verifies_here(corpus):
+    names = []
+    for case in corpus["cases"]:
+        verified = _verifier(corpus).verify(
+            case["response"],
+            message_type="reasoning_response",
+            expected_device_id=corpus["device_id"],
+            expected_request_id=case["request_id"],
+            now_ms_value=corpus["signed_at_ms"] + 1,
+        )
+        assert verified["device_id"] == corpus["device_id"]
+        assert verified["confidence"] == case["emitted_confidence"], case["name"]
+        if case.get("provider_error"):
+            assert verified["error"]
+        names.append(case["name"])
+    assert {
+        "below_agreement_zone_rounds_to_zero",
+        "half_unit_rounds_up",
+        "five_decimals_round_to_four",
+        "error_response",
+    } <= set(names)
+
+
+def test_confidence_arrives_in_the_agreement_zone(corpus):
+    """Every emitted confidence is exactly 0 or at least 1e-4, so CPython's
+    repr and Go's formatting agree and the signature survives re-serialisation."""
+    for case in corpus["cases"]:
+        emitted = case["response"]["confidence"]
+        assert emitted == 0 or emitted >= 1e-4, case["name"]
+        assert emitted == round(case["provider_confidence"], 4), case["name"]
+
+
+@pytest.mark.parametrize(
+    "field, value, reason",
+    [
+        ("text", "forged", "invalid_signature"),
+        ("action_tier", "D", "invalid_signature"),
+        ("confidence", 0.9999, "invalid_signature"),
+        ("device_id", "site-b", "device_mismatch"),
+    ],
+)
+def test_a_forged_field_is_refused(corpus, field, value, reason):
+    case = corpus["cases"][2]
+    forged = dict(case["response"])
+    forged[field] = value
+    with pytest.raises(GatewayMessageAuthError, match=reason):
+        _verifier(corpus).verify(
+            forged,
+            message_type="reasoning_response",
+            expected_device_id=corpus["device_id"],
+            expected_request_id=case["request_id"],
+            now_ms_value=corpus["signed_at_ms"] + 1,
+        )


### PR DESCRIPTION
## What does this PR do?

The gateway's reasoning dispatcher now signs its responses (ori-platform/ori-gateway#92). The proof that this runtime accepts them has to run through this runtime's own `GatewayMessageAuthenticator`, not a Go verifier, so the dispatcher pins the responses it emits under a fixed clock and a published test secret as a fixture — confidences on both sides of the `1e-4` boundary where Go and CPython spell a float differently, and a signed error response — and this test vendors that file and verifies every response here, asserts each `confidence` is exactly the rounded value in the agreement zone, and refuses forged `text`, `action_tier`, `confidence` and `device_id`. The gateway's own test holds the fixture byte-for-byte to what its code emits, so the two files cannot drift apart silently.

## Type of change

- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: tests only
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs ori-platform/ori-gateway#88, ori-platform/ori-gateway#79

## Testing notes

Six tests, pyright clean. Merge after ori-platform/ori-gateway#92 or alongside it; the fixture is the one committed there.