### PR TITLE
fix(installer): discard the script bytecode pip leaves in the release venv bin

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -3,4 +3,11 @@
 Changes merged to `main` after `v2.5.0-rc.6` are collected here until the next
 candidate or release is cut.
 
-_No changes yet._
+## Fixed
+
+- The installer no longer refuses a release whose venv `bin` carries a
+  `__pycache__` directory. `v2.5.0-rc.6` cannot be installed on a Pi in either
+  scope because its wheelhouse's `pyftdi` scripts are byte-compiled there at
+  install time; the relocation now discards that cache and still refuses
+  anything else at that name or any other directory in `bin`.
+

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -45,7 +45,7 @@ installed.
 | `v2.5.0-rc.3` | published | first candidate to build a bundle; installed on the bench Pi against the system `python3.13`, and found to carry no GPIO capability at all |
 | `v2.5.0-rc.4` | protection preflight, full test matrix, build | the bundle builder refused `setuptools` as ambiguous, so no bundle was built or signed |
 | `v2.5.0-rc.5` | published | the GPIO packaging candidate; installed on the bench Pi against the system `python3.13`, where the release venv resolves `LGPIOFactory` by default from `lgpio` staged inside the release tree, with nothing resolving from outside it |
-| `v2.5.0-rc.6` | — | the evidence exchange candidate: published to exercise runtime-to-gateway carriage, custody and checkpoints on hardware |
+| `v2.5.0-rc.6` | published | the evidence exchange candidate; its Pi wheelhouse carries `pyftdi`, whose scripts pip byte-compiles into `venv/bin/__pycache__`, and the shebang relocation refuses that directory, so the bundle cannot be installed on a Pi in either scope. With the relocation fix substituted into the installer, the same bundle installed under user scope and carried checkpoints to a LAN gateway with envelope auth |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -2365,6 +2365,7 @@ def _repair_relocated_shebangs(staging: Path, destination: Path) -> None:
     old_bin = f"{staging}/venv/bin/".encode()
     new_bin = f"{destination}/venv/bin/".encode()
     staging_reference = str(staging).encode()
+    _discard_script_bytecode(bin_dir)
     try:
         entries = sorted(bin_dir.iterdir())
     except OSError as exc:
@@ -2428,6 +2429,40 @@ def _repair_relocated_shebangs(staging: Path, destination: Path) -> None:
 
     _assert_no_staging_references(bin_dir, staging_reference)
     _fsync_directory(bin_dir)
+
+
+def _discard_script_bytecode(bin_dir: Path) -> None:
+    """Remove the bytecode cache pip leaves beside ``.py`` scripts in ``bin``.
+
+    A wheel may install plain ``.py`` scripts into ``bin`` (pyftdi does), and
+    pip byte-compiles them at install time into ``bin/__pycache__``. That cache
+    is the one directory a correct venv can carry there: it embeds the staging
+    path in every ``.pyc``, is regenerated on demand, and is never executed as
+    an entry point. Removing it keeps the rule that nothing but regular files
+    and the interpreter symlinks live in ``bin``, and lets the staging-reference
+    scan stay strict. Anything else at that name is refused, because a symlink
+    or a file called ``__pycache__`` was not written by pip.
+    """
+    cache = bin_dir / "__pycache__"
+    try:
+        info = os.lstat(cache)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        raise LinuxInstallError(
+            "offline_install_failed", "cannot inspect release venv bin bytecode cache"
+        ) from exc
+    if not stat.S_ISDIR(info.st_mode):
+        raise LinuxInstallError(
+            "offline_install_failed",
+            "unexpected special file in release venv bin: __pycache__",
+        )
+    try:
+        shutil.rmtree(cache)
+    except OSError as exc:
+        raise LinuxInstallError(
+            "offline_install_failed", "cannot remove release venv bin bytecode cache"
+        ) from exc
 
 
 def _rewrite_preserving_mode(path: Path, content: bytes, mode: int) -> None:

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -3784,3 +3784,71 @@ def test_uninstall_leaves_the_service_account_in_place(tmp_path: Path) -> None:
 
     assert account_commands == []
     assert not layout.releases.exists()
+
+
+def _relocatable_bin(tmp_path: Path) -> tuple[Path, Path, Path]:
+    """A staged venv bin as pip leaves it after installing a wheel with scripts."""
+    staging = tmp_path / ".staging"
+    destination = tmp_path / "release"
+    bin_dir = destination / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    interpreter = f"#!{staging / 'venv' / 'bin' / 'python'}\n"
+    for name in ("ori-runtime", "i2cscan.py"):
+        script = bin_dir / name
+        script.write_text(interpreter + "print('hi')\n", encoding="utf-8")
+        script.chmod(0o755)
+    (bin_dir / "python").symlink_to("/usr/bin/python3")
+    return staging, destination, bin_dir
+
+
+def test_script_bytecode_pip_left_in_bin_is_discarded_not_refused(
+    tmp_path: Path,
+) -> None:
+    """pyftdi installs .py scripts into bin and pip byte-compiles them there."""
+    from ori.installer.linux import _repair_relocated_shebangs
+
+    staging, destination, bin_dir = _relocatable_bin(tmp_path)
+    cache = bin_dir / "__pycache__"
+    cache.mkdir()
+    (cache / "i2cscan.cpython-313.pyc").write_bytes(
+        b"\x00pyc" + str(staging / "venv" / "bin" / "i2cscan.py").encode()
+    )
+
+    _repair_relocated_shebangs(staging, destination)
+
+    assert not cache.exists()
+    expected = f"#!{destination / 'venv' / 'bin' / 'python'}"
+    for name in ("ori-runtime", "i2cscan.py"):
+        first = (bin_dir / name).read_text(encoding="utf-8").splitlines()[0]
+        assert first == expected, name
+    assert sorted(p.name for p in bin_dir.iterdir()) == [
+        "i2cscan.py",
+        "ori-runtime",
+        "python",
+    ]
+
+
+def test_a_bytecode_cache_that_is_not_a_directory_is_refused(tmp_path: Path) -> None:
+    from ori.installer.linux import _repair_relocated_shebangs
+
+    staging, destination, bin_dir = _relocatable_bin(tmp_path)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    (bin_dir / "__pycache__").symlink_to(elsewhere)
+
+    with pytest.raises(LinuxInstallError) as excinfo:
+        _repair_relocated_shebangs(staging, destination)
+    assert excinfo.value.code == "offline_install_failed"
+    assert "__pycache__" in str(excinfo.value)
+    assert elsewhere.exists(), "a refused link must never be followed or removed"
+
+
+def test_other_directories_in_bin_are_still_refused(tmp_path: Path) -> None:
+    from ori.installer.linux import _repair_relocated_shebangs
+
+    staging, destination, bin_dir = _relocatable_bin(tmp_path)
+    (bin_dir / "plugins").mkdir()
+
+    with pytest.raises(LinuxInstallError) as excinfo:
+        _repair_relocated_shebangs(staging, destination)
+    assert "plugins" in str(excinfo.value)


### PR DESCRIPTION
## What does this PR do?

`v2.5.0-rc.6` cannot be installed on a Raspberry Pi in either scope. Its Pi wheelhouse carries `pyftdi` (pulled in by the `adafruit-circuitpython-ads1x15` calibration work), and that wheel installs four plain `.py` scripts into `venv/bin`; pip byte-compiles them at install time into `venv/bin/__pycache__`. The shebang-relocation pass refuses any entry in `bin` that is not a regular file, so the install stops at `offline_install_failed: unexpected special file in release venv bin: __pycache__` and rolls back. Found on the bench Pi with a user-scope install under the stock `umask 0002`; the system-scope path runs the same code.

The relocation now removes that cache before inspecting `bin`: it is the one directory a correct venv can carry there, it embeds the staging path in every `.pyc`, it is regenerated on demand, and it is never an entry point. Anything else at that name — a symlink, a file — is still refused, and other directories in `bin` are still refused. The `.py` scripts themselves are regular executable files and get their shebangs rebound like every other console script.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: installer relocation only, no capability change
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #398

## Testing notes

Three new tests drive `_repair_relocated_shebangs` directly: the cache is discarded and the `.py` script's shebang rebound; a symlinked `__pycache__` is refused without following it; another directory in `bin` is still refused. Removing the discard fails the first two by name. `tests/test_linux_installer.py`: 167 passed on macOS under `umask 0022` and `0002`, and in a Debian Trixie arm64 container as a normal user under both umasks; full suite 4716 passed; mypy and pyright clean.

Proven on the bench Pi: with this `linux.py` substituted into a scratch venv built from the rc.6 wheelhouse, `ori-install-linux install --scope user` against the real signed rc.6 bundle completed under `umask 0002`, the user service came up, and the runtime connected its heartbeat, export, reasoning and both evidence routes to a LAN gateway with envelope auth. A new candidate is needed to carry the fix; rc.6 stays as published, and its row should record this outcome.