### PR TITLE
fix(evidence): carry the shutdown checkpoint before the routes are torn down

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -10,4 +10,13 @@ candidate or release is cut.
   scope because its wheelhouse's `pyftdi` scripts are byte-compiled there at
   install time; the relocation now discards that cache and still refuses
   anything else at that name or any other directory in `bin`.
+- The shutdown checkpoint is now carried before the evidence routes are torn
+  down. The stop path set the shutdown event first, which is what closes the
+  outbound route, so the flush that followed found no session and the
+  checkpoint waited for the next start; on the bench Pi the ledger showed it
+  retained with no attempt. The checkpoint is issued and flushed before the
+  event is set, the route drains once more on shutdown while the session is
+  still granted, and drains are serialised so a nudge that overlaps the flush
+  no longer carries the same artifact twice. Proven on the bench Pi against a
+  LAN gateway: one attempt, acknowledged and retired before the route closed.
 

--- a/ori/gateway/evidence_outbound.py
+++ b/ori/gateway/evidence_outbound.py
@@ -291,6 +291,7 @@ class MqttEvidenceOutboundPublisher:
         self._lost: asyncio.Event | None = None
         self._granted: asyncio.Event | None = None
         self._wake: asyncio.Event | None = None
+        self._drain_lock = asyncio.Lock()
 
     @property
     def topic(self) -> str:
@@ -374,9 +375,18 @@ class MqttEvidenceOutboundPublisher:
                 )
         if not shutdown_event.is_set():
             raise ConnectionError("subscription lost")
+        # Shutting down with the session still granted: carry what was retained
+        # since the last drain before the route is closed.
+        await self.drain()
 
     async def drain(self) -> int:
         """Publish every retained artifact whose retry is due. Returns the count."""
+        # One drain at a time: a nudge and a shutdown flush that overlap would
+        # both read the same undue rows and carry each artifact twice.
+        async with self._drain_lock:
+            return await self._drain()
+
+    async def _drain(self) -> int:
         if not self._connected or self._client is None:
             return 0
         published = 0

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -1327,6 +1327,11 @@ class OriRuntime:
         if self._shutdown_event.is_set():
             return
         logger.info("[runtime] shutdown initiated")
+        # Retain a shutdown checkpoint and hand the courier what it can take
+        # while the routes are still up: setting the shutdown event is what
+        # tears them down, so this has to come first or the flush finds a
+        # closed route and the checkpoint waits for the next start.
+        await self._issue_shutdown_checkpoint()
         self._shutdown_event.set()
         if self._status_indicator is not None:
             self._status_indicator.set_runtime_state(RuntimeHealthState.DEGRADED)
@@ -1353,12 +1358,6 @@ class OriRuntime:
                 len(tier_d_tasks),
             )
             await asyncio.wait(tier_d_tasks, timeout=TIER_D_DRAIN_TIMEOUT)
-
-        # 1b. Retain a shutdown checkpoint and hand the courier what it can
-        #     take before the route is cancelled, so an orderly stop is
-        #     distinguishable from a crash. Retention is durable; the flush is
-        #     best effort and whatever it misses goes out at the next start.
-        await self._issue_shutdown_checkpoint()
 
         # 2. Cancel tracked background tasks only — never cancel the task
         #    running start() itself, which returns naturally once the shutdown

--- a/tests/evidence/test_outbound_route.py
+++ b/tests/evidence/test_outbound_route.py
@@ -14,6 +14,7 @@ import base64
 import hashlib
 import json
 import pathlib
+import threading
 from typing import Any, cast
 
 import pytest
@@ -808,3 +809,90 @@ async def test_the_checkpoint_loop_issues_nothing_when_shut_down_first():
     runtime._shutdown_event.set()
     await asyncio.wait_for(runtime._evidence_checkpoint_loop(cast(Any, attestor)), 1.0)
     assert attestor.checkpoints == 0
+
+
+async def test_shutdown_drains_what_was_retained_before_closing(rig):
+    client = _FakeClient()
+    publisher = _publisher(rig, client, retry_interval_s=60.0)
+    shutdown = asyncio.Event()
+    task = asyncio.create_task(publisher.serve_until(shutdown))
+    try:
+        await _until(lambda: publisher.connected)
+        checkpoint = rig.queue_checkpoint()
+        assert _carried(client) == []
+    finally:
+        shutdown.set()
+        await asyncio.wait_for(task, 2.0)
+    carried = _carried(client)
+    assert [c["artifact_type"] for c in carried] == ["checkpoint"]
+    assert (
+        base64.b64decode(carried[0]["artifact_b64"])
+        == checkpoint["artifact_json"].encode()
+    )
+    assert client.disconnected == 1, "the route was closed after the final drain"
+
+
+async def test_a_flush_overlapping_a_nudged_drain_carries_each_artifact_once(rig):
+    release = threading.Event()
+    in_flight = threading.Event()
+
+    class _SlowClient(_FakeClient):
+        def publish(self, topic, payload, qos=0, retain=False):
+            in_flight.set()
+            release.wait(2.0)
+            return super().publish(topic, payload, qos, retain)
+
+    client = _SlowClient()
+    publisher = _publisher(rig, client, retry_interval_s=60.0)
+    shutdown = asyncio.Event()
+    task = asyncio.create_task(publisher.serve_until(shutdown))
+    try:
+        await _until(lambda: publisher.connected)
+        rig.queue_checkpoint()
+        publisher.nudge()
+        await asyncio.to_thread(in_flight.wait, 2.0)
+        flush = asyncio.create_task(publisher.flush(2.0))
+        await asyncio.sleep(0.05)
+        release.set()
+        assert await flush == 0
+    finally:
+        shutdown.set()
+        await asyncio.wait_for(task, 2.0)
+    assert [c["artifact_type"] for c in _carried(client)] == ["checkpoint"]
+    (row,) = rig.executor.run(rig.ledger.pending_artifacts, 10)
+    assert int(row["attempts"]) == 1
+
+
+async def test_stop_flushes_the_shutdown_checkpoint_while_routes_are_up():
+    """The shutdown event tears the routes down, so the flush precedes it."""
+    from ori.runtime import OriRuntime
+
+    runtime = OriRuntime(config_path="/unused/ori.yaml")
+    seen: dict[str, Any] = {}
+
+    class _Attestor:
+        available = True
+
+        async def issue_checkpoint(self):
+            seen["issued_while_shutting_down"] = runtime._shutdown_event.is_set()
+            return {"artifact_type": "checkpoint"}
+
+        def set_sealed_listener(self, listener):
+            pass
+
+        def close(self):
+            pass
+
+    class _Publisher:
+        async def flush(self, timeout_s: float) -> int:
+            seen["flushed_while_shutting_down"] = runtime._shutdown_event.is_set()
+            return 1
+
+    runtime._evidence_attestor = cast(Any, _Attestor())
+    runtime._evidence_outbound_publisher = cast(Any, _Publisher())
+    await runtime.stop()
+    assert seen == {
+        "issued_while_shutting_down": False,
+        "flushed_while_shutting_down": False,
+    }
+    assert runtime._shutdown_event.is_set()


### PR DESCRIPTION
## What does this PR do?

Stopping the runtime retained a shutdown checkpoint that never left the device. `stop()` set the shutdown event before issuing the checkpoint, and that event is what ends the outbound route's serve loop and closes its client; by the time the flush ran there was no session, so it published nothing and the ledger kept the checkpoint at zero attempts until the next start. Found on the bench Pi against a LAN gateway with envelope auth, where the outbox showed the retained checkpoint with `attempts: 0` and the gateway queue held nothing.

Three changes, each with a test that fails without it:

- `stop()` issues and flushes the checkpoint before setting the shutdown event, while the routes are still up.
- The outbound route drains once more when the shutdown event fires and the session is still granted, so anything sealed after the last drain is carried before the client closes.
- Drains are serialised. The sealed-artifact nudge and the shutdown flush overlapped, both read the same undue row, and the checkpoint was carried twice; the gateway deduplicates by digest, but the ledger's attempt count was wrong.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: shutdown ordering inside the evidence route; no capability is added or removed
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #445

## Testing notes

`tests/evidence/test_outbound_route.py`: a stub attestor and publisher record whether the shutdown event was set when the checkpoint was issued and flushed (both must be false); a fake client sees a checkpoint queued after the last drain carried once on shutdown and the client disconnected after it; a client that blocks in `publish` while a flush overlaps a nudged drain produces one carriage and one attempt. Reverting each change fails its test by name. Full suite 4716 passed; mypy and pyright clean.

Proven on the bench Pi with these two modules substituted into the installed release under user scope, against a LAN gateway with envelope auth: the checkpoint retained by the earlier stop was carried and retired at the next start; a stop with the fix carried the new checkpoint with one attempt and the ledger retired it as `queued` 59 ms later, acknowledged before the route closed.