### PR TITLE
chore(release): prepare v2.5.0-rc.7

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -1,22 +1,6 @@
 # Ori Runtime — Unreleased
 
-Changes merged to `main` after `v2.5.0-rc.6` are collected here until the next
+Changes merged to `main` after `v2.5.0-rc.7` are collected here until the next
 candidate or release is cut.
 
-## Fixed
-
-- The installer no longer refuses a release whose venv `bin` carries a
-  `__pycache__` directory. `v2.5.0-rc.6` cannot be installed on a Pi in either
-  scope because its wheelhouse's `pyftdi` scripts are byte-compiled there at
-  install time; the relocation now discards that cache and still refuses
-  anything else at that name or any other directory in `bin`.
-- The shutdown checkpoint is now carried before the evidence routes are torn
-  down. The stop path set the shutdown event first, which is what closes the
-  outbound route, so the flush that followed found no session and the
-  checkpoint waited for the next start; on the bench Pi the ledger showed it
-  retained with no attempt. The checkpoint is issued and flushed before the
-  event is set, the route drains once more on shutdown while the session is
-  still granted, and drains are serialised so a nudge that overlaps the flush
-  no longer carries the same artifact twice. Proven on the bench Pi against a
-  LAN gateway: one attempt, acknowledged and retired before the route closed.
-
+_No changes yet._

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.6` is the current candidate.
+Minor release, in progress. `v2.5.0-rc.7` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -46,6 +46,7 @@ installed.
 | `v2.5.0-rc.4` | protection preflight, full test matrix, build | the bundle builder refused `setuptools` as ambiguous, so no bundle was built or signed |
 | `v2.5.0-rc.5` | published | the GPIO packaging candidate; installed on the bench Pi against the system `python3.13`, where the release venv resolves `LGPIOFactory` by default from `lgpio` staged inside the release tree, with nothing resolving from outside it |
 | `v2.5.0-rc.6` | published | the evidence exchange candidate; its Pi wheelhouse carries `pyftdi`, whose scripts pip byte-compiles into `venv/bin/__pycache__`, and the shebang relocation refuses that directory, so the bundle cannot be installed on a Pi in either scope. With the relocation fix substituted into the installer, the same bundle installed under user scope and carried checkpoints to a LAN gateway with envelope auth |
+| `v2.5.0-rc.7` | — | the evidence exchange candidate re-cut with the installer fix and the shutdown checkpoint fix, so the bundle can be installed on a Pi and an orderly stop carries its checkpoint |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.
@@ -109,18 +110,29 @@ Four candidates have now been spent on release-only steps, each closing the
 particular hole that burned its predecessor rather than the class. What is
 different at `v2.5.0-rc.5` is coverage rather than intent: every stage a bundle
 passes through before signing now runs on a branch. Signing, publish and
-reverify cannot — they need a release credential — and no v2.5.0 candidate has
-reached them yet.
+reverify cannot — they need a release credential — and `v2.5.0-rc.5` was the
+first candidate to reach them.
+
+`v2.5.0-rc.6` published and could not be installed on a Pi. Its wheelhouse
+carries `pyftdi`, whose four plain scripts pip byte-compiles into
+`venv/bin/__pycache__` at install time, and the shebang relocation refuses any
+entry in `bin` that is not a regular file. The refusal was the correct default
+against the wrong case: that cache is the one directory a correct venv can
+carry there, and it is never an entry point. The relocation now discards it and
+still refuses anything else. The same bundle, installed with the fix, then
+showed a second defect: the shutdown checkpoint was retained but never
+carried, because the stop path closed the evidence routes before flushing. Both
+are fixed in `v2.5.0-rc.7`, and both were only reachable on hardware.
 
 ## What this candidate is for
 
-`v2.5.0-rc.6` is **the evidence exchange candidate**. `v2.5.0-rc.5` answered
+`v2.5.0-rc.7` is **the evidence exchange candidate**. `v2.5.0-rc.5` answered
 the GPIO packaging question: on the bench Pi, against the system `python3.13`,
 the release venv resolves `LGPIOFactory` by default from the `lgpio` module
 staged inside the release tree, and nothing resolves from outside it. That
 result stands and this candidate re-carries it unchanged.
 
-What `v2.5.0-rc.6` exists to exercise on hardware is the runtime's side of
+What `v2.5.0-rc.7` exists to exercise on hardware is the runtime's side of
 `evidence-exchange/v1` against a real gateway:
 
 1. Sealed envelopes and checkpoints leave on the outbound carriage as exact
@@ -134,8 +146,10 @@ What `v2.5.0-rc.6` exists to exercise on hardware is the runtime's side of
 
 It pairs with `ori-gateway` at `5bf34c6` or later, which carries custody
 through its durable return queue and signs every acknowledgement from a
-persisted clock. Proven so far on a loopback broker between the two; the bench
-Pi is where this candidate earns its row.
+persisted clock. Carriage and checkpoint acknowledgement have run from the
+bench Pi to a LAN gateway under `v2.5.0-rc.6` with the two fixes substituted
+in; this candidate exists to carry them as a signed bundle, and the bench Pi is
+where it earns its row.
 
 **It is still not a Tier D candidate, and an actuation demonstration must not
 be claimed from it.** The relay has no commissioned controller-loss posture and
@@ -228,7 +242,9 @@ released only by an authenticated acknowledgement: a queued checkpoint is
 retired because the gateway's durable queue now owns retry, while an envelope
 stays awaiting custody until the custody acknowledgement arrives inbound.
 PUBACK retires nothing. Checkpoints are issued on a release-owned interval and
-at clean shutdown, retained before anything is sent.
+at clean shutdown, retained before anything is sent; the shutdown checkpoint is
+flushed before the routes are torn down, so an orderly stop is distinguishable
+from a crash at the gateway rather than only in the ledger.
 
 What ingest refuses is retained by the ledger — the newest 200, immutable —
 and surfaces in health as `ingest_refusal_count` and `last_ingest_refusal`, so
@@ -262,6 +278,9 @@ and `ori/security/remote_commands/`; no behaviour changed with the move.
 - Production code is free of pyright diagnostics, and the check is enforced in
   CI so the clean half cannot regrow.
 - An installation keeps the identity it already carries across upgrades.
+- The shebang relocation discards the `__pycache__` pip leaves in a release
+  venv's `bin` and still refuses anything else that is not a regular file
+  there.
 - The startup notification now reports connected sensors and rules with a
   connected declared input, claims notification only, and says explicitly that
   no safety cutoff is commissioned. Its fixed disclaimer cannot be removed by
@@ -313,8 +332,8 @@ key is refused rather than bounded by a guess.
   mutable skill action list, which for overcurrent dispatches alerts and never
   reaches an actuator. A pin factory that works is a prerequisite for fixing
   these, not evidence that they are.
-- **No evidence exchange is proven end to end.** The carriage, custody and
-  checkpoint round-trip has run on a loopback broker between this runtime and
-  the gateway; no authority has received an artifact from a deployed gateway,
+- **No evidence exchange is proven end to end.** Carriage and checkpoint
+  acknowledgement have run from the bench Pi to a LAN gateway, and custody on
+  a loopback broker; no authority has received an artifact from a deployed gateway,
   and no release carries the authority-key registry that would let this
   runtime verify what one returns.

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -110,8 +110,9 @@ Four candidates have now been spent on release-only steps, each closing the
 particular hole that burned its predecessor rather than the class. What is
 different at `v2.5.0-rc.5` is coverage rather than intent: every stage a bundle
 passes through before signing now runs on a branch. Signing, publish and
-reverify cannot — they need a release credential — and `v2.5.0-rc.5` was the
-first candidate to reach them.
+reverify cannot — they need a release credential. `v2.5.0-rc.3` was the first
+candidate to reach them, and `v2.5.0-rc.5` the first to do so with every
+pre-signing stage also covered on a branch.
 
 `v2.5.0-rc.6` published and could not be installed on a Pi. Its wheelhouse
 carries `pyftdi`, whose four plain scripts pip byte-compiles into
@@ -244,7 +245,8 @@ stays awaiting custody until the custody acknowledgement arrives inbound.
 PUBACK retires nothing. Checkpoints are issued on a release-owned interval and
 at clean shutdown, retained before anything is sent; the shutdown checkpoint is
 flushed before the routes are torn down, so an orderly stop is distinguishable
-from a crash at the gateway rather than only in the ledger.
+from a crash at the gateway rather than only in the ledger, and drains are
+serialised so a nudge that overlaps the flush cannot carry an artifact twice.
 
 What ingest refuses is retained by the ledger — the newest 200, immutable —
 and surfaces in health as `ingest_refusal_count` and `last_ingest_refusal`, so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc6"
+version = "2.5.0rc7"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## What does this PR do?

Prepares the `v2.5.0-rc.7` candidate. `v2.5.0-rc.6` cannot be installed on a Raspberry Pi in either scope (#448) and never carried its shutdown checkpoint (#449); both fixes are on `main` and this candidate exists to carry them as a signed bundle. The version moves to `2.5.0rc7`, the unreleased notes are folded into the v2.5.0 notes with a candidate row and a paragraph on what rc.6 taught, and the stale claim that no candidate had reached signing is corrected: rc.3 was the first to reach signing, publish and reverify, and rc.5 the first to do so with every pre-signing stage also covered on a branch.

## Type of change

- [x] `chore` — release preparation

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: version and release notes only
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #445

## Testing notes

`scripts/check_release_identity.py --tag v2.5.0-rc.7` reports `version=2.5.0-rc.7`; the disclosure audit passes on the notes; no private stem in the diff. A development-signed build of this branch's first commit (`a4fd74f`, tag `evidence/rc7-rollback-base`) installed on the bench Pi 4 under Trixie with stock Python 3.13 and survived a reboot as part of the health-gated rollback evidence run in #451.

Merge last, after #451, so the notes at the tag commit describe everything the candidate carries; then `git tag -s v2.5.0-rc.7` on the merged commit.
