### PR TITLE
fix(commissioning): check the binding version as an integer

### DIFF
--- a/ori/security/commissioning/binding.py
+++ b/ori/security/commissioning/binding.py
@@ -464,6 +464,9 @@ def _numbers_in_zone(node: Any) -> None:
 
 def st_parses(b: Any, ctx: VerifierContext) -> None:
     _closed(b, BINDING_KEYS)
+    # Integer first: True == 1 and 1.0 == 1 in Python, and both spell
+    # different signing bytes.
+    _whole(b["v"])
     _bad(b["v"] != 1)
     _encodable_tree(b)
     for name in ("device_id", "signer_id", "actor", "reason"):
@@ -751,6 +754,7 @@ class ProfileContext:
 def verify_firmware_profile(pr: Any, ctx: ProfileContext, sig_b64: str) -> None:
     """Same authority discipline as a binding, then the binding-match checks."""
     _closed(pr, PROFILE_KEYS)
+    _whole(pr["v"])
     _bad(pr["v"] != 1)
     _encodable_tree(pr)
     for name in ("device_id", "firmware_device_id", "channel"):

--- a/tests/test_commissioned_binding_vectors.py
+++ b/tests/test_commissioned_binding_vectors.py
@@ -2,12 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """The runtime's mirror of the commissioned-safety-binding golden corpus.
 
-The runtime is a **consumer** of this contract and has no verifier of its own
-yet — that arrives with the safety registry in #324 and the actuation seam in
-#397. So this file makes a deliberately narrow claim, and the narrowness is the
-point: it checks that the published corpus is internally coherent under a
-verifier written from the contract text, and it does **not** show that any
-runtime code behaves correctly, because none of it reads a binding.
+The verifier under test is the runtime's own, `ori.security.commissioning.binding`,
+driven through the thin `tests/golden` module. The corpus holds it to every
+published accept and reject case at its declared stage; the mutation tables
+below hold it to the neighbouring shapes the corpus does not enumerate, and to
+returning a verdict rather than raising on input chosen to break a decoder.
 
 Provenance and drift live where the other vendored sets keep them: the
 `MANIFEST.json` beside the corpus pins the ori-specs commit it came from and
@@ -268,6 +267,11 @@ GRAMMAR_MUTATIONS: dict[str, Callable[[dict], Any]] = {
     "calibration_ref_empty": lambda b: b["zones"][0]["sensor"].update(
         {"calibration_ref": ""}
     ),
+    # `v` is an integer, exactly 1. `True == 1` and `1.0 == 1` in Python, so a
+    # check written as `!= 1` accepts both; each spells different signing bytes.
+    "v_as_a_boolean": lambda b: b.update({"v": True}),
+    "v_as_a_float": lambda b: b.update({"v": 1.0}),
+    "v_of_another_version": lambda b: b.update({"v": 2}),
 }
 
 B64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
@@ -463,3 +467,46 @@ def test_neither_envelope_form_raises_on_hostile_input() -> None:
                 )
             else:
                 pytest.fail(f"{form}[{index}] was accepted")
+
+
+@pytest.mark.parametrize("name", sorted(GRAMMAR_MUTATIONS), ids=str)
+def test_grammar_mutations_are_malformed(name: str) -> None:
+    """Every neighbouring shape the corpus does not enumerate is `malformed`."""
+    case = _mutated(GRAMMAR_MUTATIONS[name])
+    with pytest.raises(RefusedError) as excinfo:
+        run(case["binding"], case["verifier_context"], case["signature_b64"])
+    assert excinfo.value.reason == "malformed", name
+    assert excinfo.value.stage == "parses", name
+
+
+@pytest.mark.parametrize("version", [True, 1.0], ids=["boolean", "float"])
+def test_a_signed_non_integer_version_is_refused(version: Any) -> None:
+    """Signed by the commissioning key, so only the grammar can refuse it.
+
+    A verifier that compared `v` by value accepted these: the canonical bytes
+    carry `true` or `1.0`, the signature covers them, and a byte-strict
+    consumer refuses the same document.
+    """
+    from tests.commissioning.signing import sign_envelope
+
+    binding = copy.deepcopy(BASE["binding"])
+    binding["v"] = version
+    envelope = sign_envelope(binding, VECTORS["commissioning_test_seed_hex"])
+    with pytest.raises(RefusedError) as excinfo:
+        run_envelope(envelope, BASE["verifier_context"])
+    assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")
+
+
+@pytest.mark.parametrize(
+    "version", [True, 1.0, "1"], ids=["boolean", "float", "string"]
+)
+def test_a_profile_with_a_non_integer_version_is_refused(version: Any) -> None:
+    profile = copy.deepcopy(PROFILE_CASES[0]["firmware_profile"])
+    profile["v"] = version
+    with pytest.raises(RefusedError) as excinfo:
+        run_profile(
+            profile,
+            PROFILE_CASES[0]["verifier_context"],
+            PROFILE_CASES[0]["signature_b64"],
+        )
+    assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")


### PR DESCRIPTION
## What does this PR do?

`st_parses` checked the binding version with `b["v"] != 1`. In Python `True == 1` and `1.0 == 1`, so a document carrying `"v": true` or `"v": 1.0` passed the grammar; the canonical bytes carry `true` or `1.0`, so a document signed that way verified and was accepted, while a byte-strict consumer of the same file refuses it as `malformed`. The contract's field-type table requires an integer, exactly `1`, and states that a boolean is not a number. The firmware-profile grammar carried the same check. Both now require an integer through `_whole` before comparing.

The grammar-mutation table in `tests/test_commissioned_binding_vectors.py` was defined and consumed by nothing, so its twenty-four shapes were never run. A parametrized test now drives it; all twenty-four pass, and the version shapes join it. The signed reproduction from the issue is a test of its own: a document signed by the corpus commissioning key with a boolean or float version, refused at `parses`. The module docstring, which still said the runtime had no verifier of its own, now describes what the file holds.

No authority moves with this change. Only the commissioning key holder could produce an accepted document with a malformed version; what was broken was the property that one document reaches one verdict everywhere, which is the contract's ratification condition.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #458. The runtime half; the issue closes when the corpus vectors from ori-specs#142 are re-vendored.

## Testing notes

With the fix reverted, exactly six tests fail by name: the boolean and float entries of the mutation table, the two signed reproductions, and the two profile cases. `mypy ori/` and `pyright ori/` report zero. The full suite passes: 4842 passed, 28 skipped.
