### PR TITLE
fix(commissioning): refuse a binding file with a repeated key

### DIFF
--- a/ori/security/commissioning/binding.py
+++ b/ori/security/commissioning/binding.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import base64
 import binascii
 import hashlib
+import json
 import re
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -284,6 +285,31 @@ def canonical_bytes(value: Any) -> bytes:
 
 def canonical_hash(value: Any) -> str:
     return "sha256:" + hashlib.sha256(canonical_bytes(value)).hexdigest()
+
+
+def _pairs_without_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    obj: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in obj:
+            raise ValueError(f"duplicate object key {key!r}")
+        obj[key] = value
+    return obj
+
+
+def parse_document(text: str) -> Any:
+    """Decode a wire document, refusing what a decoded object can no longer show.
+
+    A repeated key collapses before any grammar check can see it, and which
+    occurrence survives depends on the parser: this one keeps the last, a
+    first-wins parser on a device reads the other, and the signature verifies
+    over whichever this side kept. evidence/v2 requires a verifier parsing
+    bytes to reject the duplicate during parsing, so the wire form is refused
+    here rather than repaired.
+    """
+    try:
+        return json.loads(text, object_pairs_hook=_pairs_without_duplicates)
+    except ValueError:
+        raise BindingRefusedError("parses", "malformed") from None
 
 
 # ── grammar ───────────────────────────────────────────────────────────────

--- a/ori/security/commissioning/loader.py
+++ b/ori/security/commissioning/loader.py
@@ -27,6 +27,7 @@ from ori.security.commissioning.binding import (
     ZoneState,
     actuator_identity,
     canonical_bytes,
+    parse_document,
     verify_binding_envelope,
 )
 from ori.security.commissioning.profiles import ProfileSet
@@ -240,11 +241,12 @@ async def load_commissioning_state(
         return state
 
     try:
-        document = json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError):
+        document = parse_document(path.read_text(encoding="utf-8"))
+    except (OSError, BindingRefusedError):
         state.last_verdict = Verdict("parses", "malformed", None, now_ms())
         logger.warning(
-            "[commissioning] %s is not readable JSON; binding in force unchanged", path
+            "[commissioning] %s is not a readable document; binding in force unchanged",
+            path,
         )
         return state
 

--- a/tests/commissioning/test_loader.py
+++ b/tests/commissioning/test_loader.py
@@ -271,3 +271,47 @@ async def test_undemonstrated_zones_are_refused_under_hardened_posture_only(
     assert hardened.last_verdict.reason == "undemonstrated_binding"
     development = await _load(tmp_path, store, posture="development", **common)
     assert development.in_force is not None
+
+
+def _write_text(data_path: Path, text: str) -> Path:
+    target = data_path / BINDING_RELATIVE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(text)
+    return target
+
+
+@pytest.mark.parametrize(
+    "duplicate",
+    [
+        ('"binding_seq": 1', '"binding_seq": 5, "binding_seq": 1'),
+        ('"v": 1', '"v": 1, "v": 1'),
+        ('"gpio_pin": 26', '"gpio_pin": 27, "gpio_pin": 26'),
+        ('"signature": "ed25519:', '"signature": "x", "signature": "ed25519:'),
+    ],
+    ids=["different_values", "equal_values", "nested", "envelope"],
+)
+async def test_a_duplicate_key_is_refused_before_anything_is_read(
+    tmp_path: Path, store: StateStore, duplicate: tuple[str, str]
+) -> None:
+    """A last-wins decoder would verify the signature over the surviving value.
+
+    The file with `"binding_seq": 5, "binding_seq": 1` decodes to the accepted
+    document and verifies against its signature; a first-wins parser on a
+    device reads 5 from the same bytes. So the wire form is refused during
+    parsing, whichever value survives and even when both are equal.
+    """
+    _write(tmp_path, _envelope())
+    accepted = await _load(tmp_path, store)
+    assert accepted.in_force is not None
+    text = json.dumps(_envelope(), indent=1)
+    old, new = duplicate
+    assert old in text
+    _write_text(tmp_path, text.replace(old, new, 1))
+    state = await _load(tmp_path, store)
+    assert state.last_verdict is not None
+    assert (state.last_verdict.stage, state.last_verdict.reason) == (
+        "parses",
+        "malformed",
+    )
+    assert state.in_force is not None
+    assert state.in_force.canonical_hash == accepted.in_force.canonical_hash

--- a/tests/test_commissioned_binding_vectors.py
+++ b/tests/test_commissioned_binding_vectors.py
@@ -510,3 +510,35 @@ def test_a_profile_with_a_non_integer_version_is_refused(version: Any) -> None:
             PROFILE_CASES[0]["signature_b64"],
         )
     assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")
+
+
+# --------------------------------------------------------------------------
+# The wire form
+# --------------------------------------------------------------------------
+#
+# The corpus stores decoded objects, so it cannot carry what only bytes can
+# express. A repeated key is the case evidence/v2 names: it collapses before
+# any grammar check sees it, and which occurrence survives depends on the
+# parser.
+
+
+def test_a_wire_document_with_a_repeated_key_is_malformed() -> None:
+    from ori.security.commissioning.binding import parse_document
+
+    text = json.dumps(
+        {"binding": BASE["binding"], "signature": "ed25519:" + BASE["signature_b64"]},
+        indent=1,
+    )
+    assert parse_document(text) == json.loads(text)
+    for old, new in (
+        ('"binding_seq": 1', '"binding_seq": 5, "binding_seq": 1'),
+        ('"v": 1', '"v": 1, "v": 1'),
+        ('"gpio_pin": 26', '"gpio_pin": 27, "gpio_pin": 26'),
+        ('"signature": "ed25519:', '"signature": "x", "signature": "ed25519:'),
+    ):
+        assert old in text
+        with pytest.raises(RefusedError) as excinfo:
+            parse_document(text.replace(old, new, 1))
+        assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")
+    with pytest.raises(RefusedError):
+        parse_document("{not json")


### PR DESCRIPTION
## What does this PR do?

The loader decoded `commissioning/binding.json` with `json.loads`, which keeps the last of a repeated key. A file carrying `"binding_seq": 5, "binding_seq": 1` therefore decoded to the accepted document and verified against its signature, while a first-wins parser on a device reads `5` from the same bytes; nothing in the retained state or in health shows which reading a consumer took. `evidence/v2`, whose canonical rules the binding contract adopts, says the canonical form of such an object is undefined and that a verifier parsing bytes must reject it during parsing. The grammar cannot see it, because the duplicate collapses before any check runs.

The wire form is now decoded through `parse_document` in the verifier module, whose `object_pairs_hook` refuses a repeated key at any level, the envelope included, and even when both values are equal. The loader reads through it and records the refusal as `parses`/`malformed` with the binding in force unchanged, exactly as it already did for an unreadable file. The verifier's decoded-object entry points are unchanged; the corpus stores decoded objects and cannot express this case, which is why the tests are written against bytes.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #460

## Testing notes

Four loader tests present a file with a repeated key — different values, equal values, nested inside the actuator identity, and beside the signature in the envelope — after an accepted binding is in force, and assert the verdict and that the binding in force keeps its hash. A parser test covers the same shapes directly and that a well-formed document decodes unchanged. With the hook removed, all of them fail. `mypy ori/` and `pyright ori/` report zero; the full suite passes: 4815 passed, 28 skipped.
