### PR TITLE
fix(commissioning): refuse a binding nested past the recursion limit, and never let the verifier stop the runtime

### DIFF
--- a/ori/security/commissioning/binding.py
+++ b/ori/security/commissioning/binding.py
@@ -279,7 +279,16 @@ def canonical_bytes(value: Any) -> bytes:
     """Canonical bytes, refusing rather than raising on what cannot be encoded."""
     try:
         return canonical_json(value)
-    except (CanonicalisationError, UnicodeEncodeError, ValueError, TypeError):
+    except (
+        CanonicalisationError,
+        UnicodeEncodeError,
+        ValueError,
+        TypeError,
+        RecursionError,
+    ):
+        # RecursionError: the loader canonicalises an unverified document to
+        # ask whether it is the one already in force, before any grammar has
+        # bounded its depth. A document that deep is malformed, not a crash.
         raise BindingRefusedError("parses", "malformed") from None
 
 
@@ -308,7 +317,9 @@ def parse_document(text: str) -> Any:
     """
     try:
         return json.loads(text, object_pairs_hook=_pairs_without_duplicates)
-    except ValueError:
+    except (ValueError, RecursionError):
+        # json.loads itself recurses per nesting level and raises past the
+        # interpreter's limit; that is input, and the verdict is malformed.
         raise BindingRefusedError("parses", "malformed") from None
 
 
@@ -456,33 +467,44 @@ def _parse_proof(proof: Any, kind: str) -> None:
         _bad(("sensor_before" in observation) != ("sensor_after" in observation))
 
 
+def _walk(node: Any) -> Any:
+    """Every value in the tree, keys included, without recursion.
+
+    The walkers run over the document before the grammar has bounded its
+    shape, so a value nested past the interpreter's recursion limit reached
+    them first. An explicit stack has no such limit, and the grammar then
+    refuses the nesting at whichever leaf it fails to type.
+    """
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        yield current
+        if isinstance(current, dict):
+            stack.extend(current.keys())
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+
+
 def _encodable_tree(node: Any) -> None:
-    if isinstance(node, str):
-        _encodable(node)
-    elif isinstance(node, dict):
-        for key, value in node.items():
-            if isinstance(key, str):
-                _encodable(key)
-            _encodable_tree(value)
-    elif isinstance(node, list):
-        for value in node:
-            _encodable_tree(value)
+    for value in _walk(node):
+        if isinstance(value, str):
+            _encodable(value)
 
 
 def _numbers_in_zone(node: Any) -> None:
-    """The D-011 agreement zone, recursively."""
-    if isinstance(node, bool):
-        return
-    if isinstance(node, int) and abs(node) > 9007199254740991:
-        raise BindingRefusedError("parses", "malformed")
-    if isinstance(node, float) and node != 0.0 and not (1e-4 <= abs(node) < 1e16):
-        raise BindingRefusedError("parses", "malformed")
-    if isinstance(node, dict):
-        for value in node.values():
-            _numbers_in_zone(value)
-    elif isinstance(node, list):
-        for value in node:
-            _numbers_in_zone(value)
+    """The D-011 agreement zone, at every depth."""
+    for value in _walk(node):
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and abs(value) > 9007199254740991:
+            raise BindingRefusedError("parses", "malformed")
+        if (
+            isinstance(value, float)
+            and value != 0.0
+            and not (1e-4 <= abs(value) < 1e16)
+        ):
+            raise BindingRefusedError("parses", "malformed")
 
 
 # ── stages ────────────────────────────────────────────────────────────────

--- a/ori/security/commissioning/loader.py
+++ b/ori/security/commissioning/loader.py
@@ -282,6 +282,22 @@ async def load_commissioning_state(
             refusal.reason,
         )
         return state
+    except Exception:  # noqa: BLE001 - a verifier defect must not stop the runtime
+        # The contract's rule for input that breaks the verifier rather than a
+        # check is a malformed verdict, and its rule for a document failing any
+        # stage is that the binding in force is unchanged. Letting the error
+        # propagate would abort startup, Tier D protection included, over a
+        # file that should have been refused. The problem marker keeps the
+        # distinction visible: this was not a grammar refusal.
+        state.last_verdict = Verdict("parses", "malformed", presented_seq, now_ms())
+        if "binding_verifier_error" not in state.problems:
+            state.problems.append("binding_verifier_error")
+        logger.exception(
+            "[commissioning] binding at %s could not be verified; binding in force "
+            "unchanged",
+            path,
+        )
+        return state
 
     await store.retain_commissioned_binding(
         binding_seq=accepted.binding_seq,

--- a/tests/commissioning/test_loader.py
+++ b/tests/commissioning/test_loader.py
@@ -315,3 +315,53 @@ async def test_a_duplicate_key_is_refused_before_anything_is_read(
     )
     assert state.in_force is not None
     assert state.in_force.canonical_hash == accepted.in_force.canonical_hash
+
+
+async def test_a_file_nested_past_the_recursion_limit_is_a_parse_refusal(
+    tmp_path: Path, store: StateStore
+) -> None:
+    """json.loads raises RecursionError here, and that is not a ValueError."""
+    _write(tmp_path, _envelope())
+    accepted = await _load(tmp_path, store)
+    _write_text(tmp_path, "[" * 200_000)
+    state = await _load(tmp_path, store)
+    assert state.last_verdict is not None
+    assert (state.last_verdict.stage, state.last_verdict.reason) == (
+        "parses",
+        "malformed",
+    )
+    assert state.in_force is not None and accepted.in_force is not None
+    assert state.in_force.canonical_hash == accepted.in_force.canonical_hash
+
+
+async def test_a_verifier_error_leaves_the_binding_in_force_and_is_reported(
+    tmp_path: Path, store: StateStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A verifier defect degrades one document, never the runtime.
+
+    The contract's verdict for input that breaks the verifier is malformed and
+    the binding in force is unchanged; the problem marker keeps it visible that
+    no grammar check decided this.
+    """
+    _write(tmp_path, _envelope())
+    accepted = await _load(tmp_path, store)
+    revised = _envelope()
+    revised["binding"]["binding_seq"] = 2
+    _write(tmp_path, revised)
+
+    def _broken(*_: Any, **__: Any) -> Any:
+        raise RuntimeError("verifier defect")
+
+    monkeypatch.setattr(
+        "ori.security.commissioning.loader.verify_binding_envelope", _broken
+    )
+    state = await _load(tmp_path, store)
+    assert state.last_verdict is not None
+    assert (state.last_verdict.stage, state.last_verdict.reason) == (
+        "parses",
+        "malformed",
+    )
+    assert state.last_verdict.binding_seq == 2
+    assert "binding_verifier_error" in state.problems
+    assert state.in_force is not None and accepted.in_force is not None
+    assert state.in_force.canonical_hash == accepted.in_force.canonical_hash

--- a/tests/commissioning/test_runtime_startup.py
+++ b/tests/commissioning/test_runtime_startup.py
@@ -366,3 +366,31 @@ async def test_without_an_accepted_zone_the_pin_is_not_driven_and_relay_actions_
         not {"trip_relay", "release_relay", "close_gas_valve"} & observed["executors"]
     )
     assert observed["health"]["commissioning"]["actuator"] is None
+
+
+async def test_a_binding_file_that_breaks_the_decoder_does_not_stop_the_runtime(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file the verifier must refuse must not abort startup instead.
+
+    Nested past the interpreter's recursion limit, the file raised out of
+    json.loads and then out of start(); the runtime, Tier D included, did not
+    come up. It now starts degraded with the refusal reported.
+    """
+    _patch_external(monkeypatch)
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(SEED))
+    target = tmp_path / BINDING_RELATIVE_PATH
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("[" * 200_000)
+    runtime = OriRuntime(config_path=str(_write_config(tmp_path)))
+    observed: dict[str, Any] = {}
+
+    async def _observe() -> None:
+        observed["health"] = await _started_health(runtime)
+
+    await asyncio.gather(runtime.start(), _observe())
+    block = observed["health"]["commissioning"]
+    assert block["last_verdict"]["stage"] == "parses"
+    assert block["last_verdict"]["reason"] == "malformed"
+    assert block["actuation_licensed"] is False
+    assert observed["health"]["status"] == "degraded"

--- a/tests/test_commissioned_binding_vectors.py
+++ b/tests/test_commissioned_binding_vectors.py
@@ -22,6 +22,7 @@ import base64
 import copy
 import hashlib
 import json
+import sys
 from pathlib import Path
 from typing import Any, Callable
 
@@ -542,3 +543,46 @@ def test_a_wire_document_with_a_repeated_key_is_malformed() -> None:
         assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")
     with pytest.raises(RefusedError):
         parse_document("{not json")
+
+
+def _nested(depth: int) -> list:
+    """A list nested `depth` deep, built without recursion."""
+    value: list = []
+    for _ in range(depth):
+        value = [value]
+    return value
+
+
+@pytest.mark.parametrize(
+    "place",
+    [
+        lambda b, v: b.update({"supersedes": v}),
+        lambda b, v: b["zones"][0].update({"zone_id": v}),
+        lambda b, v: b["zones"][0]["actuator"]["identity"].update({"gpio_pin": v}),
+        lambda b, v: b["zones"][0]["proof"]["observations"][0].update(
+            {"instrument": v}
+        ),
+        lambda b, v: b["zones"].append(v),
+    ],
+    ids=["supersedes", "zone_id", "gpio_pin", "instrument", "zone"],
+)
+def test_nesting_past_the_recursion_limit_is_malformed_not_a_crash(place: Any) -> None:
+    """The grammar bounds the document's shape; nothing before it may recurse.
+
+    Built past the interpreter's limit so that any recursive walk over the
+    unchecked tree raises instead of refusing. The canonical form is checked
+    the same way, because the loader canonicalises an unverified document to
+    ask whether it is the one already in force.
+    """
+    from ori.security.commissioning.binding import canonical_bytes, parse_document
+
+    deep = _nested(sys.getrecursionlimit() * 4)
+    case = _mutated(lambda b: place(b, deep))
+    with pytest.raises(RefusedError) as excinfo:
+        run(case["binding"], case["verifier_context"], case["signature_b64"])
+    assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")
+    with pytest.raises(RefusedError):
+        canonical_bytes(case["binding"])
+    with pytest.raises(RefusedError) as excinfo:
+        parse_document("[" * (sys.getrecursionlimit() * 4))
+    assert (excinfo.value.stage, excinfo.value.reason) == ("parses", "malformed")


### PR DESCRIPTION
## What does this PR do?

A `commissioning/binding.json` nested past the interpreter's recursion limit raised `RecursionError` out of `json.loads`, and one nested a little less deeply raised it out of the verifier's recursive walkers, which run over the document before the grammar has bounded its shape. The loader caught only the parse `ValueError` and the verifier's own refusals, and `start()` has no handler around the commissioning load, so the error propagated and the runtime — Tier D protection included — did not come up over a file it should have refused. The contract's verdict for input that breaks a decoder rather than a check is `malformed`, and its rule for a document failing any stage is that the binding in force is unchanged.

Three changes, each with a test that fails without it:

- `_encodable_tree` and `_numbers_in_zone` walk with an explicit work list, so no depth can crash them; the grammar then refuses the nesting at whichever leaf it fails to type.
- `parse_document` and `canonical_bytes` map `RecursionError` to `malformed`. `json.loads` recurses per nesting level, and the loader canonicalises an unverified document to ask whether it is the one already in force, before any grammar has bounded its depth.
- The loader treats anything the verifier raises other than a refusal as a `parses`/`malformed` verdict with the binding in force unchanged, logs the exception, and records a `binding_verifier_error` problem so health shows that no grammar check decided it. A verifier defect degrades one document rather than the runtime.

Producing the file takes the installer path or root, since `/opt/ori/data` is root-owned on a system install. The failure mode was still wrong in kind: the runtime did not start over a file it should have refused.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #459

## Testing notes

Verifier: a document nested to four times the recursion limit at five positions (`supersedes`, a zone id, a pin, an instrument, a whole zone) is refused `malformed` at `parses`, `canonical_bytes` refuses it, and `parse_document` refuses the raw text. Loader: a 200,000-deep file after an accepted binding leaves the binding in force with the refusal recorded; a verifier patched to raise `RuntimeError` on a revision leaves the binding in force, records the verdict against the presented sequence, and adds the problem marker. Runtime: the same file beside the config starts a development runtime degraded with the verdict in health, where it aborted before.

Reverting each boundary in turn fails its tests by name: the recursive walkers, the `RecursionError` mapping in `canonical_bytes`, the one in `parse_document`, and the loader guard. `mypy ori/` and `pyright ori/` report zero; the full suite passes: 4823 passed, 28 skipped.

A differential run of 4,089 mutated, re-signed documents against the ori-cli Go verifier now disagrees on eight cases only, all the non-canonical number spellings (`1E1`, `10.00`) whose verdict ori-specs#142 has to decide; every structural mutation, duplicate key and deep nesting reaches the same verdict on both sides.
