### PR TITLE
test(commissioning): wait for the relay executors before driving them

### DIFF
--- a/tests/commissioning/test_runtime_startup.py
+++ b/tests/commissioning/test_runtime_startup.py
@@ -294,10 +294,16 @@ async def test_the_relay_is_driven_only_through_the_commissioned_seam(
     observed: dict[str, Any] = {}
 
     async def _observe() -> None:
+        # The dispatcher exists before the relay executors are registered on
+        # it, and device policy is awaited in between; waiting for the
+        # dispatcher alone can observe it with no `trip_relay` yet.
         deadline = asyncio.get_running_loop().time() + 30.0
-        while runtime._dispatcher is None:
+        while (
+            runtime._dispatcher is None
+            or "trip_relay" not in runtime._dispatcher._executors
+        ):
             if asyncio.get_running_loop().time() > deadline:
-                raise AssertionError("the runtime did not come up in time")
+                raise AssertionError("the relay executors were not registered in time")
             await asyncio.sleep(0.05)
         actuator = runtime._commissioned_actuator
         assert actuator is not None


### PR DESCRIPTION
## What does this PR do?

`test_the_relay_is_driven_only_through_the_commissioned_seam` polled until `runtime._dispatcher` existed and then drove `trip_relay` through it. The dispatcher is assigned about 130 lines before the relay executors are registered on it, and device policy is awaited in between, so a poll that wakes inside that window sees the dispatcher with no `trip_relay` yet and fails with `KeyError: 'trip_relay'`. CI hit that window once, on one interpreter, while the same test passed on the others and locally.

The window is real rather than inferred: patching `_load_cached_device_policy` to yield for 200 ms reproduces the exact failure on every run of the original test, and the fixed test passes under the same patch. The test now waits for the executor it is about to drive, with the same deadline, and names what it was waiting for if the deadline passes.

## Type of change

- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

None; a test race found by CI.

## Testing notes

`tests/commissioning/test_runtime_startup.py` passes on three consecutive runs. With `OriRuntime._load_cached_device_policy` patched to `await asyncio.sleep(0.2)` first, the original test fails with `KeyError: 'trip_relay'` and the fixed test passes; the probe was run in a temporary file and is not committed.
