### PR TITLE
feat(commissioning): expose the binding inventory and delivery over the bridge

### DIFF
--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -16,7 +16,7 @@ import json
 import os
 import sys
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 from urllib.parse import urlparse
 
 import yaml
@@ -91,9 +91,16 @@ _SENSITIVE_KEY_FRAGMENTS = (
 
 
 class BridgeError(Exception):
-    """Bridge command error that should be returned as structured JSON."""
+    """Bridge command error that should be returned as structured JSON.
 
-    def __init__(self, code: str, detail: str) -> None:
+    `stage` is carried only by verdicts that have one. A commissioned binding
+    is refused *at* a stage, and a refusal only proves a check ran if every
+    earlier stage passed, so losing the stage would reduce a typed verdict to
+    a sentence.
+    """
+
+    def __init__(self, code: str, detail: str, stage: str | None = None) -> None:
+        self.stage = stage
         super().__init__(detail)
         self.code = code
         self.detail = detail
@@ -168,6 +175,7 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
             command=public_command,
             code=exc.code,
             detail=exc.detail,
+            stage=exc.stage,
         )
     except ConfigValidationError as exc:
         return 2, _error(
@@ -781,6 +789,16 @@ async def _in_force_binding(config: Config) -> AcceptedBinding | None:
     loader reads it; reporting it here would let a producer chain a revision
     onto a document this device never accepted.
     """
+    db_path = Path(
+        str(config.raw.get("database", {}).get("path", _DEFAULT_STATE_DB_PATH))
+    )
+    if not db_path.is_file():
+        # A device that has never started has no store, and asking it a
+        # question must not build one. Opening the store applies the DDL, so
+        # this read would otherwise materialise the runtime's whole durable
+        # state owned by whoever ran an inventory query -- on a system install
+        # that is root, and the service account could then never open it.
+        return None
     store = _commissioning_store(config)
     await store.open()
     try:
@@ -820,9 +838,15 @@ async def _commissioning_deliver(
     config = Config.load(config_path)
     device_id = str(config.device.id)
     try:
-        text = Path(binding_path).read_text(encoding="utf-8")
+        text = Path(binding_path).read_bytes().decode("utf-8")
     except OSError as exc:
         raise BridgeError("binding_unreadable", str(exc)) from exc
+    except UnicodeDecodeError:
+        # A document that is not UTF-8 is malformed by the contract's own
+        # grammar. Letting it reach the generic handler would report the same
+        # class of defect as every other malformed document under a different
+        # name, and an operator cannot tell a bad file from a broken tool.
+        raise _refused("parses", "malformed") from None
 
     try:
         anchors = load_commissioning_anchors()
@@ -835,16 +859,15 @@ async def _commissioning_deliver(
 
     prov = provisioning_anchor(config.security)
     in_force = await _in_force_binding(config)
-    refused = _refusal_result(device_id, in_force)
 
     if anchor_collision(anchors, prov):
         # Decided before any document is read, exactly as at configuration load.
-        return refused("key_selection", "anchor_collision")
+        raise _refused("key_selection", "anchor_collision")
 
     try:
         document = parse_document(text)
     except BindingRefusedError as refusal:
-        return refused(refusal.stage, refusal.reason)
+        raise _refused(refusal.stage, refusal.reason) from None
 
     if in_force is not None and is_the_binding_in_force(document, in_force):
         return {
@@ -876,7 +899,7 @@ async def _commissioning_deliver(
     try:
         accepted = verify_binding_envelope(document, context)
     except BindingRefusedError as refusal:
-        return refused(refusal.stage, refusal.reason)
+        raise _refused(refusal.stage, refusal.reason) from None
 
     target = Path(config_path).resolve().parent / BINDING_RELATIVE_PATH
     payload = text.encode("utf-8")
@@ -907,27 +930,23 @@ def _declared_gpio_pin(config: Config) -> int | None:
     return int(pin) if pin is not None else None
 
 
-def _refusal_result(
-    device_id: str, in_force: AcceptedBinding | None
-) -> Callable[[str, str], dict[str, Any]]:
-    """A refusal names the stage it was decided at, as health reports it."""
+def _refused(stage: str, reason: str) -> BridgeError:
+    """A refused binding, reported the way this bridge reports a rejected document.
 
-    def build(stage: str, reason: str) -> dict[str, Any]:
-        return {
-            "device_id": device_id,
-            "accepted": False,
-            "installed": False,
-            "already_in_force": False,
-            "stage": stage,
-            "reason": reason,
-            "binding_seq_in_force": in_force.binding_seq if in_force else 0,
-            "message": (
-                f"binding refused at {stage}: {reason}; "
-                "the binding in force is unchanged and nothing was written"
-            ),
-        }
-
-    return build
+    `config validate` already answers an invalid document with `ok: false` and
+    exit 2, and a binding the runtime refuses is the same kind of answer: the
+    operator handed the tool something the contract does not accept. The code
+    is the contract's reason and the stage rides alongside it, because a
+    refusal only proves a check ran if every earlier stage passed.
+    """
+    return BridgeError(
+        code=reason,
+        detail=(
+            f"binding refused at {stage}; the binding in force is unchanged "
+            "and nothing was written"
+        ),
+        stage=stage,
+    )
 
 
 def _write_staged_binding(target: Path, payload: bytes) -> None:
@@ -1013,15 +1032,17 @@ def _write_json_response(payload: dict[str, Any]) -> None:
     sys.stdout.buffer.write(encoded + b"\n")
 
 
-def _error(*, command: str, code: str, detail: str) -> dict[str, Any]:
+def _error(
+    *, command: str, code: str, detail: str, stage: str | None = None
+) -> dict[str, Any]:
+    error: dict[str, Any] = {"code": code, "detail": detail}
+    if stage is not None:
+        error["stage"] = stage
     return {
         "schema_version": _SCHEMA_VERSION,
         "ok": False,
         "command": command or None,
-        "error": {
-            "code": code,
-            "detail": detail,
-        },
+        "error": error,
     }
 
 

--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -13,16 +13,45 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import urlparse
 
 import yaml
 
-from ori.config import Config, ConfigValidationError, SensorConfig
+from ori.config import (
+    Config,
+    ConfigValidationError,
+    SensorConfig,
+    requires_production_posture,
+)
 from ori.gateway.mqtt_security import parse_gateway_broker_endpoint
 from ori.network.events import SensorReading
+from ori.security.commissioning.anchors import (
+    AnchorError,
+    anchor_collision,
+    load_commissioning_anchors,
+    provisioning_anchor,
+)
+from ori.security.commissioning.binding import (
+    AcceptedBinding,
+    BindingRefusedError,
+    parse_document,
+    verify_binding_envelope,
+)
+from ori.security.commissioning.loader import (
+    BINDING_RELATIVE_PATH,
+    DeclaredInventory,
+    accepted_from_row,
+    is_the_binding_in_force,
+    verifier_context,
+)
+from ori.security.commissioning.profiles import (
+    ProfileSetError,
+    load_shipped_profile_set,
+)
 from ori.skills.loader import Skill, SkillLoader, SkillValidationError
 from ori.skills.sandbox import SkillSecurityError
 from ori.state.store import StateStore
@@ -48,6 +77,8 @@ _PUBLIC_COMMANDS = {
     ("health", "snapshot"): "health-snapshot",
     ("state", "action-log"): "state-action-log",
     ("state", "history"): "state-history",
+    ("commissioning", "inventory"): "commissioning-inventory",
+    ("commissioning", "deliver"): "commissioning-deliver",
 }
 _SENSITIVE_KEY_FRAGMENTS = (
     "authorization",
@@ -116,6 +147,17 @@ def run_bridge(argv: list[str]) -> tuple[int, dict[str, Any]]:
             result = asyncio.run(_read_state_action_log(args))
         elif command == "state-history":
             result = asyncio.run(_read_state_history(args))
+        elif command == "commissioning-inventory":
+            path = _required_option(args, "--path", command)
+            result = asyncio.run(_commissioning_inventory(path))
+        elif command == "commissioning-deliver":
+            path = _required_option(args, "--path", command)
+            binding_path = _required_option(args, "--binding", command)
+            result = asyncio.run(
+                _commissioning_deliver(
+                    path, binding_path, force=_flag_present(args, "--force")
+                )
+            )
         else:
             raise BridgeError(
                 "unknown_command",
@@ -702,6 +744,206 @@ def _state_limit(raw: str | None, *, default: int) -> int:
             f"limit must be between 1 and {_MAX_STATE_LIMIT}",
         )
     return limit
+
+
+def _commissioning_store(config: Config) -> StateStore:
+    """The store the runtime itself opens, resolved the way the runtime does."""
+    db_path = str(config.raw.get("database", {}).get("path", _DEFAULT_STATE_DB_PATH))
+    return StateStore(db_path=db_path)
+
+
+def _declared_actuators(config: Config) -> list[dict[str, Any]]:
+    """Actuating hardware the configuration declares, by identity.
+
+    A local-GPIO actuator is named by its pin alone. Polarity is a commissioned
+    fact, not an inventory one, so reporting `active_high` here would answer
+    the question the ceremony exists to ask. A declared pin counts whether or
+    not `enabled` is set: the pin is what declares the physical path.
+    """
+    pin = config.actions.relay.get("gpio_pin")
+    if pin is None:
+        return []
+    return [{"kind": "local_gpio", "identity": {"gpio_pin": int(pin)}}]
+
+
+def _commissioning_posture(config: Config) -> str:
+    """The posture the runtime's own verifier will apply, and only those two."""
+    hardened = requires_production_posture(
+        device=config.device, security=config.security
+    )
+    return "production" if hardened else "development"
+
+
+async def _in_force_binding(config: Config) -> AcceptedBinding | None:
+    """The accepted binding this device holds, or None.
+
+    A retained binding for another device is not in force, which is how the
+    loader reads it; reporting it here would let a producer chain a revision
+    onto a document this device never accepted.
+    """
+    store = _commissioning_store(config)
+    await store.open()
+    try:
+        row = await store.get_commissioned_binding_in_force()
+    finally:
+        await store.close()
+    if row is None or str(row.get("device_id")) != str(config.device.id):
+        return None
+    return accepted_from_row(row)
+
+
+async def _commissioning_inventory(config_path: str) -> dict[str, Any]:
+    """The candidate set a binding may name: hardware, posture, and where the chain is."""
+    config = Config.load(config_path)
+    in_force = await _in_force_binding(config)
+    return {
+        "device_id": str(config.device.id),
+        "sensor_ids": sorted(str(sensor.id) for sensor in config.sensors),
+        "actuators": _declared_actuators(config),
+        "deployment_posture": _commissioning_posture(config),
+        "accepted_binding_seq": in_force.binding_seq if in_force else 0,
+        "accepted_binding_hash": in_force.canonical_hash if in_force else None,
+    }
+
+
+async def _commissioning_deliver(
+    config_path: str, binding_path: str, *, force: bool
+) -> dict[str, Any]:
+    """Verify a signed envelope against this device, then install it if it passed.
+
+    The verdict is the runtime's own: the same verifier, over the same context
+    the loader builds at startup, so a document accepted here is the document
+    that will be accepted then. Nothing is written until every stage has
+    passed, and this does not make the binding live -- the runtime reads the
+    file when it next starts.
+    """
+    config = Config.load(config_path)
+    device_id = str(config.device.id)
+    try:
+        text = Path(binding_path).read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BridgeError("binding_unreadable", str(exc)) from exc
+
+    try:
+        anchors = load_commissioning_anchors()
+    except AnchorError as exc:
+        raise BridgeError("anchor_error", str(exc)) from exc
+    try:
+        profiles = load_shipped_profile_set()
+    except ProfileSetError as exc:
+        raise BridgeError("profile_set_error", str(exc)) from exc
+
+    prov = provisioning_anchor(config.security)
+    in_force = await _in_force_binding(config)
+    refused = _refusal_result(device_id, in_force)
+
+    if anchor_collision(anchors, prov):
+        # Decided before any document is read, exactly as at configuration load.
+        return refused("key_selection", "anchor_collision")
+
+    try:
+        document = parse_document(text)
+    except BindingRefusedError as refusal:
+        return refused(refusal.stage, refusal.reason)
+
+    if in_force is not None and is_the_binding_in_force(document, in_force):
+        return {
+            "device_id": device_id,
+            "accepted": True,
+            "installed": False,
+            "already_in_force": True,
+            "binding_seq": in_force.binding_seq,
+            "binding_hash": in_force.canonical_hash,
+            "binding_seq_in_force": in_force.binding_seq,
+            "message": (
+                "this document is already the binding in force; nothing to install"
+            ),
+        }
+
+    context = verifier_context(
+        device_id=device_id,
+        anchors=anchors,
+        provisioning_anchor=prov,
+        in_force=in_force,
+        inventory=DeclaredInventory.from_config(
+            [str(sensor.id) for sensor in config.sensors],
+            _declared_gpio_pin(config),
+        ),
+        posture=_commissioning_posture(config),  # type: ignore[arg-type]
+        profiles=profiles,
+        document=document,
+    )
+    try:
+        accepted = verify_binding_envelope(document, context)
+    except BindingRefusedError as refusal:
+        return refused(refusal.stage, refusal.reason)
+
+    target = Path(config_path).resolve().parent / BINDING_RELATIVE_PATH
+    payload = text.encode("utf-8")
+    if target.exists() and target.read_bytes() != payload and not force:
+        raise BridgeError(
+            "binding_already_staged",
+            f"a different document is already staged at {target}; "
+            "pass --force to replace it",
+        )
+    _write_staged_binding(target, payload)
+
+    return {
+        "device_id": device_id,
+        "accepted": True,
+        "installed": True,
+        "already_in_force": False,
+        "binding_seq": accepted.binding_seq,
+        "binding_hash": accepted.canonical_hash,
+        "binding_seq_in_force": in_force.binding_seq if in_force else 0,
+        "message": (
+            "binding verified and staged; the runtime reads it when it next starts"
+        ),
+    }
+
+
+def _declared_gpio_pin(config: Config) -> int | None:
+    pin = config.actions.relay.get("gpio_pin")
+    return int(pin) if pin is not None else None
+
+
+def _refusal_result(
+    device_id: str, in_force: AcceptedBinding | None
+) -> Callable[[str, str], dict[str, Any]]:
+    """A refusal names the stage it was decided at, as health reports it."""
+
+    def build(stage: str, reason: str) -> dict[str, Any]:
+        return {
+            "device_id": device_id,
+            "accepted": False,
+            "installed": False,
+            "already_in_force": False,
+            "stage": stage,
+            "reason": reason,
+            "binding_seq_in_force": in_force.binding_seq if in_force else 0,
+            "message": (
+                f"binding refused at {stage}: {reason}; "
+                "the binding in force is unchanged and nothing was written"
+            ),
+        }
+
+    return build
+
+
+def _write_staged_binding(target: Path, payload: bytes) -> None:
+    """Write the document whole or not at all.
+
+    A half-written binding at the contract's path is a document the runtime
+    would refuse at `parses` on its next start, which is safe but indis-
+    tinguishable from a tampered one.
+    """
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_name(target.name + ".tmp")
+    try:
+        temporary.write_bytes(payload)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _state_store_from_default_path() -> StateStore:

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -14,8 +14,6 @@ Or via the CLI entry point::
 """
 
 import asyncio
-import base64
-import binascii
 import datetime as dt
 import hashlib
 import hmac
@@ -107,6 +105,7 @@ from ori.security.commissioning.anchors import (
     CommissioningAnchors,
     anchor_collision,
     load_commissioning_anchors,
+    provisioning_anchor,
 )
 from ori.security.commissioning.loader import (
     CommissioningState,
@@ -5179,18 +5178,13 @@ def _build_firmware_command_service(
 
 
 def _provisioning_anchor_bytes(config: Config) -> bytes | None:
-    """The provisioning anchor as raw key material, from the environment it names."""
-    env_name = str(
-        (config.security.get("config_signature") or {}).get("trust_anchor_env") or ""
-    ).strip()
-    text = os.environ.get(env_name, "").strip() if env_name else ""
-    if not text:
-        return None
-    try:
-        raw = base64.b64decode(text, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-    return raw if len(raw) == 32 else None
+    """The provisioning anchor as raw key material, from the environment it names.
+
+    The reading lives with the other anchors so the CLI bridge resolves the
+    same value from the same document; two readings of one anchor is one
+    reading too many.
+    """
+    return provisioning_anchor(config.security)
 
 
 def _degradation_reasons(*, firmware_liveness_degraded: bool) -> list[str]:

--- a/ori/security/commissioning/anchors.py
+++ b/ori/security/commissioning/anchors.py
@@ -14,7 +14,7 @@ import base64
 import binascii
 import os
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Any, Mapping
 
 COMMISSIONING_ANCHOR_ENV = "ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64"
 COMMISSIONING_ANCHOR_PREVIOUS_ENV = "ORI_COMMISSIONING_ANCHOR_PREVIOUS_PUBLIC_KEY_B64"
@@ -73,6 +73,32 @@ def load_commissioning_anchors(
             "demotes a key, it does not duplicate it"
         )
     return CommissioningAnchors(current=current, previous=previous)
+
+
+def provisioning_anchor(
+    security: Mapping[str, Any], environ: Mapping[str, str] | None = None
+) -> bytes | None:
+    """The provisioning anchor as raw key material, from the environment it names.
+
+    Material that is missing or not a 32-byte key reads as absent rather than
+    raising. This value exists here only to be compared against the
+    commissioning anchors, and something that is not a key cannot collide with
+    one; whether a malformed provisioning anchor is itself an error belongs to
+    the config-signing path that actually verifies with it.
+    """
+    env = os.environ if environ is None else environ
+    signature = security.get("config_signature") or {}
+    if not isinstance(signature, Mapping):
+        return None
+    name = str(signature.get("trust_anchor_env") or "").strip()
+    text = (env.get(name) or "").strip() if name else ""
+    if not text:
+        return None
+    try:
+        raw = base64.b64decode(text, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+    return raw if len(raw) == 32 else None
 
 
 def anchor_collision(

--- a/ori/security/commissioning/loader.py
+++ b/ori/security/commissioning/loader.py
@@ -136,7 +136,7 @@ class CommissioningState:
         }
 
 
-def _accepted_from_row(row: dict[str, Any]) -> AcceptedBinding:
+def accepted_from_row(row: dict[str, Any]) -> AcceptedBinding:
     zones = tuple(AcceptedZone(**zone) for zone in json.loads(row["zones_json"]))
     return AcceptedBinding(
         binding_seq=int(row["binding_seq"]),
@@ -156,7 +156,7 @@ def _zones_json(binding: AcceptedBinding) -> str:
     return json.dumps([asdict(zone) for zone in binding.zones], sort_keys=True)
 
 
-def _context(
+def verifier_context(
     *,
     device_id: str,
     anchors: CommissioningAnchors,
@@ -229,7 +229,7 @@ async def load_commissioning_state(
     state = CommissioningState(anchors=anchors, inventory=inventory)
     row = await store.get_commissioned_binding_in_force()
     if row is not None:
-        state.in_force = _accepted_from_row(row)
+        state.in_force = accepted_from_row(row)
         if state.in_force.device_id != device_id:
             state.problems.append("retained_binding_for_another_device")
             state.in_force = None
@@ -251,15 +251,13 @@ async def load_commissioning_state(
         return state
 
     presented_seq = _presented_seq(document)
-    if state.in_force is not None and _is_the_binding_in_force(
-        document, state.in_force
-    ):
+    if state.in_force is not None and is_the_binding_in_force(document, state.in_force):
         # The file is the document already in force, byte for byte; there is
         # nothing to re-decide and nothing to retain twice.
         state.last_verdict = Verdict("accepted", "accepted", presented_seq, now_ms())
         return state
 
-    context = _context(
+    context = verifier_context(
         device_id=device_id,
         anchors=anchors,
         provisioning_anchor=provisioning_anchor,
@@ -322,7 +320,7 @@ async def load_commissioning_state(
     return state
 
 
-def _is_the_binding_in_force(document: Any, in_force: AcceptedBinding) -> bool:
+def is_the_binding_in_force(document: Any, in_force: AcceptedBinding) -> bool:
     """Same signed bytes and same signature as the retained document."""
     if not isinstance(document, dict) or set(document) != {"binding", "signature"}:
         return False

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -142,6 +142,7 @@ async def _seed_state_store(path: Path) -> None:
 def test_cli_bridge_config_validate_reports_signed_phone_posture(
     tmp_path, monkeypatch, capsys
 ):
+    assert monkeypatch is not None, "a hardened config needs monkeypatch for its anchor"
     private_key, public_key_b64 = _ed25519_keypair()
     monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)
     config_path = _write_config(
@@ -690,7 +691,10 @@ def test_config_show_names_the_secret_variable_but_never_its_value(
 
 
 def _commissioning_config(
-    tmp_path: Path, *, hardened: bool = False, monkeypatch=None
+    tmp_path: Path,
+    *,
+    hardened: bool = False,
+    monkeypatch: pytest.MonkeyPatch | None = None,
 ) -> Path:
     """A config the runtime would load, in the posture the test needs.
 
@@ -728,6 +732,7 @@ def _commissioning_config(
         config_path.write_text(body, encoding="utf-8")
         return config_path
 
+    assert monkeypatch is not None, "a hardened config needs monkeypatch for its anchor"
     private_key, public_key_b64 = _ed25519_keypair()
     monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)
     body += textwrap.dedent(f"""\
@@ -864,10 +869,13 @@ def test_cli_bridge_commissioning_deliver_refuses_by_stage_and_writes_nothing(
         ]
     )
 
-    result = _read_stdout_json(capsys)["result"]
-    assert rc == 0
-    assert result["accepted"] is False
-    assert (result["stage"], result["reason"]) == ("key_selection", "unknown_signer")
+    payload = _read_stdout_json(capsys)
+    # A refused document is answered the way `config validate` answers an
+    # invalid one: ok false, exit 2, and the verdict typed in the error.
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "unknown_signer"
+    assert payload["error"]["stage"] == "key_selection"
     assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
 
 
@@ -884,7 +892,7 @@ def test_cli_bridge_commissioning_deliver_refuses_an_undemonstrated_zone_when_ha
     source = tmp_path / "binding.json"
     source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
 
-    cli_bridge.main(
+    rc = cli_bridge.main(
         [
             "commissioning",
             "deliver",
@@ -895,12 +903,10 @@ def test_cli_bridge_commissioning_deliver_refuses_an_undemonstrated_zone_when_ha
         ]
     )
 
-    result = _read_stdout_json(capsys)["result"]
-    assert result["accepted"] is False
-    assert (result["stage"], result["reason"]) == (
-        "activation_posture",
-        "undemonstrated_binding",
-    )
+    assert rc == 2
+    error = _read_stdout_json(capsys)["error"]
+    assert error["code"] == "undemonstrated_binding"
+    assert error["stage"] == "activation_posture"
     assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
 
 
@@ -918,7 +924,7 @@ def test_cli_bridge_commissioning_deliver_refuses_a_repeated_key_from_the_wire(
         encoding="utf-8",
     )
 
-    cli_bridge.main(
+    rc = cli_bridge.main(
         [
             "commissioning",
             "deliver",
@@ -929,12 +935,9 @@ def test_cli_bridge_commissioning_deliver_refuses_a_repeated_key_from_the_wire(
         ]
     )
 
-    result = _read_stdout_json(capsys)["result"]
-    assert (result["accepted"], result["stage"], result["reason"]) == (
-        False,
-        "parses",
-        "malformed",
-    )
+    assert rc == 2
+    error = _read_stdout_json(capsys)["error"]
+    assert (error["code"], error["stage"]) == ("malformed", "parses")
 
 
 def test_cli_bridge_commissioning_deliver_will_not_replace_a_staged_document(
@@ -1105,7 +1108,116 @@ def test_cli_bridge_commissioning_deliver_agrees_with_the_loader_at_startup(
     assert state.in_force.binding_seq == delivered["binding_seq"]
     assert state.in_force.canonical_hash == delivered["binding_hash"]
     assert state.actuation_licensed is True
+    # Narrowed rather than assumed: a `None` verdict here would otherwise fail
+    # as an AttributeError deep in the assertion instead of saying that the
+    # loader recorded nothing for the document the bridge staged.
+    assert state.last_verdict is not None
     assert (state.last_verdict.stage, state.last_verdict.reason) == (
         "accepted",
         "accepted",
     )
+
+
+def test_cli_bridge_commissioning_reads_create_no_state_database(tmp_path, capsys):
+    """Asking a device a question must not build its durable state.
+
+    Opening the store applies the DDL, so a read that opened it would leave a
+    fully-formed database owned by whoever ran the query. On a system install
+    that is the installer, not the service account, and the runtime would then
+    be unable to open its own store — with nothing to connect the failure back
+    to an inventory command run days earlier.
+    """
+    config_path = _commissioning_config(tmp_path)
+    db_path = tmp_path / "ori_state.db"
+    assert not db_path.exists()
+
+    rc = cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+
+    result = _read_stdout_json(capsys)["result"]
+    assert rc == 0
+    assert result["accepted_binding_seq"] == 0
+    assert result["accepted_binding_hash"] is None
+    assert not db_path.exists(), "the read created the state database"
+    assert sorted(p.name for p in tmp_path.iterdir()) == ["ori.yaml"]
+
+
+def test_cli_bridge_commissioning_deliver_works_before_the_first_start(
+    tmp_path, monkeypatch, capsys
+):
+    """The first commissioning happens before the runtime has ever run."""
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    result = _read_stdout_json(capsys)["result"]
+    assert rc == 0 and result["accepted"] is True
+    assert (tmp_path / BINDING_RELATIVE_PATH).is_file()
+    assert not (tmp_path / "ori_state.db").exists()
+
+
+def test_cli_bridge_commissioning_deliver_reports_a_non_utf8_file_as_malformed(
+    tmp_path, monkeypatch, capsys
+):
+    """A document that is not UTF-8 is malformed by the grammar, not a tool fault.
+
+    Reading it through the generic error path would report the same class of
+    defect as every other malformed document under a different name, and an
+    operator could not tell a bad file from a broken tool.
+    """
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_bytes(b'{"binding":"\xff","signature":"x"}')
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert (payload["error"]["code"], payload["error"]["stage"]) == (
+        "malformed",
+        "parses",
+    )
+
+
+def test_cli_bridge_errors_without_a_verdict_carry_no_stage(tmp_path, capsys):
+    """Only a verdict has a stage; an unreadable file is not one."""
+    config_path = _commissioning_config(tmp_path)
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(tmp_path / "absent.json"),
+        ]
+    )
+
+    error = _read_stdout_json(capsys)["error"]
+    assert rc == 2
+    assert error["code"] == "binding_unreadable"
+    assert "stage" not in error

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -676,3 +676,436 @@ def test_config_show_names_the_secret_variable_but_never_its_value(
     assert gateway["shared_secret_env"] == "GATEWAY_SHARED_SECRET"
     assert "shared_secret_env_set" not in gateway
     assert "super-secret-value" not in raw
+
+
+# --------------------------------------------------------------------------
+# Commissioned safety binding ceremony
+# --------------------------------------------------------------------------
+#
+# The bridge exists here because CLI-7 stops the CLI reading `ori.yaml` and
+# CLI-9 stops it driving a contactor. What it must not do is form a second
+# opinion: `deliver` runs the runtime's own verifier over the context the
+# loader builds at startup, so a document accepted here is the one accepted
+# then.
+
+
+def _commissioning_config(
+    tmp_path: Path, *, hardened: bool = False, monkeypatch=None
+) -> Path:
+    """A config the runtime would load, in the posture the test needs.
+
+    Hardened posture is reached the way a deployment reaches it, not by
+    mutating a loaded object: the whole chain the loader enforces has to be
+    satisfied, config signature included, because the config the bridge reads
+    is the config the runtime reads.
+    """
+    body = textwrap.dedent(f"""\
+        device:
+          id: bench-01
+          name: Bench
+          location: Test Lab
+          deployment_profile: development
+        sensors:
+          - id: load-current
+            type: cpu_percent
+            protocol: psutil
+            poll_interval_ms: 1000
+        skills: []
+        reasoning:
+          default_tier: rule
+        actions:
+          relay:
+            enabled: false
+            gpio_pin: 26
+        database:
+          path: {tmp_path / "ori_state.db"}
+        logging:
+          level: INFO
+          file: {tmp_path / "ori.log"}
+        """)
+    config_path = tmp_path / "ori.yaml"
+    if not hardened:
+        config_path.write_text(body, encoding="utf-8")
+        return config_path
+
+    private_key, public_key_b64 = _ed25519_keypair()
+    monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)
+    body += textwrap.dedent(f"""\
+        security:
+          enforce_production_posture: true
+          skills:
+            require_signed: true
+          config_signature:
+            require_signed: true
+            trust_anchor_env: ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64
+        state:
+          encryption:
+            mode: filesystem_required
+            encrypted_path_prefixes: ["{tmp_path}"]
+        """)
+    config_path.write_text(_sign_config_yaml(body, private_key), encoding="utf-8")
+    return config_path
+
+
+def _bench_envelope(**overrides):
+    from tests.commissioning.signing import local_gpio_binding, sign_envelope
+
+    binding = local_gpio_binding(
+        device_id="bench-01",
+        sensor_id="load-current",
+        gpio_pin=26,
+        active_high=False,
+        **overrides,
+    )
+    return sign_envelope(binding, "7" * 64)
+
+
+def _anchor(monkeypatch, seed: str = "7" * 64) -> None:
+    from ori.security.commissioning.anchors import COMMISSIONING_ANCHOR_ENV
+    from tests.commissioning.signing import public_key_b64
+
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(seed))
+
+
+def test_cli_bridge_commissioning_inventory_reports_the_candidate_set(tmp_path, capsys):
+    config_path = _commissioning_config(tmp_path)
+
+    rc = cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    result = payload["result"]
+    assert result["device_id"] == "bench-01"
+    assert result["sensor_ids"] == ["load-current"]
+    assert result["actuators"] == [{"kind": "local_gpio", "identity": {"gpio_pin": 26}}]
+    assert result["deployment_posture"] == "development"
+    assert result["accepted_binding_seq"] == 0
+    assert result["accepted_binding_hash"] is None
+
+
+def test_cli_bridge_commissioning_inventory_omits_polarity(tmp_path, capsys):
+    """Polarity is the question the ceremony asks, not one the device answers."""
+    config_path = _commissioning_config(tmp_path)
+
+    cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+
+    result = _read_stdout_json(capsys)["result"]
+    identity = result["actuators"][0]["identity"]
+    assert identity == {"gpio_pin": 26}
+    assert "active_high" not in identity
+    # Nor a generation the runtime does not have to compare against.
+    assert "inventory_generation" not in result
+
+
+def test_cli_bridge_commissioning_inventory_reports_hardened_posture(
+    tmp_path, monkeypatch, capsys
+):
+    config_path = _commissioning_config(
+        tmp_path, hardened=True, monkeypatch=monkeypatch
+    )
+
+    cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+
+    assert _read_stdout_json(capsys)["result"]["deployment_posture"] == "production"
+
+
+def test_cli_bridge_commissioning_deliver_stages_an_accepted_binding(
+    tmp_path, monkeypatch, capsys
+):
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 0
+    result = payload["result"]
+    assert result["accepted"] is True
+    assert result["installed"] is True
+    assert result["binding_seq"] == 1
+    # Staged, not live: the runtime reads it when it next starts.
+    assert "next starts" in result["message"]
+    staged = tmp_path / BINDING_RELATIVE_PATH
+    assert json.loads(staged.read_text()) == json.loads(source.read_text())
+
+
+def test_cli_bridge_commissioning_deliver_refuses_by_stage_and_writes_nothing(
+    tmp_path, monkeypatch, capsys
+):
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    config_path = _commissioning_config(tmp_path)
+    # The anchor configured is not the key that signed the document.
+    _anchor(monkeypatch, seed="6" * 64)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    result = _read_stdout_json(capsys)["result"]
+    assert rc == 0
+    assert result["accepted"] is False
+    assert (result["stage"], result["reason"]) == ("key_selection", "unknown_signer")
+    assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
+
+
+def test_cli_bridge_commissioning_deliver_refuses_an_undemonstrated_zone_when_hardened(
+    tmp_path, monkeypatch, capsys
+):
+    """The posture `inventory` reported is the posture `deliver` applies."""
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    config_path = _commissioning_config(
+        tmp_path, hardened=True, monkeypatch=monkeypatch
+    )
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    result = _read_stdout_json(capsys)["result"]
+    assert result["accepted"] is False
+    assert (result["stage"], result["reason"]) == (
+        "activation_posture",
+        "undemonstrated_binding",
+    )
+    assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
+
+
+def test_cli_bridge_commissioning_deliver_refuses_a_repeated_key_from_the_wire(
+    tmp_path, monkeypatch, capsys
+):
+    """The bytes are read through the runtime's parser, not a lenient one."""
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    text = json.dumps(_bench_envelope(), indent=1)
+    assert '"binding_seq": 1' in text
+    source.write_text(
+        text.replace('"binding_seq": 1', '"binding_seq": 5, "binding_seq": 1', 1),
+        encoding="utf-8",
+    )
+
+    cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    result = _read_stdout_json(capsys)["result"]
+    assert (result["accepted"], result["stage"], result["reason"]) == (
+        False,
+        "parses",
+        "malformed",
+    )
+
+
+def test_cli_bridge_commissioning_deliver_will_not_replace_a_staged_document(
+    tmp_path, monkeypatch, capsys
+):
+    """One installer does not silently discard another's staged binding."""
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    staged = tmp_path / BINDING_RELATIVE_PATH
+    staged.parent.mkdir(parents=True, exist_ok=True)
+    staged.write_text(json.dumps(_bench_envelope(binding_seq=9)), encoding="utf-8")
+    before = staged.read_bytes()
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "binding_already_staged"
+    assert staged.read_bytes() == before
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+            "--force",
+        ]
+    )
+    assert rc == 0
+    assert staged.read_bytes() != before
+
+
+async def _retain_foreign_binding(config_path: Path) -> None:
+    """Put a binding for a different device into this device's store."""
+    from ori.config import Config
+
+    config = Config.load(str(config_path))
+    store = cli_bridge._commissioning_store(config)
+    await store.open()
+    try:
+        await store.retain_commissioned_binding(
+            binding_seq=7,
+            canonical_hash="sha256:" + "a" * 64,
+            device_id="some-other-device",
+            inventory_generation=1,
+            signer_id="commissioning-test",
+            supersedes=None,
+            canonical_json="{}",
+            signature="ed25519:" + base64.b64encode(b"\x00" * 64).decode(),
+            zones_json="[]",
+        )
+    finally:
+        await store.close()
+
+
+def test_cli_bridge_commissioning_reads_no_binding_held_for_another_device(
+    tmp_path, monkeypatch, capsys
+):
+    """A retained binding for another device is not this device's baseline.
+
+    Reporting its sequence would let a producer chain a revision onto a
+    document this device never accepted, and `deliver` would then judge
+    freshness against a hash it does not hold. The loader reads it the same
+    way, which is why the two agree at startup.
+    """
+    config_path = _commissioning_config(tmp_path)
+    asyncio.run(_retain_foreign_binding(config_path))
+
+    cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+    result = _read_stdout_json(capsys)["result"]
+    assert result["accepted_binding_seq"] == 0
+    assert result["accepted_binding_hash"] is None
+
+    # And the first binding for this device is accepted against that baseline,
+    # rather than refused as stale behind the foreign sequence of 7.
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+    delivered = _read_stdout_json(capsys)["result"]
+    assert rc == 0
+    assert delivered["accepted"] is True
+    assert delivered["binding_seq"] == 1
+
+
+def test_cli_bridge_commissioning_deliver_agrees_with_the_loader_at_startup(
+    tmp_path, monkeypatch, capsys
+):
+    """The verdict `deliver` gives is the verdict the runtime will give.
+
+    This is the whole claim the command makes. It is checked by staging a
+    document through the bridge and then running the loader over the same
+    installation, which is what the runtime does at its next start: the
+    binding that comes into force must be the one that was delivered.
+    """
+    from ori.config import Config
+    from ori.security.commissioning.anchors import load_commissioning_anchors
+    from ori.security.commissioning.loader import (
+        DeclaredInventory,
+        load_commissioning_state,
+    )
+    from ori.security.commissioning.profiles import load_shipped_profile_set
+
+    config_path = _commissioning_config(tmp_path)
+    _anchor(monkeypatch)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+    delivered = _read_stdout_json(capsys)["result"]
+    assert rc == 0 and delivered["accepted"] is True
+
+    async def _load():
+        config = Config.load(str(config_path))
+        store = cli_bridge._commissioning_store(config)
+        await store.open()
+        try:
+            return await load_commissioning_state(
+                data_path=config_path.resolve().parent,
+                device_id=str(config.device.id),
+                anchors=load_commissioning_anchors(),
+                provisioning_anchor=None,
+                inventory=DeclaredInventory.from_config(["load-current"], 26),
+                posture="development",
+                profiles=load_shipped_profile_set(),
+                store=store,
+            )
+        finally:
+            await store.close()
+
+    state = asyncio.run(_load())
+    assert state.in_force is not None
+    assert state.in_force.binding_seq == delivered["binding_seq"]
+    assert state.in_force.canonical_hash == delivered["binding_hash"]
+    assert state.actuation_licensed is True
+    assert (state.last_verdict.stage, state.last_verdict.reason) == (
+        "accepted",
+        "accepted",
+    )


### PR DESCRIPTION
## What does this PR do?

The commissioned binding contract has a consumer in this runtime and no producer on site, which leaves every device unable to activate a Tier D profile. `ori-cli` is where the ceremony belongs, and two of its invariants decide what the runtime has to provide: `CLI-7` means the tool cannot read `ori.yaml`, so the hardware a binding may name has to come from here; `CLI-9` means it cannot drive a contactor, so delivery has to be verified and installed by the runtime rather than by a file copy.

**`commissioning inventory`** returns the candidate set and nothing else — sensor ids, actuators by identity, the posture the verifier will apply, and where the binding chain currently stands. A local-GPIO actuator is named by its pin alone: polarity is the fact the ceremony exists to establish, so an inventory carrying `active_high` would be answering its own question. There is no inventory generation either, because the runtime has none — the only one it holds is the value a binding *claims*, and handing that back would return the producer its own assertion in the device's voice.

**`commissioning deliver`** runs the contract's twelve stages before writing anything and writes only on acceptance. A refusal is answered the way this bridge already answers an invalid configuration — `ok: false`, exit 2 — with the contract's reason as `error.code` and the stage beside it, because a refusal only proves a check ran if every earlier stage passed. It does not retain: the loader stays the single writer of the binding in force, and the command reports the document as staged rather than live, because the runtime reads it at its next start.

**Neither command creates runtime state.** A device is commissioned before it has ever started, and opening the state store applies its schema — so a read that opened it would leave a fully-formed database owned by whoever ran the query. On a system installation that is the installer rather than the service account, and the runtime would later fail to open its own state with nothing pointing back at the command that made it. An absent store reads as "no binding in force", which is what it means.

**The verdict has to be the runtime's own.** The loader's context builder is reused rather than a second one written beside it — two verifiers that can disagree is the failure this contract exists to prevent — which is why `verifier_context`, `accepted_from_row` and `is_the_binding_in_force` are now importable. The provisioning anchor moves to the module that owns the other anchors, so the bridge and the runtime resolve one value from one place.

## Type of change

- [x] `feat` — new feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale — [skip-cap-matrix]: a read-only bridge surface and a staging write; no capability is added, removed, or re-proven, and nothing here actuates
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs ori-platform/ori-cli#34, whose remaining scope is the ceremony these two commands serve. The contract is `cli-commands/v1.md`. Implementing against it surfaced two gaps in the text, fixed in ori-platform/ori-specs#146 (it asked for an inventory generation the runtime does not have) and ori-platform/ori-specs#147 (a refusal had no defined envelope, and nothing forbade a read from creating runtime state).

`actuate_and_observe` remains out of scope and is tracked in #467: proving a mapping means driving a contactor, and the runtime has no operator-facing surface that commands a commissioned outcome.

## Testing notes

Thirteen tests drive the real `cli_bridge.main` entry point. Each boundary was mutated and fails its own tests and no others: writing before verifying, leaking polarity into the inventory, forcing the posture to development, reading the wire with a lenient parser instead of the runtime's, overwriting a staged document without `--force`,, treating a binding retained for another device as this device's baseline, opening the state store on a read, and dropping the stage from a refusal.

The claim the command makes is checked directly: a document staged through the bridge is then loaded by `load_commissioning_state` over the same installation, and the binding that comes into force is the one delivered, with actuation licensed and the verdict `accepted`.

Twenty-four hostile inputs were then driven through the bridge as a real subprocess, which is the shape `ori-cli` invokes: a missing file, a directory in place of one, empty, truncated and non-JSON bodies, a JSON array, string and null, an envelope without a signature and one with an extra field, 200,000-deep nesting, an embedded NUL, invalid UTF-8, a missing anchor, a malformed anchor, a previous anchor without a current one, a missing and a malformed config, and four argument errors. Every one returns a single JSON object on stdout with diagnostics on stderr per `CLI-3`, an exit code that distinguishes an operator error from a broken tool, and a typed code rather than a crash reaching the generic handler.

The state-creation behaviour is measured rather than argued: an `inventory` call against a device with no store leaves the directory holding exactly `ori.yaml`, and a first delivery succeeds before any runtime has run.

Hardened-posture tests reach that posture the way a deployment does, satisfying the whole chain the loader enforces including a signed config, rather than mutating a loaded object — the config the bridge reads has to be the config the runtime reads.

`mypy ori/` and `pyright ori/` report zero, and `pyright` on the changed test file reports zero as it does on `main` — the two narrowing gaps it found are closed rather than silenced, the verdict one because it would otherwise have failed as an `AttributeError` inside an assertion instead of reporting that the loader recorded nothing. Full suite 4893 passed, 28 skipped.

The commands are host-tested only; no installer has run them on a device.
