### PR TITLE
docs(evidence): the neutral reclaim, demonstrated at the coil and observer-paced

### DIFF
--- a/docs/evidence/2026-09-01-pi4-gpio-controller-loss.md
+++ b/docs/evidence/2026-09-01-pi4-gpio-controller-loss.md
@@ -91,12 +91,159 @@ the pad was still `op -- pn | hi`:
   pin after reclaim:   26: ip    pd | lo // GPIO26 = input
 ```
 
-**Reclaiming the freed line as an input cleared the driving pad.** That is
-direct evidence that a supervising process can recover from application-process
-loss by claiming the dead process's line as an input — an act that derives
-nothing from the zone's asserted polarity — and it is the distinction between
-application-process loss, where the kernel and a supervisor remain available,
-and a kernel failure, where nothing does.
+**Reclaiming the freed line as an input cleared the driving pad — but this run
+claimed with `SET_PULL_DOWN`, an explicitly chosen bias** that on this
+high-trigger wiring happens to oppose the trigger level. It demonstrates that
+the line is recoverable after process loss; it does not demonstrate a neutral
+mechanism. The neutral variant was demonstrated separately, below.
+
+### Neutral reclamation, observer-paced (same day, later run)
+
+The reclaim was repeated with `lgpio.SET_PULL_NONE` — no bias selected — and
+paced by the observer: each phase halted on an Enter press until LED1 had been
+judged, because an earlier self-pacing script moved faster than a person can
+attribute an LED change to a phase. (Three same-day fast runs produced
+identical pad traces but unattributable LED timing, and one further run was
+performed with the relay board unpowered and is void for any coil claim; both
+are recorded here as discarded, like the `pkill` attempt above.)
+
+The holder commands the coil through `RelayAction.acquire_at`, the GPIO
+acquisition primitive invoked beneath `CommissionedActuator.acquire_commanding`.
+This isolates process-loss behaviour after acquisition; it does not test
+binding verification or commissioned outcome resolution. As run —
+`/home/ori/bench/hold_energised.py`, with `PYTHONPATH` pointing at this
+repository's source tree:
+
+```python
+"""Hold the coil energised through the real seam, then wait to be killed.
+
+Uses `acquire_at`, the same path the commissioning proof uses, so what is
+observed on controller loss is what that path leaves behind.
+"""
+import asyncio, os, signal, sys, time
+from ori.actions.relay import RelayAction
+
+async def main() -> None:
+    relay = RelayAction()
+    await relay.acquire_at(26, True, coil_state="energised")
+    print(f"  coil commanded ENERGISED, pid {os.getpid()}", flush=True)
+    print("  LED1 should be ON now. Confirm, then this will be killed.", flush=True)
+    try:
+        while True:
+            await asyncio.sleep(1)
+    except asyncio.CancelledError:
+        pass
+
+# No handlers: SIGKILL cannot be caught anyway, and the point is what the
+# kernel leaves when the process simply stops existing.
+asyncio.run(main())
+```
+
+The pacing script starts the holder, kills it by exact PID, claims and frees
+the line, and blocks on the observer between phases —
+`/home/ori/bench/gate1d.py`:
+
+```python
+"""Neutral-reclaim observation, paced by the observer.
+
+Nothing advances until Enter is pressed, so every LED judgement has an
+unambiguous owner phase.
+"""
+import os, signal, subprocess, time
+
+def pin() -> str:
+    return subprocess.run(["pinctrl", "get", "26"], capture_output=True, text=True).stdout.strip()
+
+def pause(msg: str) -> None:
+    input(f"\n>>> {msg}\n>>> press Enter when you have judged LED1... ")
+
+env = dict(os.environ, PYTHONPATH="/home/ori/bench/src")
+holder = subprocess.Popen(
+    ["./venv/bin/python", "hold_energised.py"],
+    cwd="/home/ori/bench", env=env, start_new_session=True,
+    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+)
+time.sleep(3)
+print(f"PHASE 1 — coil commanded ENERGISED (holder pid {holder.pid})")
+print(f"  pin: {pin()}")
+pause("LED1 should be ON now. Confirm it.")
+
+os.kill(holder.pid, signal.SIGKILL)
+holder.wait()
+time.sleep(0.5)
+print(f"\nPHASE 2 — holder SIGKILLed (confirmed dead: {holder.returncode is not None})")
+print(f"  pin: {pin()}")
+pause("Per the standing evidence LED1 should have STAYED ON. Did it?")
+
+import lgpio
+h = lgpio.gpiochip_open(0)
+lgpio.gpio_claim_input(h, 26, lgpio.SET_PULL_NONE)
+time.sleep(0.3)
+print(f"\nPHASE 3 — line claimed as input, NO pull (nothing chosen)")
+print(f"  pin: {pin()}")
+pause("THE QUESTION: did LED1 go OUT at this claim, and stay out?")
+
+lgpio.gpio_free(h, 26)
+lgpio.gpiochip_close(h)
+time.sleep(0.3)
+print(f"\nPHASE 4 — claim freed")
+print(f"  pin: {pin()}")
+pause("LED1 should still be out. Confirm, then done.")
+print("\nReport the four phase judgements.")
+```
+
+Invoked as `ssh -t ori-pi '~/bench/gate1d.sh'`, where `gate1d.sh` is
+`cd /home/ori/bench && exec ./venv/bin/python gate1d.py`. Captured output:
+
+```
+❯ ssh -t ori-pi '~/bench/gate1d.sh'
+PHASE 1 — coil commanded ENERGISED (holder pid 1937)
+  pin: 26: op -- pn | hi // GPIO26 = output
+
+>>> LED1 should be ON now. Confirm it.
+>>> press Enter when you have judged LED1...
+
+PHASE 2 — holder SIGKILLed (confirmed dead: True)
+  pin: 26: op -- pn | hi // GPIO26 = output
+
+>>> Per the standing evidence LED1 should have STAYED ON. Did it?
+>>> press Enter when you have judged LED1...
+
+PHASE 3 — line claimed as input, NO pull (nothing chosen)
+  pin: 26: ip    pn | lo // GPIO26 = input
+
+>>> THE QUESTION: did LED1 go OUT at this claim, and stay out?
+>>> press Enter when you have judged LED1...
+
+PHASE 4 — claim freed
+  pin: 26: ip    pn | lo // GPIO26 = input
+
+>>> LED1 should still be out. Confirm, then done.
+>>> press Enter when you have judged LED1...
+
+Report the four phase judgements.
+Connection to 192.168.0.104 closed.
+```
+
+The observer's judgement at each pause: phase 1, LED1 on; phase 2, LED1
+stayed on; phase 3, LED1 out by the time the prompt printed — the only event
+between the phase-2 judgement and that prompt was the input claim — and it
+stayed out; phase 4, still out.
+
+```
+PHASE 1 — coil commanded ENERGISED     pin: 26: op -- pn | hi   LED1: ON
+PHASE 2 — holder SIGKILLed (dead)      pin: 26: op -- pn | hi   LED1: STAYED ON
+PHASE 3 — claimed input, NO pull       pin: 26: ip    pn | lo   LED1: WENT OUT, stayed out
+PHASE 4 — claim freed                  pin: 26: ip    pn | lo   LED1: still out
+```
+
+**A neutral no-pull input claim cleared the driving pad and de-energised the
+coil on this platform and wiring.** That is the supervisor mechanism
+demonstrated end to end with nothing derived from the zone's asserted polarity
+— and it is the distinction between application-process loss, where the kernel
+and a supervisor remain available, and a kernel failure, where nothing does.
+Whether neutral reclamation clears the pad on another platform is a
+qualification question, not an assumption.
 
 ### 3. Loss of the Pi's power (board independently powered)
 


### PR DESCRIPTION
## What does this PR do?

The controller-loss evidence record presented the input-reclaim experiment as the recovery mechanism, but that run claimed the freed line with `SET_PULL_DOWN` — an explicitly chosen bias that on this high-trigger wiring happens to oppose the trigger level. A supervising process that must not derive a state from unproven polarity cannot rest on a demonstration that chose one, so the record now distinguishes that run from a neutral variant and adds the neutral demonstration itself.

The neutral run claimed the line with `SET_PULL_NONE` and was paced by the observer: each phase halted on an Enter press until the channel LED had been judged, because a self-pacing script moves faster than a person can attribute an LED change to a phase. Commanded energised: on. SIGKILLed: stayed on. Claimed as input with no pull: went out and stayed out. Freed: still out. A neutral claim — deriving nothing, choosing no pull — cleared the driving pad and de-energised the coil on this platform and wiring. Three same-day fast runs with identical pad traces but unattributable LED timing, and one run against an unpowered relay board, are recorded as discarded alongside the existing discarded `pkill` attempt.

The section carries the full reproduction chain: the holder and pacing scripts verbatim as run, the invocation, and the captured output with the `pinctrl` reading at each phase. The prose states the experiment's scope precisely — the holder commands the coil through `RelayAction.acquire_at`, the GPIO acquisition primitive invoked beneath `CommissionedActuator.acquire_commanding`, so this isolates process-loss behaviour after acquisition and tests neither binding verification nor commissioned outcome resolution. Whether neutral reclamation clears the pad on another platform remains a qualification question, not an assumption.

## Type of change

- [x] `docs` — documentation only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Related issue

Refs #397

## Testing notes

The observation itself is human-judged at the channel LED on the bench Pi 4, with pad state captured by `pinctrl` at every phase; the embedded scripts and invocation reproduce it. Full suite: 5046 passed, 28 skipped; the evidence disclosure gate passes with this document's audit classification unchanged.