### PR TITLE
feat(safety): activate release-shipped profiles from commissioned zones

### DIFF
--- a/ori/safety/__init__.py
+++ b/ori/safety/__init__.py
@@ -1,0 +1,9 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""The release-owned safety registry (safety-profile/v1, #324).
+
+Tier D conditions come from the release-shipped profile set, activate from
+commissioned zones, and owe nothing to installed skills. This package holds
+that machinery; the profile grammar itself lives with the commissioning
+modules that already consume it.
+"""

--- a/ori/safety/activation.py
+++ b/ori/safety/activation.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Which release-shipped profiles protect which commissioned zones.
+
+Activation is a pure decision over an accepted binding's zones and the loaded
+profile set: every eligible zone-profile pair activates, is pending that
+profile's ratification, or is refused — the consumer does not choose, and no
+skill, configuration or policy is an input. Checks that repeat the binding
+verifier's are recomputed here on purpose: a check that holds only because an
+earlier check held is not a boundary.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable
+
+from ori.security.commissioning.profiles import Profile, ProfileSet
+
+POSITIVE_IS_LOAD_DRAW = "positive_is_load_draw"
+UNDEMONSTRATED = "undemonstrated"
+
+START = "start"
+START_DEGRADED = "start_degraded"
+REFUSE = "refuse"
+
+
+@dataclass(frozen=True)
+class ZoneFacts:
+    """The commissioned facts activation consults, and nothing else."""
+
+    zone_id: str
+    sensor_id: str
+    quantity: str
+    unit: str
+    direction: str
+    range_min: float
+    range_max: float
+    rated_capacity_parameter: str
+    rated_capacity_value: float
+    proof_method: str
+
+    @classmethod
+    def from_accepted_zone(cls, zone: Any) -> "ZoneFacts":
+        return cls(
+            zone_id=zone.zone_id,
+            sensor_id=zone.sensor_id,
+            quantity=zone.quantity,
+            unit=zone.unit,
+            direction=zone.direction,
+            range_min=zone.range_min,
+            range_max=zone.range_max,
+            rated_capacity_parameter=zone.rated_capacity_parameter,
+            rated_capacity_value=zone.rated_capacity_value,
+            proof_method=zone.proof_method,
+        )
+
+
+@dataclass(frozen=True)
+class ActivatedProfile:
+    zone_id: str
+    sensor_id: str
+    profile_id: str
+    trip_point: float
+    outcome: str
+
+
+@dataclass(frozen=True)
+class ActivationRefusal:
+    zone_id: str
+    profile_id: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class PendingProfile:
+    zone_id: str
+    profile_id: str
+
+
+@dataclass(frozen=True)
+class ActivationResult:
+    activated: tuple[ActivatedProfile, ...]
+    refused: tuple[ActivationRefusal, ...]
+    pending: tuple[PendingProfile, ...]
+    uncovered_zones: tuple[str, ...]
+
+    def startup_verdict(self, *, hardened: bool) -> str:
+        """Whether the consumer may start, per safety-profile/v1.
+
+        A refused eligible zone refuses hardened startup outright; in
+        development the consumer starts degraded with those zones' profiles
+        inactive. Pending ratification and uncovered zones never block: the
+        site has done nothing wrong.
+        """
+        if not self.refused:
+            return START
+        return REFUSE if hardened else START_DEGRADED
+
+
+def trip_point(profile: Profile, zone: ZoneFacts) -> float:
+    """The value the condition compares against, on this zone."""
+    if profile.kind == "upper_capacity_multiplier":
+        assert profile.multiplier is not None
+        return profile.multiplier * zone.rated_capacity_value
+    assert profile.threshold is not None
+    return profile.threshold
+
+
+def activate(profile_set: ProfileSet, zones: Iterable[ZoneFacts]) -> ActivationResult:
+    """Run the contract's ordered activation checks for every eligible pair."""
+    activated: list[ActivatedProfile] = []
+    refused: list[ActivationRefusal] = []
+    pending: list[PendingProfile] = []
+    uncovered: list[str] = []
+
+    for zone in zones:
+        eligible = [p for p in profile_set.profiles if p.quantity == zone.quantity]
+        if not eligible:
+            uncovered.append(zone.zone_id)
+            continue
+        for profile in eligible:
+            verdict = _check_pair(profile, zone)
+            if verdict is None:
+                activated.append(
+                    ActivatedProfile(
+                        zone_id=zone.zone_id,
+                        sensor_id=zone.sensor_id,
+                        profile_id=profile.id,
+                        trip_point=trip_point(profile, zone),
+                        outcome=profile.outcome,
+                    )
+                )
+            elif verdict == "pending_ratification":
+                pending.append(
+                    PendingProfile(zone_id=zone.zone_id, profile_id=profile.id)
+                )
+            else:
+                refused.append(
+                    ActivationRefusal(
+                        zone_id=zone.zone_id, profile_id=profile.id, reason=verdict
+                    )
+                )
+
+    return ActivationResult(
+        activated=tuple(activated),
+        refused=tuple(refused),
+        pending=tuple(pending),
+        uncovered_zones=tuple(uncovered),
+    )
+
+
+def _check_pair(profile: Profile, zone: ZoneFacts) -> str | None:
+    """The ordered checks for one eligible pair; None means it activates."""
+    if profile.status != "ratified":
+        return "pending_ratification"
+    if zone.unit != profile.unit:
+        return "unit_mismatch"
+    if zone.direction != POSITIVE_IS_LOAD_DRAW:
+        return "direction_unsupported"
+    if (
+        profile.kind == "upper_capacity_multiplier"
+        and zone.rated_capacity_parameter != profile.capacity_parameter
+    ):
+        return "parameter_mismatch"
+    point = trip_point(profile, zone)
+    if not zone.range_min <= point <= zone.range_max:
+        return "trip_point_unobservable"
+    if zone.proof_method == UNDEMONSTRATED:
+        return "undemonstrated_binding"
+    return None

--- a/tests/safety/__init__.py
+++ b/tests/safety/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/safety/test_activation.py
+++ b/tests/safety/test_activation.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Activation held to the vendored safety-profile corpus, case by case."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ori.safety.activation import (
+    ActivationResult,
+    ZoneFacts,
+    activate,
+)
+from ori.security.commissioning.profiles import (
+    load_profile_set,
+    load_shipped_profile_set,
+)
+
+CORPUS = json.loads(
+    (
+        Path(__file__).parent.parent / "vectors/safety_profile/activation.json"
+    ).read_text()
+)
+FIXTURE_SET = load_profile_set(CORPUS["fixtures"])
+HARDENED = {"staging": True, "production": True, "development": False}
+
+
+def _zone(raw: dict) -> ZoneFacts:
+    sensor = raw["sensor"]
+    return ZoneFacts(
+        zone_id=raw["zone_id"],
+        sensor_id=sensor["sensor_id"],
+        quantity=sensor["quantity"],
+        unit=sensor["unit"],
+        direction=sensor["direction"],
+        range_min=sensor["range_min"],
+        range_max=sensor["range_max"],
+        rated_capacity_parameter=raw["rated_capacity"]["parameter"],
+        rated_capacity_value=raw["rated_capacity"]["value"],
+        proof_method=raw["proof_method"],
+    )
+
+
+def _run(case: dict) -> ActivationResult:
+    profile_set = (
+        FIXTURE_SET if case["profile_set"] == "fixtures" else load_shipped_profile_set()
+    )
+    return activate(profile_set, [_zone(z) for z in case["zones"]])
+
+
+@pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["name"])
+def test_activation_case(case: dict) -> None:
+    result = _run(case)
+    expect = case["expect"]
+    profile_set = (
+        FIXTURE_SET if case["profile_set"] == "fixtures" else load_shipped_profile_set()
+    )
+    sensor_by_zone = {z["zone_id"]: z["sensor"]["sensor_id"] for z in case["zones"]}
+    outcome_by_profile = {p.id: p.outcome for p in profile_set.profiles}
+
+    # The complete activated record: this tuple is what will eventually
+    # authorise a physical outcome, so every field is held to its source.
+    assert {
+        (a.zone_id, a.profile_id, a.trip_point, a.sensor_id, a.outcome)
+        for a in result.activated
+    } == {
+        (
+            e["zone_id"],
+            e["profile"],
+            e["trip_point"],
+            sensor_by_zone[e["zone_id"]],
+            outcome_by_profile[e["profile"]],
+        )
+        for e in expect["activated"]
+    }
+    assert {(r.zone_id, r.profile_id, r.reason) for r in result.refused} == {
+        (e["zone_id"], e["profile"], e["reason"]) for e in expect["refused"]
+    }
+    assert {(p.zone_id, p.profile_id) for p in result.pending} == {
+        (e["zone_id"], e["profile"]) for e in expect["pending_ratification"]
+    }
+    assert sorted(result.uncovered_zones) == sorted(expect["uncovered_zones"])
+    assert (
+        result.startup_verdict(hardened=HARDENED[case["posture"]]) == expect["startup"]
+    )
+
+
+def test_skills_are_not_an_input() -> None:
+    """activate() has no parameter through which a skill could reach it; the
+    corpus cases that vary installed_skills therefore run identically."""
+    varied = [c for c in CORPUS["cases"] if c["installed_skills"]]
+    assert varied, "the corpus carries a case with a skill installed"
+    for case in varied:
+        twin = dict(case, installed_skills=[])
+        assert _run(case) == _run(twin)
+
+
+def test_shipped_set_activates_nothing_today() -> None:
+    """Every shipped profile is a candidate; a fully commissioned zone gets
+    pending_ratification, never activation, until ratification flips a status."""
+    shipped = load_shipped_profile_set()
+    assert all(p.status == "candidate" for p in shipped.profiles)
+
+
+def test_pending_ratification_precedes_every_site_fact() -> None:
+    """The contract decides pending_ratification before examining any site
+    fact. A candidate profile over a zone that would fail every later check
+    yields only pending — a refusal here would tell the site it did
+    something wrong, and it did not."""
+    candidate = load_profile_set(
+        [
+            {
+                "v": 1,
+                "id": "fixture.candidate.v1",
+                "status": "candidate",
+                "observes": {"quantity": "current", "unit": "ampere"},
+                "condition": {
+                    "kind": "upper_capacity_multiplier",
+                    "capacity_parameter": "rated_capacity_amps",
+                    "multiplier": 2.0,
+                },
+                "outcome": "open_protected_circuit",
+            }
+        ]
+    )
+    hostile_zone = ZoneFacts(
+        zone_id="hostile",
+        sensor_id="load-current-hostile",
+        quantity="current",
+        unit="volt",
+        direction="positive_is_generation",
+        range_min=0.0,
+        range_max=1.0,
+        rated_capacity_parameter="some_other_parameter",
+        rated_capacity_value=500.0,
+        proof_method="undemonstrated",
+    )
+    result = activate(candidate, [hostile_zone])
+    assert [(p.zone_id, p.profile_id) for p in result.pending] == [
+        ("hostile", "fixture.candidate.v1")
+    ]
+    assert result.refused == ()
+    assert result.activated == ()
+    assert result.startup_verdict(hardened=True) == "start"
+
+
+def test_zone_facts_from_accepted_zone() -> None:
+    """The production join, exercised with a real AcceptedZone."""
+    from ori.security.commissioning.binding import AcceptedZone
+
+    zone = AcceptedZone(
+        zone_id="main-distribution",
+        sensor_id="load-current-main",
+        quantity="current",
+        unit="ampere",
+        direction="positive_is_load_draw",
+        range_min=0.0,
+        range_max=30.0,
+        noise_floor=0.05,
+        calibration_ref="cal-2026-08",
+        rated_capacity_parameter="rated_capacity_amps",
+        rated_capacity_value=10.0,
+        kind="local_gpio",
+        identity={"chip": "gpiochip0", "line": 26, "active_high": True},
+        mapping={
+            "open_protected_circuit": "energised",
+            "close_protected_circuit": "de_energised",
+            "de_energised_terminal_state": "open",
+        },
+        proof_method="actuate_and_observe",
+        proof_performed_at_ms=1756684800000,
+        control_proof_method="commanded_and_observed",
+        control_proof_performed_at_ms=1756684900000,
+    )
+    facts = ZoneFacts.from_accepted_zone(zone)
+    assert facts == ZoneFacts(
+        zone_id="main-distribution",
+        sensor_id="load-current-main",
+        quantity="current",
+        unit="ampere",
+        direction="positive_is_load_draw",
+        range_min=0.0,
+        range_max=30.0,
+        rated_capacity_parameter="rated_capacity_amps",
+        rated_capacity_value=10.0,
+        proof_method="actuate_and_observe",
+    )


### PR DESCRIPTION
## What does this PR do?

Stage 1 of the release-owned safety registry (#324): the safety-profile contract's activation half, as a pure decision the runtime will call at startup. Which release-shipped Tier D profiles protect which commissioned zones is decided by the contract's ordered checks alone — pending ratification before any site fact is examined, then unit, direction, the capacity parameter for multiplier kinds only, trip-point observability inclusive at full scale, and demonstrated proof — and every eligible pair activates, is pending, or is refused: the consumer does not choose, and there is no enabled-profile list, per-site opt-out, or ordering preference to carry. Checks the binding verifier already makes are recomputed here on purpose, because a check that holds only because an earlier check held is not a boundary.

Skills are structurally not an input: the activation function has no parameter through which a skill, its manifest, or its configuration could reach the decision, and the corpus cases that vary installed skills are asserted to run identically. The startup verdict follows the contract's posture rules — any refused eligible zone refuses hardened startup outright and degrades a development start, while pending ratification and uncovered zones never block, because the site has done nothing wrong. Every shipped profile is a candidate today, so the shipped set activates nothing anywhere until ratification flips a status; a test pins that fact rather than assuming it.

All sixteen vendored activation vectors drive the tests case by case, asserting the complete activated record — zone, profile, trip point, sensor id, and physical outcome — since that tuple is what will eventually authorise actuation. Targeted tests isolate the ordered precedence with a candidate profile over a zone that fails every later check, and exercise the production join from a contract-valid AcceptedZone. Eight boundary mutations each fail the named test for the property they break, including moving the status check below the site facts, blanking the outcome, and swapping the sensor id.

Proof level: host-tested pure activation logic. Nothing here yet activates in the running runtime, enforces hardened startup, evaluates readings, or commands hardware; evaluation, trip state, wiring, and the migration of the five packaged Tier D triggers follow in later stages, and this PR does not close #324.

## Type of change

- [x] `feat` — new feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #324

## Testing notes

Twenty focused tests, all sixteen vendored activation vectors parameterised by name; full suite 5066 passed, 28 skipped. The vendored safety-profile corpus is unchanged and matches its pinned specs revision.