### PR TITLE
feat(safety): evaluate a reading against an active profile

### DIFF
--- a/ori/safety/evaluation.py
+++ b/ori/safety/evaluation.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""One reading against one active profile: trip, no_trip, or rejected_input.
+
+The comparison is decided first: a saturating sensor reporting beyond full
+scale on the hazard side still reports more than the trip point, because the
+trip point is bounded to lie within range at activation. Only a reading that
+does not satisfy the condition is then tested against the declared range, and
+a value outside it on the non-hazard side is a sensor reporting something it
+cannot have measured. A rejected reading never trips and never silently
+vanishes; the alerting that obligation implies belongs to the runtime wiring,
+not to this decision.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+TRIP = "trip"
+NO_TRIP = "no_trip"
+REJECTED_INPUT = "rejected_input"
+
+# The contract's closed rejection vocabulary, in its decided order. A boolean
+# is tested before a number because in some languages it is one; zero_quality
+# covers a quality that is absent, not a number, or not greater than zero.
+REASON_ORDER = (
+    "boolean",
+    "non_numeric",
+    "non_finite",
+    "unit_mismatch",
+    "zero_quality",
+    "out_of_range",
+)
+
+
+@dataclass(frozen=True)
+class EvaluationVerdict:
+    verdict: str
+    reason: str | None = None
+
+
+def evaluate_reading(
+    value: Any,
+    unit: Any,
+    quality: Any,
+    *,
+    expected_unit: str,
+    trip_point: float,
+    range_min: float,
+    range_max: float,
+) -> EvaluationVerdict:
+    """The contract's evaluation verdict for one reading on one active zone."""
+    if isinstance(value, bool):
+        return EvaluationVerdict(REJECTED_INPUT, "boolean")
+    if not isinstance(value, (int, float)):
+        return EvaluationVerdict(REJECTED_INPUT, "non_numeric")
+    # Every int is finite, at any magnitude; math.isfinite would raise
+    # OverflowError converting one beyond float range, and a hostile reading
+    # must produce a verdict, never an exception. Comparisons below stay
+    # exact: Python compares arbitrary-precision ints against floats without
+    # converting through float.
+    if isinstance(value, float) and not math.isfinite(value):
+        return EvaluationVerdict(REJECTED_INPUT, "non_finite")
+    if unit != expected_unit:
+        return EvaluationVerdict(REJECTED_INPUT, "unit_mismatch")
+    if (
+        isinstance(quality, bool)
+        or not isinstance(quality, (int, float))
+        or not quality > 0
+    ):
+        return EvaluationVerdict(REJECTED_INPUT, "zero_quality")
+    if value > trip_point:
+        return EvaluationVerdict(TRIP)
+    if range_min <= value <= range_max:
+        return EvaluationVerdict(NO_TRIP)
+    return EvaluationVerdict(REJECTED_INPUT, "out_of_range")

--- a/tests/safety/test_evaluation.py
+++ b/tests/safety/test_evaluation.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Evaluation held to the vendored safety-profile corpus, case by case."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ori.safety.evaluation import REASON_ORDER, evaluate_reading
+
+CORPUS = json.loads(
+    (
+        Path(__file__).parent.parent / "vectors/safety_profile/evaluation.json"
+    ).read_text()
+)
+NON_FINITE = {"nan": math.nan, "+inf": math.inf, "-inf": -math.inf}
+
+
+def _decode_value(raw: Any) -> Any:
+    if isinstance(raw, dict) and set(raw) == {"non_finite"}:
+        return NON_FINITE[raw["non_finite"]]
+    return raw
+
+
+@pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["name"])
+def test_evaluation_case(case: dict) -> None:
+    reading = case["reading"]
+    verdict = evaluate_reading(
+        _decode_value(reading.get("value")),
+        reading.get("unit"),
+        reading.get("quality"),
+        expected_unit=case["zone"]["sensor"]["unit"],
+        trip_point=case["trip_point"],
+        range_min=case["zone"]["sensor"]["range_min"],
+        range_max=case["zone"]["sensor"]["range_max"],
+    )
+    assert verdict.verdict == case["expect"]["verdict"]
+    assert verdict.reason == case["expect"].get("reason")
+
+
+def test_reason_order_matches_the_corpus() -> None:
+    assert list(REASON_ORDER) == CORPUS["rejection_reason_order"]
+
+
+def test_every_verdict_and_reason_is_exercised() -> None:
+    """The corpus must stop at every verdict and every rejection reason, so a
+    silently narrowed vendored corpus cannot leave a reason untested."""
+    verdicts = {c["expect"]["verdict"] for c in CORPUS["cases"]}
+    reasons = {
+        c["expect"]["reason"] for c in CORPUS["cases"] if "reason" in c["expect"]
+    }
+    assert verdicts == {"trip", "no_trip", "rejected_input"}
+    assert reasons == set(REASON_ORDER)
+
+
+BOUNDS = {
+    "expected_unit": "ampere",
+    "trip_point": 20.0,
+    "range_min": 0.0,
+    "range_max": 30.0,
+}
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "unit", "quality", "verdict", "reason"),
+    [
+        # A reading is data from a wire; the evaluator returns a verdict for
+        # every input and never raises. Integers beyond float range are
+        # finite numbers and get the contractually selected verdict.
+        ("huge_positive_int_trips", 10**400, "ampere", 1.0, "trip", None),
+        (
+            "huge_negative_int_out_of_range",
+            -(10**400),
+            "ampere",
+            1.0,
+            "rejected_input",
+            "out_of_range",
+        ),
+        ("huge_int_quality_evaluates", 25.0, "ampere", 10**400, "trip", None),
+        # Overlapping faults resolve to the first reason in the decided
+        # order, which the corpus does not isolate for these pairs.
+        (
+            "non_numeric_before_unit",
+            "25.0",
+            "volt",
+            1.0,
+            "rejected_input",
+            "non_numeric",
+        ),
+        (
+            "non_finite_before_unit",
+            math.nan,
+            "volt",
+            1.0,
+            "rejected_input",
+            "non_finite",
+        ),
+        (
+            "non_finite_before_quality",
+            math.inf,
+            "ampere",
+            0.0,
+            "rejected_input",
+            "non_finite",
+        ),
+        (
+            "zero_quality_before_out_of_range",
+            -5.0,
+            "ampere",
+            0.0,
+            "rejected_input",
+            "zero_quality",
+        ),
+        (
+            "nan_quality_is_zero_quality",
+            25.0,
+            "ampere",
+            math.nan,
+            "rejected_input",
+            "zero_quality",
+        ),
+    ],
+    ids=lambda v: (
+        v if isinstance(v, str) and not v.replace(".", "").isdigit() else None
+    ),
+)
+def test_hostile_and_overlapping_readings(
+    name: str, value: Any, unit: Any, quality: Any, verdict: str, reason: Any
+) -> None:
+    got = evaluate_reading(value, unit, quality, **BOUNDS)
+    assert (got.verdict, got.reason) == (verdict, reason)


### PR DESCRIPTION
## What does this PR do?

Stage 2 of the release-owned safety registry (#324), stacked on the activation stage: the safety-profile contract's evaluation half as a pure, total decision. One reading against one active zone yields trip, no_trip, or rejected_input with a reason from the closed vocabulary in its decided order. The comparison is decided first, so a saturating sensor reporting beyond full scale on the hazard side still trips — the trip point is bounded to lie within range at activation — and only a reading that does not satisfy the condition is tested against the declared range, where a value outside it on the non-hazard side is a sensor reporting something it cannot have measured. A boolean is refused before a number because in some languages it is one, and a quality that is absent, not a number, or not greater than zero refuses as zero_quality.

The evaluator is total over hostile input: an integer beyond float range is a finite number, not an exception — the isfinite test applies to floats alone and comparisons stay exact through Python's arbitrary-precision ordering — because a reading is data from a wire and the future Tier D event path must get a verdict, never a crash. Overlapping faults resolve to the first reason in the decided order, tested for the pairs the corpus does not isolate: non-numeric and non-finite before unit, non-finite before quality, zero quality before out of range.

All twenty-five vendored evaluation vectors drive the tests case by case, the reason order is pinned to the corpus's own declaration, and a coverage test requires the corpus to stop at every verdict and every rejection reason. Eight boundary mutations each fail a named case, including removing the integer guard, reordering non-numeric below unit, and deciding the range before quality.

Proof level: host-tested pure evaluation logic. Rejected-input Tier A alerting, bounded suppression, degraded health, and the measurement-loss watch are deliberately retained for the wiring stage, which owns every side effect this decision obliges. This PR merges into the Stage 1 branch and does not close #324.

## Type of change

- [x] `feat` — new feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #324

## Testing notes

Thirty-five focused tests; full suite at this commit 5101 passed, 28 skipped. Vendored vectors unchanged.