### PR TITLE
feat(safety): the trip-state machine for one active zone

### DIFF
--- a/ori/safety/trip_state.py
+++ b/ori/safety/trip_state.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""One zone's trip state: inactive, armed, tripped — and what may move it.
+
+The machine is pure: durable state arrives as an input at every start, and
+the outcomes it names (`close_protected_circuit` on a successful arm or
+reset, `open_protected_circuit` on a trip) are commands for the caller to
+execute through the zone's commissioned mapping — executed before the record
+is written, because safety never waits for storage. The crash window that
+ordering opens is closed by the arming rule, not by a pre-write: a runtime
+that trips, dies before recording, and restarts into a live hazard never
+arms, because it has no credible reading until the first one arrives, and
+that one trips it.
+
+A trip latches. From tripped, no reading, restart, configuration value,
+skill, remote command, DevicePolicy, entitlement change, or binding revision
+moves the zone anywhere; the only exit is the local, manual, conditional
+reset. `armed` is not durable: a restart from armed returns to inactive, and
+the safety path is confirmed again before the circuit is closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ori.safety.evaluation import (
+    NO_TRIP,
+    REASON_ORDER,
+    REJECTED_INPUT,
+    TRIP,
+    EvaluationVerdict,
+)
+
+INACTIVE = "inactive"
+ARMED = "armed"
+TRIPPED = "tripped"
+
+
+class DurableStateError(ValueError):
+    """The durable record holds a value this machine never wrote. Corruption,
+    truncation, and a future version's vocabulary are indistinguishable here,
+    and none of them may silently erase a latch: the caller refuses startup."""
+
+
+class VerdictError(ValueError):
+    """An evaluation verdict outside the closed vocabulary, or a reason that
+    contradicts it. An invalid internal verdict must never clear the
+    condition, count as credible, or move the state."""
+
+
+OPEN_PROTECTED_CIRCUIT = "open_protected_circuit"
+CLOSE_PROTECTED_CIRCUIT = "close_protected_circuit"
+
+NO_AUTHORITY = "no_authority"
+
+
+@dataclass(frozen=True)
+class Transition:
+    state: str
+    refusal: str | None = None
+    outcome: str | None = None
+    rejected: str | None = None
+
+
+class ZoneTripState:
+    """The safety-profile trip-state machine for one active zone."""
+
+    def __init__(self) -> None:
+        self.state = INACTIVE
+        self._safety_path_confirmed = False
+        self._credible_reading_seen = False
+        self._condition_active = False
+
+    def startup(self, durable_state: str | None) -> Transition:
+        """A (re)start: durable `tripped` reloads; `armed` is contractually
+        non-durable and returns to inactive, as do `inactive` and no record
+        at all. Anything else is a record this machine never wrote and
+        refuses before any per-start fact is touched — an unknown value
+        normalised to inactive would erase a latch."""
+        if durable_state not in (None, INACTIVE, ARMED, TRIPPED):
+            raise DurableStateError(
+                f"durable trip state {durable_state!r} is outside the vocabulary"
+            )
+        self._safety_path_confirmed = False
+        self._credible_reading_seen = False
+        self._condition_active = False
+        self.state = TRIPPED if durable_state == TRIPPED else INACTIVE
+        return Transition(self.state)
+
+    def confirm_safety_path(self) -> Transition:
+        self._safety_path_confirmed = True
+        return Transition(self.state)
+
+    def observe(self, verdict: EvaluationVerdict) -> Transition:
+        """A reading's evaluation verdict, applied to the state. Only the
+        closed vocabulary is accepted: an unknown verdict, or a reason that
+        contradicts its verdict, refuses without touching any per-start fact
+        — treating it as credible would let an invalid internal value clear
+        the condition and close the protected circuit."""
+        if verdict.verdict == REJECTED_INPUT:
+            if verdict.reason not in REASON_ORDER:
+                raise VerdictError(
+                    f"rejected_input carries reason {verdict.reason!r}, "
+                    "outside the closed vocabulary"
+                )
+            return Transition(self.state, rejected=verdict.reason)
+        if verdict.verdict not in (TRIP, NO_TRIP) or verdict.reason is not None:
+            raise VerdictError(
+                f"verdict {verdict.verdict!r} with reason {verdict.reason!r} "
+                "is outside the closed vocabulary"
+            )
+        self._credible_reading_seen = True
+        self._condition_active = verdict.verdict == TRIP
+        if verdict.verdict == TRIP and self.state != TRIPPED:
+            self.state = TRIPPED
+            return Transition(self.state, outcome=OPEN_PROTECTED_CIRCUIT)
+        return Transition(self.state)
+
+    def arm(self) -> Transition:
+        """Arming closes the circuit; the refusals are ordered by contract."""
+        if self.state == TRIPPED:
+            return Transition(self.state, refusal=TRIPPED)
+        if not self._safety_path_confirmed:
+            return Transition(self.state, refusal="safety_path_unconfirmed")
+        if not self._credible_reading_seen:
+            return Transition(self.state, refusal="no_credible_reading")
+        self.state = ARMED
+        return Transition(self.state, outcome=CLOSE_PROTECTED_CIRCUIT)
+
+    def reset(self) -> Transition:
+        """The local, manual, conditional exit from tripped."""
+        if self.state != TRIPPED:
+            return Transition(self.state, refusal="not_tripped")
+        if not self._credible_reading_seen:
+            return Transition(self.state, refusal="no_credible_reading")
+        if self._condition_active:
+            return Transition(self.state, refusal="condition_active")
+        self.state = ARMED
+        return Transition(self.state, outcome=CLOSE_PROTECTED_CIRCUIT)
+
+    def external(self, source: str) -> Transition:
+        """A remote command, skill, configuration document, DevicePolicy, or
+        binding revision. Refused in every state; nothing moves."""
+        del source
+        return Transition(self.state, refusal=NO_AUTHORITY)

--- a/tests/safety/test_trip_state.py
+++ b/tests/safety/test_trip_state.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""The trip-state machine held to the vendored lifecycle corpus, event by event."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ori.safety.evaluation import EvaluationVerdict, evaluate_reading
+from ori.safety.trip_state import (
+    DurableStateError,
+    Transition,
+    VerdictError,
+    ZoneTripState,
+)
+
+CORPUS = json.loads(
+    (Path(__file__).parent.parent / "vectors/safety_profile/lifecycle.json").read_text()
+)
+NON_FINITE = {"nan": math.nan, "+inf": math.inf, "-inf": -math.inf}
+
+
+def _decode_value(raw: Any) -> Any:
+    if isinstance(raw, dict) and set(raw) == {"non_finite"}:
+        return NON_FINITE[raw["non_finite"]]
+    return raw
+
+
+def _apply(machine: ZoneTripState, case: dict, event: dict) -> Transition:
+    kind = event["event"]
+    if kind in ("startup", "restart"):
+        durable = event["durable_state"]
+        return machine.startup(None if durable == "none" else durable)
+    if kind == "safety_path_confirmed":
+        return machine.confirm_safety_path()
+    if kind == "reading":
+        sensor = case["zone"]["sensor"]
+        verdict = evaluate_reading(
+            _decode_value(event["value"]),
+            sensor["unit"],
+            event.get("quality", 1.0),
+            expected_unit=sensor["unit"],
+            trip_point=case["trip_point"],
+            range_min=sensor["range_min"],
+            range_max=sensor["range_max"],
+        )
+        return machine.observe(verdict)
+    if kind == "arm_attempt":
+        return machine.arm()
+    if kind == "reset_attempt":
+        return machine.reset()
+    if kind == "external":
+        return machine.external(event["source"])
+    raise AssertionError(f"unknown corpus event {kind}")
+
+
+@pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["name"])
+def test_lifecycle_case(case: dict) -> None:
+    machine = ZoneTripState()
+    for index, event in enumerate(case["events"]):
+        transition = _apply(machine, case, event)
+        where = f"event {index} ({event['event']})"
+        assert transition.state == event["expect_state"], where
+        assert machine.state == event["expect_state"], where
+        assert transition.refusal == event.get("expect_refusal"), where
+        assert transition.outcome == event.get("expect_outcome"), where
+        assert transition.rejected == event.get("expect_rejected"), where
+
+
+def test_refusal_vocabularies_match_the_corpus() -> None:
+    assert CORPUS["arm_refusals"] == [
+        "tripped",
+        "safety_path_unconfirmed",
+        "no_credible_reading",
+    ]
+    assert CORPUS["reset_refusals"] == [
+        "not_tripped",
+        "no_credible_reading",
+        "condition_active",
+    ]
+    assert CORPUS["external_refusal"] == "no_authority"
+
+
+def test_every_external_source_is_refused_in_every_state() -> None:
+    """One machine walked through inactive, armed, and tripped, with every
+    external source refused in each state and nothing reset in between."""
+    sources = (
+        "remote_command",
+        "skill",
+        "configuration",
+        "device_policy",
+        "binding_revision",
+    )
+    machine = ZoneTripState()
+
+    machine.startup(None)
+    assert machine.state == "inactive"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "inactive"
+
+    machine.confirm_safety_path()
+    machine.observe(
+        evaluate_reading(
+            5.0,
+            "ampere",
+            1.0,
+            expected_unit="ampere",
+            trip_point=20.0,
+            range_min=0.0,
+            range_max=30.0,
+        )
+    )
+    assert machine.arm().state == "armed"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "armed"
+
+    machine.observe(
+        evaluate_reading(
+            25.0,
+            "ampere",
+            1.0,
+            expected_unit="ampere",
+            trip_point=20.0,
+            range_min=0.0,
+            range_max=30.0,
+        )
+    )
+    assert machine.state == "tripped"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "tripped"
+
+
+def test_arm_refusal_order_tripped_before_unconfirmed_path() -> None:
+    """A tripped zone with an unconfirmed safety path refuses as tripped:
+    the contract orders the refusals, and telling an operator to confirm the
+    safety path of a zone that is latched open misstates which fact governs."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    transition = machine.arm()
+    assert transition.refusal == "tripped"
+    assert machine.state == "tripped"
+
+
+@pytest.mark.parametrize("durable", ["trippped", "future_state", "", "TRIPPED", "none"])
+def test_unknown_durable_state_refuses_startup(durable: str) -> None:
+    """A record the machine never wrote must refuse, never normalise to
+    inactive: corruption, truncation, and a future version's vocabulary are
+    indistinguishable, and each would otherwise erase a latch."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    with pytest.raises(DurableStateError):
+        machine.startup(durable)
+
+
+def test_armed_and_inactive_durable_records_return_to_inactive() -> None:
+    for durable in (None, "inactive", "armed"):
+        machine = ZoneTripState()
+        assert machine.startup(durable).state == "inactive"
+
+
+def test_unknown_verdict_cannot_authorize_reset() -> None:
+    """The demonstrated attack: an invalid internal verdict counted as a
+    credible, condition-clear reading would let reset close the protected
+    circuit. It must refuse without touching any per-start fact."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    with pytest.raises(VerdictError):
+        machine.observe(EvaluationVerdict("future_verdict"))
+    assert machine.state == "tripped"
+    transition = machine.reset()
+    assert transition.refusal == "no_credible_reading"
+    assert machine.state == "tripped"
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [
+        EvaluationVerdict("rejected_input", "future_reason"),
+        EvaluationVerdict("rejected_input"),
+        EvaluationVerdict("trip", "out_of_range"),
+        EvaluationVerdict("no_trip", "boolean"),
+    ],
+    ids=[
+        "rejected_unknown_reason",
+        "rejected_no_reason",
+        "trip_with_reason",
+        "no_trip_with_reason",
+    ],
+)
+def test_contradictory_verdict_reason_pairs_refuse(verdict: EvaluationVerdict) -> None:
+    machine = ZoneTripState()
+    machine.startup(None)
+    machine.confirm_safety_path()
+    with pytest.raises(VerdictError):
+        machine.observe(verdict)
+    assert machine.arm().refusal == "no_credible_reading"


### PR DESCRIPTION
## What does this PR do?

Stage 3 of the release-owned safety registry (#324), stacked on the evaluation stage: the safety-profile contract's trip state as a pure per-zone machine — inactive, armed, tripped — with durable state arriving as an input at every start and the outcomes it names commanded by the caller through the zone's commissioned mapping, before any record is written, because safety never waits for storage. The crash window that ordering opens is closed by the arming rule rather than a pre-write: a runtime that trips, dies before recording, and restarts into a live hazard never arms, because it has no credible reading until the first one arrives, and that one trips it.

A trip latches: from tripped, no reading, restart, or external input moves the zone, and a remote command, skill, configuration document, DevicePolicy, or binding revision is refused with no_authority in every state. Armed is not durable — a restart from armed returns to inactive with every per-start fact forgotten, so the safety path is confirmed again before the circuit is closed. Inactive means unarmed, not unprotected: a credible hazard reading trips from inactive exactly as it does from armed. Reset is the only exit from tripped, refused in the contract's order.

The machine fails closed on both of its input surfaces. A durable record outside the vocabulary — corruption, truncation, or a future version's value — refuses startup rather than normalising to inactive, because an unknown value read as inactive erases a latch; armed and inactive records return to inactive as the contract's non-durability requires. An evaluation verdict outside the closed vocabulary, or a reason contradicting its verdict, refuses without touching any per-start fact, because an invalid internal verdict counted as a credible condition-clear reading would let a reset close the protected circuit.

All eleven vendored lifecycle vectors drive the tests event by event, plus local tests walking one machine through inactive, armed, and tripped with every external source refused in each state, and for the one refusal ordering the corpus does not isolate: a tripped zone with an unconfirmed safety path refuses as tripped, because telling an operator to confirm the path of a latched zone misstates which fact governs. Eleven boundary mutations each fail a named case, including both demonstrated fail-open attacks re-enacted as mutants.

Proof level: host-tested pure lifecycle logic. Persistence, outcome-before-record ordering, failed-outcome retries, the startup coil command, local reset provenance, alerts, measurement-loss handling, health reporting, and the pre-execution authority check remain Stage 4 responsibilities. This PR merges into the Stage 2 branch and does not close #324.

## Type of change

- [x] `feat` — new feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #324

## Testing notes

Eighty focused Stage 1–3 tests; full suite 5126 passed, 28 skipped. Vendored vectors unchanged and matching their pinned specs revision.