### PR TITLE
feat(safety): land the reviewed evaluation and trip-state stages on main

### DIFF
--- a/ori/safety/evaluation.py
+++ b/ori/safety/evaluation.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""One reading against one active profile: trip, no_trip, or rejected_input.
+
+The comparison is decided first: a saturating sensor reporting beyond full
+scale on the hazard side still reports more than the trip point, because the
+trip point is bounded to lie within range at activation. Only a reading that
+does not satisfy the condition is then tested against the declared range, and
+a value outside it on the non-hazard side is a sensor reporting something it
+cannot have measured. A rejected reading never trips and never silently
+vanishes; the alerting that obligation implies belongs to the runtime wiring,
+not to this decision.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+TRIP = "trip"
+NO_TRIP = "no_trip"
+REJECTED_INPUT = "rejected_input"
+
+# The contract's closed rejection vocabulary, in its decided order. A boolean
+# is tested before a number because in some languages it is one; zero_quality
+# covers a quality that is absent, not a number, or not greater than zero.
+REASON_ORDER = (
+    "boolean",
+    "non_numeric",
+    "non_finite",
+    "unit_mismatch",
+    "zero_quality",
+    "out_of_range",
+)
+
+
+@dataclass(frozen=True)
+class EvaluationVerdict:
+    verdict: str
+    reason: str | None = None
+
+
+def evaluate_reading(
+    value: Any,
+    unit: Any,
+    quality: Any,
+    *,
+    expected_unit: str,
+    trip_point: float,
+    range_min: float,
+    range_max: float,
+) -> EvaluationVerdict:
+    """The contract's evaluation verdict for one reading on one active zone."""
+    if isinstance(value, bool):
+        return EvaluationVerdict(REJECTED_INPUT, "boolean")
+    if not isinstance(value, (int, float)):
+        return EvaluationVerdict(REJECTED_INPUT, "non_numeric")
+    # Every int is finite, at any magnitude; math.isfinite would raise
+    # OverflowError converting one beyond float range, and a hostile reading
+    # must produce a verdict, never an exception. Comparisons below stay
+    # exact: Python compares arbitrary-precision ints against floats without
+    # converting through float.
+    if isinstance(value, float) and not math.isfinite(value):
+        return EvaluationVerdict(REJECTED_INPUT, "non_finite")
+    if unit != expected_unit:
+        return EvaluationVerdict(REJECTED_INPUT, "unit_mismatch")
+    if (
+        isinstance(quality, bool)
+        or not isinstance(quality, (int, float))
+        or not quality > 0
+    ):
+        return EvaluationVerdict(REJECTED_INPUT, "zero_quality")
+    if value > trip_point:
+        return EvaluationVerdict(TRIP)
+    if range_min <= value <= range_max:
+        return EvaluationVerdict(NO_TRIP)
+    return EvaluationVerdict(REJECTED_INPUT, "out_of_range")

--- a/ori/safety/trip_state.py
+++ b/ori/safety/trip_state.py
@@ -1,0 +1,145 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""One zone's trip state: inactive, armed, tripped — and what may move it.
+
+The machine is pure: durable state arrives as an input at every start, and
+the outcomes it names (`close_protected_circuit` on a successful arm or
+reset, `open_protected_circuit` on a trip) are commands for the caller to
+execute through the zone's commissioned mapping — executed before the record
+is written, because safety never waits for storage. The crash window that
+ordering opens is closed by the arming rule, not by a pre-write: a runtime
+that trips, dies before recording, and restarts into a live hazard never
+arms, because it has no credible reading until the first one arrives, and
+that one trips it.
+
+A trip latches. From tripped, no reading, restart, configuration value,
+skill, remote command, DevicePolicy, entitlement change, or binding revision
+moves the zone anywhere; the only exit is the local, manual, conditional
+reset. `armed` is not durable: a restart from armed returns to inactive, and
+the safety path is confirmed again before the circuit is closed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ori.safety.evaluation import (
+    NO_TRIP,
+    REASON_ORDER,
+    REJECTED_INPUT,
+    TRIP,
+    EvaluationVerdict,
+)
+
+INACTIVE = "inactive"
+ARMED = "armed"
+TRIPPED = "tripped"
+
+
+class DurableStateError(ValueError):
+    """The durable record holds a value this machine never wrote. Corruption,
+    truncation, and a future version's vocabulary are indistinguishable here,
+    and none of them may silently erase a latch: the caller refuses startup."""
+
+
+class VerdictError(ValueError):
+    """An evaluation verdict outside the closed vocabulary, or a reason that
+    contradicts it. An invalid internal verdict must never clear the
+    condition, count as credible, or move the state."""
+
+
+OPEN_PROTECTED_CIRCUIT = "open_protected_circuit"
+CLOSE_PROTECTED_CIRCUIT = "close_protected_circuit"
+
+NO_AUTHORITY = "no_authority"
+
+
+@dataclass(frozen=True)
+class Transition:
+    state: str
+    refusal: str | None = None
+    outcome: str | None = None
+    rejected: str | None = None
+
+
+class ZoneTripState:
+    """The safety-profile trip-state machine for one active zone."""
+
+    def __init__(self) -> None:
+        self.state = INACTIVE
+        self._safety_path_confirmed = False
+        self._credible_reading_seen = False
+        self._condition_active = False
+
+    def startup(self, durable_state: str | None) -> Transition:
+        """A (re)start: durable `tripped` reloads; `armed` is contractually
+        non-durable and returns to inactive, as do `inactive` and no record
+        at all. Anything else is a record this machine never wrote and
+        refuses before any per-start fact is touched — an unknown value
+        normalised to inactive would erase a latch."""
+        if durable_state not in (None, INACTIVE, ARMED, TRIPPED):
+            raise DurableStateError(
+                f"durable trip state {durable_state!r} is outside the vocabulary"
+            )
+        self._safety_path_confirmed = False
+        self._credible_reading_seen = False
+        self._condition_active = False
+        self.state = TRIPPED if durable_state == TRIPPED else INACTIVE
+        return Transition(self.state)
+
+    def confirm_safety_path(self) -> Transition:
+        self._safety_path_confirmed = True
+        return Transition(self.state)
+
+    def observe(self, verdict: EvaluationVerdict) -> Transition:
+        """A reading's evaluation verdict, applied to the state. Only the
+        closed vocabulary is accepted: an unknown verdict, or a reason that
+        contradicts its verdict, refuses without touching any per-start fact
+        — treating it as credible would let an invalid internal value clear
+        the condition and close the protected circuit."""
+        if verdict.verdict == REJECTED_INPUT:
+            if verdict.reason not in REASON_ORDER:
+                raise VerdictError(
+                    f"rejected_input carries reason {verdict.reason!r}, "
+                    "outside the closed vocabulary"
+                )
+            return Transition(self.state, rejected=verdict.reason)
+        if verdict.verdict not in (TRIP, NO_TRIP) or verdict.reason is not None:
+            raise VerdictError(
+                f"verdict {verdict.verdict!r} with reason {verdict.reason!r} "
+                "is outside the closed vocabulary"
+            )
+        self._credible_reading_seen = True
+        self._condition_active = verdict.verdict == TRIP
+        if verdict.verdict == TRIP and self.state != TRIPPED:
+            self.state = TRIPPED
+            return Transition(self.state, outcome=OPEN_PROTECTED_CIRCUIT)
+        return Transition(self.state)
+
+    def arm(self) -> Transition:
+        """Arming closes the circuit; the refusals are ordered by contract."""
+        if self.state == TRIPPED:
+            return Transition(self.state, refusal=TRIPPED)
+        if not self._safety_path_confirmed:
+            return Transition(self.state, refusal="safety_path_unconfirmed")
+        if not self._credible_reading_seen:
+            return Transition(self.state, refusal="no_credible_reading")
+        self.state = ARMED
+        return Transition(self.state, outcome=CLOSE_PROTECTED_CIRCUIT)
+
+    def reset(self) -> Transition:
+        """The local, manual, conditional exit from tripped."""
+        if self.state != TRIPPED:
+            return Transition(self.state, refusal="not_tripped")
+        if not self._credible_reading_seen:
+            return Transition(self.state, refusal="no_credible_reading")
+        if self._condition_active:
+            return Transition(self.state, refusal="condition_active")
+        self.state = ARMED
+        return Transition(self.state, outcome=CLOSE_PROTECTED_CIRCUIT)
+
+    def external(self, source: str) -> Transition:
+        """A remote command, skill, configuration document, DevicePolicy, or
+        binding revision. Refused in every state; nothing moves."""
+        del source
+        return Transition(self.state, refusal=NO_AUTHORITY)

--- a/tests/safety/test_evaluation.py
+++ b/tests/safety/test_evaluation.py
@@ -1,0 +1,134 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Evaluation held to the vendored safety-profile corpus, case by case."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ori.safety.evaluation import REASON_ORDER, evaluate_reading
+
+CORPUS = json.loads(
+    (
+        Path(__file__).parent.parent / "vectors/safety_profile/evaluation.json"
+    ).read_text()
+)
+NON_FINITE = {"nan": math.nan, "+inf": math.inf, "-inf": -math.inf}
+
+
+def _decode_value(raw: Any) -> Any:
+    if isinstance(raw, dict) and set(raw) == {"non_finite"}:
+        return NON_FINITE[raw["non_finite"]]
+    return raw
+
+
+@pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["name"])
+def test_evaluation_case(case: dict) -> None:
+    reading = case["reading"]
+    verdict = evaluate_reading(
+        _decode_value(reading.get("value")),
+        reading.get("unit"),
+        reading.get("quality"),
+        expected_unit=case["zone"]["sensor"]["unit"],
+        trip_point=case["trip_point"],
+        range_min=case["zone"]["sensor"]["range_min"],
+        range_max=case["zone"]["sensor"]["range_max"],
+    )
+    assert verdict.verdict == case["expect"]["verdict"]
+    assert verdict.reason == case["expect"].get("reason")
+
+
+def test_reason_order_matches_the_corpus() -> None:
+    assert list(REASON_ORDER) == CORPUS["rejection_reason_order"]
+
+
+def test_every_verdict_and_reason_is_exercised() -> None:
+    """The corpus must stop at every verdict and every rejection reason, so a
+    silently narrowed vendored corpus cannot leave a reason untested."""
+    verdicts = {c["expect"]["verdict"] for c in CORPUS["cases"]}
+    reasons = {
+        c["expect"]["reason"] for c in CORPUS["cases"] if "reason" in c["expect"]
+    }
+    assert verdicts == {"trip", "no_trip", "rejected_input"}
+    assert reasons == set(REASON_ORDER)
+
+
+BOUNDS = {
+    "expected_unit": "ampere",
+    "trip_point": 20.0,
+    "range_min": 0.0,
+    "range_max": 30.0,
+}
+
+
+@pytest.mark.parametrize(
+    ("name", "value", "unit", "quality", "verdict", "reason"),
+    [
+        # A reading is data from a wire; the evaluator returns a verdict for
+        # every input and never raises. Integers beyond float range are
+        # finite numbers and get the contractually selected verdict.
+        ("huge_positive_int_trips", 10**400, "ampere", 1.0, "trip", None),
+        (
+            "huge_negative_int_out_of_range",
+            -(10**400),
+            "ampere",
+            1.0,
+            "rejected_input",
+            "out_of_range",
+        ),
+        ("huge_int_quality_evaluates", 25.0, "ampere", 10**400, "trip", None),
+        # Overlapping faults resolve to the first reason in the decided
+        # order, which the corpus does not isolate for these pairs.
+        (
+            "non_numeric_before_unit",
+            "25.0",
+            "volt",
+            1.0,
+            "rejected_input",
+            "non_numeric",
+        ),
+        (
+            "non_finite_before_unit",
+            math.nan,
+            "volt",
+            1.0,
+            "rejected_input",
+            "non_finite",
+        ),
+        (
+            "non_finite_before_quality",
+            math.inf,
+            "ampere",
+            0.0,
+            "rejected_input",
+            "non_finite",
+        ),
+        (
+            "zero_quality_before_out_of_range",
+            -5.0,
+            "ampere",
+            0.0,
+            "rejected_input",
+            "zero_quality",
+        ),
+        (
+            "nan_quality_is_zero_quality",
+            25.0,
+            "ampere",
+            math.nan,
+            "rejected_input",
+            "zero_quality",
+        ),
+    ],
+    ids=lambda v: (
+        v if isinstance(v, str) and not v.replace(".", "").isdigit() else None
+    ),
+)
+def test_hostile_and_overlapping_readings(
+    name: str, value: Any, unit: Any, quality: Any, verdict: str, reason: Any
+) -> None:
+    got = evaluate_reading(value, unit, quality, **BOUNDS)
+    assert (got.verdict, got.reason) == (verdict, reason)

--- a/tests/safety/test_trip_state.py
+++ b/tests/safety/test_trip_state.py
@@ -1,0 +1,202 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""The trip-state machine held to the vendored lifecycle corpus, event by event."""
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ori.safety.evaluation import EvaluationVerdict, evaluate_reading
+from ori.safety.trip_state import (
+    DurableStateError,
+    Transition,
+    VerdictError,
+    ZoneTripState,
+)
+
+CORPUS = json.loads(
+    (Path(__file__).parent.parent / "vectors/safety_profile/lifecycle.json").read_text()
+)
+NON_FINITE = {"nan": math.nan, "+inf": math.inf, "-inf": -math.inf}
+
+
+def _decode_value(raw: Any) -> Any:
+    if isinstance(raw, dict) and set(raw) == {"non_finite"}:
+        return NON_FINITE[raw["non_finite"]]
+    return raw
+
+
+def _apply(machine: ZoneTripState, case: dict, event: dict) -> Transition:
+    kind = event["event"]
+    if kind in ("startup", "restart"):
+        durable = event["durable_state"]
+        return machine.startup(None if durable == "none" else durable)
+    if kind == "safety_path_confirmed":
+        return machine.confirm_safety_path()
+    if kind == "reading":
+        sensor = case["zone"]["sensor"]
+        verdict = evaluate_reading(
+            _decode_value(event["value"]),
+            sensor["unit"],
+            event.get("quality", 1.0),
+            expected_unit=sensor["unit"],
+            trip_point=case["trip_point"],
+            range_min=sensor["range_min"],
+            range_max=sensor["range_max"],
+        )
+        return machine.observe(verdict)
+    if kind == "arm_attempt":
+        return machine.arm()
+    if kind == "reset_attempt":
+        return machine.reset()
+    if kind == "external":
+        return machine.external(event["source"])
+    raise AssertionError(f"unknown corpus event {kind}")
+
+
+@pytest.mark.parametrize("case", CORPUS["cases"], ids=lambda c: c["name"])
+def test_lifecycle_case(case: dict) -> None:
+    machine = ZoneTripState()
+    for index, event in enumerate(case["events"]):
+        transition = _apply(machine, case, event)
+        where = f"event {index} ({event['event']})"
+        assert transition.state == event["expect_state"], where
+        assert machine.state == event["expect_state"], where
+        assert transition.refusal == event.get("expect_refusal"), where
+        assert transition.outcome == event.get("expect_outcome"), where
+        assert transition.rejected == event.get("expect_rejected"), where
+
+
+def test_refusal_vocabularies_match_the_corpus() -> None:
+    assert CORPUS["arm_refusals"] == [
+        "tripped",
+        "safety_path_unconfirmed",
+        "no_credible_reading",
+    ]
+    assert CORPUS["reset_refusals"] == [
+        "not_tripped",
+        "no_credible_reading",
+        "condition_active",
+    ]
+    assert CORPUS["external_refusal"] == "no_authority"
+
+
+def test_every_external_source_is_refused_in_every_state() -> None:
+    """One machine walked through inactive, armed, and tripped, with every
+    external source refused in each state and nothing reset in between."""
+    sources = (
+        "remote_command",
+        "skill",
+        "configuration",
+        "device_policy",
+        "binding_revision",
+    )
+    machine = ZoneTripState()
+
+    machine.startup(None)
+    assert machine.state == "inactive"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "inactive"
+
+    machine.confirm_safety_path()
+    machine.observe(
+        evaluate_reading(
+            5.0,
+            "ampere",
+            1.0,
+            expected_unit="ampere",
+            trip_point=20.0,
+            range_min=0.0,
+            range_max=30.0,
+        )
+    )
+    assert machine.arm().state == "armed"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "armed"
+
+    machine.observe(
+        evaluate_reading(
+            25.0,
+            "ampere",
+            1.0,
+            expected_unit="ampere",
+            trip_point=20.0,
+            range_min=0.0,
+            range_max=30.0,
+        )
+    )
+    assert machine.state == "tripped"
+    for source in sources:
+        assert machine.external(source).refusal == "no_authority"
+        assert machine.state == "tripped"
+
+
+def test_arm_refusal_order_tripped_before_unconfirmed_path() -> None:
+    """A tripped zone with an unconfirmed safety path refuses as tripped:
+    the contract orders the refusals, and telling an operator to confirm the
+    safety path of a zone that is latched open misstates which fact governs."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    transition = machine.arm()
+    assert transition.refusal == "tripped"
+    assert machine.state == "tripped"
+
+
+@pytest.mark.parametrize("durable", ["trippped", "future_state", "", "TRIPPED", "none"])
+def test_unknown_durable_state_refuses_startup(durable: str) -> None:
+    """A record the machine never wrote must refuse, never normalise to
+    inactive: corruption, truncation, and a future version's vocabulary are
+    indistinguishable, and each would otherwise erase a latch."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    with pytest.raises(DurableStateError):
+        machine.startup(durable)
+
+
+def test_armed_and_inactive_durable_records_return_to_inactive() -> None:
+    for durable in (None, "inactive", "armed"):
+        machine = ZoneTripState()
+        assert machine.startup(durable).state == "inactive"
+
+
+def test_unknown_verdict_cannot_authorize_reset() -> None:
+    """The demonstrated attack: an invalid internal verdict counted as a
+    credible, condition-clear reading would let reset close the protected
+    circuit. It must refuse without touching any per-start fact."""
+    machine = ZoneTripState()
+    machine.startup("tripped")
+    with pytest.raises(VerdictError):
+        machine.observe(EvaluationVerdict("future_verdict"))
+    assert machine.state == "tripped"
+    transition = machine.reset()
+    assert transition.refusal == "no_credible_reading"
+    assert machine.state == "tripped"
+
+
+@pytest.mark.parametrize(
+    "verdict",
+    [
+        EvaluationVerdict("rejected_input", "future_reason"),
+        EvaluationVerdict("rejected_input"),
+        EvaluationVerdict("trip", "out_of_range"),
+        EvaluationVerdict("no_trip", "boolean"),
+    ],
+    ids=[
+        "rejected_unknown_reason",
+        "rejected_no_reason",
+        "trip_with_reason",
+        "no_trip_with_reason",
+    ],
+)
+def test_contradictory_verdict_reason_pairs_refuse(verdict: EvaluationVerdict) -> None:
+    machine = ZoneTripState()
+    machine.startup(None)
+    machine.confirm_safety_path()
+    with pytest.raises(VerdictError):
+        machine.observe(verdict)
+    assert machine.arm().refusal == "no_credible_reading"


### PR DESCRIPTION
## What does this PR do?

Lands Stage 2 and Stage 3 of the safety registry on main. Both were reviewed and merged as stacked PRs — #487 and #488 — but a stacked PR merges into its base branch, so their squashes landed on the intermediate stage branches rather than main, leaving main with activation alone. This branch is main plus those two squash commits, cherry-picked with their origins recorded, and its tree is byte-identical to the fully stacked Stage 3 branch: no content beyond what was already reviewed is introduced here.

## Type of change

- [x] `feat` — new feature

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [ ] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [ ] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Refs #324, #487, #488

## Testing notes

Tree verified byte-identical to the reviewed Stage 3 stack head; 80 focused safety tests and the full suite (5126 passed, 28 skipped) pass on this branch.