### PR TITLE
ci(hooks): check the pull request title as the commit message it becomes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,32 @@
+# The pull request title is a commit message. GitHub's squash merge uses it
+# whenever a pull request carries more than one commit, and the first commit's
+# message only when it carries exactly one — so a prose title on a multi-commit
+# pull request lands a non-conventional commit on main, having passed every
+# commit-level gate on the way. The commit-msg hook cannot see it.
+#
+# Kept out of ci.yml so that `edited` does not re-run the test matrix every
+# time someone adjusts a title or a description.
+name: PR title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  conventional:
+    name: Conventional commit format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Check the pull request title
+        # The title is read from the environment rather than interpolated into
+        # the script: it is attacker-influenced text, and `${{ }}` would splice
+        # it into the shell before bash ever sees a quote.
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: python3 scripts/check_conventional_subject.py --env PR_TITLE

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,26 +78,7 @@ repos:
         name: Conventional commit format
         language: python
         stages: [commit-msg]
-        entry: python
-        args:
-          - -c
-          - |-
-            import re
-            import sys
-
-            msg = open(sys.argv[1]).read().split("\n")[0]
-            pattern = (
-                r"^(feat|fix|docs|test|skill|refactor|perf|build|ci|chore|revert|security)"
-                r"(\([a-z0-9/-]+\))?: .{1,100}$"
-            )
-            if not re.match(pattern, msg):
-                print("❌ Commit message does not follow Conventional Commits format.")
-                print(f"   Got: {msg!r}")
-                print("   Expected: type(scope): description")
-                print(
-                    "   Valid types: feat fix docs test skill refactor perf build ci chore revert security"
-                )
-                sys.exit(1)
+        entry: python3 scripts/check_conventional_subject.py --commit-msg-file
         pass_filenames: true
 
   # ── Basic file hygiene ───────────────────────────────────────────────────────

--- a/scripts/check_conventional_subject.py
+++ b/scripts/check_conventional_subject.py
@@ -1,0 +1,78 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Hold a commit subject, or a pull request title, to Conventional Commits.
+
+Both are checked because they are the same artifact. GitHub's squash merge uses
+the pull request title as the commit message whenever a pull request carries
+more than one commit, and the first commit's message only when it carries
+exactly one — so a prose title on a multi-commit pull request lands a
+non-conventional commit on the default branch, having passed every commit-level
+gate on the way.
+
+The pattern lives here rather than inline in the hook so the commit-message
+check and the pull request check cannot drift apart.
+
+    python3 scripts/check_conventional_subject.py --commit-msg-file <path>
+    python3 scripts/check_conventional_subject.py --env PR_TITLE
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+TYPES = (
+    "feat",
+    "fix",
+    "docs",
+    "test",
+    "skill",
+    "refactor",
+    "perf",
+    "build",
+    "ci",
+    "chore",
+    "revert",
+    "security",
+)
+PATTERN = re.compile(r"^(" + "|".join(TYPES) + r")(\([a-z0-9/-]+\))?: .{1,100}$")
+
+
+def check(subject: str, source: str) -> int:
+    subject = subject.split("\n")[0].strip()
+    if PATTERN.match(subject):
+        return 0
+    print(f"{source} does not follow Conventional Commits format.")
+    print(f"   Got: {subject!r}")
+    print("   Expected: type(scope): description")
+    print(f"   Valid types: {' '.join(TYPES)}")
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--commit-msg-file")
+    group.add_argument(
+        "--env",
+        help="Name of an environment variable holding the subject. The value is "
+        "read from the environment rather than passed as an argument, so a "
+        "title containing shell metacharacters cannot reach a shell.",
+    )
+    args = parser.parse_args()
+
+    if args.commit_msg_file:
+        with open(args.commit_msg_file, encoding="utf-8") as handle:
+            return check(handle.read(), "Commit message")
+
+    value = os.environ.get(args.env)
+    if value is None:
+        print(f"{args.env} is not set; nothing to check.")
+        return 1
+    return check(value, "Pull request title")
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Why

GitHub's squash merge uses the **pull request title** whenever a pull request carries more than one commit, and the first commit's message only when it carries exactly one. So a prose title on a multi-commit pull request lands a non-conventional commit on `main` — having passed the commit-msg hook on every commit inside it, because the hook cannot see the title.

That is not hypothetical. `ori-specs` `096b81e` is on `main` reading "Safety qualification fixture: the bounded instrument for exercising an unratified condition", squashed from a four-commit PR whose commits were all conventional. A sibling PR the same day escaped only because it happened to carry one commit.

## What this adds

The pattern moves out of the hook's inline script into `scripts/check_conventional_subject.py`, which both callers use, so the commit check and the title check cannot drift apart. The valid type list and the 100-character bound are unchanged.

A separate `PR title` workflow checks the title on `opened`, `edited`, `reopened` and `synchronize`. It is separate from `ci.yml` deliberately: adding `edited` to the existing trigger would re-run the whole test matrix every time someone adjusts a title or a description.

The title is read from the **environment** rather than interpolated into the run script. It is attacker-influenced text, and `${{ }}` substitution would splice it into the shell before bash saw a quote.

## Verification

The checker was exercised in both modes: it accepts this PR's own title and rejects the exact prose title that caused the problem, a subject over 100 characters, and an unknown type. `scripts/check_workflows.py` passes, and the new workflow pins `actions/checkout` to the same SHA `ci.yml` already uses. `ruff`, `ruff format` and `mypy` clean; pre-commit green, including the rewired commit-msg hook validating this commit.
