### PR TITLE
fix(hal): let the i2c adapter survive a driver that reports an unusable platform

### DIFF
--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -6,6 +6,7 @@ import logging
 import math
 import threading
 import time
+from collections.abc import Callable
 from typing import Any
 
 from ori.hal.ac_measurement import (
@@ -166,20 +167,26 @@ _DRIVER_INSTALL_HINT = {
 
 
 # The availability flag remains the single answer to "can this be used". The
-# reason dict only explains a False. Reading the flag through `globals()` keeps
-# the two in step under `patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", ...)`,
-# which is how the suite simulates a Pi.
-_DRIVER_FLAG = {
-    "smbus2": "_SMBUS_AVAILABLE",
-    "bme280": "_BME280_AVAILABLE",
-    "ads1115": "_ADS1115_AVAILABLE",
-    "blinka": "_BLINKA_AVAILABLE",
-    "scd40": "_SCD40_AVAILABLE",
+# reason dict only explains a False.
+#
+# Each entry names its flag directly rather than resolving it through
+# `globals()`. The indirect form worked and made the flags invisible to static
+# analysis, which then reported every one of them as an unused global — a tool
+# reporting less than the truth because of how the code was written, which is
+# worth avoiding rather than suppressing. A lambda reads the module global when
+# it is called, so `patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", ...)` still
+# takes, which is how the suite simulates a Pi.
+_DRIVER_AVAILABLE: dict[str, Callable[[], bool]] = {
+    "smbus2": lambda: _SMBUS_AVAILABLE,
+    "bme280": lambda: _BME280_AVAILABLE,
+    "ads1115": lambda: _ADS1115_AVAILABLE,
+    "blinka": lambda: _BLINKA_AVAILABLE,
+    "scd40": lambda: _SCD40_AVAILABLE,
 }
 
 
 def _driver_missing(driver: str) -> bool:
-    return not globals().get(_DRIVER_FLAG[driver], False)
+    return not _DRIVER_AVAILABLE[driver]()
 
 
 def i2c_driver_unavailable_reason(sensor_type: str) -> str | None:

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -44,45 +44,86 @@ CALIBRATION_SCHEMAS = {
 }
 
 # Optional hardware libraries — guarded so the module imports cleanly on any host.
+#
+# The guards catch `ImportError` *and* `RuntimeError`, and the second one is the
+# point. adafruit-blinka raises `RuntimeError` from
+# `raise_for_missing_platform_dependency` when its platform library is absent,
+# so an `ImportError` guard let that escape and crashed this module on import.
+# It crashed only on a Raspberry Pi: a host with no blinka at all raises
+# `ImportError` and the narrow guard held, so every developer machine and every
+# CI job passed while the supported target could not import the module.
+#
+# It is deliberately not `except Exception`. A driver reporting an unusable
+# platform is an expected state; a driver raising `TypeError` or `AttributeError`
+# at import time is a defect, and swallowing that would turn a bug into a
+# capability this runtime quietly does not have.
+#
+# The reason is kept rather than reduced to a boolean, so a refusal can say
+# which import failed and why instead of guessing "not installed" at an
+# operator whose problem is a missing platform library.
+_DRIVER_FAILURE = (ImportError, RuntimeError)
+
+_DRIVER_UNAVAILABLE: dict[str, str] = {}
+
+
+def _unavailable(capability: str, exc: BaseException) -> None:
+    _DRIVER_UNAVAILABLE[capability] = f"{type(exc).__name__}: {exc}"
+
+
 try:
     import smbus2 as smbus  # type: ignore[import-untyped]
 
     _SMBUS_AVAILABLE = True
-except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
     smbus = None
     _SMBUS_AVAILABLE = False
+    _unavailable("smbus2", exc)
 
 try:
     import bme280 as _bme280_lib  # type: ignore[import-untyped]
 
     _BME280_AVAILABLE = True
-except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
     _bme280_lib = None
     _BME280_AVAILABLE = False
+    _unavailable("bme280", exc)
 
 try:
     import adafruit_ads1x15.ads1x15 as _ads1x15  # type: ignore[import-untyped]
     import adafruit_ads1x15.ads1115 as _ads1115  # type: ignore[import-untyped]
     import adafruit_ads1x15.analog_in as _analog_in  # type: ignore[import-untyped]
-    import board as _board  # type: ignore[import-untyped]
-    import busio as _busio  # type: ignore[import-untyped]
 
     _ADS1115_AVAILABLE = True
-except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
     _ads1115 = None
     _ads1x15 = None
     _analog_in = None
+    _ADS1115_AVAILABLE = False
+    _unavailable("ads1115", exc)
+
+# blinka is a separate dependency from the ADS1115 driver and separate sensors
+# need it. Folding the two into one block made `scd40` — which needs blinka for
+# its bus but not the ADC driver at all — report a missing `adafruit_ads1x15`,
+# and told an operator to install a package their device does not use.
+try:
+    import board as _board  # type: ignore[import-untyped]
+    import busio as _busio  # type: ignore[import-untyped]
+
+    _BLINKA_AVAILABLE = True
+except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
     _board = None
     _busio = None
-    _ADS1115_AVAILABLE = False
+    _BLINKA_AVAILABLE = False
+    _unavailable("blinka", exc)
 
 try:
     import adafruit_scd4x  # type: ignore[import-untyped]
 
     _SCD40_AVAILABLE = True
-except ImportError:  # pragma: no cover - exercised on non-Pi hosts
+except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
     adafruit_scd4x = None
     _SCD40_AVAILABLE = False
+    _unavailable("scd40", exc)
 
 # Sensor types that require the ADS1115 ADC
 _ADS_SENSOR_TYPES = frozenset({"ads1115_current", "ads1115_voltage"})
@@ -96,6 +137,84 @@ _SUPPORTED = frozenset(
         "scd40",
     }
 )
+
+# Which drivers each sensor type cannot be read without. Tuples, not single
+# names: `scd40` needs its own driver *and* the blinka bundle, because
+# `busio`/`board` come from there, and `bme280` needs `smbus2` as well as the
+# calibration library. A one-driver-per-type map looks right and silently
+# under-reports exactly those two.
+#
+# `_require_drivers` below is called by every `_connect_*`, so this table and
+# the connect path cannot disagree about what a type needs: a type whose entry
+# is wrong fails at connect too, rather than passing a startup gate and being
+# skipped later.
+_SENSOR_TYPE_DRIVERS: dict[str, tuple[str, ...]] = {
+    "bme280": ("smbus2", "bme280"),
+    "ads1115_current": ("ads1115", "blinka"),
+    "ads1115_voltage": ("ads1115", "blinka"),
+    "scd40": ("scd40", "blinka"),
+}
+
+# What to tell an operator to install, per driver key.
+_DRIVER_INSTALL_HINT = {
+    "smbus2": "pip install smbus2",
+    "bme280": "pip install RPi.bme280",
+    "ads1115": "pip install adafruit-circuitpython-ads1x15",
+    "blinka": "install a blinka platform library for this board (rpi-lgpio on Raspberry Pi OS Trixie)",
+    "scd40": "pip install adafruit-circuitpython-scd4x",
+}
+
+
+# The availability flag remains the single answer to "can this be used". The
+# reason dict only explains a False. Reading the flag through `globals()` keeps
+# the two in step under `patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", ...)`,
+# which is how the suite simulates a Pi.
+_DRIVER_FLAG = {
+    "smbus2": "_SMBUS_AVAILABLE",
+    "bme280": "_BME280_AVAILABLE",
+    "ads1115": "_ADS1115_AVAILABLE",
+    "blinka": "_BLINKA_AVAILABLE",
+    "scd40": "_SCD40_AVAILABLE",
+}
+
+
+def _driver_missing(driver: str) -> bool:
+    return not globals().get(_DRIVER_FLAG[driver], False)
+
+
+def i2c_driver_unavailable_reason(sensor_type: str) -> str | None:
+    """Why this sensor type's drivers are unusable, or ``None``.
+
+    ``None`` means every driver it needs imported. It does **not** mean the
+    sensor can be read: a wrong address, a bus this adapter refuses, an
+    unsupported type, or a device that does not answer all fail later, at
+    ``connect()``. The boundary covering those is the hardened refusal in the
+    runtime's sensor startup, not this function.
+    """
+    reasons = []
+    for driver in _SENSOR_TYPE_DRIVERS.get(sensor_type, ()):
+        if not _driver_missing(driver):
+            continue
+        detail = _DRIVER_UNAVAILABLE.get(driver, "not available")
+        reasons.append(f"{driver} ({detail})")
+    return "; ".join(reasons) or None
+
+
+def _require_drivers(sensor_type: str) -> None:
+    """Refuse a connect whose drivers are unusable, naming what failed."""
+    reason = i2c_driver_unavailable_reason(sensor_type)
+    if reason is None:
+        return
+    hints = " ".join(
+        _DRIVER_INSTALL_HINT[driver]
+        for driver in _SENSOR_TYPE_DRIVERS.get(sensor_type, ())
+        if _driver_missing(driver) and driver in _DRIVER_INSTALL_HINT
+    )
+    raise AdapterConnectionError(
+        f"I2CAdapter: '{sensor_type}' needs drivers that did not import: "
+        f"{reason}. Try: {hints}"
+    )
+
 
 # Calibration keys read from a sensor's nested ``calibration`` block. The two
 # required ones have no default: a clamp's sensitivity and the supply frequency
@@ -450,30 +569,16 @@ class I2CAdapter(BaseAdapter):
             self._connect_scd40()
 
     def _connect_bme280(self) -> None:
-        if not _SMBUS_AVAILABLE or smbus is None:
-            raise AdapterConnectionError(
-                "I2CAdapter: 'smbus2' is not installed. Run: pip install smbus2"
-            )
-        if not _BME280_AVAILABLE or _bme280_lib is None or smbus is None:
-            raise AdapterConnectionError(
-                "I2CAdapter: 'RPi.bme280' is not installed. Run: pip install RPi.bme280"
-            )
+        _require_drivers("bme280")
+        assert smbus is not None and _bme280_lib is not None
         self._bus = smbus.SMBus(self._bus_number)
         self._bme280_params = _bme280_lib.load_calibration_params(
             self._bus, self._address
         )
 
     def _connect_ads1115(self) -> None:
-        if (
-            not _ADS1115_AVAILABLE
-            or _ads1115 is None
-            or _ads1x15 is None
-            or _analog_in is None
-        ):
-            raise AdapterConnectionError(
-                "I2CAdapter: Adafruit ADS1x15 library is not installed. "
-                "Run: pip install adafruit-circuitpython-ads1x15"
-            )
+        _require_drivers(self._sensor_type)
+        assert _ads1115 is not None and _ads1x15 is not None
         i2c = _get_shared_busio_i2c(self._bus_number)
         # The driver defaults are 128 SPS in single-shot mode, which yields
         # about two samples per 50 Hz cycle. Continuous conversion at the
@@ -487,16 +592,10 @@ class I2CAdapter(BaseAdapter):
         )
 
     def _connect_scd40(self) -> None:
-        if not _SCD40_AVAILABLE or adafruit_scd4x is None:
-            raise AdapterConnectionError(
-                "I2CAdapter: 'adafruit-circuitpython-scd4x' is not installed. "
-                "Run: pip install adafruit-circuitpython-scd4x"
-            )
-        if not _ADS1115_AVAILABLE or _ads1115 is None or _analog_in is None:
-            # busio/board come from the same adafruit-blinka bundle
-            raise AdapterConnectionError(
-                "I2CAdapter: 'adafruit-blinka' (busio/board) is not installed."
-            )
+        # scd40 needs blinka as well as its own driver, because busio and board
+        # come from there — but not the ADS1115 driver. The table says so.
+        _require_drivers("scd40")
+        assert adafruit_scd4x is not None
         i2c = _get_shared_busio_i2c(self._bus_number)
         self._scd4x = adafruit_scd4x.SCD4X(i2c)
         self._scd4x.start_periodic_measurement()

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -5,6 +5,7 @@ import asyncio
 import math
 import os
 import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -173,9 +174,15 @@ class TestConnect:
         adapter = I2CAdapter()
         with (
             patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", False),
-            pytest.raises(AdapterConnectionError, match="ADS1x15"),
+            pytest.raises(AdapterConnectionError) as excinfo,
         ):
             await adapter.connect(_config(sensor_type="ads1115_current"))
+        message = str(excinfo.value)
+        # Which sensor, which driver, and what to do about it — a bare library
+        # name leaves an operator guessing which of several sensors is down.
+        assert "ads1115_current" in message
+        assert "ads1115" in message
+        assert "pip install" in message
 
     async def test_connect_scd40_missing_lib_raises(self):
         adapter = I2CAdapter()
@@ -208,6 +215,7 @@ class TestConnect:
         adapter = I2CAdapter()
         with (
             patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
+            patch("ori.hal.i2c_adapter._BLINKA_AVAILABLE", True),
             patch("ori.hal.i2c_adapter._ads1115"),
             patch("ori.hal.i2c_adapter._ads1x15"),
             patch("ori.hal.i2c_adapter._analog_in"),
@@ -221,6 +229,7 @@ class TestConnect:
         adapter = I2CAdapter()
         with (
             patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
+            patch("ori.hal.i2c_adapter._BLINKA_AVAILABLE", True),
             patch("ori.hal.i2c_adapter._busio", create=True),
             patch("ori.hal.i2c_adapter._board", create=True),
             patch("ori.hal.i2c_adapter._ads1115", create=True),
@@ -243,6 +252,7 @@ class TestConnect:
         adapter = I2CAdapter()
         with (
             patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
+            patch("ori.hal.i2c_adapter._BLINKA_AVAILABLE", True),
             patch("ori.hal.i2c_adapter._busio", create=True),
             patch("ori.hal.i2c_adapter._board", create=True),
             patch("ori.hal.i2c_adapter._ads1115", create=True),
@@ -819,3 +829,131 @@ class TestPiIntegration:
         assert reading.sensor_type == "ads1115_current"
         assert reading.unit == "ampere"
         await adapter.close()
+
+
+class TestDriverGuardWidth:
+    """The optional-driver guards must not care how a driver fails.
+
+    adafruit-blinka's `board` raises RuntimeError when its platform library is
+    absent, which an `except ImportError` guard let escape — crashing this
+    module on import. It crashed only on a Raspberry Pi: a host with no blinka
+    raises ImportError, so the narrow guard held everywhere the suite ran.
+    """
+
+    @staticmethod
+    def _probe(error_expr: str) -> dict:
+        """Import the adapter in a subprocess with `board` raising `error_expr`.
+
+        A subprocess rather than a reimport: popping the module from
+        `sys.modules` and re-importing leaves this file's module-level
+        `I2CAdapter` bound to a stale class whose globals are the old module
+        dict, so every later `patch("ori.hal.i2c_adapter....")` in this file
+        would patch a different object. That is invisible while this class is
+        last in the file and breaks two dozen unrelated tests the moment it is
+        not.
+        """
+        import json
+        import subprocess
+        import sys
+        from types import ModuleType  # noqa: F401  (used inside the child)
+
+        program = f"""
+import builtins, json, sys
+from types import ModuleType
+
+# The driver has to be importable for the guard to reach `board` at all: on a
+# host without it the block fails at the first import and never gets there.
+parent = ModuleType("adafruit_ads1x15")
+sys.modules["adafruit_ads1x15"] = parent
+for child in ("ads1x15", "ads1115", "analog_in"):
+    module = ModuleType("adafruit_ads1x15." + child)
+    setattr(parent, child, module)
+    sys.modules["adafruit_ads1x15." + child] = module
+sys.modules["busio"] = ModuleType("busio")
+
+real_import = builtins.__import__
+def fake_import(name, *args, **kwargs):
+    if name == "board":
+        raise {error_expr}
+    return real_import(name, *args, **kwargs)
+builtins.__import__ = fake_import
+
+import ori.hal.i2c_adapter as m
+print(json.dumps({{
+    "ads1115_available": m._ADS1115_AVAILABLE,
+    "blinka_available": m._BLINKA_AVAILABLE,
+    "smbus_available": m._SMBUS_AVAILABLE,
+    "ads_reason": m.i2c_driver_unavailable_reason("ads1115_current"),
+    "scd40_reason": m.i2c_driver_unavailable_reason("scd40"),
+    "bme280_reason": m.i2c_driver_unavailable_reason("bme280"),
+}}))
+"""
+        completed = subprocess.run(
+            [sys.executable, "-c", program],
+            capture_output=True,
+            text=True,
+            cwd=str(Path(__file__).resolve().parent.parent),
+        )
+        assert completed.returncode == 0, completed.stderr
+        return json.loads(completed.stdout.strip().splitlines()[-1])
+
+    def test_a_runtime_error_from_board_does_not_crash_the_import(self):
+        result = self._probe(
+            "RuntimeError(\"The platform library 'RPi' was not found\")"
+        )
+
+        # The ADS1115 driver itself imported: only blinka failed, and the two
+        # are separate dependencies.
+        assert result["ads1115_available"] is True
+        assert result["blinka_available"] is False
+        reason = result["ads_reason"]
+        assert reason is not None
+        assert "blinka" in reason
+        assert "RuntimeError" in reason
+        # The operator needs the real cause: "not installed" would send them
+        # after a package that is already there.
+        assert "platform library 'RPi'" in reason
+
+    def test_an_import_error_is_still_handled(self):
+        result = self._probe("ImportError(\"No module named 'board'\")")
+
+        assert result["blinka_available"] is False
+        assert "ImportError" in result["ads_reason"]
+
+    def test_scd40_reports_blinka_and_not_the_ads1115_driver(self):
+        """scd40 needs blinka for its bus, and the ADS1115 driver never.
+
+        Folding board/busio into the ADS1115 guard made scd40 report a missing
+        `adafruit_ads1x15` and told an operator to install a package their
+        device does not use — while a CO2-only Pi, which has blinka and scd4x
+        but no ads1x15, would be refused for a sensor that works.
+        """
+        result = self._probe(
+            "RuntimeError(\"The platform library 'RPi' was not found\")"
+        )
+
+        reason = result["scd40_reason"]
+        assert reason is not None
+        assert "blinka" in reason
+        assert "ads1115" not in reason
+
+    def test_one_broken_guard_does_not_contaminate_another(self):
+        """Each guarded block records only its own failure."""
+        result = self._probe("RuntimeError('boom')")
+
+        assert "boom" in result["ads_reason"]
+        assert "boom" not in (result["bme280_reason"] or "")
+
+    def test_bme280_reports_smbus2_which_it_also_needs(self):
+        from ori.hal.i2c_adapter import _DRIVER_UNAVAILABLE, _SENSOR_TYPE_DRIVERS
+
+        assert "smbus2" in _SENSOR_TYPE_DRIVERS["bme280"]
+        # Every recorded driver must be reachable through some sensor type, or
+        # the table and the guards have drifted.
+        reachable = {d for drivers in _SENSOR_TYPE_DRIVERS.values() for d in drivers}
+        assert set(_DRIVER_UNAVAILABLE) <= reachable
+
+    def test_a_sensor_type_needing_no_driver_reports_nothing(self):
+        from ori.hal.i2c_adapter import i2c_driver_unavailable_reason
+
+        assert i2c_driver_unavailable_reason("cpu_percent") is None

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9,6 +9,7 @@ are mocked.  No real hardware, credentials, or network calls are made.
 
 import asyncio
 import base64
+import contextlib
 import json
 import logging
 import os
@@ -53,6 +54,7 @@ from ori.runtime import (
     _setup_success_message,
     _validate_required_runtime_capabilities,
     _warn_sms_webhook_security_posture,
+    requires_production_posture,
 )
 from ori.security.gateway_messages import (
     GatewayMessageAuthConfig,
@@ -662,6 +664,174 @@ def test_build_gateway_message_encryptor_requires_auth_enabled():
 
     with pytest.raises(ValueError, match="gateway auth"):
         _build_gateway_message_encryptor(config)
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sensor_connect_does_not_take_the_runtime_down(
+    minimal_config, monkeypatch
+):
+    """A sensor that cannot connect is skipped; the runtime keeps running.
+
+    This is the boundary a hardened refusal was briefly placed at, and the
+    reason it was withdrawn. Aborting startup on any unconnectable sensor lets
+    an unrelated network-backed sensor take the whole runtime down, and with it
+    every protection the device does have — Tier D included. A safety runtime
+    that will not start is not failing closed; it has removed the agent.
+
+    The sensor is still not silently fine: it is absent from the connected set
+    and reported disconnected on the health surface.
+    """
+    from ori.hal.base import AdapterConnectionError
+    from ori.hal.psutil_adapter import PsutilAdapter
+
+    attempts: list[str] = []
+
+    async def _refuse(self, config):
+        attempts.append(config.get("sensor_id", "?"))
+        raise AdapterConnectionError("simulated: device does not answer")
+
+    monkeypatch.setattr(PsutilAdapter, "connect", _refuse)
+
+    runtime = OriRuntime(config_path=str(minimal_config))
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        # Wait for the sensor loop, not merely for the event bus: the bus is
+        # built well before any adapter is connected, so breaking on it would
+        # assert against a runtime that had not reached the boundary yet.
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not attempts:
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+
+        # The runtime came up rather than aborting.
+        assert not start_task.done(), (
+            "startup aborted on an unconnectable sensor: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+        assert runtime._event_bus is not None
+        # And the sensor is absent, not quietly counted as present.
+        assert "cpu-sensor" not in runtime._connected_sensor_ids
+        # Without this the test passes whether or not the refusal ever fired:
+        # any exception from connect() produces the same skip.
+        assert attempts, "connect() was never attempted, so nothing was proven"
+    finally:
+        await runtime.stop()
+        start_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await start_task
+
+
+@pytest.mark.asyncio
+async def test_a_failed_sensor_connect_is_non_fatal_under_hardened_posture_too(
+    minimal_config, monkeypatch
+):
+    """The same boundary, with `enforce_production_posture` on.
+
+    The development case alone does not guard the regression it exists for:
+    reinstating a hardened-only refusal leaves it green, because development
+    never refuses. This is the posture where the withdrawn behaviour would
+    fire, so it is the one that has to hold.
+
+    Aborting here would let any unconnectable sensor — a network-backed one on
+    a slow broker, say — take down a runtime that is protecting something else
+    entirely. A safety runtime that will not start has removed the agent, which
+    is not the same as failing closed.
+    """
+    import base64
+
+    import yaml
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from ori.hal.base import AdapterConnectionError
+    from ori.hal.psutil_adapter import PsutilAdapter
+    from ori.security.config_signatures import (
+        CONFIG_SIGNATURE_SCHEMA,
+        canonical_config_signature_payload,
+    )
+
+    # A genuinely hardened config, not a stubbed posture: production posture
+    # demands signed skills, signed config and an encrypted state path, and
+    # none of those relate to the sensor boundary under test. Satisfying them
+    # is what makes `requires_production_posture` true at the sensor loop,
+    # which is the only reason this test differs from its development twin.
+    private_key = Ed25519PrivateKey.generate()
+    public_key_b64 = base64.b64encode(
+        private_key.public_key().public_bytes(
+            encoding=serialization.Encoding.Raw,
+            format=serialization.PublicFormat.Raw,
+        )
+    ).decode("ascii")
+
+    raw = yaml.safe_load(minimal_config.read_text(encoding="utf-8"))
+    assert "security" not in raw, "fixture now sets security; merge rather than assign"
+    raw["security"] = {
+        "enforce_production_posture": True,
+        "skills": {"require_signed": True},
+        "config_signature": {"require_signed": True},
+    }
+    # Local reasoning is a host capability the hardened gate also checks, and it
+    # is nothing to do with this boundary; turn it off rather than ship a model.
+    raw.setdefault("reasoning", {})["default_tier"] = "rule"
+    raw["state"] = {
+        "encryption": {
+            "mode": "filesystem_required",
+            "encrypted_path_prefixes": [str(minimal_config.parent)],
+        }
+    }
+    raw["config_signature"] = {
+        "schema": CONFIG_SIGNATURE_SCHEMA,
+        "signer_id": "product-provisioning-test",
+        "signed_at_ms": 1_800_000_000_000,
+        "signature": "ed25519:",
+    }
+    signature = private_key.sign(canonical_config_signature_payload(raw))
+    raw["config_signature"]["signature"] = "ed25519:" + base64.b64encode(
+        signature
+    ).decode("ascii")
+
+    hardened = minimal_config.parent / "ori-hardened.yaml"
+    hardened.write_text(yaml.safe_dump(raw, sort_keys=False), encoding="utf-8")
+    # The anchor is delivered out of band, as the signing contract requires.
+    monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)
+
+    attempts: list[str] = []
+
+    async def _refuse(self, config):
+        attempts.append(config.get("sensor_id", "?"))
+        raise AdapterConnectionError("simulated: device does not answer")
+
+    monkeypatch.setattr(PsutilAdapter, "connect", _refuse)
+
+    runtime = OriRuntime(config_path=str(hardened))
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not attempts:
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+
+        assert attempts, "connect() was never attempted, so nothing was proven"
+        # Without this the test would pass on a config that silently stayed in
+        # development, which is the posture it exists to exclude.
+        assert runtime._config is not None
+        assert requires_production_posture(
+            device=runtime._config.device,
+            security=runtime._config.security,
+        ), "the hardened posture did not take; this test proves nothing"
+        assert not start_task.done(), (
+            "hardened startup aborted on an unconnectable sensor: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+        assert runtime._event_bus is not None
+        assert "cpu-sensor" not in runtime._connected_sensor_ids
+    finally:
+        await runtime.stop()
+        start_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await start_task
 
 
 @pytest.fixture

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -9,7 +9,6 @@ are mocked.  No real hardware, credentials, or network calls are made.
 
 import asyncio
 import base64
-import contextlib
 import json
 import logging
 import os
@@ -669,13 +668,17 @@ def test_build_gateway_message_encryptor_requires_auth_enabled():
 async def _stop_and_join(runtime, start_task: asyncio.Task) -> None:
     """Shut a started runtime down and join its task.
 
-    The cancellation is expected, so `CancelledError` is suppressed; awaiting
-    the task is what joins it, and is the point rather than its value.
+    The join asserts the task actually stopped: a runtime that hangs on
+    shutdown would otherwise leave the test to time out somewhere less
+    informative.
     """
     await runtime.stop()
     start_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await start_task
+    # `asyncio.wait` joins without re-raising the task's CancelledError, and
+    # returns what is still pending — so the teardown asserts the runtime task
+    # actually stopped rather than discarding an awaited value.
+    _, pending = await asyncio.wait({start_task}, timeout=10)
+    assert not pending, "the runtime task did not stop"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -666,6 +666,18 @@ def test_build_gateway_message_encryptor_requires_auth_enabled():
         _build_gateway_message_encryptor(config)
 
 
+async def _stop_and_join(runtime, start_task: asyncio.Task) -> None:
+    """Shut a started runtime down and join its task.
+
+    The cancellation is expected, so `CancelledError` is suppressed; awaiting
+    the task is what joins it, and is the point rather than its value.
+    """
+    await runtime.stop()
+    start_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await start_task
+
+
 @pytest.mark.asyncio
 async def test_a_failed_sensor_connect_does_not_take_the_runtime_down(
     minimal_config, monkeypatch
@@ -716,10 +728,7 @@ async def test_a_failed_sensor_connect_does_not_take_the_runtime_down(
         # any exception from connect() produces the same skip.
         assert attempts, "connect() was never attempted, so nothing was proven"
     finally:
-        await runtime.stop()
-        start_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await start_task
+        await _stop_and_join(runtime, start_task)
 
 
 @pytest.mark.asyncio
@@ -828,10 +837,7 @@ async def test_a_failed_sensor_connect_is_non_fatal_under_hardened_posture_too(
         assert runtime._event_bus is not None
         assert "cpu-sensor" not in runtime._connected_sensor_ids
     finally:
-        await runtime.stop()
-        start_task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await start_task
+        await _stop_and_join(runtime, start_task)
 
 
 @pytest.fixture


### PR DESCRIPTION
## What does this PR do?

`import ori.hal.i2c_adapter` raised `RuntimeError` on the certified `v2.5.0-rc.7` install on the production-supported Raspberry Pi. Reproduced on the bench Pi 4, Raspberry Pi OS Trixie, stock Python 3.13.5:

```
$ sudo /opt/ori/current/venv/bin/python -c "import ori.hal.i2c_adapter"
RuntimeError: The platform library 'RPi' was not found.
```

**Why it went unnoticed.** The module guarded its optional driver imports with `except ImportError`. adafruit-blinka's `board` raises `RuntimeError` when its platform library is absent, so the guard missed it. On any host with no blinka the same import raises `ImportError`, the narrow guard holds, and the adapter degrades as designed — so every developer machine and every CI job passed while the one platform the code exists for could not load it. The crash is latent besides: nothing imports the module until an `i2c` sensor is configured, which is why a healthy bench service said nothing about it.

The guard now catches the platform-unavailable class, `ImportError` and `RuntimeError`, and deliberately **not** `Exception`. A driver reporting an unusable platform is an expected state; a driver raising `TypeError` at import is a defect, and swallowing that would turn a bug into a capability the runtime quietly does not have.

**blinka is separated from the ADS1115 driver.** They are separate dependencies and different sensors need them. Folding both into one block made `scd40` — which needs blinka for its bus and never needs the ADC driver — report a missing `adafruit_ads1x15` and tell an operator to install a package their device does not use, while a CO2-only Pi with blinka and `scd4x` but no ads1x15 would be refused for a sensor that works. One table now states what each sensor type needs and every connect path reads it, so the reason an operator is shown and the reason a connect refuses cannot drift apart. The reason carries the real failure rather than "not installed", which would send someone after a package that is already present.

## What this deliberately does not change

Behaviour on a failed connect: the sensor is skipped and logged, in every posture. An earlier draft refused a hardened start instead, and it was withdrawn under review. A refusal that cannot tell which sensor matters lets an unrelated network-backed sensor abort startup and take down every protection the device does have; a safety runtime that will not start has removed the agent rather than failed closed. The correct per-pair rule is #497, which waits on the safety registry becoming non-dormant in #324.

Two tests now drive a real `OriRuntime.start()` with a failing `connect()` — one of them under a genuinely enforced production posture, with signed skills, encrypted state, a real Ed25519 config signature and an out-of-band trust anchor — so that withdrawn behaviour cannot return unnoticed. Reinstating it fails the hardened test and only that test.

`ori/runtime.py` and `docs/CAPABILITY_MATRIX.md` are byte-identical to `main`.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Verification

Verified on the bench Pi against the certified rc.7 venv, same interpreter, same absent platform library — the module imports instead of crashing, `ads1115 driver present: True`, `blinka present: False`, and `scd40` reports `blinka` with no mention of `ads1115`.

Mutations, each failing by its own tests: narrowing the guard to `ImportError` only; restoring the scd40-to-ads1115 conflation; dropping blinka from `ads1115_current`; emptying the driver table; making the skip fatal; and reinstating the withdrawn hardened refusal.

Full suite 5229 passed, 28 skipped. `ruff check`, `ruff format --check`, `mypy ori/` (161 files) clean. `guard-capability-matrix.sh` OK.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

Capability behaviour is unchanged: the adapter degrades where it previously crashed, and no capability claim moves. The matrix guard passes without an edit.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

Closes #494
