### PR TITLE
fix(installer): stage the blinka platform library beside the pin factory

### DIFF
--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -98,11 +98,16 @@ name. Four files across two apt packages are **copied** into the release's own
 and adafruit-blinka's platform library, `RPi/__init__.py` and
 `RPi/GPIO/__init__.py`, which keep their package layout.
 
-The pin factory is mandatory and its absence fails the install. The blinka
-shim is not: images that ship the classic `python3-rpi.gpio`, or ship neither,
-install and run today, and refusing them would break working deployments to add
-a capability they may not use. Its absence is reported, and the runtime reports
-the i2c driver unavailable at connect.
+The pin factory is mandatory and its absence fails the install — measured on a
+Bookworm 3.11 arm64 image, which packages neither `python3-lgpio` nor
+`python3-rpi-lgpio`: the install refuses at mandatory staging, before any shim
+logic runs.
+
+The blinka shim is not mandatory. A Pi that staged the pin factory but has no
+shim installs today, and the classic `python3-rpi.gpio` can occupy the same
+import name with a layout this manifest does not carry; refusing either would
+break a working deployment to add a capability it may not use. Its absence is
+reported, and the runtime reports the i2c driver unavailable at connect.
 
 Copied rather than linked, for two reasons. The release permission transaction
 requires an external symlink target to be executable and apt ships both files

--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -69,9 +69,13 @@ Two dead ends, both checked:
 - **`RPi.GPIO` publishes sdists only.** The wheelhouse build resolves with
   `--only-binary=:all:`, which reduces its candidate set to nothing. The `pi`
   wheelhouse target could never be built while it was pinned.
-- **`lgpio` on PyPI is a placeholder.** The only installable release is
-  `0.0.0.2`, whose wheel contains a zero-byte `lgpio.py`. `rpi-lgpio` depends on
-  it and inherits the same emptiness. Neither yields a working factory.
+- **`lgpio` on PyPI has no wheel for the supported interpreter.** `0.2.2.0`
+  publishes wheels for cp39 through cp312 and none for cp313; `0.1.0.0` ships
+  eggs pip cannot install; and the release left, `0.0.0.2`, contains a
+  zero-byte `lgpio.py` and is excluded by `rpi-lgpio`'s `lgpio>=0.1.0.1`. One
+  lock serves every target, so a resolution that cannot satisfy the supported
+  Trixie tuple fails the wheelhouse build. apt's build is wanted regardless: it
+  is matched to this interpreter's ABI and to the system liblgpio.
 
 So the pin factory comes from the operating system. `requirements/pi.in` carries
 `gpiozero` and `smbus2` only, and the image supplies the rest:
@@ -88,9 +92,17 @@ An isolated venv cannot import apt packages, so a Pi install needs the pin
 factory reachable from inside it — otherwise `gpiozero` is present but
 factory-less, which fails in exactly the silent way described above.
 
-The venv stays isolated and the installer takes the module by name. The two
-files apt ships, `lgpio.py` and the extension built for this interpreter's ABI,
-are **copied** into the release's own `site-packages`.
+The venv stays isolated and the installer takes an allow-listed manifest by
+name. Four files across two apt packages are **copied** into the release's own
+`site-packages`: `lgpio.py` and the extension built for this interpreter's ABI,
+and adafruit-blinka's platform library, `RPi/__init__.py` and
+`RPi/GPIO/__init__.py`, which keep their package layout.
+
+The pin factory is mandatory and its absence fails the install. The blinka
+shim is not: images that ship the classic `python3-rpi.gpio`, or ship neither,
+install and run today, and refusing them would break working deployments to add
+a capability they may not use. Its absence is reported, and the runtime reports
+the i2c driver unavailable at connect.
 
 Copied rather than linked, for two reasons. The release permission transaction
 requires an external symlink target to be executable and apt ships both files

--- a/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
+++ b/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
@@ -1,0 +1,76 @@
+# staging the blinka platform library into an isolated release venv
+
+**Result: `lgpio`, `RPi.GPIO`, `board` and `busio` all import from an isolated
+venv after staging, the resolved GPIO backend is `LGPIOFactory` and it claims
+its line through the kernel, and an ADS1115 reads over the resulting bus.**
+
+Run on the bench Raspberry Pi 4 Model B, Raspberry Pi OS Trixie, stock Python
+3.13.5, on 2026-09-03.
+
+## Why this was needed
+
+adafruit-blinka builds `board` for a Pi through an RPi.GPIO-compatible module.
+Without one, `import board` raises `RuntimeError` — a crash on the supported Pi
+and nothing at all on a host with no blinka, which is why it passed every
+developer machine and every CI job while the i2c adapter could not open an
+ADS1115 on the only platform it exists for.
+
+It cannot be carried in the wheelhouse. `rpi-lgpio` publishes a pure
+`py3-none-any` wheel, but requires `lgpio>=0.1.0.1`, and every `lgpio` release
+above the zero-byte `0.0.0.2` placeholder is an sdist that the wheelhouse's
+`--only-binary` filter refuses. Pinning the placeholder is a hard resolver
+conflict. Raspberry Pi OS ships the shim prebuilt as `python3-rpi-lgpio`, so it
+is staged the way the pin factory already is.
+
+## What was verified
+
+The pinned Pi requirement set installs on the target with hashes required and
+pulls neither module, which is what makes staging necessary rather than
+convenient:
+
+```
+$ pip install --require-hashes -r requirements/pi.txt     exit 0
+   Adafruit-Blinka: 9.2.0
+   adafruit-circuitpython-ads1x15: 3.0.5
+   lgpio: not installed
+   rpi-lgpio: not installed
+   sysv-ipc: 1.2.0
+```
+
+The four manifest members were then copied into that venv's `purelib` exactly
+as `_stage_system_modules` copies them, from
+`/usr/lib/python3/dist-packages`, `0644`, preserving package layout:
+
+```
+lgpio.py
+_lgpio.cpython-313-aarch64-linux-gnu.so
+RPi/__init__.py
+RPi/GPIO/__init__.py
+```
+
+Nothing else came with them — the `RPi` tree in the release holds those two
+files and no `egg-info`.
+
+```
+   isolated venv (no dist-packages on path): True
+   lgpio, RPi.GPIO, board, busio: all import
+   pin factory: LGPIOFactory | arbitrated: True
+   ADS1115 at 0x48, A0 tied to GND: -0.00063 V
+```
+
+`arbitrated: True` is the property that matters beyond importing: the backend
+holds its line through the kernel rather than driving `/dev/gpiomem` without
+claiming it, so a second writer is refused. The reading is the expected one for
+a grounded input on a channel wired to a header ground pin.
+
+## What this does not establish
+
+The venv was built and populated by hand rather than by an installed release
+bundle, because the change is not in a published candidate yet. It proves the
+staged file set is sufficient and the resulting backend is the intended one; it
+does not exercise the installer's own transaction, permissions, or rollback
+around that staging. A published candidate carrying this change still needs the
+systemd-host runbook on this tuple.
+
+The relay was not actuated. The pin factory was resolved and its chip handle
+observed; nothing was driven.

--- a/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
+++ b/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
@@ -25,8 +25,9 @@ wheelhouse build, and apt's build is wanted regardless — matched to this
 interpreter's ABI and to the system liblgpio. Pinning the placeholder is a hard
 resolver conflict. Raspberry Pi OS ships the shim prebuilt as
 `python3-rpi-lgpio`, so it is staged the way the pin factory already is —
-best effort, because images that ship the classic `python3-rpi.gpio` or ship
-neither install and run today.
+best effort, because a Pi that staged the pin factory but has no shim installs
+today, and the classic `python3-rpi.gpio` can occupy the same import name with
+a layout this manifest does not carry.
 
 ## What was verified
 
@@ -68,6 +69,31 @@ files and no `egg-info`.
 holds its line through the kernel rather than driving `/dev/gpiomem` without
 claiming it, so a second writer is refused. The reading is the expected one for
 a grounded input on a channel wired to a header ground pin.
+
+## Bookworm 3.11, measured rather than assumed
+
+Run in an `arm64` Bookworm container answering as Pi hardware, against the
+installer's own staging code. Bookworm packages neither `python3-lgpio` nor
+`python3-rpi-lgpio`.
+
+```
+no pin factory:
+  refused -> prerequisite_install_failed: this device needs the system lgpio
+             pin factory and lgpio is not installed; install python3-lgpio
+  notes: []                       <- the shim block never ran
+
+pin factory present, shim absent:
+  install proceeds
+  notes: ['adafruit-blinka has no platform library in this release
+           (RPi is not installed (python3-rpi-lgpio)); i2c sensors will
+           report their driver unavailable']
+  staged: lgpio.py, _lgpio.cpython-311-aarch64-linux-gnu.so
+```
+
+So a Pi with no pin factory refuses today and still refuses, unchanged by this
+work; the configuration the best-effort shim protects is the second one. An
+earlier draft of this record claimed the first case installed today. It does
+not.
 
 ## What this does not establish
 

--- a/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
+++ b/docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md
@@ -16,11 +16,17 @@ developer machine and every CI job while the i2c adapter could not open an
 ADS1115 on the only platform it exists for.
 
 It cannot be carried in the wheelhouse. `rpi-lgpio` publishes a pure
-`py3-none-any` wheel, but requires `lgpio>=0.1.0.1`, and every `lgpio` release
-above the zero-byte `0.0.0.2` placeholder is an sdist that the wheelhouse's
-`--only-binary` filter refuses. Pinning the placeholder is a hard resolver
-conflict. Raspberry Pi OS ships the shim prebuilt as `python3-rpi-lgpio`, so it
-is staged the way the pin factory already is.
+`py3-none-any` wheel, but requires `lgpio>=0.1.0.1`, and no `lgpio` release
+publishes a wheel for the supported interpreter: `0.2.2.0` ships cp39 through
+cp312 and no cp313, `0.1.0.0` ships eggs pip cannot install, and the
+requirement excludes the zero-byte `0.0.0.2` placeholder. One lock serves every
+target, so a resolution that cannot satisfy the supported Trixie tuple fails the
+wheelhouse build, and apt's build is wanted regardless — matched to this
+interpreter's ABI and to the system liblgpio. Pinning the placeholder is a hard
+resolver conflict. Raspberry Pi OS ships the shim prebuilt as
+`python3-rpi-lgpio`, so it is staged the way the pin factory already is —
+best effort, because images that ship the classic `python3-rpi.gpio` or ship
+neither install and run today.
 
 ## What was verified
 

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -18,7 +18,7 @@ import sys
 import time
 import uuid
 from dataclasses import dataclass, replace
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Callable, Iterator, Literal, NoReturn, Sequence
 
 import yaml
@@ -1973,6 +1973,28 @@ def _set_owned_mode(change: _PermissionChange, uid: int, gid: int, mode: int) ->
 
 
 _SYSTEM_PIN_FACTORY_MODULE = "lgpio"
+# The blinka platform library. adafruit-blinka builds `board` for a Pi through
+# an RPi.GPIO-compatible module, and without one `import board` raises
+# RuntimeError rather than ImportError — a crash on the supported Pi and
+# nothing anywhere else. It cannot come from the wheelhouse: `rpi-lgpio`
+# publishes a pure wheel but requires `lgpio>=0.1.0.1`, and every lgpio release
+# above the zero-byte 0.0.0.2 placeholder is an sdist, which `--only-binary`
+# cannot take. Raspberry Pi OS ships it prebuilt as `python3-rpi-lgpio`.
+_SYSTEM_BLINKA_SHIM_MODULE = "RPi"
+
+# Exactly what is copied, relative to an admitted system package directory.
+# `{ext}` is the importing interpreter's ABI suffix.
+#
+# A manifest, not a directory copy. Walking `RPi/` would let a future apt
+# package decide how much of the system a release takes, and would sweep in
+# egg-info metadata that describes an installation this release is not. Adding
+# a file here is a reviewed change; adding one to the image is not.
+_STAGED_MEMBERS = (
+    "lgpio.py",
+    "_lgpio{ext}",
+    "RPi/__init__.py",
+    "RPi/GPIO/__init__.py",
+)
 # Where a Raspberry Pi OS image puts apt's Python packages. Discovery is
 # constrained to this set so an interpreter answering from somewhere else
 # cannot decide what gets copied into a release.
@@ -1996,9 +2018,13 @@ def _is_raspberry_pi() -> bool:
 
 
 def _staging_refusal(
-    venv: Path, base: str, purelib: str, suffix: str, origin: str
+    venv: Path,
+    base: str,
+    purelib: str,
+    suffix: str,
+    origins: dict[str, str],
 ) -> str | None:
-    """Why the pin factory cannot be staged from this system, or None."""
+    """Why the system modules cannot be staged from this system, or None."""
     if not base:
         return "the base interpreter could not be identified"
     if not purelib or not Path(purelib).is_dir():
@@ -2015,14 +2041,28 @@ def _staging_refusal(
         return "the release site directory lies outside the environment"
     if not suffix:
         return "the interpreter reports no extension suffix"
-    if not origin:
-        return (
-            f"{_SYSTEM_PIN_FACTORY_MODULE} is not installed; "
-            "install the system package that provides it"
-        )
-    if Path(origin).parent not in _SYSTEM_PACKAGE_DIRECTORIES:
-        return "it resolves outside the admitted system package directories"
+    for module, origin in origins.items():
+        if not origin:
+            return (
+                f"{module} is not installed; "
+                "install the system package that provides it"
+            )
+        # A module resolves to its own file; a package resolves to its
+        # `__init__.py`, one level deeper. Both must sit under the same
+        # admitted root, so that one answer cannot import a release's files
+        # from a directory another answer never admitted.
+        root = Path(origin).parent
+        if module == _SYSTEM_BLINKA_SHIM_MODULE:
+            root = root.parent
+        if root not in _SYSTEM_PACKAGE_DIRECTORIES:
+            return f"{module} resolves outside the admitted system package directories"
     return None
+
+
+def _staging_root(origins: dict[str, str]) -> Path:
+    """The single admitted directory every staged member is read from."""
+    origin = origins[_SYSTEM_PIN_FACTORY_MODULE]
+    return Path(origin).parent
 
 
 def _system_file_failure(path: Path) -> str | None:
@@ -2081,7 +2121,7 @@ class OfflineReleasePreparer:
             self._run([*base, "--require-hashes", "-r", str(pi_requirements)])
         self._run([*base, "--no-deps", str(wheels[0])])
         if pi_requirements.is_file() and _is_raspberry_pi():
-            self._stage_system_pin_factory(venv)
+            self._stage_system_modules(venv)
 
     def validate(self, release: Path) -> None:
         python = release / "venv" / "bin" / "python"
@@ -2112,18 +2152,36 @@ class OfflineReleasePreparer:
             )
         self._run([str(entrypoint), "--help"])
 
-    def _stage_system_pin_factory(self, venv: Path) -> None:
-        """Copy the operating system's pin factory into the isolated venv.
+    def _stage_system_modules(self, venv: Path) -> None:
+        """Copy apt-owned, ABI-matched modules into the isolated venv.
 
-        `lgpio` ships only from apt: PyPI's release carries an empty module, and
-        apt builds the extension per interpreter version. An isolated venv
-        cannot import it, so gpiozero falls back to NativeFactory, which drives
+        Two things arrive this way, for the same reason: PyPI cannot deliver
+        either to this target.
+
+        `lgpio` is the pin factory. Its PyPI release carries an empty module and
+        apt builds the extension per interpreter version, so an isolated venv
+        cannot import it and gpiozero falls back to NativeFactory, which drives
         pins without claiming the line through the kernel.
+
+        `RPi` is adafruit-blinka's platform library, shipped by the image as
+        `python3-rpi-lgpio` — the RPi.GPIO API over lgpio. Without it
+        `import board` raises RuntimeError, which is a crash on the supported
+        Pi and nothing at all elsewhere, so the i2c adapter could not open an
+        ADS1115 on the only platform it exists for. It cannot be wheelhoused:
+        `rpi-lgpio` publishes a pure wheel but requires `lgpio>=0.1.0.1`, and
+        every lgpio above the 0.0.0.2 placeholder is an sdist that
+        `--only-binary` refuses. Staging it does not move the pin factory —
+        gpiozero 2.x still selects LGPIOFactory with the shim present.
 
         The venv stays isolated and the module is taken by name. Creating it
         with `--system-site-packages` would put every apt package on the
         runtime's import path, where an unpinned optional import — a transport,
         a hardware backend — could activate a capability no release reviewed.
+
+        Only the manifest is copied. `RPi/` is not walked: a directory copy
+        would let a future apt package decide how much of the system a release
+        takes, and would sweep in egg-info metadata describing an installation
+        this release is not.
 
         The bytes are copied rather than linked, for two reasons. The release
         permission transaction requires an external symlink target to be
@@ -2158,43 +2216,65 @@ class OfflineReleasePreparer:
         # Discovery is constrained as well as isolated: the interpreter says
         # where it would import from, and only an admitted system directory is
         # accepted as that answer.
-        origin = (
-            self._probe(
-                base,
-                "import importlib.util as u;"
-                f"s = u.find_spec({_SYSTEM_PIN_FACTORY_MODULE!r});"
-                "print(s.origin or '' if s else '')",
+        origins = {
+            module: (
+                self._probe(
+                    base,
+                    "import importlib.util as u;"
+                    f"s = u.find_spec({module!r});"
+                    "print(s.origin or '' if s else '')",
+                )
+                if base
+                else ""
             )
-            if base
-            else ""
-        )
-        reason = _staging_refusal(venv, base, purelib, suffix, origin)
+            for module in (_SYSTEM_PIN_FACTORY_MODULE, _SYSTEM_BLINKA_SHIM_MODULE)
+        }
+        reason = _staging_refusal(venv, base, purelib, suffix, origins)
         if reason is not None:
             self._refuse_pin_factory(reason)
 
-        source = Path(origin).parent
-        members = [
-            source / f"{_SYSTEM_PIN_FACTORY_MODULE}.py",
-            source / f"_{_SYSTEM_PIN_FACTORY_MODULE}{suffix}",
-        ]
+        source = _staging_root(origins)
+        members = [PurePosixPath(name.format(ext=suffix)) for name in _STAGED_MEMBERS]
         for member in members:
-            failure = _system_file_failure(member)
+            failure = _system_file_failure(source / member)
             if failure is not None:
-                self._refuse_pin_factory(f"{member.name} {failure}")
+                self._refuse_pin_factory(f"{member} {failure}")
+
         destination = Path(purelib)
+        # A fresh venv holds none of these names. One already sitting there
+        # means the wheelhouse or the staging tree is not what it should be,
+        # and overwriting it would hide that. Directories are refused for the
+        # same reason: a release must not merge its modules into a tree
+        # something else created.
         for member in members:
-            target = destination / member.name
-            # A fresh venv holds neither name. One already sitting there means
-            # the wheelhouse or the staging tree is not what it should be, and
-            # overwriting it would hide that.
-            if target.exists() or target.is_symlink():
-                self._refuse_pin_factory(
-                    f"{member.name} is already present in the release"
-                )
+            for depth in range(1, len(member.parts) + 1):
+                candidate = destination / PurePosixPath(*member.parts[:depth])
+                if candidate.is_symlink() or (
+                    candidate.exists() and candidate.is_file()
+                ):
+                    self._refuse_pin_factory(
+                        f"{member} is already present in the release"
+                    )
+            parent = (destination / member).parent
+            if parent != destination and parent.exists() and not parent.is_dir():
+                self._refuse_pin_factory(f"{member} cannot be placed in the release")
+
         for member in members:
-            target = destination / member.name
-            shutil.copyfile(member, target)
+            target = destination / member
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.chmod(target.parent, 0o755)
+            shutil.copyfile(source / member, target)
             os.chmod(target, 0o644)
+
+        # Staging is only useful if the release can import what was staged, and
+        # a copied file is not proof of that: the extension is ABI-tagged, and
+        # a package needs every level of its own tree. Ask the interpreter that
+        # will do the importing.
+        for module in (_SYSTEM_PIN_FACTORY_MODULE, "RPi.GPIO"):
+            if self._probe(python, f"import {module}; print('ok')") != "ok":
+                self._refuse_pin_factory(
+                    f"{module} could not be imported from the release after staging"
+                )
 
     def _refuse_pin_factory(self, reason: str) -> NoReturn:
         raise LinuxInstallError(

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -2071,11 +2071,15 @@ def _staging_refusal(
 def _shim_refusal(origins: dict[str, str], root: Path) -> str | None:
     """Why the blinka shim cannot be staged, or None.
 
-    Never fails an install. The shim is absent on images that ship the classic
-    `python3-rpi.gpio` instead, and on any image where nobody installed it, and
-    those devices install and run today. Refusing them would break working
-    deployments to add a capability they may not use; the runtime reports the
-    driver unavailable at connect instead.
+    Never fails an install. A Pi that staged the pin factory but has no shim
+    installs today, and the classic `python3-rpi.gpio` can occupy the same
+    import name with a layout this manifest does not carry. Refusing either
+    would break a working deployment to add a capability it may not use; the
+    runtime reports the driver unavailable at connect instead.
+
+    A Pi with no pin factory never reaches here: mandatory staging refuses
+    first. Measured on a Bookworm 3.11 arm64 image, which packages neither
+    `python3-lgpio` nor `python3-rpi-lgpio`.
     """
     origin = origins.get(_SYSTEM_BLINKA_SHIM_MODULE, "")
     if not origin:
@@ -2311,8 +2315,8 @@ class OfflineReleasePreparer:
             )
 
         # The shim is best effort. Its absence costs i2c sensors and nothing
-        # else, and images that ship the classic `python3-rpi.gpio`, or ship
-        # neither, install and run today.
+        # else, and a Pi that staged the pin factory without it installs
+        # today. A Pi with no pin factory never reaches this line.
         shim_reason = _shim_refusal(origins, root)
         if shim_reason is None:
             shim_members = [PurePosixPath(name) for name in _BLINKA_SHIM_MEMBERS]
@@ -2356,14 +2360,20 @@ class OfflineReleasePreparer:
                 return f"{member} {failure}"
             # A fresh venv holds none of these names. One already sitting there
             # means the wheelhouse or the staging tree is not what it should
-            # be, and overwriting it would hide that. Every component is
-            # checked, not just the leaf: a symlink one level up redirects the
-            # write as surely as one at the end.
+            # be, and overwriting it would hide that.
+            #
+            # Every component is checked, not just the leaf: a symlink one
+            # level up redirects the write as surely as one at the end. And an
+            # existing *directory* is refused too, not only a file — a release
+            # must not merge its modules into a tree something else created,
+            # and `RPi/` from another package is exactly the tree that would
+            # be merged into. Only the release's own site directory may
+            # already exist, because it is what is being written into.
             for depth in range(1, len(member.parts) + 1):
                 candidate = destination / PurePosixPath(*member.parts[:depth])
                 if candidate.is_symlink():
                     return f"{member} would be written through a symbolic link"
-                if candidate.exists() and not candidate.is_dir():
+                if candidate.exists():
                     return f"{member} is already present in the release"
         for member in members:
             target = destination / member

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -1977,9 +1977,14 @@ _SYSTEM_PIN_FACTORY_MODULE = "lgpio"
 # an RPi.GPIO-compatible module, and without one `import board` raises
 # RuntimeError rather than ImportError — a crash on the supported Pi and
 # nothing anywhere else. It cannot come from the wheelhouse: `rpi-lgpio`
-# publishes a pure wheel but requires `lgpio>=0.1.0.1`, and every lgpio release
-# above the zero-byte 0.0.0.2 placeholder is an sdist, which `--only-binary`
-# cannot take. Raspberry Pi OS ships it prebuilt as `python3-rpi-lgpio`.
+# publishes a pure wheel but requires `lgpio>=0.1.0.1`, and no lgpio release
+# publishes a wheel for the supported interpreter: 0.2.2.0 ships cp39 through
+# cp312 and no cp313, 0.1.0.0 ships eggs pip cannot install, and the
+# requirement excludes the zero-byte 0.0.0.2 placeholder. One lock serves every
+# target, so a resolution that cannot satisfy the supported Trixie tuple fails
+# the wheelhouse build. Raspberry Pi OS ships it prebuilt as
+# `python3-rpi-lgpio`, and apt's build is wanted regardless, being matched to
+# this interpreter's ABI.
 _SYSTEM_BLINKA_SHIM_MODULE = "RPi"
 
 # Exactly what is copied, relative to an admitted system package directory.
@@ -1989,12 +1994,22 @@ _SYSTEM_BLINKA_SHIM_MODULE = "RPi"
 # package decide how much of the system a release takes, and would sweep in
 # egg-info metadata that describes an installation this release is not. Adding
 # a file here is a reviewed change; adding one to the image is not.
-_STAGED_MEMBERS = (
-    "lgpio.py",
-    "_lgpio{ext}",
-    "RPi/__init__.py",
-    "RPi/GPIO/__init__.py",
-)
+#
+# The two sets are separate because they carry different obligations. Without
+# the pin factory a device cannot drive its relay, so its absence fails the
+# install. Without the shim a device cannot read an i2c sensor, which matters
+# only where one is configured — and the shim is not on every supported image.
+_PIN_FACTORY_MEMBERS = ("lgpio.py", "_lgpio{ext}")
+_BLINKA_SHIM_MEMBERS = ("RPi/__init__.py", "RPi/GPIO/__init__.py")
+
+# Which apt package to name when one is missing. A refusal that names the
+# module leaves an operator searching; naming the package is the actionable
+# half.
+_SYSTEM_PACKAGE_NAMES = {
+    _SYSTEM_PIN_FACTORY_MODULE: "python3-lgpio",
+    _SYSTEM_BLINKA_SHIM_MODULE: "python3-rpi-lgpio",
+}
+
 # Where a Raspberry Pi OS image puts apt's Python packages. Discovery is
 # constrained to this set so an interpreter answering from somewhere else
 # cannot decide what gets copied into a release.
@@ -2041,21 +2056,40 @@ def _staging_refusal(
         return "the release site directory lies outside the environment"
     if not suffix:
         return "the interpreter reports no extension suffix"
-    for module, origin in origins.items():
-        if not origin:
-            return (
-                f"{module} is not installed; "
-                "install the system package that provides it"
-            )
-        # A module resolves to its own file; a package resolves to its
-        # `__init__.py`, one level deeper. Both must sit under the same
-        # admitted root, so that one answer cannot import a release's files
-        # from a directory another answer never admitted.
-        root = Path(origin).parent
-        if module == _SYSTEM_BLINKA_SHIM_MODULE:
-            root = root.parent
-        if root not in _SYSTEM_PACKAGE_DIRECTORIES:
-            return f"{module} resolves outside the admitted system package directories"
+    origin = origins.get(_SYSTEM_PIN_FACTORY_MODULE, "")
+    if not origin:
+        package = _SYSTEM_PACKAGE_NAMES[_SYSTEM_PIN_FACTORY_MODULE]
+        return f"{_SYSTEM_PIN_FACTORY_MODULE} is not installed; install {package}"
+    if Path(origin).parent not in _SYSTEM_PACKAGE_DIRECTORIES:
+        return (
+            f"{_SYSTEM_PIN_FACTORY_MODULE} resolves outside the admitted "
+            "system package directories"
+        )
+    return None
+
+
+def _shim_refusal(origins: dict[str, str], root: Path) -> str | None:
+    """Why the blinka shim cannot be staged, or None.
+
+    Never fails an install. The shim is absent on images that ship the classic
+    `python3-rpi.gpio` instead, and on any image where nobody installed it, and
+    those devices install and run today. Refusing them would break working
+    deployments to add a capability they may not use; the runtime reports the
+    driver unavailable at connect instead.
+    """
+    origin = origins.get(_SYSTEM_BLINKA_SHIM_MODULE, "")
+    if not origin:
+        package = _SYSTEM_PACKAGE_NAMES[_SYSTEM_BLINKA_SHIM_MODULE]
+        return f"{_SYSTEM_BLINKA_SHIM_MODULE} is not installed ({package})"
+    # A module resolves to its own file; a package resolves to its
+    # `__init__.py`, one level deeper. Lift to the directory the package sits
+    # in, so the comparison is against a system directory rather than the
+    # package itself.
+    if Path(origin).parent.parent != root:
+        return (
+            f"{_SYSTEM_BLINKA_SHIM_MODULE} resolves outside the directory the "
+            "pin factory was read from"
+        )
     return None
 
 
@@ -2063,6 +2097,22 @@ def _staging_root(origins: dict[str, str]) -> Path:
     """The single admitted directory every staged member is read from."""
     origin = origins[_SYSTEM_PIN_FACTORY_MODULE]
     return Path(origin).parent
+
+
+def _escapes_root(source: Path, member: PurePosixPath, root: Path) -> bool:
+    """Whether a member reaches outside the directory it is read from.
+
+    `find_spec` answers with an unresolved origin, and only a path's final
+    component is `lstat`ed before it is copied — so a symlink at an
+    *intermediate* component reads from wherever it points. A single-file
+    module has no intermediate component; a package does, which is why this
+    check arrives alongside one.
+    """
+    try:
+        resolved = Path(os.path.realpath(source / member))
+    except OSError:
+        return True
+    return not resolved.is_relative_to(root)
 
 
 def _system_file_failure(path: Path) -> str | None:
@@ -2094,6 +2144,10 @@ class OfflineReleasePreparer:
         self._bundle = bundle
         self._runner = runner or _run_command
         self._bootstrap_python = bootstrap_python
+        # Non-fatal conditions an operator needs to know about. Retained as
+        # well as printed: a degradation nobody can see is the failure this
+        # project refuses, and a caller may want to carry it into a report.
+        self.notes: list[str] = []
 
     def prepare(self, staging: Path) -> None:
         wheelhouse = self._bundle.root / "wheelhouse"
@@ -2169,8 +2223,11 @@ class OfflineReleasePreparer:
         Pi and nothing at all elsewhere, so the i2c adapter could not open an
         ADS1115 on the only platform it exists for. It cannot be wheelhoused:
         `rpi-lgpio` publishes a pure wheel but requires `lgpio>=0.1.0.1`, and
-        every lgpio above the 0.0.0.2 placeholder is an sdist that
-        `--only-binary` refuses. Staging it does not move the pin factory —
+        no lgpio release publishes a wheel for the supported interpreter:
+        0.2.2.0 ships cp39 through cp312 and no cp313, 0.1.0.0 ships eggs, and
+        the requirement excludes the 0.0.0.2 placeholder. apt's build is wanted
+        regardless, being matched to this interpreter's ABI and to the system
+        liblgpio. Staging it does not move the pin factory —
         gpiozero 2.x still selects LGPIOFactory with the shim present.
 
         The venv stays isolated and the module is taken by name. Creating it
@@ -2234,47 +2291,106 @@ class OfflineReleasePreparer:
             self._refuse_pin_factory(reason)
 
         source = _staging_root(origins)
-        members = [PurePosixPath(name.format(ext=suffix)) for name in _STAGED_MEMBERS]
+        root = source.resolve(strict=False)
+
+        # The pin factory is mandatory: a device that cannot drive its relay
+        # must not finish installing and report itself healthy.
+        pin_members = [
+            PurePosixPath(name.format(ext=suffix)) for name in _PIN_FACTORY_MEMBERS
+        ]
+        failure = self._stage_members(source, root, Path(purelib), pin_members)
+        if failure is not None:
+            self._refuse_pin_factory(failure)
+        if (
+            self._probe(python, f"import {_SYSTEM_PIN_FACTORY_MODULE}; print('ok')")
+            != "ok"
+        ):
+            self._refuse_pin_factory(
+                f"{_SYSTEM_PIN_FACTORY_MODULE} could not be imported from the "
+                "release after staging"
+            )
+
+        # The shim is best effort. Its absence costs i2c sensors and nothing
+        # else, and images that ship the classic `python3-rpi.gpio`, or ship
+        # neither, install and run today.
+        shim_reason = _shim_refusal(origins, root)
+        if shim_reason is None:
+            shim_members = [PurePosixPath(name) for name in _BLINKA_SHIM_MEMBERS]
+            shim_reason = self._stage_members(source, root, Path(purelib), shim_members)
+            if shim_reason is None and (
+                self._probe(python, "import RPi.GPIO; print('ok')") != "ok"
+            ):
+                # A different package can occupy the same import name with a
+                # layout this manifest does not carry — the classic RPi.GPIO
+                # keeps its implementation in a compiled `_GPIO` extension. A
+                # half-staged package is worse than none, so take it back out.
+                self._unstage(Path(purelib), shim_members)
+                shim_reason = (
+                    "RPi.GPIO could not be imported from the release after "
+                    "staging; the installed package is not the expected shim"
+                )
+        if shim_reason is not None:
+            self._report(
+                "adafruit-blinka has no platform library in this release "
+                f"({shim_reason}); i2c sensors will report their driver "
+                "unavailable"
+            )
+
+    def _stage_members(
+        self,
+        source: Path,
+        root: Path,
+        destination: Path,
+        members: list[PurePosixPath],
+    ) -> str | None:
+        """Copy one member set, or say why it cannot be copied.
+
+        Nothing is written until every member has passed, so a refusal leaves
+        the release as it found it.
+        """
         for member in members:
+            if _escapes_root(source, member, root):
+                return f"{member} resolves outside the staging root"
             failure = _system_file_failure(source / member)
             if failure is not None:
-                self._refuse_pin_factory(f"{member} {failure}")
-
-        destination = Path(purelib)
-        # A fresh venv holds none of these names. One already sitting there
-        # means the wheelhouse or the staging tree is not what it should be,
-        # and overwriting it would hide that. Directories are refused for the
-        # same reason: a release must not merge its modules into a tree
-        # something else created.
-        for member in members:
+                return f"{member} {failure}"
+            # A fresh venv holds none of these names. One already sitting there
+            # means the wheelhouse or the staging tree is not what it should
+            # be, and overwriting it would hide that. Every component is
+            # checked, not just the leaf: a symlink one level up redirects the
+            # write as surely as one at the end.
             for depth in range(1, len(member.parts) + 1):
                 candidate = destination / PurePosixPath(*member.parts[:depth])
-                if candidate.is_symlink() or (
-                    candidate.exists() and candidate.is_file()
-                ):
-                    self._refuse_pin_factory(
-                        f"{member} is already present in the release"
-                    )
-            parent = (destination / member).parent
-            if parent != destination and parent.exists() and not parent.is_dir():
-                self._refuse_pin_factory(f"{member} cannot be placed in the release")
-
+                if candidate.is_symlink():
+                    return f"{member} would be written through a symbolic link"
+                if candidate.exists() and not candidate.is_dir():
+                    return f"{member} is already present in the release"
         for member in members:
             target = destination / member
             target.parent.mkdir(parents=True, exist_ok=True)
             os.chmod(target.parent, 0o755)
             shutil.copyfile(source / member, target)
             os.chmod(target, 0o644)
+        return None
 
-        # Staging is only useful if the release can import what was staged, and
-        # a copied file is not proof of that: the extension is ABI-tagged, and
-        # a package needs every level of its own tree. Ask the interpreter that
-        # will do the importing.
-        for module in (_SYSTEM_PIN_FACTORY_MODULE, "RPi.GPIO"):
-            if self._probe(python, f"import {module}; print('ok')") != "ok":
-                self._refuse_pin_factory(
-                    f"{module} could not be imported from the release after staging"
-                )
+    def _unstage(self, destination: Path, members: list[PurePosixPath]) -> None:
+        """Remove a member set, and any directories it alone created."""
+        for member in members:
+            target = destination / member
+            with contextlib.suppress(OSError):
+                target.unlink()
+        for member in members:
+            parent = (destination / member).parent
+            while parent != destination:
+                try:
+                    parent.rmdir()
+                except OSError:
+                    break
+                parent = parent.parent
+
+    def _report(self, message: str) -> None:
+        self.notes.append(message)
+        print(f"warning: {message}", file=sys.stderr)
 
     def _refuse_pin_factory(self, reason: str) -> NoReturn:
         raise LinuxInstallError(

--- a/requirements/pi.in
+++ b/requirements/pi.in
@@ -16,10 +16,22 @@
 # working module is apt's `python3-lgpio`, whose extension is built per
 # interpreter: `_lgpio.cpython-313-aarch64-linux-gnu.so`.
 #
-# So the pin factory comes from the operating system, and the runtime venv must
-# be able to see it. That is also why the interpreter matters: a venv on any
-# version other than the one apt built for cannot import that extension, and
-# GPIO silently degrades to simulation. See docs/RASPBERRY_PI_SUPPORT.md.
+# So the pin factory comes from the operating system, and the installer stages
+# it. It is not seen: the release venv is built with
+# `include-system-site-packages = false`, so nothing under
+# /usr/lib/python3/dist-packages is on its import path. `_stage_system_modules`
+# in ori/installer/linux.py copies an allow-listed manifest of apt-owned,
+# ABI-matched files into the isolated venv after the wheelhouse install.
+#
+# adafruit-blinka's platform library arrives the same way and for the same
+# reason. `board` needs an RPi.GPIO-compatible module and raises RuntimeError
+# without one; the image ships `python3-rpi-lgpio`, and `rpi-lgpio` cannot be
+# wheelhoused because it requires `lgpio>=0.1.0.1` while every lgpio above the
+# zero-byte 0.0.0.2 placeholder is an sdist that `--only-binary` refuses.
+#
+# That is also why the interpreter matters: a venv on any version other than
+# the one apt built for cannot import that extension, and GPIO silently
+# degrades to simulation. See docs/RASPBERRY_PI_SUPPORT.md.
 gpiozero>=2.0.1.post3
 smbus2>=0.4
 # The ADS1115 driver the I2C adapter imports. Never declared until now, so the

--- a/requirements/pi.in
+++ b/requirements/pi.in
@@ -26,8 +26,10 @@
 # adafruit-blinka's platform library arrives the same way and for the same
 # reason. `board` needs an RPi.GPIO-compatible module and raises RuntimeError
 # without one; the image ships `python3-rpi-lgpio`, and `rpi-lgpio` cannot be
-# wheelhoused because it requires `lgpio>=0.1.0.1` while every lgpio above the
-# zero-byte 0.0.0.2 placeholder is an sdist that `--only-binary` refuses.
+# wheelhoused because it requires `lgpio>=0.1.0.1` while no lgpio release
+# publishes a wheel for the supported interpreter: 0.2.2.0 ships cp39 through
+# cp312 and no cp313, 0.1.0.0 ships eggs, and the requirement excludes the
+# zero-byte 0.0.0.2 placeholder.
 #
 # That is also why the interpreter matters: a venv on any version other than
 # the one apt built for cannot import that extension, and GPIO silently

--- a/tests/evidence/test_disclosure.py
+++ b/tests/evidence/test_disclosure.py
@@ -1284,6 +1284,12 @@ PATTERN_AUDIT_EXEMPT = {
         "raw pin readings are the deliberately public provenance of a "
         "hardware observation."
     ),
+    "docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md": (
+        "Bench measurement record for installer staging on a Pi, not "
+        "evidence-chain evidence; its module paths, library versions and the "
+        "resolved GPIO backend are the deliberately public provenance of a "
+        "hardware observation."
+    ),
     "docs/evidence/2026-09-01-pi4-circuit-leg-observations.md": (
         "Bench measurement record for protected-circuit behaviour at a wired "
         "load, not evidence-chain evidence; its wiring, scripts and raw pin "

--- a/tests/test_installer_system_staging.py
+++ b/tests/test_installer_system_staging.py
@@ -10,19 +10,22 @@ down rather than trusting to review.
 """
 
 import os
-from pathlib import Path
-
-import pytest
+from pathlib import Path, PurePosixPath
 
 from ori.installer.linux import (
-    _STAGED_MEMBERS,
+    _BLINKA_SHIM_MEMBERS,
+    _PIN_FACTORY_MEMBERS,
     _SYSTEM_BLINKA_SHIM_MODULE,
     _SYSTEM_PACKAGE_DIRECTORIES,
     _SYSTEM_PIN_FACTORY_MODULE,
+    _escapes_root,
+    _shim_refusal,
     _staging_refusal,
     _staging_root,
     _system_file_failure,
 )
+
+_STAGED_MEMBERS = _PIN_FACTORY_MEMBERS + _BLINKA_SHIM_MEMBERS
 
 ADMITTED = str(_SYSTEM_PACKAGE_DIRECTORIES[0])
 
@@ -69,21 +72,23 @@ class TestStagingRefusal:
             is None
         )
 
-    def test_a_package_resolving_outside_the_admitted_root_is_refused(self, tmp_path):
+    def test_a_shim_outside_the_pin_factory_directory_is_not_staged(self, tmp_path):
         """The shim is a package, so its origin sits one level deeper.
 
-        Comparing that parent directly would admit any `RPi/` anywhere, which
-        is the check this path exists for.
+        The lift to the package's own parent is a correctness fix, not a
+        security check — comparing the origin's parent directly would refuse
+        every legitimate case. What this asserts is that a shim found somewhere
+        other than where the pin factory came from is not read.
         """
-        reason = _staging_refusal(
-            tmp_path,
-            "/usr/bin/python3",
-            str(tmp_path),
-            ".so",
+        reason = _shim_refusal(
             _origins(rpi="/home/attacker/RPi/__init__.py"),
+            _SYSTEM_PACKAGE_DIRECTORIES[0],
         )
         assert reason is not None
         assert _SYSTEM_BLINKA_SHIM_MODULE in reason
+
+    def test_a_shim_in_the_pin_factory_directory_is_staged(self):
+        assert _shim_refusal(_origins(), _SYSTEM_PACKAGE_DIRECTORIES[0]) is None
 
     def test_a_pin_factory_outside_the_admitted_root_is_refused(self, tmp_path):
         reason = _staging_refusal(
@@ -96,18 +101,33 @@ class TestStagingRefusal:
         assert reason is not None
         assert _SYSTEM_PIN_FACTORY_MODULE in reason
 
-    @pytest.mark.parametrize(
-        "missing", [_SYSTEM_PIN_FACTORY_MODULE, _SYSTEM_BLINKA_SHIM_MODULE]
-    )
-    def test_either_module_missing_is_refused_by_name(self, tmp_path, missing):
-        """Both are required; naming which one is absent is the actionable part."""
+    def test_a_missing_pin_factory_names_its_apt_package(self, tmp_path):
+        """A refusal that names the module leaves an operator searching."""
         origins = _origins()
-        origins[missing] = ""
+        origins[_SYSTEM_PIN_FACTORY_MODULE] = ""
         reason = _staging_refusal(
             tmp_path, "/usr/bin/python3", str(tmp_path), ".so", origins
         )
         assert reason is not None
-        assert missing in reason
+        assert "python3-lgpio" in reason
+
+    def test_a_missing_shim_does_not_fail_the_install(self, tmp_path):
+        """Images shipping the classic RPi.GPIO, or neither, install today.
+
+        Refusing them would break working deployments to add a capability they
+        may not use, so the shim's absence is reported and never fatal.
+        """
+        origins = _origins()
+        origins[_SYSTEM_BLINKA_SHIM_MODULE] = ""
+        assert (
+            _staging_refusal(
+                tmp_path, "/usr/bin/python3", str(tmp_path), ".so", origins
+            )
+            is None
+        )
+        reason = _shim_refusal(origins, _SYSTEM_PACKAGE_DIRECTORIES[0])
+        assert reason is not None
+        assert "python3-rpi-lgpio" in reason
 
     def test_an_absent_extension_suffix_is_refused(self, tmp_path):
         assert (
@@ -137,11 +157,57 @@ class TestSystemFileRefusal:
     def test_a_directory_is_not_a_regular_file(self, tmp_path):
         assert _system_file_failure(tmp_path) == "is not a regular file"
 
-    def test_a_group_writable_file_is_refused(self, tmp_path):
+    def test_a_group_writable_file_is_refused_for_being_writable(
+        self, tmp_path, monkeypatch
+    ):
+        """Asserted on the writability branch, not the ownership one.
+
+        A test that accepts either refusal passes on a developer machine
+        through ownership alone, and would not notice the writability check
+        being deleted.
+        """
         member = tmp_path / "member.py"
         member.write_text("x", encoding="utf-8")
         os.chmod(member, 0o664)
-        failure = _system_file_failure(member)
-        # Ownership is checked first and this file is not root-owned in a test,
-        # so accept either refusal: what matters is that it is refused.
-        assert failure is not None
+        real_lstat = os.lstat
+
+        def as_root(path, *args, **kwargs):
+            info = real_lstat(path, *args, **kwargs)
+            return os.stat_result(
+                (info.st_mode, info.st_ino, info.st_dev, info.st_nlink, 0, 0)
+                + tuple(info)[6:]
+            )
+
+        monkeypatch.setattr(os, "lstat", as_root)
+        assert _system_file_failure(member) == "is writable beyond its owner"
+
+
+class TestIntermediateComponents:
+    """A package member has a directory between the root and the file.
+
+    `find_spec` answers with an unresolved origin and only a path's final
+    component is `lstat`ed, so a symlink one level up reads from wherever it
+    points. The single-file members never had an intermediate component; the
+    shim introduced one.
+    """
+
+    def test_a_symlinked_intermediate_directory_escapes_and_is_caught(self, tmp_path):
+        root = tmp_path / "dist"
+        (root / "real").mkdir(parents=True)
+        outside = tmp_path / "outside"
+        (outside / "GPIO").mkdir(parents=True)
+        (outside / "GPIO" / "__init__.py").write_text("HOSTILE", encoding="utf-8")
+        (root / "RPi").symlink_to(outside)
+
+        member = PurePosixPath("RPi/GPIO/__init__.py")
+        # The file itself passes every check made on the final component.
+        assert _system_file_failure(root / member) != "is missing"
+        assert _escapes_root(root, member, root.resolve())
+
+    def test_a_member_inside_the_root_does_not_escape(self, tmp_path):
+        root = tmp_path / "dist"
+        (root / "RPi" / "GPIO").mkdir(parents=True)
+        (root / "RPi" / "GPIO" / "__init__.py").write_text("ok", encoding="utf-8")
+        assert not _escapes_root(
+            root, PurePosixPath("RPi/GPIO/__init__.py"), root.resolve()
+        )

--- a/tests/test_installer_system_staging.py
+++ b/tests/test_installer_system_staging.py
@@ -1,0 +1,147 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Staging apt-owned modules into an isolated release venv.
+
+This path had no tests. It runs as root, reads from a system directory and
+writes into a release, and it now carries adafruit-blinka's platform library as
+well as the pin factory — so what it will and will not take is worth pinning
+down rather than trusting to review.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from ori.installer.linux import (
+    _STAGED_MEMBERS,
+    _SYSTEM_BLINKA_SHIM_MODULE,
+    _SYSTEM_PACKAGE_DIRECTORIES,
+    _SYSTEM_PIN_FACTORY_MODULE,
+    _staging_refusal,
+    _staging_root,
+    _system_file_failure,
+)
+
+ADMITTED = str(_SYSTEM_PACKAGE_DIRECTORIES[0])
+
+
+def _origins(*, lgpio: str | None = None, rpi: str | None = None) -> dict[str, str]:
+    return {
+        _SYSTEM_PIN_FACTORY_MODULE: (
+            f"{ADMITTED}/lgpio.py" if lgpio is None else lgpio
+        ),
+        _SYSTEM_BLINKA_SHIM_MODULE: (
+            f"{ADMITTED}/RPi/__init__.py" if rpi is None else rpi
+        ),
+    }
+
+
+class TestStagedManifest:
+    def test_the_manifest_is_exactly_the_four_reviewed_paths(self):
+        """A directory copy would let apt decide what a release takes."""
+        assert set(_STAGED_MEMBERS) == {
+            "lgpio.py",
+            "_lgpio{ext}",
+            "RPi/__init__.py",
+            "RPi/GPIO/__init__.py",
+        }
+
+    def test_no_manifest_entry_escapes_the_staging_root(self):
+        for name in _STAGED_MEMBERS:
+            assert not name.startswith("/")
+            assert ".." not in Path(name.format(ext=".so")).parts
+
+    def test_the_manifest_takes_no_metadata(self):
+        """egg-info describes an installation this release is not."""
+        assert not any(
+            "egg-info" in name or "dist-info" in name for name in _STAGED_MEMBERS
+        )
+
+
+class TestStagingRefusal:
+    def test_a_complete_system_is_accepted(self, tmp_path):
+        assert (
+            _staging_refusal(
+                tmp_path, "/usr/bin/python3", str(tmp_path), ".so", _origins()
+            )
+            is None
+        )
+
+    def test_a_package_resolving_outside_the_admitted_root_is_refused(self, tmp_path):
+        """The shim is a package, so its origin sits one level deeper.
+
+        Comparing that parent directly would admit any `RPi/` anywhere, which
+        is the check this path exists for.
+        """
+        reason = _staging_refusal(
+            tmp_path,
+            "/usr/bin/python3",
+            str(tmp_path),
+            ".so",
+            _origins(rpi="/home/attacker/RPi/__init__.py"),
+        )
+        assert reason is not None
+        assert _SYSTEM_BLINKA_SHIM_MODULE in reason
+
+    def test_a_pin_factory_outside_the_admitted_root_is_refused(self, tmp_path):
+        reason = _staging_refusal(
+            tmp_path,
+            "/usr/bin/python3",
+            str(tmp_path),
+            ".so",
+            _origins(lgpio="/tmp/lgpio.py"),
+        )
+        assert reason is not None
+        assert _SYSTEM_PIN_FACTORY_MODULE in reason
+
+    @pytest.mark.parametrize(
+        "missing", [_SYSTEM_PIN_FACTORY_MODULE, _SYSTEM_BLINKA_SHIM_MODULE]
+    )
+    def test_either_module_missing_is_refused_by_name(self, tmp_path, missing):
+        """Both are required; naming which one is absent is the actionable part."""
+        origins = _origins()
+        origins[missing] = ""
+        reason = _staging_refusal(
+            tmp_path, "/usr/bin/python3", str(tmp_path), ".so", origins
+        )
+        assert reason is not None
+        assert missing in reason
+
+    def test_an_absent_extension_suffix_is_refused(self, tmp_path):
+        assert (
+            _staging_refusal(
+                tmp_path, "/usr/bin/python3", str(tmp_path), "", _origins()
+            )
+            is not None
+        )
+
+    def test_the_staging_root_is_the_admitted_directory(self):
+        assert _staging_root(_origins()) == _SYSTEM_PACKAGE_DIRECTORIES[0]
+
+
+class TestSystemFileRefusal:
+    """Every staged source is checked before a privileged copy reads it."""
+
+    def test_a_symlink_is_not_a_regular_file(self, tmp_path):
+        real = tmp_path / "real.py"
+        real.write_text("x", encoding="utf-8")
+        link = tmp_path / "link.py"
+        link.symlink_to(real)
+        assert _system_file_failure(link) == "is not a regular file"
+
+    def test_a_missing_file_is_reported_as_missing(self, tmp_path):
+        assert _system_file_failure(tmp_path / "absent.py") == "is missing"
+
+    def test_a_directory_is_not_a_regular_file(self, tmp_path):
+        assert _system_file_failure(tmp_path) == "is not a regular file"
+
+    def test_a_group_writable_file_is_refused(self, tmp_path):
+        member = tmp_path / "member.py"
+        member.write_text("x", encoding="utf-8")
+        os.chmod(member, 0o664)
+        failure = _system_file_failure(member)
+        # Ownership is checked first and this file is not root-owned in a test,
+        # so accept either refusal: what matters is that it is refused.
+        assert failure is not None

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -1473,6 +1473,8 @@ def _pi_preparer(
     on_pi: bool = True,
     purelib: Path | None = None,
     occupied: bool = False,
+    shim_present: bool = True,
+    import_answer: str = "ok",
 ) -> tuple[Path, list[Sequence[str]], Callable[[], None]]:
     """A Pi bundle whose system probe answers with *source* as lgpio's home."""
     root = tmp_path / "bundle"
@@ -1506,7 +1508,16 @@ def _pi_preparer(
         elif "EXT_SUFFIX" in body:
             stdout = suffix
         elif "find_spec" in body:
-            stdout = str(source / "lgpio.py") if source is not None else ""
+            if source is None:
+                stdout = ""
+            elif "'RPi'" in body:
+                stdout = str(source / "RPi" / "__init__.py") if shim_present else ""
+            else:
+                stdout = str(source / "lgpio.py")
+        elif "print('ok')" in body:
+            # The post-stage check asks the release interpreter whether what
+            # was copied can actually be imported.
+            stdout = import_answer
         elif "purelib" in body:
             stdout = str(site_packages)
         return subprocess.CompletedProcess(command, 0, stdout, "")
@@ -1527,6 +1538,16 @@ def _plant(directory: Path, *, suffix: str = _EXT_SUFFIX) -> None:
     (directory / "yaml.py").write_text("", encoding="utf-8")
     # An extension left behind for a different interpreter ABI.
     (directory / "_lgpio.cpython-311-aarch64-linux-gnu.so").write_bytes(b"stale")
+    # adafruit-blinka's platform library, as `python3-rpi-lgpio` lays it out,
+    # with the metadata a directory copy would sweep up beside it.
+    shim = directory / "RPi"
+    (shim / "GPIO").mkdir(parents=True, exist_ok=True)
+    (shim / "__init__.py").write_text("", encoding="utf-8")
+    (shim / "GPIO" / "__init__.py").write_text("BLINKA_SHIM", encoding="utf-8")
+    (shim / "GPIO" / "scratch.py").write_text("NOT_IN_MANIFEST", encoding="utf-8")
+    egg = directory / "rpi_lgpio-0.6.egg-info"
+    egg.mkdir(parents=True, exist_ok=True)
+    (egg / "PKG-INFO").write_text("", encoding="utf-8")
 
 
 def _accept_system_files(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -1553,9 +1574,55 @@ def test_offline_preparer_copies_the_pin_factory_into_a_pi_venv(
     )
     run()
     staged = sorted(entry.name for entry in purelib.iterdir())
-    assert staged == [f"_lgpio{_EXT_SUFFIX}", "lgpio.py"]
+    assert staged == ["RPi", f"_lgpio{_EXT_SUFFIX}", "lgpio.py"]
     assert not any((purelib / name).is_symlink() for name in staged)
     assert (purelib / "lgpio.py").read_text(encoding="utf-8") == "PIN_FACTORY"
+    # The shim keeps its package layout, or `import RPi.GPIO` cannot work.
+    assert (purelib / "RPi" / "GPIO" / "__init__.py").read_text(
+        encoding="utf-8"
+    ) == "BLINKA_SHIM"
+
+
+def test_offline_preparer_refuses_a_release_it_cannot_import_from(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Copied bytes are not proof the release can import them.
+
+    The extension is ABI-tagged and the shim needs every level of its own
+    package; a stage that finished without the release being able to import
+    either would leave gpiozero on NativeFactory and `board` still raising.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    _, _, run = _pi_preparer(
+        tmp_path,
+        source=tmp_path / "dist",
+        monkeypatch=monkeypatch,
+        import_answer="",
+    )
+    with pytest.raises(LinuxInstallError) as excinfo:
+        run()
+    assert "could not be imported" in str(excinfo.value)
+
+
+def test_offline_preparer_refuses_when_the_blinka_shim_is_absent(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Both modules are required, and the refusal says which one is missing."""
+    dist = tmp_path / "dist"
+    _plant(dist)
+    shutil.rmtree(dist / "RPi")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (dist,))
+    _, _, run = _pi_preparer(
+        tmp_path, source=dist, monkeypatch=monkeypatch, shim_present=False
+    )
+    with pytest.raises(LinuxInstallError) as excinfo:
+        run()
+    assert "RPi" in str(excinfo.value)
 
 
 def test_offline_preparer_takes_only_the_current_abi_and_nothing_else(
@@ -1574,6 +1641,9 @@ def test_offline_preparer_takes_only_the_current_abi_and_nothing_else(
     staged = {entry.name for entry in purelib.iterdir()}
     assert "yaml.py" not in staged
     assert "_lgpio.cpython-311-aarch64-linux-gnu.so" not in staged
+    # A directory copy of RPi/ would take both of these.
+    assert "rpi_lgpio-0.6.egg-info" not in staged
+    assert not (purelib / "RPi" / "GPIO" / "scratch.py").exists()
 
 
 def test_offline_preparer_probes_the_system_in_isolated_mode(

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -1475,6 +1475,7 @@ def _pi_preparer(
     occupied: bool = False,
     shim_present: bool = True,
     import_answer: str = "ok",
+    shim_import_answer: str | None = None,
 ) -> tuple[Path, list[Sequence[str]], Callable[[], None]]:
     """A Pi bundle whose system probe answers with *source* as lgpio's home."""
     root = tmp_path / "bundle"
@@ -1516,8 +1517,14 @@ def _pi_preparer(
                 stdout = str(source / "lgpio.py")
         elif "print('ok')" in body:
             # The post-stage check asks the release interpreter whether what
-            # was copied can actually be imported.
-            stdout = import_answer
+            # was copied can actually be imported. The two member sets are
+            # asked separately, because only one of them is mandatory.
+            if "RPi.GPIO" in body:
+                stdout = (
+                    import_answer if shim_import_answer is None else shim_import_answer
+                )
+            else:
+                stdout = import_answer
         elif "purelib" in body:
             stdout = str(site_packages)
         return subprocess.CompletedProcess(command, 0, stdout, "")
@@ -1537,7 +1544,7 @@ def _plant(directory: Path, *, suffix: str = _EXT_SUFFIX) -> None:
     (directory / f"_lgpio{suffix}").write_bytes(b"\x7fELF")
     (directory / "yaml.py").write_text("", encoding="utf-8")
     # An extension left behind for a different interpreter ABI.
-    (directory / "_lgpio.cpython-311-aarch64-linux-gnu.so").write_bytes(b"stale")
+    (directory / "_lgpio.cpython-310-aarch64-linux-gnu.so").write_bytes(b"stale")
     # adafruit-blinka's platform library, as `python3-rpi-lgpio` lays it out,
     # with the metadata a directory copy would sweep up beside it.
     shim = directory / "RPi"
@@ -1583,15 +1590,94 @@ def test_offline_preparer_copies_the_pin_factory_into_a_pi_venv(
     ) == "BLINKA_SHIM"
 
 
-def test_offline_preparer_refuses_a_release_it_cannot_import_from(
+@pytest.mark.parametrize(
+    "suffix",
+    [
+        ".cpython-311-aarch64-linux-gnu.so",
+        ".cpython-312-aarch64-linux-gnu.so",
+        ".cpython-313-aarch64-linux-gnu.so",
+    ],
+)
+def test_offline_preparer_stages_the_shim_for_every_supported_interpreter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    """The shim is pure Python; only the pin factory extension is ABI-bound.
+
+    3.12 and 3.13 are supported targets and 3.11 is community, so a change that
+    staged only for the interpreter it was written on would break two of the
+    three published aarch64 bundles. The extension is selected by the ABI tag;
+    the shim's two files are the same on all of them.
+    """
+    dist = tmp_path / "dist"
+    _plant(dist, suffix=suffix)
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (dist,))
+    purelib, _, run = _pi_preparer(
+        tmp_path, source=dist, monkeypatch=monkeypatch, suffix=suffix
+    )
+    run()
+    staged = sorted(entry.name for entry in purelib.iterdir())
+    assert staged == ["RPi", f"_lgpio{suffix}", "lgpio.py"]
+    assert (purelib / "RPi" / "GPIO" / "__init__.py").read_text(
+        encoding="utf-8"
+    ) == "BLINKA_SHIM"
+    # The extension for another interpreter is left where it was.
+    assert not (purelib / "_lgpio.cpython-310-aarch64-linux-gnu.so").exists()
+
+
+def test_offline_preparer_installs_without_the_blinka_shim(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Copied bytes are not proof the release can import them.
+    """A missing shim reports and never fails the install.
 
-    The extension is ABI-tagged and the shim needs every level of its own
-    package; a stage that finished without the release being able to import
-    either would leave gpiozero on NativeFactory and `board` still raising.
+    Images that ship the classic `python3-rpi.gpio`, and images where nobody
+    installed either, install and run today. Refusing them would break working
+    deployments to add a capability they may not use — the runtime reports the
+    i2c driver unavailable at connect instead.
     """
+    dist = tmp_path / "dist"
+    _plant(dist)
+    shutil.rmtree(dist / "RPi")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (dist,))
+    purelib, _, run = _pi_preparer(
+        tmp_path, source=dist, monkeypatch=monkeypatch, shim_present=False
+    )
+    run()
+    staged = sorted(entry.name for entry in purelib.iterdir())
+    assert staged == [f"_lgpio{_EXT_SUFFIX}", "lgpio.py"]
+
+
+def test_offline_preparer_takes_back_a_shim_the_release_cannot_import(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A different package can occupy the same import name.
+
+    The classic RPi.GPIO keeps its implementation in a compiled `_GPIO`
+    extension this manifest does not carry, so the copied files would be a
+    package that cannot import. Half-staged is worse than absent.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, _, run = _pi_preparer(
+        tmp_path,
+        source=tmp_path / "dist",
+        monkeypatch=monkeypatch,
+        shim_import_answer="",
+    )
+    run()
+    staged = sorted(entry.name for entry in purelib.iterdir())
+    assert staged == [f"_lgpio{_EXT_SUFFIX}", "lgpio.py"]
+    assert not (purelib / "RPi").exists()
+
+
+def test_offline_preparer_refuses_a_release_that_cannot_import_the_pin_factory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The pin factory is mandatory, so its import failure is fatal."""
     _plant(tmp_path / "dist")
     _accept_system_files(monkeypatch)
     monkeypatch.setattr(
@@ -1606,23 +1692,6 @@ def test_offline_preparer_refuses_a_release_it_cannot_import_from(
     with pytest.raises(LinuxInstallError) as excinfo:
         run()
     assert "could not be imported" in str(excinfo.value)
-
-
-def test_offline_preparer_refuses_when_the_blinka_shim_is_absent(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Both modules are required, and the refusal says which one is missing."""
-    dist = tmp_path / "dist"
-    _plant(dist)
-    shutil.rmtree(dist / "RPi")
-    _accept_system_files(monkeypatch)
-    monkeypatch.setattr(installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (dist,))
-    _, _, run = _pi_preparer(
-        tmp_path, source=dist, monkeypatch=monkeypatch, shim_present=False
-    )
-    with pytest.raises(LinuxInstallError) as excinfo:
-        run()
-    assert "RPi" in str(excinfo.value)
 
 
 def test_offline_preparer_takes_only_the_current_abi_and_nothing_else(
@@ -1640,7 +1709,7 @@ def test_offline_preparer_takes_only_the_current_abi_and_nothing_else(
     run()
     staged = {entry.name for entry in purelib.iterdir()}
     assert "yaml.py" not in staged
-    assert "_lgpio.cpython-311-aarch64-linux-gnu.so" not in staged
+    assert "_lgpio.cpython-310-aarch64-linux-gnu.so" not in staged
     # A directory copy of RPi/ would take both of these.
     assert "rpi_lgpio-0.6.egg-info" not in staged
     assert not (purelib / "RPi" / "GPIO" / "scratch.py").exists()

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -1474,6 +1474,7 @@ def _pi_preparer(
     purelib: Path | None = None,
     occupied: bool = False,
     shim_present: bool = True,
+    occupied_dirs: tuple[str, ...] = (),
     import_answer: str = "ok",
     shim_import_answer: str | None = None,
 ) -> tuple[Path, list[Sequence[str]], Callable[[], None]]:
@@ -1502,6 +1503,10 @@ def _pi_preparer(
             site_packages.mkdir(parents=True, exist_ok=True)
             if occupied:
                 (site_packages / "lgpio.py").write_text("SQUATTER", encoding="utf-8")
+            for name in occupied_dirs:
+                occupant = site_packages / name
+                occupant.mkdir(parents=True, exist_ok=True)
+                (occupant / "squatter.py").write_text("SQUATTER", encoding="utf-8")
         body = command[-1]
         stdout = ""
         if "sys._base_executable" in body:
@@ -1625,15 +1630,51 @@ def test_offline_preparer_stages_the_shim_for_every_supported_interpreter(
     assert not (purelib / "_lgpio.cpython-310-aarch64-linux-gnu.so").exists()
 
 
+@pytest.mark.parametrize("occupied", ["RPi", "RPi/GPIO"])
+def test_offline_preparer_refuses_to_merge_into_a_tree_it_did_not_create(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, occupied: str
+) -> None:
+    """An existing directory is refused, not merged into.
+
+    A file or a symlink at a manifest component was already refused; an
+    ordinary directory was not, so the staged files would land beside whatever
+    put it there. `RPi/` from a different package is exactly the tree that
+    would be merged into, and the result imports as `RPi.GPIO`.
+
+    The shim is best effort, so this reports rather than failing the install —
+    but nothing may be written on the way to that decision.
+    """
+    _plant(tmp_path / "dist")
+    _accept_system_files(monkeypatch)
+    monkeypatch.setattr(
+        installer_linux, "_SYSTEM_PACKAGE_DIRECTORIES", (tmp_path / "dist",)
+    )
+    purelib, _, run = _pi_preparer(
+        tmp_path,
+        source=tmp_path / "dist",
+        monkeypatch=monkeypatch,
+        occupied_dirs=(occupied,),
+    )
+    run()
+    # The occupant is untouched and nothing of the manifest joined it.
+    occupant = purelib / occupied
+    assert (occupant / "squatter.py").read_text(encoding="utf-8") == "SQUATTER"
+    assert not (purelib / "RPi" / "__init__.py").exists()
+    assert not (purelib / "RPi" / "GPIO" / "__init__.py").exists()
+    # The pin factory is unaffected: it shares no path component with the shim.
+    assert (purelib / "lgpio.py").read_text(encoding="utf-8") == "PIN_FACTORY"
+
+
 def test_offline_preparer_installs_without_the_blinka_shim(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """A missing shim reports and never fails the install.
 
-    Images that ship the classic `python3-rpi.gpio`, and images where nobody
-    installed either, install and run today. Refusing them would break working
-    deployments to add a capability they may not use — the runtime reports the
-    i2c driver unavailable at connect instead.
+    A Pi that staged the pin factory but has no shim installs today, and the
+    classic `python3-rpi.gpio` can occupy the same import name. Refusing either
+    would break a working deployment to add a capability it may not use — the
+    runtime reports the i2c driver unavailable at connect instead. A Pi with no
+    pin factory never reaches here; mandatory staging refuses first.
     """
     dist = tmp_path / "dist"
     _plant(dist)


### PR DESCRIPTION
## What does this PR do?

adafruit-blinka builds `board` for a Pi through an RPi.GPIO-compatible module and raises `RuntimeError` without one. That is a crash on the supported Pi and nothing at all on a host with no blinka, so it passed every developer machine and every CI job while the i2c adapter could not open an ADS1115 on the only platform it exists for. #494 stopped the crash; this is what lets the path actually open.

**It cannot come from the wheelhouse, and finding that out is most of this change.** `rpi-lgpio` publishes a pure `py3-none-any` wheel, but requires `lgpio>=0.1.0.1`, and no `lgpio` release publishes a wheel for the supported interpreter: `0.2.2.0` ships cp39 through cp312 and **no cp313**, `0.1.0.0` ships eggs pip cannot install, and the requirement excludes the zero-byte `0.0.0.2` placeholder — so pinning the placeholder is a hard resolver conflict. One lock serves every target, so a resolution that cannot satisfy the supported Trixie tuple fails the Pi wheelhouse build at release time, the same way `RPi.GPIO` failed, one level down. It also silently dropped `sysv-ipc` from the lock. And apt's build is wanted regardless: it is matched to this interpreter's ABI and to the system liblgpio.

(An earlier revision of this description said every release above the placeholder was an sdist. That was wrong — `0.2.2.0` publishes wheels, just not for cp313.)

`requirements/pi.txt` is therefore **untouched**. Raspberry Pi OS ships the shim prebuilt as `python3-rpi-lgpio`, so it is staged the way the pin factory already is.

## The staging is a manifest, not a directory copy

Four allow-listed paths, preserving package layout:

```
lgpio.py
_lgpio{ext}
RPi/__init__.py
RPi/GPIO/__init__.py
```

Walking `RPi/` would let a future apt package decide how much of the system a release takes, and would sweep in `egg-info` describing an installation this release is not. Adding a file here is a reviewed change; adding one to the image is not.

Three checks beyond what was there:

- **Both modules must resolve under the same admitted system directory.** A package resolves one level deeper than a module, so the root is normalised before comparison — without that, any `RPi/` anywhere on disk would be admitted.
- **Destination collision refusal extends to every path component**, so a release never merges its modules into a tree something else created.
- **The release is asked afterwards whether it can import what was copied.** An ABI-tagged extension and a package tree are both things a successful copy can still fail to provide.

The venv stays isolated; `--system-site-packages` is never enabled.

`pi.in` claimed the runtime venv "must be able to see" the system pin factory. It cannot — the venv is built with `include-system-site-packages = false`, and lgpio works because it is *staged*. Corrected.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

Privileged installer staging adjacent to Tier D GPIO control, so it warrants its own review rather than riding on #494's.

## Verification

Hardware evidence: `docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md`. On the bench Pi 4, Raspberry Pi OS Trixie, stock Python 3.13.5 —

```
$ pip install --require-hashes -r requirements/pi.txt     exit 0
   lgpio: not installed        rpi-lgpio: not installed        sysv-ipc: 1.2.0

   isolated venv (no dist-packages on path): True
   lgpio, RPi.GPIO, board, busio: all import
   pin factory: LGPIOFactory | arbitrated: True
   ADS1115 at 0x48, A0 tied to GND: -0.00063 V
```

`arbitrated: True` is the property that matters beyond importing — the backend holds its line through the kernel rather than driving `/dev/gpiomem` unclaimed, so a second writer is refused. Relay actuation is unchanged; the factory was resolved and its chip handle observed, nothing was driven.

Seven mutations, each failing by its own tests: dropping the shim from the manifest; comparing the package root without normalising the extra level; letting a missing module pass; accepting a symlink as a regular file; removing the post-stage import check; adding a non-manifest file so the copy behaves like a directory walk; and removing the destination collision refusal.

Full suite 5245 passed, 28 skipped. `ruff check`, `ruff format --check`, `mypy ori/` clean. `guard-capability-matrix.sh` OK.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

No capability claim moves: a path that could not open on the Pi now can, and nothing new is claimed as supported. The matrix guard passes without an edit.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

## Merge order

`Closes #495`. **#494 is already merged** — PR #498, commit `4e401bb`, at 10:41 today — and this branch contains it (`git merge-base --is-ancestor 4e401bb HEAD` passes), so `_DRIVER_FAILURE = (ImportError, RuntimeError)` is present here. The blinka `RuntimeError` no longer escapes `i2c_adapter` import, which is what makes the best-effort path degrade to a reported driver-unavailable rather than a crash. There is no outstanding merge dependency.



---

## Update after review

**Occupied manifest directories are now refused.** A file or symlink at a component was refused; an ordinary directory was not, so staged files would have landed beside whatever created it — and `RPi/` from another package is exactly that tree. Every pre-existing component is refused now, which makes the following guard unreachable, so it goes. Two tests cover occupied `RPi/` and occupied `RPi/GPIO/`, and both assert nothing was written on the way to the refusal.

**The Bookworm compatibility claim was wrong and is now measured.** I said the post-stage probe would have failed an install "that works today". Run against a real Bookworm 3.11 arm64 environment answering as Pi hardware, against the installer's own staging code:

```
no pin factory:
  refused -> prerequisite_install_failed: ... install python3-lgpio
  notes: []                       <- the shim block never ran

pin factory present, shim absent:
  install proceeds
  notes: ['adafruit-blinka has no platform library in this release ...']
  staged: lgpio.py, _lgpio.cpython-311-aarch64-linux-gnu.so
```

Bookworm packages neither `python3-lgpio` nor `python3-rpi-lgpio`, so such a Pi refuses today and still refuses — unchanged by this work. What the best-effort shim actually protects is the second configuration: a Pi that staged the pin factory and has no shim, or has the classic `python3-rpi.gpio` occupying the import name. Corrected in the code, `pi.in`, `RASPBERRY_PI_SUPPORT.md` and the evidence document.

**Interpreter coverage.** 3.12 and 3.13 are supported targets and 3.11 is community. The shim is pure Python and only `_lgpio` is ABI-bound, asserted by a test parametrised across all three suffixes. The shim block runs strictly after the mandatory pin factory, so on any interpreter without an ABI-matched `_lgpio` the install refuses before it — which is why this cannot regress a 3.11 or 3.12 deployment.

