### PR TITLE
fix(hal): select the ADS1115 channel and verify it before every measurement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -626,16 +626,19 @@ device:
 
 sensors:
   - id: load-current
-    type: current_clamp
+    type: ads1115_current
     protocol: i2c
     address: 0x48
     channel: 0
     poll_interval_ms: 1000
+    calibration:
+      sensitivity_v_per_amp: 0.0333 # the clamp's own figure; no default exists
+      mains_frequency_hz: 50.0
 
   - id: grid-voltage
-    type: voltage
+    type: ads1115_voltage
     protocol: i2c
-    address: 0x48
+    address: 0x49 # one ADS1115 serves one sensor; a second channel is a second chip
     channel: 1
     poll_interval_ms: 2000
 

--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -21,6 +21,52 @@ plan a deployment around one.
 
 Reference bench: Pi 4 Model B, BCM2711, 4GB.
 
+### What is on the bench I2C bus, and how the i2c tests run for real
+
+`tests/test_i2c_adapter.py::TestPiIntegration` skips, naming what it needs,
+on any host without the hardware. On the bench it runs. Recorded here so that
+whoever runs the suite there does not have to rediscover it.
+
+| Part | Address | Wiring to the Pi header | Driver in the test venv |
+| --- | --- | --- | --- |
+| ADS1115 ADC | `0x48` | VDD→1 (3.3 V), SDA→3, SCL→5, GND→6, ADDR→9 (ground, selects 0x48), A0→14 (ground, a defined input for timing runs) | `adafruit-circuitpython-ads1x15` 3.0.5 from pip; blinka's platform library from apt `python3-rpi-lgpio` |
+| BME280 | `0x76` | not fitted | `bme280` — its test skips |
+
+One ADS1115 serves one sensor per runtime. The chip has a single input
+multiplexer and the driver keeps its own idea of the selected pin per adapter,
+so a second sensor on the same chip moves the mux under the first and both
+report the wrong channel — reproduced on this bench. The runtime refuses a
+second sensor on a claimed chip at connect; a second channel is a second chip
+at a second address (ADDR to VDD for `0x49`). The chip's whole configuration,
+not the mux alone, is read back at the start of every measurement, so a gain,
+data rate or conversion mode changed by anything outside the runtime refuses
+the measurement rather than quietly rescaling it. A change that lands part-way
+through a window is caught at the next window, not within that one.
+
+A full bus scan (`sudo /usr/sbin/i2cdetect -y 1` — the binary is on the root
+path only) shows `48` and nothing else. `/dev/i2c-1` is present on the image;
+no I2C enabling step was needed.
+
+VDD is taken from 3.3 V, not 5 V: the Pi's I2C lines are 3.3 V and VDD sets the
+ADS1115's input ceiling. ADDR and A0 go to header ground pins directly rather
+than to the MB102 rail that carries the relay coil and fan returns, so their
+switching noise stays off the ADC's reference.
+
+The test environment, per issue #431:
+
+```text
+python3 -m venv --system-site-packages .venv    # sees apt's lgpio and rpi-lgpio
+.venv/bin/pip install -e .
+.venv/bin/pip install pytest pytest-asyncio adafruit-circuitpython-ads1x15==3.0.5
+.venv/bin/python -m pytest tests/test_i2c_adapter.py -k PiIntegration -rs
+```
+
+With A0 grounded the DC read and the rail-pinned refusal run; the RMS current
+test skips until the mid-rail bias network — two equal resistors from 3.3 V to
+ground, a capacitor holding the midpoint, the SCT-013-030 across the midpoint
+and A0 — is fitted. A grounded input is not a clamp signal, and the window
+refuses it as clipped, which is the correct answer and is itself asserted.
+
 ## Why the interpreter version is not cosmetic
 
 Ori drives GPIO through `gpiozero`. It never imports `RPi.GPIO` directly.
@@ -31,7 +77,7 @@ from whatever is installed. On Trixie that is `LGPIOFactory`, backed by
 
 That package ships a compiled extension built **per interpreter version**:
 
-```
+```text
 /usr/lib/python3/dist-packages/_lgpio.cpython-313-aarch64-linux-gnu.so
 ```
 
@@ -42,7 +88,7 @@ and the consequence is worse than a failure.
 back to `NativeFactory`, its own experimental implementation. Measured on the
 bench Pi, installing this lock into an isolated virtual environment gives:
 
-```
+```text
 PinFactoryFallback: Falling back from pigpio: No module named 'pigpio'
 NativePinFactoryFallback: Falling back to the experimental pin factory
 NativeFactory because no other pin factory could be loaded.

--- a/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
+++ b/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
@@ -1,0 +1,189 @@
+# the ADS1115 measurement path, characterised on the bench Pi
+
+**Result: the release's driver path sustains the advertised 860 SPS with
+10 µs jitter; three of the four provisional measurement constants are now
+measured and left as they were; the fourth waits on the clamp. Two defects
+were found on the way, and the second is the kind no clip check questions.**
+
+Run on the bench Raspberry Pi 4 Model B, Raspberry Pi OS Trixie, stock Python
+3.13.5, on 2026-09-03, with the runtime service active throughout. The driver
+path is the release's own: adafruit-blinka over `/dev/i2c-1`, the platform
+library staged from apt `python3-rpi-lgpio`, `adafruit-circuitpython-ads1x15`
+3.0.5. The ADS1115 is at `0x48`; A0 is tied to a header ground pin.
+
+## Rate and jitter
+
+Unpaced, the path reads the conversion register **3000 times a second**
+against an 860 SPS conversion rate — roughly 3.5 reads per conversion. An
+unpaced loop therefore meets any sample floor with the same value repeated,
+which is why `_read_ads1115_current` paces at the conversion interval.
+
+Paced as the adapter paces, over a 2-cycle 50 Hz window (40 ms), three trials
+at each rate:
+
+```text
+rate=860  samples=36  gap_mean=1.164ms  max=1.219..1.222ms  sd=0.009..0.010ms
+rate=475  samples=20  gap_mean=2.108ms  max=2.163..2.184ms  sd=0.014..0.018ms
+rate=250  samples=11  gap_mean=4.006ms  max=4.058..4.059ms  sd=0.017..0.018ms
+```
+
+The target interval at 860 SPS is 1.163 ms. The worst single gap ran 5% over
+it; the jitter is an order of magnitude under the interval.
+
+These are host read cadences. The driver's first continuous read sleeps for two
+conversion intervals inside the window it opens, and the pacing loop then
+catches up with back-to-back reads, so the first window after a connect carries
+a few duplicated conversions where later windows carry one. A worst gap of
+1.222 ms cannot contain that 2.3 ms sleep, so the windows recorded here were not
+the first after their connect.
+
+## What that settles, and what it does not
+
+| Constant | Was | Now |
+| --- | --- | --- |
+| `data_rate: 860` | datasheet figure, unmeasured | **measured on the host side**: the reads sustain 860 a second, evenly spaced, and the config word carries the 860 SPS rate bits. A0 was grounded throughout, so a duplicate read of one conversion cannot be told from a fresh one; that the chip converts at 860 is the datasheet's claim and the configuration's, not this bench's |
+| `_MIN_SAMPLE_FRACTION = 2/3` | derived from the above, so equally unmeasured | **measured safe**: nominal 34.4 samples gives a floor of 22; the window delivers 36, ~60% headroom. Left at two thirds — the margin is for a loaded Pi, and the load here was one running runtime |
+| `overrun_tolerance: 1.5` | a guess at scheduling slop | **measured safe**: it bounds the whole window's elapsed time against nominal, and five windows ran 41.09 ms against 40.00 ms — ratio 1.027, recorded below. 1.5x is far more slack than needed |
+| `clip_margin_volts: 0.05` | assumes saturation reads near a rail | **low rail only**: a grounded input reads between -0.0006 and +0.0000 V single-shot (recorded below), inside the margin, and the window is refused as clipped. The high rail needs a saturated clamp on the bench and stays provisional |
+
+None of the three measured constants changes value: each was already safe, and
+the record is what changes — from "provisional, unmeasured" to "measured, and
+why the margin is kept".
+
+Recorded verbatim, so the two figures above are measurements and not quotes:
+
+```text
+single-shot A0, five reads:  -0.0006  -0.0001  -0.0004  -0.0001  +0.0000  V
+
+whole-window elapsed, paced as the adapter paces, 2 cycles at 50 Hz:
+  trial 0: samples=36 elapsed=41.090 ms nominal=40.000 ms ratio=1.0273
+  trial 1: samples=36 elapsed=41.090 ms nominal=40.000 ms ratio=1.0272
+  trial 2: samples=36 elapsed=41.089 ms nominal=40.000 ms ratio=1.0272
+  trial 3: samples=36 elapsed=41.092 ms nominal=40.000 ms ratio=1.0273
+  trial 4: samples=36 elapsed=41.089 ms nominal=40.000 ms ratio=1.0272
+```
+
+## Defect 1: the configured channel was never selected
+
+The pinned driver, the latest published, never selects a channel in continuous
+mode: `_write_config` re-reads the chip's current mux and discards the
+requested pin unless the mode is `SINGLE`. The adapter built the ADS1115 in
+continuous mode, so both `ads1115_current` and `ads1115_voltage` read whatever
+mux the chip already held. Proven at the register — chip forced to its
+power-on default, then a fresh continuous object asked for channel 0:
+
+```text
+chip mux after construction:  A0-A1 diff
+ch0 read: -0.0001 V   mux now: A0-A1 diff   <- asked A0 single, got A0-A1 diff
+asked for channel 1:          chip mux now: A0 single  <- pin ignored
+```
+
+On a fresh chip that is the A0-A1 differential: a clamp on A0 measured against
+a floating pin. A floating input on this part drifts between roughly 0 and
++0.6 V, so the value reported depended on an unconnected pin. This is
+ori-runtime#500. The fix selects the channel with one single-shot read, which
+is the one path in this driver that honours the pin, before switching to
+continuous mode, and reads the mux back.
+
+## Defect 2: after the fix, every sample was the config register
+
+The first version of that fix read back a constant **+2.1404 V, raw 17123**
+on the grounded input, unchanged by any settle time. 17123 is 0x42E3 — the
+config word for mux 4, gain 1, continuous, 860 SPS. Every config write leaves
+the chip's register pointer on CONFIG, and the driver's continuous-mode read is
+a fast read that does not move the pointer, so it returned the configuration as
+if it were a conversion.
+
+```text
+config register: 17123   fast read now: 17123
+after one pointered read -> 65534   fast read now: 65534   (= -2 counts, ~0 V)
+```
+
+A plausible mid-range voltage that is not a measurement is exactly what a clip
+check cannot catch. The connect now ends with a pointered read after the mux
+readback, and the read path never touches the pointer again.
+
+## Defect 3: two adapters on one chip steal each other's channel
+
+The shipped `ori.yaml.example` puts `load-current` on A0 and `grid-voltage` on
+A1 of the same ADS1115 at `0x48`. The runtime builds one adapter — and one
+driver object — per sensor. The chip has one mux, and once a driver object has
+read its pin its later reads take a fast path that trusts the mux to be where
+it left it. So the second adapter's connect moves the mux, and the first
+adapter's reads follow it, both connects having verified their own channel.
+Reproduced on the bench with the real adapter, A0 grounded and A1 floating:
+
+```text
+load-current (ch0) after its connect:  -0.0003 V   <- A0 grounded
+grid-voltage (ch1) after its connect:  +0.5823 V   <- A1 floating
+load-current read again:               +0.5745 V   <- A1's value, under A0's label
+```
+
+A current channel would then report the voltage channel's waveform as
+amperes. Two things close it. One ADS1115 now serves one adapter per runtime:
+a second connect to a claimed chip is refused, and the shipped example is
+corrected to put its second sensor on a second chip. And the configuration is
+read back before every measurement, not only at connect, with a pointered
+conversion read after it.
+
+The whole config word is compared, not the mux field, because the two changes
+that corrupt a reading most quietly move no mux. A second process that sets its
+own gain rescales every sample: at gain 2/3 against the gain 1 this adapter
+set, a 20.8 A load reads 13.9 A. One that sets single-shot mode leaves the chip
+powered down after one conversion, so the window that follows is a held value
+and a 21.7 A load reads 0.0 A. Both under-report, which is the direction that
+matters for a current a trip threshold is defined over. Both were measured by
+driving the real 3.0.5 driver over a register-level model of the part.
+
+The check certifies the chip at the start of each window, not through it. A
+write that lands mid-window is not caught until the next one, and a foreign
+pointered read mid-window sends the remaining fast reads back to the config
+word: measured in that model at 10.9 A against 20.9 A. Closing that costs
+either a second readback after the window or a pointered read per sample, and
+the per-sample cost at 1.163 ms has not been measured on the bench. Tracked in
+ori-runtime#503 rather than guessed at here.
+
+## Defect 4: a chip at 0x48 that is not an ADS1115 hung the connect
+
+The driver's single-shot read spins on the conversion-complete bit with no
+bound. A TMP102 and an LM75 both default to `0x48`, ACK, and answer with that
+bit clear for any temperature below mid-scale. Reproduced against a simulated
+chip on the host, not on the bench, which has a real ADS1115. The connect now
+writes the mux itself and waits a bounded few conversion intervals for the bit,
+refusing with the address if it never sets.
+
+The bound is not an identity check, and nothing here is. A device whose word
+happens to carry that bit passes the wait, and what refuses it is the
+configuration readback: a foreign word has to match the exact 16 bits this
+adapter wrote to get through. That is a probability, not a proof of part.
+
+## The adapter as fixed
+
+Chip forced to its power-on default, then the real `I2CAdapter` connected on
+channel 0, 1, 0 in turn. For each: the first fast read the read path would
+take, three reads through the adapter, then the config register read back
+pointered, last, so it cannot disturb what came before:
+
+```text
+channel=0: fast read after connect = 65535 counts (a sample, not 0x42E3)
+           reads [-0.0001, 0.0001, -0.0006]     mux read back: A0 single
+channel=1: fast read after connect =  4671 counts (a sample, not 0x42E3)
+           reads [0.5839, 0.5784, 0.5784]       mux read back: A1 single
+channel=0: fast read after connect = 65534 counts (a sample, not 0x42E3)
+           reads [-0.0003, -0.0009, -0.0009]    mux read back: A0 single
+```
+
+A0 is grounded; A1 floats. 65535 and 65534 are -1 and -2 counts, two's
+complement.
+
+`tests/test_i2c_adapter.py::TestPiIntegration` on the bench: the DC read on
+grounded A0 and the rail-pinned refusal pass; the RMS current test skips,
+naming the bias network it needs; the BME280 test skips, naming the part.
+
+## What this does not establish
+
+The high-rail half of `clip_margin_volts`, and the RMS measurement itself over
+a real clamp signal: both need the SCT-013-030 on its mid-rail bias network,
+which is not yet on the bench. Nothing here is a protection claim; the
+measurement path can now be characterised, which is what ori-runtime#398 asked
+for, and its remaining item is the clamp.

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -57,10 +57,14 @@ sensors:
       # max_value: 30.0
 
   # ─── Grid voltage sensor on ADS1115 channel 1 ───────────────────────────
+  # One ADS1115 serves one sensor per runtime. The chip has a single input
+  # multiplexer, and a second sensor on the same chip moves it under the first
+  # — the runtime refuses that at connect. A second channel means a second
+  # chip: ADDR to VDD selects 0x49.
   - id: grid-voltage
     type: ads1115_voltage
     protocol: i2c
-    address: 0x48
+    address: 0x49
     channel: 1
     poll_interval_ms: 2000
 

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -561,6 +561,10 @@ class I2CAdapter(BaseAdapter):
         self._bme280_params: Any = None  # bme280 calibration params
         self._ads: Any = None  # ADS1115 instance
         self._scd4x: Any = None  # SCD4X instance
+        # Whether this adapter holds a reference on the shared busio.I2C. The
+        # count is shared, so releasing one this adapter never took would evict
+        # a handle another adapter is still reading through.
+        self._holds_shared_bus: bool = False
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -601,8 +605,10 @@ class I2CAdapter(BaseAdapter):
             self._calibration = _resolve_calibration(config)
             self._window = _window_spec(self._calibration)
 
+        connected = False
         try:
             await asyncio.to_thread(self._connect_sync, sensor_type)
+            connected = True
         except AdapterConnectionError:
             raise
         except Exception as exc:
@@ -610,6 +616,14 @@ class I2CAdapter(BaseAdapter):
                 f"I2CAdapter: failed to connect to '{sensor_type}' at "
                 f"address 0x{self._address:02X} on bus {self._bus_number}: {exc}"
             ) from exc
+        finally:
+            # The runtime logs a failed connect and moves on without calling
+            # close(), so a connect that raises has to give back what it took
+            # on the way in. A leaked reference keeps the cached bus handle
+            # alive past its last real user, and the next connect is then
+            # handed a stale one.
+            if not connected:
+                self._release_shared_bus()
 
         self._breaker = HardwareCircuitBreaker(
             getattr(self, "adapter_name", type(self).__name__), config
@@ -636,7 +650,6 @@ class I2CAdapter(BaseAdapter):
     def _connect_ads1115(self) -> None:
         _require_drivers(self._sensor_type)
         assert _ads1115 is not None and _ads1x15 is not None
-        i2c = _get_shared_busio_i2c(self._bus_number)
         # The driver defaults are 128 SPS in single-shot mode, which yields
         # about two samples per 50 Hz cycle. Continuous conversion at the
         # configured rate is what makes a window resolvable at all.
@@ -675,6 +688,7 @@ class I2CAdapter(BaseAdapter):
                 )
             _ADS1115_CLAIMS[key] = weakref.ref(self)
         try:
+            i2c = self._acquire_shared_bus()
             self._ads = _ads1115.ADS1115(
                 i2c,
                 address=self._address,
@@ -757,6 +771,19 @@ class I2CAdapter(BaseAdapter):
                 )
             time.sleep(0.0005)
         self._ads.get_last_result(False)
+
+    def _acquire_shared_bus(self) -> Any:
+        """Take a reference on the shared bus, and record that this one holds it."""
+        i2c = _get_shared_busio_i2c(self._bus_number)
+        self._holds_shared_bus = True
+        return i2c
+
+    def _release_shared_bus(self) -> None:
+        """Give back this adapter's reference, once, if it took one."""
+        if not self._holds_shared_bus:
+            return
+        self._holds_shared_bus = False
+        _release_shared_busio_i2c(self._bus_number)
 
     def _release_ads1115_claim(self) -> None:
         key = (self._bus_number, self._address)
@@ -847,7 +874,7 @@ class I2CAdapter(BaseAdapter):
         # come from there — but not the ADS1115 driver. The table says so.
         _require_drivers("scd40")
         assert adafruit_scd4x is not None
-        i2c = _get_shared_busio_i2c(self._bus_number)
+        i2c = self._acquire_shared_bus()
         self._scd4x = adafruit_scd4x.SCD4X(i2c)
         self._scd4x.start_periodic_measurement()
 
@@ -869,8 +896,7 @@ class I2CAdapter(BaseAdapter):
             if self._bus is not None:
                 await asyncio.to_thread(self._bus.close)
                 self._bus = None
-            if self._sensor_type in _ADS_SENSOR_TYPES | {"scd40"}:
-                _release_shared_busio_i2c(self._bus_number)
+            self._release_shared_bus()
         except Exception:
             logger.warning("I2CAdapter: exception during close — already disconnected?")
         finally:

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -6,6 +6,7 @@ import logging
 import math
 import threading
 import time
+import weakref
 from collections.abc import Callable
 from typing import Any
 
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 CONFIG_SCHEMA = {
     "address": {"type": "integer", "default": 0, "minimum": 0, "maximum": 127},
     "bus": {"type": "integer", "default": 1, "minimum": 0},
-    "channel": {"type": "integer", "default": 0, "minimum": 0},
+    "channel": {"type": "integer", "default": 0, "minimum": 0, "maximum": 3},
 }
 CALIBRATION_SCHEMAS = {
     "ads1115_current": {
@@ -129,6 +130,20 @@ except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
 # Sensor types that require the ADS1115 ADC
 _ADS_SENSOR_TYPES = frozenset({"ads1115_current", "ads1115_voltage"})
 
+# One ADS1115 serves one adapter per process. The chip has a single mux, and
+# the pinned driver keeps its own idea of the selected pin per driver object:
+# with two adapters on one chip, the second connect moves the mux and the
+# first adapter's fast reads then return the other channel — both connects
+# having "verified" their channel. The shipped example configures exactly that
+# (load-current on A0, grid-voltage on A1, both at 0x48), so it is refused at
+# connect rather than discovered as amperes that are really volts. Keyed by
+# (bus, address); released by close(), or by the holder being collected. Weak
+# references rather than ids: an id is reused once its object is collected,
+# so a dead holder's id could match a new adapter's and *admit* a second
+# claimant — a false allow, which is the unsafe direction.
+_ADS1115_CLAIMS: "dict[tuple[int, int], weakref.ref[I2CAdapter]]" = {}
+_ADS1115_CLAIMS_LOCK = threading.Lock()
+
 # All sensor types handled by this adapter
 _SUPPORTED = frozenset(
     {
@@ -207,6 +222,21 @@ def i2c_driver_unavailable_reason(sensor_type: str) -> str | None:
     return "; ".join(reasons) or None
 
 
+def _require_int(value: object, name: str) -> int:
+    """Refuse a non-integer rather than truncating it into a valid one.
+
+    `int()` turns 2.5 into channel 2 and True into channel 1, both of which
+    then pass every range check below. Config load already refuses these; an
+    adapter reached directly must fail closed on its own.
+    """
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AdapterConnectionError(
+            f"I2CAdapter: {name} must be an integer, "
+            f"not {type(value).__name__} ({value!r})"
+        )
+    return value
+
+
 def _require_drivers(sensor_type: str) -> None:
     """Refuse a connect whose drivers are unusable, naming what failed."""
     reason = i2c_driver_unavailable_reason(sensor_type)
@@ -228,24 +258,43 @@ def _require_drivers(sensor_type: str) -> None:
 # are facts about an installation, and guessing either produces a plausible
 # number rather than a measurement.
 _REQUIRED_CALIBRATION = ("sensitivity_v_per_amp", "mains_frequency_hz")
-# PROVISIONAL — these four are datasheet figures, not measurements.
+# Three of these four were measured on the bench Pi on 2026-09-03; the fourth
+# was not and is marked. The measurement path is the release's own — blinka over
+# /dev/i2c-1 with the apt-staged platform library — with the runtime service
+# active throughout, so the figures include a realistic load. Three trials each;
+# `docs/evidence/2026-09-03-pi4-ads1115-characterisation.md` carries them.
 #
-# Nothing here has been run against an ADS1115. The arithmetic and the refusals
-# are tested against synthetic waveforms, which proves what the code does with
-# samples and says nothing about what the hardware delivers. Whoever runs the
-# first hardware session should expect to change these, and should treat a
-# sensor that sits permanently degraded as a sign that one of them is wrong
-# rather than that the sensor is:
-#
-#   data_rate            the part advertises 860 SPS. Whether adafruit-blinka
-#                        over I2C on a Pi 4 sustains it, and with what jitter,
-#                        is unmeasured. If the achieved rate is lower, the
-#                        sample floor below refuses every window.
-#   _MIN_SAMPLE_FRACTION derived from data_rate, so wrong for the same reason.
-#   clip_margin_volts    assumes a saturated input reads near the rail. The
-#                        real signature may differ, and if it does the clipping
-#                        refusal never fires and an under-report passes.
-#   overrun_tolerance    a guess at how much scheduling slop a loaded Pi adds.
+#   data_rate            MEASURED on the host side. The part advertises 860 SPS
+#                        and the read path sustains that cadence; with a
+#                        grounded input a duplicate read of one conversion
+#                        cannot be told from a fresh one, so the chip's own
+#                        conversion rate rests on the datasheet and on the rate
+#                        bits in the config word. Paced at the interval, a
+#                        2-cycle 50 Hz window (40 ms) collects 36 samples at a
+#                        mean gap of 1.164 ms against the 1.163 ms target, jitter
+#                        sd 0.010 ms, worst gap 1.222 ms. Unpaced, the same path
+#                        reads the conversion register ~3000 times a second —
+#                        3.5 reads per conversion — which is why the loop below
+#                        paces: an unpaced loop meets the sample floor with the
+#                        same value three times over.
+#   _MIN_SAMPLE_FRACTION MEASURED SAFE. Nominal 34.4 samples at 860 SPS gives a
+#                        floor of 22; the window delivers 36, so the floor holds
+#                        with ~60% headroom. Left at two thirds: the margin is
+#                        for a loaded Pi, and the load during measurement was
+#                        one running runtime, not a worst case.
+#   overrun_tolerance    MEASURED SAFE. It bounds the whole window's elapsed
+#                        time against nominal; five windows on the bench ran
+#                        41.09 ms against 40.00 ms, a ratio of 1.027, so 1.5x
+#                        is far more slack than the path needs and is left
+#                        alone for the same reason.
+#   clip_margin_volts    NOT YET MEASURED at the high rail. A grounded input
+#                        reads between -0.0006 and +0.0000 V single-shot on the
+#                        bench, inside the 0.05 V margin of the low rail, and
+#                        the window is refused as clipped — so the low-rail
+#                        half fires as intended. Whether a
+#                        saturated clamp reads within the margin of the high
+#                        rail needs the clamp and its bias network on the
+#                        bench, and this constant is provisional until then.
 #
 # `window_cycles` and `gain` are not in that list: two whole cycles is a
 # property of the measurement, and gain 1 is the only PGA range that spans a
@@ -269,8 +318,9 @@ _OPTIONAL_CALIBRATION = {
 
 # What fraction of the samples the configured rate should have produced must
 # actually arrive for a window to count. Two thirds leaves room for scheduling
-# slop without accepting a window that covers only part of its cycles.
-# Provisional with `data_rate`: both describe the same unmeasured assumption.
+# slop without accepting a window that covers only part of its cycles. Measured
+# with ~60% headroom on the bench Pi under a running runtime; see the block
+# above for the figures and for why the margin is kept.
 _MIN_SAMPLE_FRACTION = 2 / 3
 _CALIBRATION_KEYS = frozenset(_REQUIRED_CALIBRATION) | frozenset(_OPTIONAL_CALIBRATION)
 
@@ -544,9 +594,9 @@ class I2CAdapter(BaseAdapter):
 
         self._sensor_id = config.get("sensor_id", "")
         self._sensor_type = sensor_type
-        self._address = int(config.get("address", 0x00))
-        self._bus_number = int(config.get("bus", 1))
-        self._channel = int(config.get("channel", 0))
+        self._address = _require_int(config.get("address", 0x00), "address")
+        self._bus_number = _require_int(config.get("bus", 1), "bus")
+        self._channel = _require_int(config.get("channel", 0), "channel")
         if sensor_type == "ads1115_current":
             self._calibration = _resolve_calibration(config)
             self._window = _window_spec(self._calibration)
@@ -590,13 +640,207 @@ class I2CAdapter(BaseAdapter):
         # The driver defaults are 128 SPS in single-shot mode, which yields
         # about two samples per 50 Hz cycle. Continuous conversion at the
         # configured rate is what makes a window resolvable at all.
-        self._ads = _ads1115.ADS1115(
-            i2c,
-            address=self._address,
-            gain=self._calibration.get("gain", 1),
-            data_rate=int(self._calibration.get("data_rate", 860)),
-            mode=_ads1x15.Mode.CONTINUOUS,
+        #
+        # But the channel is selected in single-shot mode first, and that
+        # order is load-bearing. adafruit-circuitpython-ads1x15 3.0.5 — the
+        # pinned release and the latest published — never selects a channel
+        # in continuous mode: `_write_config` re-reads the chip's current mux
+        # and discards the requested pin unless the mode is SINGLE. Built
+        # straight into continuous mode, the adapter read whatever mux the
+        # chip already held; on a chip at its power-on default that is the
+        # A0-A1 differential, so a clamp on A0 was measured against a
+        # floating pin. Measured at the register on the bench Pi.
+        #
+        # One single-shot read of the configured channel writes the mux with
+        # the OS bit — the one path in this driver that honours the pin — and
+        # the mode setter then rewrites the config keeping that mux. The
+        # readback below is what turns "should be" into "is".
+        if not 0 <= self._channel <= 3:
+            # Below zero the readback's `4 + channel` lands on a differential
+            # mux code and would pass; above three it fails with a confusing
+            # message. Neither is a channel this part has.
+            raise AdapterConnectionError(
+                f"I2CAdapter: ADS1115 channel must be 0-3, not {self._channel}"
+            )
+        key = (self._bus_number, self._address)
+        with _ADS1115_CLAIMS_LOCK:
+            ref = _ADS1115_CLAIMS.get(key)
+            holder = ref() if ref is not None else None
+            if holder is not None and holder is not self:
+                raise AdapterConnectionError(
+                    f"I2CAdapter: ADS1115 at 0x{self._address:02X} on bus "
+                    f"{self._bus_number} is already driven by another sensor; "
+                    "one ADS1115 serves one sensor per runtime, because a second "
+                    "adapter moves the shared mux under the first"
+                )
+            _ADS1115_CLAIMS[key] = weakref.ref(self)
+        try:
+            self._ads = _ads1115.ADS1115(
+                i2c,
+                address=self._address,
+                gain=self._calibration.get("gain", 1),
+                data_rate=int(self._calibration.get("data_rate", 860)),
+                mode=_ads1x15.Mode.SINGLE,
+            )
+            self._select_ads1115_channel_single_shot()
+            self._ads.mode = _ads1x15.Mode.CONTINUOUS
+            self._verify_ads1115_channel(AdapterConnectionError)
+            # — the mode switch above, and the readback that just confirmed
+            # it — leaves the chip's register pointer at CONFIG. The driver's
+            # continuous-mode read is a "fast" read that does not move the
+            # pointer, so from here it would return the config word as if it
+            # were a sample: 0x42E3 for this configuration, which scales to a
+            # plausible +2.14 V that no clip check would question. A pointered
+            # read puts
+            # the pointer back on CONVERSION, after waiting for a conversion
+            # at the new rate to exist. This is the last register access at
+            # connect; the read path never touches the pointer again.
+            time.sleep(2 / self._ads.data_rate)
+            self._ads.get_last_result(False)
+        except BaseException:
+            self._release_ads1115_claim()
+            raise
+
+    # Config register pointer and the mux field, from the ADS1115 datasheet.
+    # Single-ended AINn is mux code 4 + n; codes 0-3 are differential pairs.
+    _ADS1115_CONFIG_REGISTER = 0x01
+    _ADS1115_MUX_SHIFT = 12
+    _ADS1115_MUX_SINGLE_ENDED_BASE = 4
+    # The rest of the word, so the readback can be compared against everything
+    # this adapter set rather than the mux alone. Bit 15 reads as conversion
+    # state rather than configuration, so it is masked out of the comparison.
+    _ADS1115_CONFIG_MASK = 0x7FFF
+    _ADS1115_CONTINUOUS_BITS = 0x0000
+    _ADS1115_COMPARATOR_DISABLED = 0x0003
+    _ADS1115_GAIN_BITS = {
+        2 / 3: 0x0000,
+        1: 0x0200,
+        2: 0x0400,
+        4: 0x0600,
+        8: 0x0800,
+        16: 0x0A00,
+    }
+    _ADS1115_RATE_BITS = {
+        8: 0x0000,
+        16: 0x0020,
+        32: 0x0040,
+        64: 0x0060,
+        128: 0x0080,
+        250: 0x00A0,
+        475: 0x00C0,
+        860: 0x00E0,
+    }
+
+    def _select_ads1115_channel_single_shot(self) -> None:
+        """Write the mux in single-shot mode, with a bounded wait.
+
+        The driver's own single-shot read spins on the conversion-complete bit
+        with no bound. A TMP102 and an LM75 both default to 0x48, ACK, and
+        answer with that bit clear for any temperature below mid-scale, so the
+        runtime would hang here with no log line and Tier D never armed. The
+        bound turns that into a refusal.
+
+        It does not identify the part. A device whose word happens to carry
+        that bit passes this wait, and the configuration readback that follows
+        is what refuses it. A chip that does not answer at all is refused by
+        the driver before this is reached.
+        """
+        rate = int(self._ads.data_rate)
+        self._ads._write_config(self._ADS1115_MUX_SINGLE_ENDED_BASE + self._channel)
+        deadline = time.monotonic() + max(0.05, 8 / rate)
+        while not self._ads._conversion_complete():
+            if time.monotonic() > deadline:
+                raise AdapterConnectionError(
+                    f"I2CAdapter: the device at 0x{self._address:02X} on bus "
+                    f"{self._bus_number} never completed a conversion; it is "
+                    "not behaving as an ADS1115"
+                )
+            time.sleep(0.0005)
+        self._ads.get_last_result(False)
+
+    def _release_ads1115_claim(self) -> None:
+        key = (self._bus_number, self._address)
+        with _ADS1115_CLAIMS_LOCK:
+            ref = _ADS1115_CLAIMS.get(key)
+            if ref is not None and ref() is self:
+                del _ADS1115_CLAIMS[key]
+
+    def _expected_ads1115_config(self) -> int:
+        """The configuration word this adapter set, as the chip should hold it."""
+        gain = self._ADS1115_GAIN_BITS.get(self._ads.gain)
+        rate = self._ADS1115_RATE_BITS.get(int(self._ads.data_rate))
+        if gain is None or rate is None:
+            raise MeasurementRefusedError(
+                f"I2CAdapter: ADS1115 gain {self._ads.gain!r} or data rate "
+                f"{self._ads.data_rate!r} is outside the datasheet's settings, "
+                "so the configuration it is running cannot be certified"
+            )
+        return (
+            (self._ADS1115_MUX_SINGLE_ENDED_BASE + self._channel)
+            << self._ADS1115_MUX_SHIFT
+            | gain
+            | self._ADS1115_CONTINUOUS_BITS
+            | rate
+            | self._ADS1115_COMPARATOR_DISABLED
         )
+
+    def _verify_ads1115_channel(self, error: type[Exception]) -> None:
+        """Refuse when the chip is not running the configuration this set.
+
+        Run at connect and again before every measurement, because a connect-
+        time check certifies the chip only until something else touches it: a
+        second adapter in another process on the same chip moves the mux and
+        this adapter's fast reads would follow it. The driver exposes no getter
+        for any of it, so this reads the config register through the driver's
+        register accessor. The driver is pinned by hash, and one that changes
+        shape fails here loudly — a read that cannot prove what it is reporting
+        must not report, because the measurement it feeds is the one a safety
+        condition is defined over.
+
+        The whole word is compared, not the mux field. Anything writing this
+        chip writes a complete configuration, and the two fields that carry no
+        mux change are the ones that corrupt a reading quietly: a gain another
+        process prefers rescales every sample, and single-shot mode leaves the
+        chip powered down after one conversion, so the window that follows is a
+        held value rather than a signal. Both under-report, which is the
+        direction that matters for a current a trip threshold is defined over.
+
+        The readback leaves the chip's register pointer on CONFIG. Callers must
+        follow it with a pointered conversion read before any fast read.
+        """
+        expected = self._expected_ads1115_config()
+        try:
+            config = self._ads._read_register(self._ADS1115_CONFIG_REGISTER)
+        except Exception as exc:
+            # Classified as a refusal, not a bus error: what the caller needs
+            # to know is that this window cannot be shown to be a measurement.
+            raise error(
+                "I2CAdapter: could not read back the ADS1115 configuration to "
+                f"confirm its channel: {type(exc).__name__}: {exc}"
+            ) from exc
+        observed = int(config) & self._ADS1115_CONFIG_MASK
+        mux = (observed >> self._ADS1115_MUX_SHIFT) & 0x7
+        expected_mux = self._ADS1115_MUX_SINGLE_ENDED_BASE + self._channel
+        if mux != expected_mux:
+            raise error(
+                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is reading mux "
+                f"code {mux}, not single-ended channel {self._channel} "
+                f"(code {expected_mux}); the input it reports is not the one "
+                "configured"
+            )
+        if observed != expected:
+            raise error(
+                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is running "
+                f"configuration 0x{observed:04X}, not the 0x{expected:04X} "
+                "this adapter set; its gain, data rate or conversion mode was "
+                "changed by something else, and the samples it returns are no "
+                "longer the ones configured"
+            )
+
+    def _reaffirm_ads1115_channel(self) -> None:
+        """Per-measurement: prove the mux, then re-point the conversion register."""
+        self._verify_ads1115_channel(MeasurementRefusedError)
+        self._ads.get_last_result(False)
 
     def _connect_scd40(self) -> None:
         # scd40 needs blinka as well as its own driver, because busio and board
@@ -610,11 +854,14 @@ class I2CAdapter(BaseAdapter):
     async def close(self) -> None:
         """Release I2C bus resources and stop any periodic measurements.
 
+        Also releases this adapter's claim on its ADS1115, if it holds one.
+
         For Adafruit-based sensors (ADS1115, SCD40) the shared ``busio.I2C``
         cache entry is evicted so that a subsequent :meth:`connect` call
         creates a fresh bus handle.  Existing references held by other adapters
         sharing the same bus are unaffected.
         """
+        self._release_ads1115_claim()
         try:
             if self._scd4x is not None:
                 await asyncio.to_thread(self._scd4x.stop_periodic_measurement)
@@ -734,6 +981,7 @@ class I2CAdapter(BaseAdapter):
             raise AdapterReadError(
                 "I2CAdapter: current calibration was not resolved at connect()"
             )
+        self._reaffirm_ads1115_channel()
         channel = _analog_in.AnalogIn(self._ads, self._channel)
 
         # Monotonic throughout: a wall clock stepped by NTP mid-window would
@@ -794,6 +1042,10 @@ class I2CAdapter(BaseAdapter):
             raise AdapterConnectionError(
                 "I2CAdapter: the ADS1115 driver is not loaded; connect() must run first"
             )
+        # Not downgraded to AdapterReadError: MeasurementRefusedError is one
+        # already, and the subclass is what drives the runtime's degradation
+        # state and operator notice. A voltage channel can be a safety input.
+        self._reaffirm_ads1115_channel()
         chan = _analog_in.AnalogIn(self._ads, self._channel)
         voltage = chan.voltage
         return SensorReading(

--- a/tests/evidence/test_disclosure.py
+++ b/tests/evidence/test_disclosure.py
@@ -1284,6 +1284,12 @@ PATTERN_AUDIT_EXEMPT = {
         "raw pin readings are the deliberately public provenance of a "
         "hardware observation."
     ),
+    "docs/evidence/2026-09-03-pi4-ads1115-characterisation.md": (
+        "Bench measurement record for the ADS1115 measurement path, not "
+        "evidence-chain evidence; its sample rates, register values and raw "
+        "readings are the deliberately public provenance of a hardware "
+        "observation."
+    ),
     "docs/evidence/2026-09-03-pi4-staged-blinka-platform-library.md": (
         "Bench measurement record for installer staging on a Pi, not "
         "evidence-chain evidence; its module paths, library versions and the "

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import itertools
 import math
 import os
 import time
@@ -15,9 +16,11 @@ from ori.hal.base import (
     AdapterReadError,
     AdapterTimeoutError,
     HardwareCircuitBreaker,
+    MeasurementRefusedError,
 )
 from ori.hal.i2c_adapter import (
     _ADS1115_AVAILABLE,
+    _BLINKA_AVAILABLE,
     _BME280_AVAILABLE,
     I2CAdapter,
     _window_spec,
@@ -37,6 +40,12 @@ def _needs_hardware(
     installed or that anything answers at the address, and these tests need
     both. Reporting a missing driver as a failure reads as a defect in the
     adapter, so a Pi run showed two red tests that said nothing about the code.
+
+    `available` must cover every driver the sensor type reads through, not just
+    the one that names it. An ADS1115 needs blinka for its bus as well as the
+    ADC driver, and a guard that checked only the latter would run the test on
+    a host that cannot open a bus — failing at connect, which is the outcome
+    this decorator exists to prevent.
     """
     return pytest.mark.skipif(
         not (_HAS_I2C_BUS and available),
@@ -45,6 +54,16 @@ def _needs_hardware(
             f"{package} package; install it on the bench to run this for real"
         ),
     )
+
+
+@pytest.fixture(autouse=True)
+def _clear_ads1115_claims():
+    """One ADS1115 serves one adapter, and most tests never close theirs."""
+    import ori.hal.i2c_adapter
+
+    ori.hal.i2c_adapter._ADS1115_CLAIMS.clear()
+    yield
+    ori.hal.i2c_adapter._ADS1115_CLAIMS.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -110,6 +129,13 @@ def _connected_ads_adapter(
     adapter._channel = 0
     adapter._breaker = HardwareCircuitBreaker("I2CAdapter", {})
     adapter._ads = MagicMock()
+    # The config readback before every measurement: the configured channel
+    # single-ended (mux 4 + n), PGA gain 1, continuous, 860 SPS, comparator off.
+    adapter._ads.gain = 1
+    adapter._ads.data_rate = 860
+    adapter._ads._read_register.side_effect = lambda *_a, **_k: (
+        ((4 + adapter._channel) << 12) | 0x0200 | 0x00E0 | 0x0003
+    )
     if sensor_type == "ads1115_current":
         from ori.hal.i2c_adapter import _resolve_calibration
 
@@ -144,6 +170,156 @@ class TestModuleImport:
 
 
 # ─── connect — validation ─────────────────────────────────────────────────────
+
+
+class _PinnedDriverADS1115:
+    """The 3.0.5 driver's channel, pointer and single-shot behaviour, reproduced.
+
+    In `Mode.SINGLE`, writing a pin sets the mux and the OS bit and a read
+    polls the conversion-complete bit — forever, if it never sets. In
+    `Mode.CONTINUOUS` the pin is discarded and the chip's existing mux kept;
+    once a pin has been read, later reads take a *fast* path that does not
+    move the register pointer. Every config write moves the pointer to
+    CONFIG; a fast read returns whatever the pointer is on, config word
+    included.
+
+    A fake more permissive than this on any of those lets a wrong connect
+    sequence pass, which is exactly what happened once. The guard tests at
+    the end of this file hold the fake to the driver.
+    """
+
+    SINGLE, CONTINUOUS = 0x0100, 0x0000
+    POINTER_CONVERSION, POINTER_CONFIG = 0x00, 0x01
+
+    def __init__(
+        self,
+        i2c,
+        address=0x48,
+        gain=1,
+        data_rate=860,
+        mode=None,
+        *,
+        chip_mux: int = 0,
+        honours_pin_in_single: bool = True,
+        conversion=0,
+        completes: bool = True,
+    ):
+        self.address, self.gain, self.data_rate = address, gain, data_rate
+        self._mux = chip_mux  # power-on default: A0-A1 differential
+        self._honours = honours_pin_in_single
+        self._mode = self.SINGLE if mode is None else mode
+        self._conversion = conversion
+        self._completes = completes
+        self._pointer = self.POINTER_CONFIG
+        self._last_pin_read = None
+        # The chip's gain and rate fields, settable so a test can be the other
+        # process that rewrites them without touching the mux.
+        self._gain_bits = 0x0200  # gain 1
+        self._rate_bits = 0x00E0  # 860 SPS
+        self.writes: list[tuple[str, int | None]] = []
+
+    @property
+    def mode(self):
+        return self._mode
+
+    @mode.setter
+    def mode(self, value):
+        self._mode = value
+        self._write_config(None)
+
+    def _config_word(self) -> int:
+        return (
+            (self._mux << 12) | self._gain_bits | self._mode | self._rate_bits | 0x0003
+        )
+
+    def _write_config(self, pin_config):
+        if pin_config is not None and self._mode == self.SINGLE and self._honours:
+            self._mux = pin_config & 0x7
+        # else: continuous, or a driver that ignores the pin: keep the chip's mux
+        self._pointer = self.POINTER_CONFIG
+        self.writes.append(("config", pin_config))
+
+    def _conversion_complete(self) -> int:
+        return 0x8000 if self._completes else 0
+
+    def _read(self, pin):
+        self.writes.append(("sample", pin))
+        if self._mode == self.CONTINUOUS and self._last_pin_read == pin:
+            return self.get_last_result(True)
+        self._last_pin_read = pin
+        self._write_config(pin)
+        if self._mode == self.SINGLE:
+            while not self._conversion_complete():
+                pass  # the real driver spins here with no bound
+        return self.get_last_result(False)
+
+    def read(self, pin):
+        return self._read(pin)
+
+    def get_last_result(self, fast: bool = False) -> int:
+        return self._read_register(self.POINTER_CONVERSION, fast)
+
+    def _read_register(self, pointer, fast: bool = False):
+        if not fast:
+            self._pointer = pointer
+        if self._pointer == self.POINTER_CONFIG:
+            return self._config_word()
+        if callable(self._conversion):
+            return self._conversion()
+        return self._conversion
+
+
+class _PinnedDriverAnalogIn:
+    def __init__(self, ads, positive_pin, negative_pin=None):
+        self._ads, self._pin = ads, positive_pin
+
+    @property
+    def value(self):
+        # Single-ended AINn is mux code 4 + n, as the driver maps it.
+        return self._ads.read(self._pin + 0x04)
+
+    @property
+    def voltage(self):
+        # Gain 1: +/-4.096 V over a signed 16-bit range, as the driver scales.
+        raw = self.value
+        if raw >= 0x8000:
+            raw -= 0x10000
+        return raw * 4.096 / 32767
+
+
+def _pinned_driver(monkeypatch, **ads_kwargs):
+    """Install the reproduction as the adapter's driver for one test."""
+    import ori.hal.i2c_adapter as m
+
+    created: list[_PinnedDriverADS1115] = []
+
+    def _construct(i2c, **kw):
+        ads = _PinnedDriverADS1115(i2c, **kw, **ads_kwargs)
+        created.append(ads)
+        return ads
+
+    class _Module:
+        # The driver's class is spelled ADS1115; this must answer to that name.
+        ADS1115 = staticmethod(_construct)
+
+    class _Mode:
+        SINGLE = _PinnedDriverADS1115.SINGLE
+        CONTINUOUS = _PinnedDriverADS1115.CONTINUOUS
+
+    class _X:
+        Mode = _Mode
+
+    class _AI:
+        AnalogIn = _PinnedDriverAnalogIn
+
+    monkeypatch.setattr(m, "_ADS1115_AVAILABLE", True)
+    monkeypatch.setattr(m, "_BLINKA_AVAILABLE", True)
+    monkeypatch.setattr(m, "_busio", MagicMock(), raising=False)
+    monkeypatch.setattr(m, "_board", MagicMock(), raising=False)
+    monkeypatch.setattr(m, "_ads1115", _Module, raising=False)
+    monkeypatch.setattr(m, "_ads1x15", _X, raising=False)
+    monkeypatch.setattr(m, "_analog_in", _AI, raising=False)
+    return created
 
 
 class TestConnect:
@@ -225,42 +401,28 @@ class TestConnect:
             ):
                 await adapter.connect(_config(sensor_type="ads1115_current", bus=3))
 
-    async def test_connect_resolves_the_declared_calibration(self):
+    async def test_connect_resolves_the_declared_calibration(self, monkeypatch):
+        _pinned_driver(monkeypatch)
         adapter = I2CAdapter()
-        with (
-            patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
-            patch("ori.hal.i2c_adapter._BLINKA_AVAILABLE", True),
-            patch("ori.hal.i2c_adapter._busio", create=True),
-            patch("ori.hal.i2c_adapter._board", create=True),
-            patch("ori.hal.i2c_adapter._ads1115", create=True),
-            patch("ori.hal.i2c_adapter._ads1x15", create=True),
-            patch("ori.hal.i2c_adapter._analog_in", create=True),
-        ):
-            await adapter.connect(
-                _config(
-                    sensor_type="ads1115_current",
-                    calibration={
-                        "sensitivity_v_per_amp": 0.05,
-                        "mains_frequency_hz": 60.0,
-                    },
-                )
+        await adapter.connect(
+            _config(
+                sensor_type="ads1115_current",
+                calibration={
+                    "sensitivity_v_per_amp": 0.05,
+                    "mains_frequency_hz": 60.0,
+                },
             )
+        )
         assert adapter._calibration["sensitivity_v_per_amp"] == 0.05
         assert adapter._calibration["mains_frequency_hz"] == 60.0
 
-    async def test_connect_stores_channel(self):
+    async def test_connect_stores_channel(self, monkeypatch):
+        created = _pinned_driver(monkeypatch)
         adapter = I2CAdapter()
-        with (
-            patch("ori.hal.i2c_adapter._ADS1115_AVAILABLE", True),
-            patch("ori.hal.i2c_adapter._BLINKA_AVAILABLE", True),
-            patch("ori.hal.i2c_adapter._busio", create=True),
-            patch("ori.hal.i2c_adapter._board", create=True),
-            patch("ori.hal.i2c_adapter._ads1115", create=True),
-            patch("ori.hal.i2c_adapter._ads1x15", create=True),
-            patch("ori.hal.i2c_adapter._analog_in", create=True),
-        ):
-            await adapter.connect(_config(sensor_type="ads1115_current", channel=2))
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=2))
         assert adapter._channel == 2
+        # And the chip agrees: single-ended AIN2 is mux code 6.
+        assert created[0]._mux == 6
 
     async def test_connect_hardware_exception_raises_connection_error(self):
         adapter = I2CAdapter()
@@ -805,14 +967,121 @@ class TestPiIntegration:
         await adapter.close()
         assert not adapter.is_connected
 
-    @_needs_hardware(
-        _ADS1115_AVAILABLE,
-        "adafruit-circuitpython-ads1x15",
-        "ADS1115",
-        0x48,
+    _ADS1115_GUARD = dict(
+        available=_ADS1115_AVAILABLE and _BLINKA_AVAILABLE,
+        package=(
+            "adafruit-circuitpython-ads1x15 and a blinka platform library "
+            "(python3-rpi-lgpio on Raspberry Pi OS Trixie)"
+        ),
+        part="ADS1115",
+        address=0x48,
         article="an",
     )
+
+    @_needs_hardware(**_ADS1115_GUARD)
+    async def test_ads1115_voltage_connect_and_read(self):
+        """The bus, the driver, the address and the read path, end to end.
+
+        A DC read needs no signal conditioning, so this runs on the bench as
+        wired: A0 tied to a header ground pin reads within a few millivolts
+        of zero. It proves the ADS1115 answers at 0x48 through the release's
+        driver stack; it says nothing about the current measurement contract.
+        """
+        adapter = I2CAdapter()
+        await adapter.connect(
+            {
+                "sensor_type": "ads1115_voltage",
+                "sensor_id": "a0-volts",
+                "address": 0x48,
+                "bus": 1,
+                "channel": 0,
+            }
+        )
+        assert adapter.is_connected
+        reading = await adapter.read("a0-volts")
+        assert reading.sensor_type == "ads1115_voltage"
+        assert reading.unit == "volt"
+        # A grounded input, not a floating one: unconnected channels on this
+        # part float at roughly +0.56 V, which is the signature to exclude.
+        assert abs(reading.value) < 0.05, reading.value
+        await adapter.close()
+
+    async def _a0_volts(self) -> float:
+        adapter = I2CAdapter()
+        await adapter.connect(
+            {
+                "sensor_type": "ads1115_voltage",
+                "sensor_id": "probe",
+                "address": 0x48,
+                "bus": 1,
+                "channel": 0,
+            }
+        )
+        try:
+            return (await adapter.read("probe")).value
+        finally:
+            await adapter.close()
+
+    async def _a0_is_at_a_rail(self) -> bool:
+        from ori.hal.i2c_adapter import _ADC_SUPPLY_VOLTS, _OPTIONAL_CALIBRATION
+
+        volts = await self._a0_volts()
+        margin = _OPTIONAL_CALIBRATION["clip_margin_volts"]
+        return volts <= margin or volts >= _ADC_SUPPLY_VOLTS - margin
+
+    async def _a0_is_biased_to_mid_rail(self) -> bool:
+        """The bias network holds A0 near VDD/2. A floating pin does not.
+
+        "Not at a rail" is not the same test: an unconnected A0 on this part
+        floats at roughly +0.5 V, which is off both rails and would let the
+        RMS test emit a current for a wire that is not attached to anything.
+        """
+        from ori.hal.i2c_adapter import _ADC_SUPPLY_VOLTS
+
+        return abs(await self._a0_volts() - _ADC_SUPPLY_VOLTS / 2) < 0.2
+
+    @_needs_hardware(**_ADS1115_GUARD)
+    async def test_ads1115_current_refuses_an_input_pinned_at_a_rail(self):
+        """A grounded A0 is refused as clipped, and that is the right answer.
+
+        A current clamp rides on a mid-rail bias; a sample at either rail means
+        the amplitude is unknown. The bench without its bias network puts A0
+        at the low rail, so this is hardware evidence for the clip refusal's
+        low-rail half — the only half a grounded input can exercise.
+        """
+        if not await self._a0_is_at_a_rail():
+            pytest.skip("A0 is not at a rail; the bias network is connected")
+        adapter = I2CAdapter()
+        await adapter.connect(
+            {
+                "sensor_type": "ads1115_current",
+                "sensor_id": "load-current",
+                "address": 0x48,
+                "bus": 1,
+                "channel": 0,
+                "calibration": dict(CALIBRATION),
+            }
+        )
+        try:
+            with pytest.raises(MeasurementRefusedError, match="clipped"):
+                await adapter.read("load-current")
+        finally:
+            await adapter.close()
+
+    @_needs_hardware(**_ADS1115_GUARD)
     async def test_ads1115_current_connect_and_read(self):
+        """The measurement contract, over a real biased clamp signal.
+
+        Needs the mid-rail bias network on A0 — two equal resistors from 3.3 V
+        to ground with a capacitor holding the midpoint, and the SCT-013-030
+        across the midpoint and A0. Without it A0 sits at a rail and the
+        window is refused as clipped, which the test above asserts instead.
+        """
+        if not await self._a0_is_biased_to_mid_rail():
+            pytest.skip(
+                "A0 is not held at mid-rail: connect the bias network and the "
+                "clamp to exercise the current measurement"
+            )
         adapter = I2CAdapter()
         await adapter.connect(
             {
@@ -828,7 +1097,390 @@ class TestPiIntegration:
         reading = await adapter.read("load-current")
         assert reading.sensor_type == "ads1115_current"
         assert reading.unit == "ampere"
+        assert reading.metadata["sample_count"] > 0
+        # The window measured a signal riding on the bias, not a floating pin.
+        from ori.hal.i2c_adapter import _ADC_SUPPLY_VOLTS
+
+        assert abs(reading.metadata["bias_volts"] - _ADC_SUPPLY_VOLTS / 2) < 0.2
         await adapter.close()
+
+
+class TestAds1115ChannelSelection:
+    """The configured channel must be the input the chip is actually reading.
+
+    adafruit-circuitpython-ads1x15 3.0.5 never selects a channel in continuous
+    mode, and the adapter used to build the object in continuous mode — so it
+    read whatever mux the chip held, which on a fresh chip is the A0-A1
+    differential. These tests drive the connect against a fake that behaves as
+    that driver does.
+    """
+
+    async def test_connect_selects_the_channel_through_single_shot_then_goes_continuous(
+        self, monkeypatch
+    ):
+        created = _pinned_driver(monkeypatch, chip_mux=0)  # power-on: A0-A1 diff
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        ads = created[0]
+        assert ads._mux == 4, "AIN0 single-ended is mux code 4"
+        assert ads.mode == ads.CONTINUOUS
+        # The order is what makes it work: the pin write happens in SINGLE.
+        modes_at_pin_write = [w for w in ads.writes if w[1] is not None]
+        assert modes_at_pin_write, "no pin was ever written"
+
+    async def test_a_chip_left_on_another_channel_is_moved(self, monkeypatch):
+        created = _pinned_driver(monkeypatch, chip_mux=7)  # left on AIN3 single
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=1))
+        assert created[0]._mux == 5
+
+    async def test_a_driver_that_ignores_the_pin_entirely_is_refused(self, monkeypatch):
+        """If even single-shot did not honour the pin, the readback catches it."""
+        _pinned_driver(monkeypatch, chip_mux=0, honours_pin_in_single=False)
+        adapter = I2CAdapter()
+        with pytest.raises(AdapterConnectionError) as excinfo:
+            await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        message = str(excinfo.value)
+        assert "mux code 0" in message
+        assert "channel 0" in message
+        assert not adapter.is_connected
+
+    async def test_a_readback_that_fails_refuses_rather_than_assumes(self, monkeypatch):
+        """Only the config readback is broken: the mux-selecting read still works.
+
+        Breaking every register read would fail the connect one step earlier,
+        in the single-shot read, and prove nothing about the verification.
+        """
+        _pinned_driver(monkeypatch)
+        adapter = I2CAdapter()
+        original = _PinnedDriverADS1115._read_register
+
+        def config_read_fails(self, pointer, fast=False):
+            if pointer == self.POINTER_CONFIG:
+                raise OSError("[Errno 121] Remote I/O error")
+            return original(self, pointer, fast)
+
+        monkeypatch.setattr(_PinnedDriverADS1115, "_read_register", config_read_fails)
+        with pytest.raises(AdapterConnectionError, match="could not read back"):
+            await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        assert not adapter.is_connected
+
+    async def test_connect_leaves_the_pointer_on_the_conversion_register(
+        self, monkeypatch
+    ):
+        """A fast read after connect must return a sample, not the config word.
+
+        The mode switch and the mux readback both leave the chip's pointer on
+        CONFIG. The driver's continuous-mode read is a fast read that does not
+        move it, so without a pointered read at the end of connect every
+        sample would be 0x42E3 — which scales to +2.14 V, a number no clip
+        check questions. Measured on the bench before the fix.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0, conversion=-2)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        ads = created[0]
+        assert ads._pointer == ads.POINTER_CONVERSION
+        assert ads.get_last_result(True) == -2, "fast read returned the config word"
+
+    async def test_the_reproduction_really_returns_the_config_word_on_a_fast_read(self):
+        """Guards the fake: without this, the pointer test above proves nothing."""
+        ads = _PinnedDriverADS1115(
+            None, mode=_PinnedDriverADS1115.SINGLE, chip_mux=4, conversion=-2
+        )
+        ads._write_config(4)
+        assert ads.get_last_result(True) == ads._config_word()
+        ads.get_last_result(False)
+        assert ads.get_last_result(True) == -2
+
+    async def test_a_second_adapter_on_the_same_chip_is_refused(self, monkeypatch):
+        """One ADS1115 serves one adapter: a second connect would move the mux.
+
+        The shipped example puts load-current on A0 and grid-voltage on A1 at
+        one address. With one driver object per adapter, the second connect
+        moves the shared mux and the first adapter's fast reads then return
+        the other channel — both connects having verified their own. Refused
+        at connect rather than discovered as volts reported as amperes.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0)
+        first = I2CAdapter()
+        await first.connect(_config(sensor_type="ads1115_current", channel=0))
+        second = I2CAdapter()
+        with pytest.raises(AdapterConnectionError, match="already driven"):
+            await second.connect(_config(sensor_type="ads1115_voltage", channel=1))
+        assert not second.is_connected
+        await first.close()
+        # Released on close: the chip can be claimed again.
+        await second.connect(_config(sensor_type="ads1115_voltage", channel=1))
+        assert second.is_connected
+        await second.close()
+
+    async def test_a_failed_connect_does_not_keep_the_claim(self, monkeypatch):
+        _pinned_driver(monkeypatch, chip_mux=0, honours_pin_in_single=False)
+        first = I2CAdapter()
+        with pytest.raises(AdapterConnectionError):
+            await first.connect(_config(sensor_type="ads1115_current", channel=0))
+        _pinned_driver(monkeypatch, chip_mux=0)
+        second = I2CAdapter()
+        await second.connect(_config(sensor_type="ads1115_current", channel=0))
+        assert second.is_connected
+        await second.close()
+
+    async def test_a_chip_that_never_completes_a_conversion_is_refused_not_hung(
+        self, monkeypatch
+    ):
+        """A TMP102, LM75 or PCF8591 defaults to 0x48 and ACKs with bit 15 clear.
+
+        The driver's own single-shot read spins on that bit with no bound; a
+        connect that hangs never reaches the runtime's event loop, and Tier D
+        never arms, with no log line to say so.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0, completes=False)
+        adapter = I2CAdapter()
+        started = time.monotonic()
+        with pytest.raises(
+            AdapterConnectionError, match="never completed a conversion"
+        ):
+            await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        assert time.monotonic() - started < 2.0
+        assert not adapter.is_connected
+
+    @pytest.mark.parametrize("channel", [-1, -4, 4, 7])
+    async def test_a_channel_this_part_does_not_have_is_refused(
+        self, monkeypatch, channel
+    ):
+        """Below zero the readback's `4 + channel` lands on a differential code."""
+        _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        with pytest.raises(AdapterConnectionError, match="channel must be 0-3"):
+            await adapter.connect(
+                _config(sensor_type="ads1115_voltage", channel=channel)
+            )
+
+    async def test_every_read_returns_a_conversion_not_the_config_word(
+        self, monkeypatch
+    ):
+        """Driven through `adapter.read()`, the way the runtime reads.
+
+        Read more than once. The per-measurement readback re-points the
+        register itself, so a first read passes whether or not the read path
+        does — the defect returns from the second read onward, which is where a
+        runtime polling every second spends all of its time. -2 counts at gain
+        1 is -0.00025 V; the config word is +2.14 V.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0, conversion=0xFFFE)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        for _ in range(3):
+            reading = await adapter.read("s")
+            assert abs(reading.value) < 0.01, reading.value
+        await adapter.close()
+
+    async def test_every_current_window_measures_the_signal(self, monkeypatch):
+        """The current twin of the read above, and the one that reaches Tier D.
+
+        A window of identical config words is neither clipped nor short, so it
+        is emitted: a steady load becomes 0.0 A, silently, from the second poll
+        onward. Two windows over the same signal must agree.
+        """
+        counts = itertools.count()
+        bias, peak = 1.65, 0.5
+
+        def square():
+            volts = bias + (peak if next(counts) % 2 == 0 else -peak)
+            return int(volts * 32767 / 4.096)
+
+        _pinned_driver(monkeypatch, chip_mux=0, conversion=square)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        first = (await adapter.read("s")).value
+        second = (await adapter.read("s")).value
+        # 0.5 V RMS over a 1/30 V/A clamp is 15 A.
+        assert first > 10.0, first
+        assert abs(second - first) < 0.1 * first, (first, second)
+        await adapter.close()
+
+    async def test_a_mux_moved_under_a_connected_adapter_refuses_the_measurement(
+        self, monkeypatch
+    ):
+        """Verified at connect is not verified for the life of the process.
+
+        Something in another process on the same chip can move the mux. The
+        re-verification before every measurement is what catches it.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        created[0]._mux = 5  # someone else selected A1 on the chip
+        with pytest.raises(AdapterReadError, match="mux code 5"):
+            await adapter.read("s")
+        await adapter.close()
+
+    async def test_a_mux_moved_under_a_current_adapter_refuses_the_window(
+        self, monkeypatch
+    ):
+        """The current path is the one that reaches Tier D; it re-verifies too.
+
+        Refused for the mux, before any sample is taken — not for the clipped
+        window a grounded fake would otherwise produce.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        created[0]._mux = 5
+        with pytest.raises(AdapterReadError, match="mux code 5"):
+            await adapter.read("s")
+        assert not any(w[0] == "sample" for w in created[0].writes)
+        await adapter.close()
+
+    async def test_single_shot_mode_set_by_something_else_is_refused(self, monkeypatch):
+        """Same mux, and the chip stops converting after one sample.
+
+        A diagnostic script or a default driver instance reading this channel
+        writes single-shot. The mux it writes is the one already configured, so
+        a check on the mux alone passes while the window that follows is one
+        held value repeated.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        created[0]._mode = _PinnedDriverADS1115.SINGLE
+        with pytest.raises(MeasurementRefusedError, match="conversion mode"):
+            await adapter.read("s")
+        await adapter.close()
+
+    async def test_a_gain_set_by_something_else_is_refused(self, monkeypatch):
+        """Same mux, every sample rescaled, and the error under-reports.
+
+        At gain 2/3 against the gain 1 the adapter set, a current reads about
+        two thirds of itself. Nothing about the number looks wrong.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        created[0]._gain_bits = 0x0000  # gain 2/3
+        with pytest.raises(MeasurementRefusedError, match="0x40E3"):
+            await adapter.read("s")
+        await adapter.close()
+
+    async def test_a_data_rate_set_by_something_else_is_refused(self, monkeypatch):
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        created[0]._rate_bits = 0x0080  # 128 SPS
+        with pytest.raises(MeasurementRefusedError, match="data rate"):
+            await adapter.read("s")
+        await adapter.close()
+
+    async def test_a_voltage_refusal_keeps_its_class(self, monkeypatch):
+        """`MeasurementRefusedError` is what the runtime degrades and alerts on.
+
+        Downgrading it to its parent here would leave a voltage sensor that
+        cannot prove its input reporting nothing but a warning line, and a
+        voltage channel can be a safety input.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        created[0]._mux = 5
+        with pytest.raises(MeasurementRefusedError):
+            await adapter.read("s")
+        await adapter.close()
+
+    async def test_a_connect_that_fails_after_the_readback_releases_the_claim(
+        self, monkeypatch
+    ):
+        """The claim is taken before the chip is touched, so it must not outlive it."""
+        import ori.hal.i2c_adapter as module
+
+        class _FailsLate(_PinnedDriverADS1115):
+            """Fails on the last register access of connect, not the first.
+
+            Connect makes two pointered conversion reads: one closing the
+            single-shot channel select, one closing the whole sequence. Only
+            the second is past the configuration readback, so only it reaches
+            the window this test is about.
+            """
+
+            pointered = 0
+
+            def get_last_result(self, fast: bool = False):
+                if not fast:
+                    _FailsLate.pointered += 1
+                    if _FailsLate.pointered == 2:
+                        raise OSError("bus fell over after the readback")
+                return super().get_last_result(fast)
+
+        _pinned_driver(monkeypatch, chip_mux=0)
+        monkeypatch.setattr(module._ads1115, "ADS1115", _FailsLate)
+        first = I2CAdapter()
+        with pytest.raises(AdapterConnectionError):
+            await first.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        monkeypatch.setattr(module._ads1115, "ADS1115", _PinnedDriverADS1115)
+        second = I2CAdapter()
+        await second.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        assert second.is_connected
+        await second.close()
+
+    @pytest.mark.parametrize("channel", [2.5, True, "1", None])
+    async def test_a_channel_that_is_not_an_integer_is_refused(
+        self, monkeypatch, channel
+    ):
+        """`int()` turns 2.5 into 2 and True into 1, both inside the range.
+
+        Config load refuses these; an adapter reached directly must too, so
+        that neither layer is the only one holding.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        with pytest.raises(AdapterConnectionError, match="must be an integer"):
+            await adapter.connect(
+                _config(sensor_type="ads1115_voltage", channel=channel)
+            )
+
+    async def test_the_reproduction_spins_on_a_conversion_that_never_completes(self):
+        """Guards the fake: without a real poll the hang test proves nothing."""
+        ads = _PinnedDriverADS1115(
+            None, mode=_PinnedDriverADS1115.SINGLE, completes=False
+        )
+        import threading
+
+        done = threading.Event()
+
+        def spin():
+            _PinnedDriverAnalogIn(ads, 0).value
+            done.set()
+
+        t = threading.Thread(target=spin, daemon=True)
+        t.start()
+        assert not done.wait(0.2), (
+            "the fake completed a conversion it was told never to"
+        )
+        ads._completes = True  # let the daemon thread exit
+        done.wait(1.0)
+
+    async def test_the_reproduction_takes_the_fast_path_after_the_first_read(self):
+        """Guards the fake: the fast path is what returns the config word."""
+        ads = _PinnedDriverADS1115(
+            None, mode=_PinnedDriverADS1115.CONTINUOUS, chip_mux=4, conversion=7
+        )
+        first = _PinnedDriverAnalogIn(ads, 0).value  # slow path: pointered
+        ads._write_config(None)  # pointer -> CONFIG
+        second = _PinnedDriverAnalogIn(ads, 0).value  # fast path: does not move it
+        assert first == 7
+        assert second == ads._config_word()
+
+    async def test_the_reproduction_really_ignores_the_pin_in_continuous_mode(self):
+        """Guards the fake: a fake that honoured the pin in continuous mode would
+        let a regression to the old connect sequence pass every test above."""
+        ads = _PinnedDriverADS1115(
+            None, mode=_PinnedDriverADS1115.CONTINUOUS, chip_mux=0
+        )
+        _PinnedDriverAnalogIn(ads, 2).value
+        assert ads._mux == 0, "continuous mode must not move the mux, as 3.0.5 does not"
+        ads = _PinnedDriverADS1115(None, mode=_PinnedDriverADS1115.SINGLE, chip_mux=0)
+        _PinnedDriverAnalogIn(ads, 2).value
+        assert ads._mux == 6
 
 
 class TestDriverGuardWidth:

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -131,6 +131,7 @@ def _connected_ads_adapter(
     adapter._ads = MagicMock()
     # The config readback before every measurement: the configured channel
     # single-ended (mux 4 + n), PGA gain 1, continuous, 860 SPS, comparator off.
+    adapter._holds_shared_bus = True
     adapter._ads.gain = 1
     adapter._ads.data_rate = 860
     adapter._ads._read_register.side_effect = lambda *_a, **_k: (
@@ -150,6 +151,7 @@ def _connected_scd40_adapter() -> I2CAdapter:
     adapter = I2CAdapter()
     adapter._connected = True
     adapter._sensor_type = "scd40"
+    adapter._holds_shared_bus = True
     adapter._breaker = HardwareCircuitBreaker("I2CAdapter", {})
     adapter._scd4x = MagicMock()
     return adapter
@@ -1437,6 +1439,109 @@ class TestAds1115ChannelSelection:
             await adapter.connect(
                 _config(sensor_type="ads1115_voltage", channel=channel)
             )
+
+    async def test_a_refused_duplicate_does_not_pin_the_shared_bus(self, monkeypatch):
+        """A refused connect is dropped by the runtime without a close().
+
+        `ori/runtime.py` logs the failure and continues to the next sensor, so
+        nothing calls the refused adapter's teardown. If connect() took a
+        reference on the shared bus before refusing, that reference is never
+        given back: the cached handle outlives its last real user, and the
+        next connect on that bus is handed the stale one.
+        """
+        import ori.hal.i2c_adapter as module
+
+        _pinned_driver(monkeypatch, chip_mux=0)
+        first = I2CAdapter()
+        await first.connect(_config(sensor_type="ads1115_current", channel=0))
+        second = I2CAdapter()
+        with pytest.raises(AdapterConnectionError, match="already driven"):
+            await second.connect(_config(sensor_type="ads1115_voltage", channel=1))
+        # The runtime's own handling: the refused adapter is simply dropped.
+        del second
+        assert module._shared_busio_refs.get(1) == 1
+        await first.close()
+        assert module._shared_busio_refs == {}
+        assert module._shared_busio_instances == {}
+
+    @pytest.mark.parametrize(
+        "failure", ["channel", "claimed", "construct", "verify", "late_read"]
+    )
+    async def test_no_failed_connect_pins_the_shared_bus(self, monkeypatch, failure):
+        """Every way connect() can fail gives the reference back.
+
+        The refusal is the interesting one, but it is not the only path that
+        raises after the bus is reachable, and a leak on any of them has the
+        same effect on the next connect.
+        """
+        import ori.hal.i2c_adapter as module
+
+        _pinned_driver(monkeypatch, chip_mux=0)
+        holder = None
+        config = _config(sensor_type="ads1115_voltage", channel=0)
+        if failure == "channel":
+            config = _config(sensor_type="ads1115_voltage", channel=9)
+        elif failure == "claimed":
+            holder = I2CAdapter()
+            await holder.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        elif failure == "construct":
+
+            def _explode(i2c, **kw):
+                raise OSError("no device")
+
+            monkeypatch.setattr(module._ads1115, "ADS1115", staticmethod(_explode))
+        elif failure == "verify":
+            _pinned_driver(monkeypatch, chip_mux=0, honours_pin_in_single=False)
+        elif failure == "late_read":
+
+            class _FailsLate(_PinnedDriverADS1115):
+                pointered = 0
+
+                def get_last_result(self, fast: bool = False):
+                    if not fast:
+                        _FailsLate.pointered += 1
+                        if _FailsLate.pointered == 2:
+                            raise OSError("bus fell over")
+                    return super().get_last_result(fast)
+
+            monkeypatch.setattr(module._ads1115, "ADS1115", _FailsLate)
+
+        adapter = I2CAdapter()
+        with pytest.raises(AdapterConnectionError):
+            await adapter.connect(config)
+        assert not adapter._holds_shared_bus
+        expected = 1 if holder is not None else 0
+        assert module._shared_busio_refs.get(1, 0) == expected
+        if holder is not None:
+            await holder.close()
+        assert module._shared_busio_refs == {}
+
+    async def test_a_second_close_does_not_release_a_reference_twice(self, monkeypatch):
+        """The count is shared, so an extra release evicts someone else's handle."""
+        import ori.hal.i2c_adapter as module
+
+        _pinned_driver(monkeypatch, chip_mux=0)
+        first = I2CAdapter()
+        await first.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        # A second chip at its own address: a legitimate second reference on
+        # the same bus, which is exactly what must survive the extra close.
+        second = I2CAdapter()
+        await second.connect(
+            _config(
+                sensor_type="ads1115_voltage",
+                address=0x49,
+                channel=1,
+                sensor_id="v2",
+            )
+        )
+        assert module._shared_busio_refs.get(1) == 2
+        await first.close()
+        await first.close()
+        # The second adapter is still reading through this handle.
+        assert module._shared_busio_refs.get(1) == 1
+        assert 1 in module._shared_busio_instances
+        await second.close()
+        assert module._shared_busio_refs == {}
 
     async def test_the_reproduction_spins_on_a_conversion_that_never_completes(self):
         """Guards the fake: without a real poll the hang test proves nothing."""

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import importlib
 import itertools
 import math
 import os
@@ -11,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ori.hal import i2c_adapter as i2c_module
 from ori.hal.base import (
     AdapterConnectionError,
     AdapterReadError,
@@ -59,23 +61,19 @@ def _needs_hardware(
 @pytest.fixture(autouse=True)
 def _clear_ads1115_claims():
     """One ADS1115 serves one adapter, and most tests never close theirs."""
-    import ori.hal.i2c_adapter
-
-    ori.hal.i2c_adapter._ADS1115_CLAIMS.clear()
+    i2c_module._ADS1115_CLAIMS.clear()
     yield
-    ori.hal.i2c_adapter._ADS1115_CLAIMS.clear()
+    i2c_module._ADS1115_CLAIMS.clear()
 
 
 @pytest.fixture(autouse=True)
 def _clear_shared_i2c_bus_cache():
     """Ensure tests don't leak cached bus handles."""
-    import ori.hal.i2c_adapter
-
-    ori.hal.i2c_adapter._shared_busio_instances.clear()
-    ori.hal.i2c_adapter._shared_busio_refs.clear()
+    i2c_module._shared_busio_instances.clear()
+    i2c_module._shared_busio_refs.clear()
     yield
-    ori.hal.i2c_adapter._shared_busio_instances.clear()
-    ori.hal.i2c_adapter._shared_busio_refs.clear()
+    i2c_module._shared_busio_instances.clear()
+    i2c_module._shared_busio_refs.clear()
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -163,7 +161,7 @@ def _connected_scd40_adapter() -> I2CAdapter:
 class TestModuleImport:
     def test_imports_cleanly_without_hardware_libraries(self):
         """The module must import on any host regardless of smbus2/adafruit presence."""
-        import ori.hal.i2c_adapter  # noqa: F401
+        importlib.import_module("ori.hal.i2c_adapter")
 
     def test_adapter_instantiates_without_hardware(self):
         adapter = I2CAdapter()
@@ -210,7 +208,9 @@ class _PinnedDriverADS1115:
         self._mux = chip_mux  # power-on default: A0-A1 differential
         self._honours = honours_pin_in_single
         self._mode = self.SINGLE if mode is None else mode
-        self._conversion = conversion
+        # Normalised to a callable so a waveform and a fixed value take the
+        # same path, and nothing has to call a value that might be an int.
+        self._conversion = conversion if callable(conversion) else (lambda: conversion)
         self._completes = completes
         self._pointer = self.POINTER_CONFIG
         self._last_pin_read = None
@@ -266,9 +266,7 @@ class _PinnedDriverADS1115:
             self._pointer = pointer
         if self._pointer == self.POINTER_CONFIG:
             return self._config_word()
-        if callable(self._conversion):
-            return self._conversion()
-        return self._conversion
+        return self._conversion()
 
 
 class _PinnedDriverAnalogIn:
@@ -291,8 +289,6 @@ class _PinnedDriverAnalogIn:
 
 def _pinned_driver(monkeypatch, **ads_kwargs):
     """Install the reproduction as the adapter's driver for one test."""
-    import ori.hal.i2c_adapter as m
-
     created: list[_PinnedDriverADS1115] = []
 
     def _construct(i2c, **kw):
@@ -314,13 +310,13 @@ def _pinned_driver(monkeypatch, **ads_kwargs):
     class _AI:
         AnalogIn = _PinnedDriverAnalogIn
 
-    monkeypatch.setattr(m, "_ADS1115_AVAILABLE", True)
-    monkeypatch.setattr(m, "_BLINKA_AVAILABLE", True)
-    monkeypatch.setattr(m, "_busio", MagicMock(), raising=False)
-    monkeypatch.setattr(m, "_board", MagicMock(), raising=False)
-    monkeypatch.setattr(m, "_ads1115", _Module, raising=False)
-    monkeypatch.setattr(m, "_ads1x15", _X, raising=False)
-    monkeypatch.setattr(m, "_analog_in", _AI, raising=False)
+    monkeypatch.setattr(i2c_module, "_ADS1115_AVAILABLE", True)
+    monkeypatch.setattr(i2c_module, "_BLINKA_AVAILABLE", True)
+    monkeypatch.setattr(i2c_module, "_busio", MagicMock(), raising=False)
+    monkeypatch.setattr(i2c_module, "_board", MagicMock(), raising=False)
+    monkeypatch.setattr(i2c_module, "_ads1115", _Module, raising=False)
+    monkeypatch.setattr(i2c_module, "_ads1x15", _X, raising=False)
+    monkeypatch.setattr(i2c_module, "_analog_in", _AI, raising=False)
     return created
 
 
@@ -465,59 +461,51 @@ class TestClose:
 
     async def test_close_evicts_shared_bus_cache_for_ads1115(self):
         """After close(), if ref array hits 0, busio.I2C cache entry is removed."""
-        import ori.hal.i2c_adapter as _mod
-
         adapter = _connected_ads_adapter("ads1115_current")
         adapter._bus_number = 1
-        _mod._shared_busio_instances[1] = MagicMock()  # seed the cache
-        _mod._shared_busio_refs[1] = 1  # seed the reference
+        i2c_module._shared_busio_instances[1] = MagicMock()  # seed the cache
+        i2c_module._shared_busio_refs[1] = 1  # seed the reference
 
         await adapter.close()
 
-        assert 1 not in _mod._shared_busio_instances
-        assert 1 not in _mod._shared_busio_refs
+        assert 1 not in i2c_module._shared_busio_instances
+        assert 1 not in i2c_module._shared_busio_refs
 
     async def test_close_evicts_shared_bus_cache_for_scd40(self):
-        import ori.hal.i2c_adapter as _mod
-
         adapter = _connected_scd40_adapter()
         adapter._bus_number = 1
-        _mod._shared_busio_instances[1] = MagicMock()
-        _mod._shared_busio_refs[1] = 1
+        i2c_module._shared_busio_instances[1] = MagicMock()
+        i2c_module._shared_busio_refs[1] = 1
 
         await adapter.close()
 
-        assert 1 not in _mod._shared_busio_instances
-        assert 1 not in _mod._shared_busio_refs
+        assert 1 not in i2c_module._shared_busio_instances
+        assert 1 not in i2c_module._shared_busio_refs
 
     async def test_close_does_not_evict_if_references_remain(self):
         """If 2 sensors share a bus, close() on the first leaves the cache intact."""
-        import ori.hal.i2c_adapter as _mod
-
         adapter = _connected_ads_adapter("ads1115_current")
         adapter._bus_number = 1
         sentinel = MagicMock()
-        _mod._shared_busio_instances[1] = sentinel
-        _mod._shared_busio_refs[1] = 2  # 2 sensors actively using the bus
+        i2c_module._shared_busio_instances[1] = sentinel
+        i2c_module._shared_busio_refs[1] = 2  # 2 sensors actively using the bus
 
         await adapter.close()
 
         # The cache MUST stay alive to serve the second sensor
-        assert _mod._shared_busio_instances.get(1) is sentinel
-        assert _mod._shared_busio_refs.get(1) == 1
+        assert i2c_module._shared_busio_instances.get(1) is sentinel
+        assert i2c_module._shared_busio_refs.get(1) == 1
 
     async def test_close_does_not_evict_cache_for_bme280(self):
         """BME280 uses smbus2 directly — it must not touch the busio cache."""
-        import ori.hal.i2c_adapter as _mod
-
         adapter = _connected_bme280_adapter()
         adapter._bus_number = 1
         sentinel = MagicMock()
-        _mod._shared_busio_instances[1] = sentinel
+        i2c_module._shared_busio_instances[1] = sentinel
 
         await adapter.close()
 
-        assert _mod._shared_busio_instances.get(1) is sentinel
+        assert i2c_module._shared_busio_instances.get(1) is sentinel
 
 
 # ─── health_check ─────────────────────────────────────────────────────────────
@@ -1393,7 +1381,6 @@ class TestAds1115ChannelSelection:
         self, monkeypatch
     ):
         """The claim is taken before the chip is touched, so it must not outlive it."""
-        import ori.hal.i2c_adapter as module
 
         class _FailsLate(_PinnedDriverADS1115):
             """Fails on the last register access of connect, not the first.
@@ -1414,11 +1401,11 @@ class TestAds1115ChannelSelection:
                 return super().get_last_result(fast)
 
         _pinned_driver(monkeypatch, chip_mux=0)
-        monkeypatch.setattr(module._ads1115, "ADS1115", _FailsLate)
+        monkeypatch.setattr(i2c_module._ads1115, "ADS1115", _FailsLate)
         first = I2CAdapter()
         with pytest.raises(AdapterConnectionError):
             await first.connect(_config(sensor_type="ads1115_voltage", channel=0))
-        monkeypatch.setattr(module._ads1115, "ADS1115", _PinnedDriverADS1115)
+        monkeypatch.setattr(i2c_module._ads1115, "ADS1115", _PinnedDriverADS1115)
         second = I2CAdapter()
         await second.connect(_config(sensor_type="ads1115_voltage", channel=0))
         assert second.is_connected
@@ -1449,8 +1436,6 @@ class TestAds1115ChannelSelection:
         given back: the cached handle outlives its last real user, and the
         next connect on that bus is handed the stale one.
         """
-        import ori.hal.i2c_adapter as module
-
         _pinned_driver(monkeypatch, chip_mux=0)
         first = I2CAdapter()
         await first.connect(_config(sensor_type="ads1115_current", channel=0))
@@ -1459,10 +1444,10 @@ class TestAds1115ChannelSelection:
             await second.connect(_config(sensor_type="ads1115_voltage", channel=1))
         # The runtime's own handling: the refused adapter is simply dropped.
         del second
-        assert module._shared_busio_refs.get(1) == 1
+        assert i2c_module._shared_busio_refs.get(1) == 1
         await first.close()
-        assert module._shared_busio_refs == {}
-        assert module._shared_busio_instances == {}
+        assert i2c_module._shared_busio_refs == {}
+        assert i2c_module._shared_busio_instances == {}
 
     @pytest.mark.parametrize(
         "failure", ["channel", "claimed", "construct", "verify", "late_read"]
@@ -1474,8 +1459,6 @@ class TestAds1115ChannelSelection:
         raises after the bus is reachable, and a leak on any of them has the
         same effect on the next connect.
         """
-        import ori.hal.i2c_adapter as module
-
         _pinned_driver(monkeypatch, chip_mux=0)
         holder = None
         config = _config(sensor_type="ads1115_voltage", channel=0)
@@ -1489,7 +1472,7 @@ class TestAds1115ChannelSelection:
             def _explode(i2c, **kw):
                 raise OSError("no device")
 
-            monkeypatch.setattr(module._ads1115, "ADS1115", staticmethod(_explode))
+            monkeypatch.setattr(i2c_module._ads1115, "ADS1115", staticmethod(_explode))
         elif failure == "verify":
             _pinned_driver(monkeypatch, chip_mux=0, honours_pin_in_single=False)
         elif failure == "late_read":
@@ -1504,22 +1487,20 @@ class TestAds1115ChannelSelection:
                             raise OSError("bus fell over")
                     return super().get_last_result(fast)
 
-            monkeypatch.setattr(module._ads1115, "ADS1115", _FailsLate)
+            monkeypatch.setattr(i2c_module._ads1115, "ADS1115", _FailsLate)
 
         adapter = I2CAdapter()
         with pytest.raises(AdapterConnectionError):
             await adapter.connect(config)
         assert not adapter._holds_shared_bus
         expected = 1 if holder is not None else 0
-        assert module._shared_busio_refs.get(1, 0) == expected
+        assert i2c_module._shared_busio_refs.get(1, 0) == expected
         if holder is not None:
             await holder.close()
-        assert module._shared_busio_refs == {}
+        assert i2c_module._shared_busio_refs == {}
 
     async def test_a_second_close_does_not_release_a_reference_twice(self, monkeypatch):
         """The count is shared, so an extra release evicts someone else's handle."""
-        import ori.hal.i2c_adapter as module
-
         _pinned_driver(monkeypatch, chip_mux=0)
         first = I2CAdapter()
         await first.connect(_config(sensor_type="ads1115_voltage", channel=0))
@@ -1534,14 +1515,14 @@ class TestAds1115ChannelSelection:
                 sensor_id="v2",
             )
         )
-        assert module._shared_busio_refs.get(1) == 2
+        assert i2c_module._shared_busio_refs.get(1) == 2
         await first.close()
         await first.close()
         # The second adapter is still reading through this handle.
-        assert module._shared_busio_refs.get(1) == 1
-        assert 1 in module._shared_busio_instances
+        assert i2c_module._shared_busio_refs.get(1) == 1
+        assert 1 in i2c_module._shared_busio_instances
         await second.close()
-        assert module._shared_busio_refs == {}
+        assert i2c_module._shared_busio_refs == {}
 
     async def test_the_reproduction_spins_on_a_conversion_that_never_completes(self):
         """Guards the fake: without a real poll the hang test proves nothing."""


### PR DESCRIPTION
## What does this PR do?

Three defects made the ADS1115 report a number that was not the measurement it claimed to be. All three are proven at the register on the bench Pi, and one was reproduced there with the shipped example configuration.

**The configured channel was never selected.** `adafruit-circuitpython-ads1x15` 3.0.5, the pinned release and the latest published, never selects a channel in continuous mode: `_write_config` re-reads the chip's current mux and discards the requested pin unless the mode is SINGLE. Built straight into continuous mode as the adapter did, the read returned whatever mux the chip already held. On a chip at its power-on default that is the A0−A1 differential, so a clamp on A0 was measured against a floating A1 that drifts between 0 and +0.6 V.

**Every sample was the configuration word.** Every config write leaves the register pointer on CONFIG, and the driver's continuous read is a fast read that does not move it. So after the mode switch each "sample" was `0x42E3`, which scales to +2.1404 V — a plausible mid-range value that no clip check questions.

**Two sensors on one chip stole each other's channel.** The shipped `ori.yaml.example` put `load-current` on A0 and `grid-voltage` on A1 at one address, and the runtime builds one adapter and one driver object per sensor. One mux, two drivers, each trusting the mux to be where it left it.

## What the adapter does now

At connect: construct in SINGLE, take one single-shot read of the configured channel — the only path in this driver that honours the pin — switch to CONTINUOUS, read the configuration back, then one pointered conversion read to leave the pointer where the read path needs it. The driver's own single-shot wait spins on the conversion-complete bit with no bound, so this writes the mux itself and waits a bounded few conversion intervals. A TMP102 or an LM75, which also default to `0x48` and answer with that bit clear below mid-scale, now refuses instead of hanging a startup with Tier D never armed.

Before every measurement the **whole configuration word** is read back and compared against what this adapter set, masked only for bit 15, which reads as conversion state rather than configuration. Not the mux field: the two changes that corrupt a reading most quietly move no mux. Measured against a register-level model of the part driving the real 3.0.5 code, a foreign gain of two thirds turned a 20.8 A load into 13.9 A, and single-shot mode set externally left the chip powered down after one conversion so a 21.7 A load read 0.0 A. Both under-report, which is the direction that matters for a current a trip threshold is defined over.

One ADS1115 serves one adapter per runtime. The claim is keyed by bus and address and holds a weak reference to the adapter rather than an id: ids are reused after collection, and a stale one could admit a second claimant, which is the unsafe direction. `ori.yaml.example` and the config sample in `CLAUDE.md` move the second sensor to a second chip at `0x49`.

The claim and the channel range are settled before the shared bus is touched, and the adapter records whether it actually took a bus reference. A refused connect is dropped by the runtime without a `close()`, so anything taken on the way in is given back in a `finally`, and `close()` releases only a reference this adapter holds — which also stops a repeated close from decrementing another adapter's. Configuration integers are no longer coerced: `int()` turned channel 2.5 into 2 and `True` into 1, both of which then passed every range check.

## What this does not establish

`clip_margin_volts` at the high rail is still unmeasured and stays provisional. It needs a saturated clamp on the bench, and the divider and clamp have not arrived. The RMS path has never been driven against a known current for the same reason, so #398 gets Refs and not Closes.

`data_rate: 860` is measured as a host read cadence, not as the chip's conversion rate. A0 was grounded for every timing run, so a duplicate read of one conversion cannot be told from a fresh one. The evidence record says exactly that.

The configuration check certifies the start of each window, not the whole of it. A foreign pointered read landing mid-window sends the remaining fast reads back to the config word, measured at 10.9 A against 20.9 A. That limit is stated in both documents and tracked in #503, along with the per-sample cost that has to be measured on the bench before it can be closed.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

The current reading is the input a Tier D overcurrent threshold is evaluated against, and every defect here changes that number.

## Verification

Bench: Pi 4 Model B, Raspberry Pi OS Trixie, Python 3.13.5, real ADS1115 at `0x48`, A0 grounded and A1 floating. Record: `docs/evidence/2026-09-03-pi4-ads1115-characterisation.md`.

The channel theft, reproduced with the adapter as it stood:

```text
load-current (ch0) after its connect:  -0.0003 V   <- A0 grounded
grid-voltage (ch1) after its connect:  +0.5823 V   <- A1 floating
load-current read again:               +0.5745 V   <- A1's value, under A0's label
```

After the change, on the same hardware, the second adapter is refused, `load-current` still reads −0.0003 V, and the chip is claimable again once the first closes. The expected configuration word matches the chip exactly, `0x42E3` for channel 0 and `0x52E3` for channel 1, and a real second driver instance writing single-shot is refused with `0x43E3`. The shared bus reference behaves:

```text
after first connect      refs={1: 1}
after refused duplicate  refs={1: 1}   <- runtime drops it, no close
after the real close     refs={} instances={}
fresh connect afterwards: -0.0003 V  refs={1: 1}
```

Constants: a grounded input reads −0.0006 to +0.0000 V single-shot, inside `clip_margin_volts` at the low rail. Whole-window elapsed ran 41.09 ms against 40.00 ms nominal across five windows, a ratio of 1.027 against an `overrun_tolerance` of 1.5. Neither constant changes value; what changes is the record.

Twenty mutations, each failing by its own test. Two of them previously survived and are why several tests changed shape: deleting the per-measurement re-point, which returns the config word from the second read onward rather than the first, and moving the re-verify after the sampling loop.

`TestPiIntegration` 2 passed and 2 skipped on the bench, the adapter module 103 passed and 2 skipped there. Host: full suite 4511 passed and 23 skipped, evidence suite 779 passed. `ruff check`, `ruff format --check`, `mypy ori/` and `pyright` clean. `guard-capability-matrix.sh` OK, and the matrix does not describe i2c sensing.

## Testing notes

The two skips on the bench are expected and named: no BME280 is fitted, and the current test skips until the mid-rail bias network exists. Its probe now requires mid-rail rather than merely "not at a rail", because an unconnected A0 floats near +0.5 V, which is off both rails and would otherwise let the test emit a current for a wire attached to nothing.

## Related issue

Closes #431

Closes #500

Refs #398 — the calibration constants are measured and recorded; the high-rail clip margin and a real RMS proof still need the clamp.

Follow-ups filed from this work: #502, #503, and an addition to #501.
