### PR TITLE
fix(hal): accept the usb_binding block the phone's signed config carries

### DIFF
--- a/ori.yaml.phone.example
+++ b/ori.yaml.phone.example
@@ -31,6 +31,14 @@ sensors:
     auto_detect_device_path: false
     baud_rate: 9600
     poll_interval_ms: 2000
+    # Read by the Android agent, not by the runtime: it is how the phone picks
+    # the meter out of everything on its USB bus. The onboarding API writes
+    # this block into every phone starter's signed document. 4292/60000 is a
+    # CP210x bridge, which is what the kit's meter uses; read yours from the
+    # device rather than copying these.
+    usb_binding:
+      vendor_id: 4292
+      product_id: 60000
 
 skills:
   - name: energy-anomaly-detector

--- a/ori/hal/usb_serial_adapter.py
+++ b/ori/hal/usb_serial_adapter.py
@@ -35,6 +35,33 @@ CONFIG_SCHEMA = {
     "stopbits": {"type": "integer", "default": 1, "enum": [1, 2]},
     "timeout_s": {"type": "number", "default": 1.0, "minimum": 0},
     "slave_id": {"type": "integer", "default": 1, "minimum": 1, "maximum": 247},
+    # Addressed to the Android agent, not to this adapter: it is how the phone
+    # picks its meter out of everything on the USB bus. One signed document
+    # carries both sides, so the runtime's job is to stop refusing the block,
+    # not to read it.
+    #
+    # Shape only, deliberately. Which values make a usable binding is the
+    # reading party's judgement: an absent block is accepted, so refusing an
+    # empty one would draw a line this side cannot defend, and documents signed
+    # before the issuing side required real identifiers carry zeroes and were
+    # never recalled.
+    #
+    # Declared field by field because this schema admits no open object. So a
+    # field added here on the issuing side is refused by every deployed
+    # runtime, and the document is signed, so no operator can edit it out:
+    # adding one is a coordinated release, not a server change.
+    "usb_binding": {
+        "type": "object",
+        "description": (
+            "USB device identity for the Android agent; unread by the runtime"
+        ),
+        "properties": {
+            "vendor_id": {"type": "integer", "minimum": 0, "maximum": 0xFFFF},
+            "product_id": {"type": "integer", "minimum": 0, "maximum": 0xFFFF},
+            # Emitted only when the meter reports one, so it cannot be required.
+            "serial_number": {"type": "string", "default": ""},
+        },
+    },
 }
 CALIBRATION_SCHEMAS: dict[str, dict] = {}
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4031,6 +4031,13 @@ class TestLoadPhoneExample:
         assert cfg.actions.relay["enabled"] is False
         assert cfg.sensors[0].protocol == "usb_serial"
         assert cfg.sensors[0].type == "usb_power"
+        # The example is the regression guard for the block the schema once
+        # refused. Asserted here so removing it from the example is caught.
+        assert cfg.sensors[0].metadata["usb_binding"] == {
+            "vendor_id": 4292,
+            "product_id": 60000,
+            "serial_number": "",
+        }
         assert cfg.telemetry_export.enabled is False
         assert cfg.telemetry_export.api_key_env == "ORI_ENERGY_DEVICE_API_KEY"
         assert cfg.health_socket["path"] == (

--- a/tests/test_usb_serial_adapter.py
+++ b/tests/test_usb_serial_adapter.py
@@ -8,7 +8,13 @@ from unittest.mock import patch
 import pytest
 
 from ori.hal.base import AdapterConnectionError, AdapterReadError, CircuitState
-from ori.hal.usb_serial_adapter import _SENSOR_MAP, UsbSerialAdapter, _crc16
+from ori.hal.config_schema import DocumentError, validate_document, validate_schema
+from ori.hal.usb_serial_adapter import (
+    _SENSOR_MAP,
+    CONFIG_SCHEMA,
+    UsbSerialAdapter,
+    _crc16,
+)
 
 
 def _config(
@@ -249,3 +255,107 @@ class TestUsbSerialAdapter:
 
                 with pytest.raises(AdapterReadError, match="circuit breaker OPEN"):
                     await adapter.read("mains-power")
+
+
+class TestUsbBindingDeclaration:
+    """The signed document carries a block this adapter does not read.
+
+    There is one configuration document per device and the Android agent needs
+    the meter's USB identity in it, so the block travels inside this sensor.
+    The runtime's obligation is to load it, not to use it. Every phone starter
+    ever onboarded carries one, and this schema refused all of them; nothing
+    noticed because the phone package still ships a shell shim in place of a
+    runtime binary, so no such document has ever been validated.
+    """
+
+    def _schema(self):
+        return validate_schema(CONFIG_SCHEMA, name="usb_serial")
+
+    def _document(self, **extra) -> dict:
+        return {
+            "device_path": "/dev/ttyUSB0",
+            "auto_detect_device_path": False,
+            "baud_rate": 9600,
+            **extra,
+        }
+
+    def _load(self, document: dict) -> dict:
+        return validate_document(
+            document, self._schema(), context="sensors[0] (protocol='usb_serial')"
+        )
+
+    def test_a_document_carrying_a_binding_loads(self):
+        resolved = self._load(
+            self._document(usb_binding={"vendor_id": 4292, "product_id": 60000})
+        )
+        assert resolved["usb_binding"]["vendor_id"] == 4292
+        assert resolved["usb_binding"]["product_id"] == 60000
+
+    def test_the_serial_number_is_optional_and_defaults_empty(self):
+        """It is emitted only when the meter reports one."""
+        resolved = self._load(
+            self._document(usb_binding={"vendor_id": 4292, "product_id": 60000})
+        )
+        assert resolved["usb_binding"]["serial_number"] == ""
+        carried = self._load(
+            self._document(
+                usb_binding={
+                    "vendor_id": 4292,
+                    "product_id": 60000,
+                    "serial_number": "0001",
+                }
+            )
+        )
+        assert carried["usb_binding"]["serial_number"] == "0001"
+
+    def test_a_document_without_a_binding_still_loads(self):
+        """A document that omits the block loads unchanged."""
+        assert "usb_binding" not in self._load(self._document())
+        assert "usb_binding" not in self._load({"auto_detect_device_path": True})
+
+    def test_a_binding_that_names_no_device_is_accepted_like_an_absent_one(self):
+        """Shape is this side's business; identity is the reading party's.
+
+        Omitting the block entirely is accepted and is the same no-identity
+        state, so refusing an empty one would draw a line the runtime cannot
+        defend for a field it never reads.
+        """
+        assert self._load(self._document(usb_binding={}))["usb_binding"] == {
+            "serial_number": ""
+        }
+
+    def test_a_zero_identifier_is_accepted_because_older_documents_carry_one(self):
+        """Documents signed before the issuing side required real identifiers.
+
+        Those were never recalled. The agent already declines to name a meter
+        for them, which is a handled meter-binding failure; refusing them here
+        would turn it into a runtime that will not start at all.
+        """
+        resolved = self._load(
+            self._document(usb_binding={"vendor_id": 0, "product_id": 0})
+        )
+        assert resolved["usb_binding"]["vendor_id"] == 0
+
+    def test_an_identifier_outside_sixteen_bits_is_refused(self):
+        with pytest.raises(DocumentError, match="above the maximum"):
+            self._load(
+                self._document(usb_binding={"vendor_id": 0x10000, "product_id": 1})
+            )
+
+    def test_the_block_is_declared_field_by_field_not_left_open(self):
+        """An undeclared object would reopen the pass-through one level down.
+
+        The block is closed, so it cannot smuggle anything past the validator.
+        The cost is that a field added on the issuing side is refused by every
+        deployed runtime, which makes adding one a coordinated release.
+        """
+        with pytest.raises(DocumentError, match="not declared by the schema"):
+            self._load(
+                self._document(
+                    usb_binding={"vendor_id": 1, "product_id": 2, "bus_number": 3}
+                )
+            )
+
+    def test_a_binding_that_is_not_an_object_is_refused(self):
+        with pytest.raises(DocumentError, match="expected object"):
+            self._load(self._document(usb_binding=4292))


### PR DESCRIPTION
## What does this PR do?

`usb_serial`'s `CONFIG_SCHEMA` did not declare `usb_binding`, and the schema refuses any key it does not declare, so every configuration document carrying that block failed to load. The product's onboarding API writes the block into every phone deployment's signed document, which means every phone deployment ever onboarded holds a config this runtime rejects.

It has stayed invisible because the phone package still ships a shell shim in place of a real runtime binary, so no such document has ever reached `validate_document`. It becomes a total product outage on the day that shim is replaced.

The block is addressed to the Android agent rather than to this adapter. There is one signed document per device, and the agent needs the meter's USB vendor and product identifiers to pick it out of everything on the phone's bus; without them it bound whichever device enumerated first, which on a hub was the hub. So the identifiers travel inside this sensor, and the runtime's obligation is to stop refusing them, not to read them.

## Shape is validated; identity is not

The declaration enforces an object of two bounded integers and an optional string, and nothing beyond that.

That line is deliberate. Which values make a usable binding belongs to the party that reads the field, and the runtime cannot coherently take that judgement: a document with **no** block at all is accepted, and that is the same no-identity state as an empty one. Refusing the empty block while accepting its absence would be a guard the runtime cannot defend.

It would also be actively harmful at the lower bound. Documents signed before the issuing side required real identifiers carry zeroes and were never recalled. The Android agent already declines to name a meter for those, which is a handled and visible meter-binding failure. Refusing them here would convert that into a runtime that does not start at all, for a field the runtime never reads.

## The block is closed, and that has a cost worth stating

This schema admits no open object: `type: object` must declare its `properties`, recursively, because an object that does not say what may sit inside it reopens the pass-through the validator exists to close. The block is therefore enumerated field by field.

The consequence is that a field added to `usb_binding` on the issuing side would be refused by every already-deployed runtime. The document is signed, so no operator can edit the offending key out, and the remedy ships to handsets rather than to the server. **Adding a field to this block is a coordinated release, not a server-side change.** Filed as ori-platform/ori-specs#169, which is where a forward-open descriptor for data addressed to a non-runtime consumer belongs — that is a contract change, not a runtime patch.

## Type of change

- [x] `fix` — bug fix

Not marked `security`: the block reaches `adapter_connect_config` and is ignored by `UsbSerialAdapter.connect`. No tier, threshold, rated capacity, coil mapping or approval path is touched, and nothing derives an actuation outcome from it. The one safety-adjacent property is availability, and it argues for the fix: a config that will not load is a runtime that does not run, and the same emitter writes this block for the `pi` and `edge_node` profiles, which are the deployments that can carry a relay.

## Verification

Reproduced on `main` first, through `Config.load` rather than through the validator alone:

```text
sensors[0] (protocol='usb_serial').usb_binding: not declared by the schema.
Declared keys: ['auto_detect_device_path', 'baud_rate', 'baudrate', 'bytesize',
'device_path', 'parity', 'slave_id', 'stopbits', 'timeout_s']
```

A config generated by the product's own generator is refused on `main` and accepted here, resolving to `{'vendor_id': 4292, 'product_id': 60000, 'serial_number': '0001'}`. The declaration matches what that generator emits field for field, in name, type and optionality: `serial_number` is written only when non-empty, and `safe_dump` quotes it, so the emitter cannot produce the integer-typed serial this schema would refuse. The sixteen-bit ceiling matches the `le=65535` the API model already applies.

`ori.yaml.phone.example` gains the real block, so the existing example-load test exercises the path end to end rather than the schema in isolation. That test would have caught the original defect had the example carried it.

Four mutations, each killed by a named test: removing the declaration, removing the sixteen-bit ceiling, moving the lower bound to one, and deleting the block from the example. Adversarial documents driven through `Config.load` cover an absent, empty, scalar, list and string block; boolean identifiers, which are integers in Python and are refused as booleans; floats that look like integers; negative and out-of-range values; undeclared keys at both levels; and a `usb_binding` on a non-`usb_serial` sensor, which that protocol's own schema refuses.

Full suite 4519 passed with 23 skipped, evidence suite 779 passed. `ruff check`, `ruff format --check`, `mypy ori/` and `pyright` clean. `guard-capability-matrix.sh` does not cover `ori/hal/`, and the vendored corpus under `tests/vectors/sensor_configuration/` carries its own per-case schemas, so no drift is introduced.

## Testing notes

Nothing was exercised on real Android hardware, because the phone package still ships the shim. The proof is a host-generated document from the product code, driven through the real loader. The signed path was not exercised end to end either: signature verification was disabled to reach the sensor loader, and while the signature payload is canonicalised with sorted keys and already contains nested objects, that path was not run.

## Related issue

Closes #491

Follow-ups from this work: ori-platform/ori-specs#169 for the forward-open descriptor, and #505 for hostile YAML literals escaping the loader as raw interpreter errors.

