### PR TITLE
test(runtime): stop polling the alert outbox before the state store opens

### DIFF
--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -933,12 +933,18 @@ async def test_an_unconnected_sensor_notice_is_queued_when_delivery_fails(
     runtime = OriRuntime(config_path=str(minimal_config))
     start_task = asyncio.create_task(runtime.start())
     try:
+        # Not queried until the connect has actually failed. `_state_store` is
+        # assigned before `open()` creates the schema, so polling the outbox
+        # from the first iteration reads a store that has no tables yet, and
+        # on a slow machine that window is wide enough to hit. The connect
+        # loop runs long after `open()`, so this is the point from which the
+        # outbox can be asked at all.
         deadline = time.monotonic() + 10.0
         queued: list = []
         while time.monotonic() < deadline and not queued:
             if start_task.done():
                 break
-            if runtime._state_store is not None:
+            if runtime._unconnected_sensors and runtime._state_store is not None:
                 queued = await runtime._state_store.get_retryable_alerts(limit=10)
             await asyncio.sleep(0.05)
 


### PR DESCRIPTION
## What does this PR do?

`main` went red on Python 3.13 after #508 merged, with `sqlite3.OperationalError: no such table: alert_outbox`. The test is at fault, not the runtime.

`test_an_unconnected_sensor_notice_is_queued_when_delivery_fails` polls the alert outbox from its first loop iteration, guarded only by `runtime._state_store is not None`. The runtime assigns that attribute on one line and creates the schema on the next, so the guard is true before any table exists. Every iteration inside that window queries a store that has none.

The window is normally too narrow to hit, which is why the pull request was green on all three interpreters and `main` was not: the failure needs the poll to land between the assignment and the schema, and that depends on the machine.

## The fix

The outbox is not queried until the connect has actually failed. The sensor-connect loop runs long after the store opens, so `_unconnected_sensors` becoming non-empty is the earliest point from which the outbox can be asked at all, and it is also the event the test is waiting for.

## Verification

Not "it passes now". The window was widened deliberately, by delaying `StateStore.open` by half a second, and both forms were run against it:

```text
new poll, slow open:  1 passed
old poll, slow open:  sqlite3.OperationalError: no such table: alert_outbox
```

That reproduces the exact CI failure on demand and shows the fix removing it.

No other test guards a store query this way; `grep` for the pattern across `tests/` returns only this one. Full suite 4536 passed with 23 skipped, and `ruff check` and `ruff format --check` are clean.

## Type of change

- [x] `test` — tests only

No production code is touched.

## Related issue

Follows #508, which introduced the test.
