### PR TITLE
fix(hal): quarantine an ADS1115 whose configuration changed under the runtime

### DIFF
--- a/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
+++ b/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
@@ -157,6 +157,53 @@ happens to carry that bit passes the wait, and what refuses it is the
 configuration readback: a foreign word has to match the exact 16 bits this
 adapter wrote to get through. That is a probability, not a proof of part.
 
+## Defect 5: a chip taken by another writer was retried rather than refused
+
+Recorded 2026-09-04, on the same bench and the same part.
+
+A reading refused because the chip is running a configuration this process did
+not set is evidence that something else is writing it. Re-selecting the
+configuration would be a contest with that writer, and losing it intermittently
+produces a plausible number rather than a refusal — the failure would present
+as an occasional wrong value, which is worse than an outage because nothing
+about it looks wrong.
+
+So the chip is quarantined for the life of the process, keyed by bus and
+address rather than by the adapter object: `close()` releases the chip claim,
+so an adapter-scoped latch would let a second object connect, rewrite the chip
+and resume reading inside the same process, and the operator message promising
+a restart would not be true.
+
+Driven against the bench part with a second driver instance as the competing
+writer, which writes single-shot mode and leaves the mux alone:
+
+```text
+before            : -0.0001 V
+after the writer  : refused
+chip put back     : 0x42E3
+same adapter      : still refused
+new adapter       : refused at connect
+```
+
+The third line matters: the chip was returned to exactly the word the adapter
+had set, `0x42E3`, and the refusal held anyway. No reading can establish that
+the competing writer is gone, so no reading clears the refusal. Recovery is a
+restart, after an operator has removed whatever was writing the chip.
+
+A readback that cannot be performed at all does not quarantine. A dropped
+transaction is not evidence that anything took the chip, and treating it as
+such would turn one bad transfer into an outage lasting until restart.
+
+## What this does not establish
+
+A quarantine is a refusal to measure, not a protection. A device holding one is
+not protecting that channel, and nothing here restores it: the runtime does not
+restart itself, and it does not withhold a watchdog feed to force a reset. What
+a reset would do to a commissioned coil is measured in
+`2026-09-01-pi4-gpio-controller-loss.md`, which also records that a genuine
+watchdog reset was not among the conditions tested. The consequence of a
+withheld measurement having no effect beyond one notice is tracked separately.
+
 ## The adapter as fixed
 
 Chip forced to its power-on default, then the real `I2CAdapter` connected on

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -144,6 +144,15 @@ _ADS_SENSOR_TYPES = frozenset({"ads1115_current", "ads1115_voltage"})
 _ADS1115_CLAIMS: "dict[tuple[int, int], weakref.ref[I2CAdapter]]" = {}
 _ADS1115_CLAIMS_LOCK = threading.Lock()
 
+# Chips seen running a configuration this process did not set, by (bus,
+# address). Never emptied: the operator message promises that a refusal lasts
+# until the runtime restarts, and an adapter-scoped latch would not keep that
+# promise — a second adapter object over the same chip would connect, rewrite
+# it, and start reading again inside the same process. Keyed by the physical
+# chip rather than by the object, because the chip is what was taken.
+_ADS1115_QUARANTINE: dict[tuple[int, int], str] = {}
+_ADS1115_QUARANTINE_LOCK = threading.Lock()
+
 # All sensor types handled by this adapter
 _SUPPORTED = frozenset(
     {
@@ -650,6 +659,14 @@ class I2CAdapter(BaseAdapter):
     def _connect_ads1115(self) -> None:
         _require_drivers(self._sensor_type)
         assert _ads1115 is not None and _ads1x15 is not None
+        # Before the bus is touched, and before anything is written. A chip
+        # this process has already found under someone else's configuration is
+        # refused for the life of the process: connecting would mean writing
+        # the configuration back, which is the contest the refusal exists to
+        # avoid, and it would make "until runtime restart" untrue.
+        quarantined = self._ads1115_quarantined()
+        if quarantined is not None:
+            raise AdapterConnectionError(quarantined)
         # The driver defaults are 128 SPS in single-shot mode, which yields
         # about two samples per 50 Hz cycle. Continuous conversion at the
         # configured rate is what makes a window resolvable at all.
@@ -785,6 +802,21 @@ class I2CAdapter(BaseAdapter):
         self._holds_shared_bus = False
         _release_shared_busio_i2c(self._bus_number)
 
+    def _ads1115_quarantined(self) -> str | None:
+        """Why this chip is refused for the life of the process, if it is."""
+        with _ADS1115_QUARANTINE_LOCK:
+            return _ADS1115_QUARANTINE.get((self._bus_number, self._address))
+
+    def _quarantine_ads1115(self, reason: str) -> None:
+        """Refuse this chip until the process restarts.
+
+        The first reason recorded is kept: it describes the configuration the
+        chip was found running, and a later one would only describe what the
+        competing writer did next.
+        """
+        with _ADS1115_QUARANTINE_LOCK:
+            _ADS1115_QUARANTINE.setdefault((self._bus_number, self._address), reason)
+
     def _release_ads1115_claim(self) -> None:
         key = (self._bus_number, self._address)
         with _ADS1115_CLAIMS_LOCK:
@@ -811,7 +843,40 @@ class I2CAdapter(BaseAdapter):
             | self._ADS1115_COMPARATOR_DISABLED
         )
 
-    def _verify_ads1115_channel(self, error: type[Exception]) -> None:
+    def _ads1115_configuration_fault(self) -> str | None:
+        """What the chip is running, when it is not what this adapter set.
+
+        Returns the mismatch rather than raising it, so a caller can decide
+        what a mismatch means: a connect refuses the sensor, and a measurement
+        refuses and latches. A readback that cannot be performed at all is a
+        bus failure rather than evidence of a competing writer, and is raised
+        from here for the caller to classify.
+        """
+        expected = self._expected_ads1115_config()
+        config = self._ads._read_register(self._ADS1115_CONFIG_REGISTER)
+        observed = int(config) & self._ADS1115_CONFIG_MASK
+        mux = (observed >> self._ADS1115_MUX_SHIFT) & 0x7
+        expected_mux = self._ADS1115_MUX_SINGLE_ENDED_BASE + self._channel
+        if mux != expected_mux:
+            return (
+                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is reading mux "
+                f"code {mux}, not single-ended channel {self._channel} "
+                f"(code {expected_mux}); the input it reports is not the one "
+                "configured"
+            )
+        if observed != expected:
+            return (
+                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is running "
+                f"configuration 0x{observed:04X}, not the 0x{expected:04X} "
+                "this adapter set; its gain, data rate or conversion mode was "
+                "changed by something else, and the samples it returns are no "
+                "longer the ones configured"
+            )
+        return None
+
+    def _verify_ads1115_channel(
+        self, error: type[Exception], *, remedy: str = ""
+    ) -> None:
         """Refuse when the chip is not running the configuration this set.
 
         Run at connect and again before every measurement, because a connect-
@@ -835,9 +900,8 @@ class I2CAdapter(BaseAdapter):
         The readback leaves the chip's register pointer on CONFIG. Callers must
         follow it with a pointered conversion read before any fast read.
         """
-        expected = self._expected_ads1115_config()
         try:
-            config = self._ads._read_register(self._ADS1115_CONFIG_REGISTER)
+            fault = self._ads1115_configuration_fault()
         except Exception as exc:
             # Classified as a refusal, not a bus error: what the caller needs
             # to know is that this window cannot be shown to be a measurement.
@@ -845,28 +909,60 @@ class I2CAdapter(BaseAdapter):
                 "I2CAdapter: could not read back the ADS1115 configuration to "
                 f"confirm its channel: {type(exc).__name__}: {exc}"
             ) from exc
-        observed = int(config) & self._ADS1115_CONFIG_MASK
-        mux = (observed >> self._ADS1115_MUX_SHIFT) & 0x7
-        expected_mux = self._ADS1115_MUX_SINGLE_ENDED_BASE + self._channel
-        if mux != expected_mux:
-            raise error(
-                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is reading mux "
-                f"code {mux}, not single-ended channel {self._channel} "
-                f"(code {expected_mux}); the input it reports is not the one "
-                "configured"
-            )
-        if observed != expected:
-            raise error(
-                f"I2CAdapter: ADS1115 at 0x{self._address:02X} is running "
-                f"configuration 0x{observed:04X}, not the 0x{expected:04X} "
-                "this adapter set; its gain, data rate or conversion mode was "
-                "changed by something else, and the samples it returns are no "
-                "longer the ones configured"
-            )
+        if fault is not None:
+            raise error(f"{fault}{remedy}")
+
+    # What an operator can act on, and the posture it states. The refusal is
+    # not retried and the chip is not written again: a reading that refuses is
+    # evidence that something outside this process changed the configuration
+    # after connect, and this adapter's claim cannot establish exclusive
+    # ownership of the bus against another process, a reset line or a second
+    # controller. Selecting this configuration again would be a writing
+    # contest, and the failure mode of losing one intermittently is a
+    # plausible number rather than a refusal. Availability is given up so that
+    # truthfulness is not, and #508 makes the loss visible rather than healthy.
+    _REFUSAL_REMEDY = (
+        "; configuration changed after startup, so the measurement is withheld "
+        "until runtime restart — investigate a competing writer, a brownout or "
+        "a reset"
+    )
 
     def _reaffirm_ads1115_channel(self) -> None:
-        """Per-measurement: prove the mux, then re-point the conversion register."""
-        self._verify_ads1115_channel(MeasurementRefusedError)
+        """Per-measurement: prove the configuration, then re-point the register.
+
+        Nothing here writes the chip. The verification is a read, and the
+        pointered read that follows runs only once the configuration has been
+        proven, so a refused measurement leaves the device as it was found.
+
+        The refusal quarantines the chip for the life of the process. Once it
+        has been seen running a configuration this adapter did not set, later
+        readings are refused without consulting it again, even if it reads
+        correct afterwards, and a new adapter over the same chip is refused at
+        connect before it can touch the bus.
+        Something outside this process is writing the chip, and a reading
+        taken between two of its writes is a plausible number rather than a
+        measurement — the fault would present as an intermittent value, which
+        is worse than an outage because nothing about it looks wrong. Clearing
+        it needs the competing writer gone, which no reading can establish, so
+        recovery is a restart rather than the next poll going quiet.
+
+        A readback that cannot be performed at all is a bus failure and does
+        not latch: it is not evidence that anything took the chip.
+        """
+        quarantined = self._ads1115_quarantined()
+        if quarantined is not None:
+            raise MeasurementRefusedError(quarantined)
+        try:
+            fault = self._ads1115_configuration_fault()
+        except Exception as exc:
+            raise MeasurementRefusedError(
+                "I2CAdapter: could not read back the ADS1115 configuration to "
+                f"confirm its channel: {type(exc).__name__}: {exc}"
+            ) from exc
+        if fault is not None:
+            message = f"{fault}{self._REFUSAL_REMEDY}"
+            self._quarantine_ads1115(message)
+            raise MeasurementRefusedError(message)
         self._ads.get_last_result(False)
 
     def _connect_scd40(self) -> None:

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -62,8 +62,10 @@ def _needs_hardware(
 def _clear_ads1115_claims():
     """One ADS1115 serves one adapter, and most tests never close theirs."""
     i2c_module._ADS1115_CLAIMS.clear()
+    i2c_module._ADS1115_QUARANTINE.clear()
     yield
     i2c_module._ADS1115_CLAIMS.clear()
+    i2c_module._ADS1115_QUARANTINE.clear()
 
 
 @pytest.fixture(autouse=True)
@@ -1523,6 +1525,155 @@ class TestAds1115ChannelSelection:
         assert 1 in i2c_module._shared_busio_instances
         await second.close()
         assert i2c_module._shared_busio_refs == {}
+
+    async def test_a_refused_measurement_holds_and_never_rewrites_the_chip(
+        self, monkeypatch
+    ):
+        """The refusal is terminal for the process, and it is read-only.
+
+        A reading that refuses is evidence that something outside this process
+        changed the configuration after connect. This adapter's claim keeps a
+        second Ori adapter off the chip; it establishes nothing against another
+        process, a reset line or a second controller. Writing the configuration
+        back would be a contest with whatever moved it, and losing that
+        intermittently produces a plausible number instead of a refusal.
+
+        So every subsequent read refuses on its own terms, and the chip is left
+        exactly as it was found. Recovery is a restart, after the competing
+        writer is gone.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        ads = created[0]
+
+        # Something else takes the chip: same mux, different gain.
+        ads._gain_bits = 0x0000
+        settled = len([w for w in ads.writes if w[0] == "config"])
+
+        for _ in range(3):
+            with pytest.raises(MeasurementRefusedError, match="until runtime restart"):
+                await adapter.read("s")
+
+        assert len([w for w in ads.writes if w[0] == "config"]) == settled, (
+            "the adapter wrote the ADS1115 while refusing, which is a writing "
+            "contest with whatever changed it"
+        )
+
+        # The chip reading correct again does not clear it. Something outside
+        # this process is writing the chip, and a reading taken between two of
+        # its writes is a plausible number rather than a measurement — an
+        # intermittent wrong value, which is worse than an outage because
+        # nothing about it looks wrong. No reading can establish that the
+        # competing writer is gone, so no reading clears the refusal.
+        ads._gain_bits = 0x0200
+        with pytest.raises(MeasurementRefusedError, match="until runtime restart"):
+            await adapter.read("s")
+        assert len([w for w in ads.writes if w[0] == "config"]) == settled
+        await adapter.close()
+
+        # And a new adapter over the same chip is refused too, before it can
+        # acquire the bus or write anything. An adapter-scoped latch would let
+        # a second object reconnect, rewrite the chip and start reading inside
+        # the same process, which would make "until runtime restart" untrue.
+        # Asserted on the acquisition, not on the reference count: a failed
+        # connect gives its reference back, so counting before and after would
+        # pass whether or not the bus was ever touched.
+        acquisitions: list[int] = []
+        real_acquire = i2c_module._get_shared_busio_i2c
+
+        def _counted(bus_number):
+            acquisitions.append(bus_number)
+            return real_acquire(bus_number)
+
+        monkeypatch.setattr(i2c_module, "_get_shared_busio_i2c", _counted)
+
+        fresh = I2CAdapter()
+        with pytest.raises(AdapterConnectionError, match="until runtime restart"):
+            await fresh.connect(_config(sensor_type="ads1115_current", channel=0))
+        assert not fresh.is_connected
+        assert len([w for w in ads.writes if w[0] == "config"]) == settled
+        assert acquisitions == [], "the refused connect reached the bus before refusing"
+
+    async def test_a_quarantine_is_the_chip_not_the_bus(self, monkeypatch):
+        """Keyed by (bus, address): another chip is a different device.
+
+        A competing writer on one chip says nothing about a second one at its
+        own address, and refusing that too would lose a measurement nothing
+        established a problem with.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0)
+        first = I2CAdapter()
+        await first.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        first._quarantine_ads1115("something took this chip")
+
+        with pytest.raises(MeasurementRefusedError):
+            await first.read("s")
+        await first.close()
+
+        other = I2CAdapter()
+        await other.connect(
+            _config(sensor_type="ads1115_voltage", address=0x49, channel=0)
+        )
+        assert other.is_connected
+        assert abs((await other.read("s")).value) < 0.01
+        await other.close()
+
+    async def test_a_bus_error_on_the_readback_refuses_but_does_not_latch(
+        self, monkeypatch
+    ):
+        """A readback that cannot be performed is not evidence of a writer.
+
+        The latch exists because a chip running a configuration this adapter
+        did not set means something else is writing it. A bus that dropped a
+        transaction means nothing of the kind, and latching on it would turn
+        one bad transfer into an outage lasting until restart.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+
+        original = _PinnedDriverADS1115._read_register
+        broken = {"on": True}
+
+        def config_read_fails(self, pointer, fast=False):
+            if broken["on"] and pointer == self.POINTER_CONFIG and not fast:
+                raise OSError("[Errno 121] Remote I/O error")
+            return original(self, pointer, fast)
+
+        monkeypatch.setattr(_PinnedDriverADS1115, "_read_register", config_read_fails)
+        with pytest.raises(MeasurementRefusedError, match="could not read back"):
+            await adapter.read("s")
+
+        broken["on"] = False
+        # The bus recovered, so the adapter does too, without a restart.
+        assert abs((await adapter.read("s")).value) < 0.01
+        await adapter.close()
+
+    async def test_a_refusal_names_what_an_operator_should_do(self, monkeypatch):
+        """A refusal an operator cannot act on is a log line, not a report."""
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        created[0]._mux = 5
+
+        with pytest.raises(MeasurementRefusedError) as raised:
+            await adapter.read("s")
+
+        message = str(raised.value)
+        assert "withheld until runtime restart" in message
+        assert "competing writer" in message
+        await adapter.close()
+
+    async def test_a_connect_refusal_does_not_promise_a_restart(self, monkeypatch):
+        """Connect refuses the sensor outright; there is nothing to withhold."""
+        _pinned_driver(monkeypatch, chip_mux=0, honours_pin_in_single=False)
+        adapter = I2CAdapter()
+
+        with pytest.raises(AdapterConnectionError) as raised:
+            await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+
+        assert "until runtime restart" not in str(raised.value)
 
     async def test_the_reproduction_spins_on_a_conversion_that_never_completes(self):
         """Guards the fake: without a real poll the hang test proves nothing."""


### PR DESCRIPTION
## What does this PR do?

The ADS1115 adapter reads back the chip's whole configuration word before every measurement and refuses when it is not the one this process set. What happened next was wrong: the next poll checked again, so a chip that transiently read correct resumed producing readings.

A refused reading is evidence that something outside this process is writing the chip. The in-process claim keeps a second Ori adapter off it and establishes nothing against another process, a reset line or a second controller. Re-selecting the configuration would be a contest with whatever moved it, and losing that contest intermittently produces a plausible number rather than a refusal — an occasional wrong value, which is worse than an outage because nothing about it looks wrong.

So the chip is quarantined, and nothing in the poll path writes it again.

## The quarantine is the chip, for the life of the process

Keyed by bus and address rather than by the adapter object, and that distinction is the whole point. `close()` releases the chip claim, so an adapter-scoped latch would let a second adapter object connect, rewrite the chip and resume reading inside the same process. The operator message promises that the measurement is withheld until the runtime restarts, and an object-scoped latch would not keep that promise.

A later connect for a quarantined chip is refused at the top of the connect path, before the bus is acquired and before anything is written. Another chip at its own address is unaffected, because a competing writer on one says nothing about another.

A readback that cannot be performed at all does not quarantine. A dropped transaction is not evidence that anything took the chip, and treating it as such would turn one bad transfer into an outage lasting until restart.

The refusal names what an operator can act on: the configuration changed after startup, the measurement is withheld until runtime restart, and the thing to look for is a competing writer, a brownout or a reset. A connect-time refusal deliberately does not carry that wording, because there is nothing to withhold — the sensor is simply not read.

## Verification

Driven against the bench ADS1115 with a second driver instance as the competing writer, which writes single-shot mode and leaves the mux alone. Retained in `docs/evidence/2026-09-03-pi4-ads1115-characterisation.md`:

```text
before            : -0.0001 V
after the writer  : refused
chip put back     : 0x42E3
same adapter      : still refused
new adapter       : refused at connect
```

The third line is the one that matters. The chip was returned to exactly the word the adapter had set and the refusal held anyway, because no reading can establish that the competing writer is gone.

Nine mutations, each killed by a named test, including an adapter-scoped quarantine, a connect that skips the check, and a check moved to after the bus is acquired. That last one first survived: the test asserted the shared bus reference count was unchanged, which passes whether or not the bus was touched, because a failed connect returns its reference. It now spies on the acquisition itself.

Full suite 4541 passed with 23 skipped, evidence suite 779 passed, and the Pi runs 108 passed with 2 skipped. `ruff check`, `ruff format --check`, `mypy ori/` and `pyright` clean.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

It governs whether a current reading a Tier D threshold is evaluated against is emitted at all.

## What this does not establish

A quarantine is a refusal to measure, not a protection. A device holding one is not protecting that channel, and nothing here restores it.

**A mismatch found during the initial `connect()` is refused but not quarantined.** The tested scenario is a mismatch appearing under an adapter that is already connected and reading, and the runtime never reconnects, so nothing today reaches the gap. Any future reconnect or recovery design has to treat that connect-time contention case explicitly rather than assume this change settled it. Recorded on #510.

The runtime does not restart itself for this, and it does not withhold a watchdog feed to force a reset. Both were considered and rejected: a restart clears the quarantine and reconfigures the chip while the competing writer may still be there, and it removes protection for every other active safety pair for its duration; withholding a watchdog feed does not report a problem, it resets the controller, and `docs/evidence/2026-09-01-pi4-gpio-controller-loss.md` measured that a reset de-energises the coil while stating that a genuine watchdog reset was not among the conditions tested. What de-energising does to a protected circuit is commissioned per channel.

That a withheld measurement has no consequence beyond one notice is a real gap and is tracked in #510, together with the durable escalation that should close the operator-facing half of it.

## Related issue

Closes #502

#510 owns the escalation and supervision design. #503 covers what the configuration check does not see inside a window.
