### PR TITLE
fix(hal): serialise the adapter lifecycle so a close cannot straddle a connect

### DIFF
--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -574,6 +574,14 @@ class I2CAdapter(BaseAdapter):
         # count is shared, so releasing one this adapter never took would evict
         # a handle another adapter is still reading through.
         self._holds_shared_bus: bool = False
+        # Incremented by every close(), before it waits for anything, so a
+        # connect already past its own sampling point can still see it.
+        self._close_count: int = 0
+        # One lifecycle operation at a time. `_teardown()` awaits, so without
+        # this a close suspended part-way through it is invisible to a connect
+        # starting in that gap, and the rest of the stale teardown then
+        # releases what the new connect had just taken.
+        self._lifecycle = asyncio.Lock()
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -605,15 +613,46 @@ class I2CAdapter(BaseAdapter):
                 f"Supported: {sorted(_SUPPORTED)}"
             )
 
-        self._sensor_id = config.get("sensor_id", "")
-        self._sensor_type = sensor_type
-        self._address = _require_int(config.get("address", 0x00), "address")
-        self._bus_number = _require_int(config.get("bus", 1), "bus")
-        self._channel = _require_int(config.get("channel", 0), "channel")
+        # Validated into locals here and applied to the adapter only under the
+        # lock. Written straight to `self`, two concurrent connects overwrite
+        # each other's address, channel and calibration while one of them is
+        # already inside its own initialisation, and its worker thread then
+        # opens whatever the other left behind — the wrong device, or the right
+        # one on the wrong channel.
+        sensor_id = config.get("sensor_id", "")
+        address = _require_int(config.get("address", 0x00), "address")
+        bus_number = _require_int(config.get("bus", 1), "bus")
+        channel = _require_int(config.get("channel", 0), "channel")
+        calibration: dict[str, float] = {}
+        window: WindowSpec | None = None
         if sensor_type == "ads1115_current":
-            self._calibration = _resolve_calibration(config)
-            self._window = _window_spec(self._calibration)
+            calibration = _resolve_calibration(config)
+            window = _window_spec(calibration)
 
+        async with self._lifecycle:
+            if self._connected:
+                # Refused before any state is touched and before the bus is
+                # reached. Reconnecting in place would take a second shared-bus
+                # reference against one release, and would move a live
+                # adapter's device under readings already being taken from it.
+                raise AdapterConnectionError(
+                    f"I2CAdapter: already connected to '{self._sensor_type}' at "
+                    f"address 0x{self._address:02X} on bus {self._bus_number}; "
+                    "close it before connecting again"
+                )
+            self._sensor_id = sensor_id
+            self._sensor_type = sensor_type
+            self._address = address
+            self._bus_number = bus_number
+            self._channel = channel
+            self._calibration = calibration
+            self._window = window
+            await self._connect_locked(sensor_type, config)
+
+    async def _connect_locked(self, sensor_type: str, config: dict) -> None:
+        # Sampled inside the lock, so a close that has already run in full is
+        # counted here rather than mistaken for one that arrived later.
+        closes_before = self._close_count
         connected = False
         try:
             await asyncio.to_thread(self._connect_sync, sensor_type)
@@ -633,6 +672,21 @@ class I2CAdapter(BaseAdapter):
             # handed a stale one.
             if not connected:
                 self._release_shared_bus()
+
+        if self._close_count != closes_before:
+            # A close() arrived while this connect held the lock. It could not
+            # tear anything down yet, but it has declared itself, and the
+            # worker thread went on taking more meanwhile. Reporting success
+            # would leave an adapter that believes it is connected while a
+            # close already waiting tears it down, and the runtime would poll
+            # it. The connect gives everything back itself and refuses,
+            # because a connect that was closed did not connect.
+            await self._teardown()
+            raise AdapterConnectionError(
+                f"I2CAdapter: '{sensor_type}' at address "
+                f"0x{self._address:02X} on bus {self._bus_number} was closed "
+                "while it was still connecting"
+            )
 
         self._breaker = HardwareCircuitBreaker(
             getattr(self, "adapter_name", type(self).__name__), config
@@ -974,15 +1028,16 @@ class I2CAdapter(BaseAdapter):
         self._scd4x = adafruit_scd4x.SCD4X(i2c)
         self._scd4x.start_periodic_measurement()
 
-    async def close(self) -> None:
-        """Release I2C bus resources and stop any periodic measurements.
+    async def _teardown(self) -> None:
+        """Give back everything a connect may have taken, in any order.
 
-        Also releases this adapter's claim on its ADS1115, if it holds one.
+        Idempotent, because it runs from both `close()` and from a `connect()`
+        that found itself closed: the claim release checks ownership, the bus
+        release checks whether this adapter holds a reference, and the device
+        handles are cleared as they are closed.
 
-        For Adafruit-based sensors (ADS1115, SCD40) the shared ``busio.I2C``
-        cache entry is evicted so that a subsequent :meth:`connect` call
-        creates a fresh bus handle.  Existing references held by other adapters
-        sharing the same bus are unaffected.
+        Runs under the lifecycle lock in both cases, so two teardowns never
+        interleave and one cannot release what the other has just taken.
         """
         self._release_ads1115_claim()
         try:
@@ -992,11 +1047,39 @@ class I2CAdapter(BaseAdapter):
             if self._bus is not None:
                 await asyncio.to_thread(self._bus.close)
                 self._bus = None
+            # Dropped as well as released: the driver object holds the bus
+            # handle about to be evicted from the cache, so leaving it attached
+            # keeps the evicted handle alive.
+            self._ads = None
+            self._bme280_params = None
             self._release_shared_bus()
         except Exception:
             logger.warning("I2CAdapter: exception during close — already disconnected?")
-        finally:
-            self._connected = False
+
+    async def close(self) -> None:
+        """Release I2C bus resources and stop any periodic measurements.
+
+        Also releases this adapter's claim on its ADS1115, if it holds one.
+
+        For Adafruit-based sensors (ADS1115, SCD40) the shared ``busio.I2C``
+        cache entry is evicted so that a subsequent :meth:`connect` call
+        creates a fresh bus handle.  Existing references held by other adapters
+        sharing the same bus are unaffected.
+
+        The close is recorded before the lifecycle lock is even requested, so a
+        `connect()` holding it can see that a close is waiting and give back
+        what it took rather than reporting success.
+
+        Recorded before anything is released, so a `connect()` still running in
+        a worker thread can see that it was closed and give back what it took
+        after this ran.
+        """
+        self._close_count += 1
+        async with self._lifecycle:
+            try:
+                await self._teardown()
+            finally:
+                self._connected = False
 
     async def health_check(self) -> bool:
         """Return ``True`` when connected and the device handle is open."""

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -1846,3 +1846,292 @@ print(json.dumps({{
         from ori.hal.i2c_adapter import i2c_driver_unavailable_reason
 
         assert i2c_driver_unavailable_reason("cpu_percent") is None
+
+
+class TestCloseDuringConnect:
+    """A close that overtakes an in-flight connect.
+
+    `connect()` runs its hardware initialisation in a worker thread and used to
+    mark itself connected when that thread returned, whatever had happened
+    meanwhile. A `close()` in that window released what had been taken at the
+    time while the thread went on taking more, leaving an adapter that believed
+    it was connected holding a shared-bus reference `close()` had already given
+    back. The runtime would then poll a sensor whose bus nobody believes is in
+    use.
+
+    Driven for every sensor type the adapter serves, and from both sides of the
+    window, because the two orderings fail differently: a close landing after
+    the acquisition is undone by the close itself, and one landing before it is
+    undone only by the connect noticing.
+    """
+
+    def _install_drivers(self, monkeypatch, sensor_type: str):
+        if sensor_type == "bme280":
+            monkeypatch.setattr(i2c_module, "_SMBUS_AVAILABLE", True)
+            monkeypatch.setattr(i2c_module, "_BME280_AVAILABLE", True)
+            monkeypatch.setattr(i2c_module, "smbus", MagicMock(), raising=False)
+            monkeypatch.setattr(i2c_module, "_bme280_lib", MagicMock(), raising=False)
+            return
+        if sensor_type == "scd40":
+            monkeypatch.setattr(i2c_module, "_SCD40_AVAILABLE", True)
+            monkeypatch.setattr(i2c_module, "_BLINKA_AVAILABLE", True)
+            monkeypatch.setattr(i2c_module, "_busio", MagicMock(), raising=False)
+            monkeypatch.setattr(i2c_module, "_board", MagicMock(), raising=False)
+            monkeypatch.setattr(
+                i2c_module, "adafruit_scd4x", MagicMock(), raising=False
+            )
+            return
+        _pinned_driver(monkeypatch, chip_mux=0)
+
+    def _gate(self, monkeypatch, when: str, started, release):
+        """Hold the worker thread open, before or after it takes anything."""
+        original = I2CAdapter._connect_sync
+
+        def _gated(self, sensor_type):
+            if when == "after":
+                original(self, sensor_type)
+            started.set()
+            release.wait(5.0)
+            if when == "before":
+                original(self, sensor_type)
+
+        monkeypatch.setattr(I2CAdapter, "_connect_sync", _gated)
+
+    def _assert_nothing_held(self, adapter, sensor_type: str, before: dict) -> None:
+        """Per type, on the resource that type actually takes."""
+        assert adapter.is_connected is False
+        assert i2c_module._shared_busio_refs == before, (
+            "a shared bus reference outlived the connect that took it"
+        )
+        if sensor_type == "bme280":
+            assert adapter._bus is None
+        elif sensor_type == "scd40":
+            assert adapter._scd4x is None
+        else:
+            assert i2c_module._ADS1115_CLAIMS == {}
+            assert adapter._ads is None
+
+    @pytest.mark.parametrize("when", ["before", "after"])
+    @pytest.mark.parametrize(
+        "sensor_type", ["bme280", "ads1115_voltage", "ads1115_current", "scd40"]
+    )
+    async def test_a_close_during_connect_leaves_nothing_held(
+        self, monkeypatch, sensor_type, when
+    ):
+        import threading
+
+        self._install_drivers(monkeypatch, sensor_type)
+        started, release = threading.Event(), threading.Event()
+        self._gate(monkeypatch, when, started, release)
+
+        address = 0x76 if sensor_type == "bme280" else 0x48
+        before = dict(i2c_module._shared_busio_refs)
+        adapter = I2CAdapter()
+        connecting = asyncio.create_task(
+            adapter.connect(_config(sensor_type=sensor_type, address=address))
+        )
+        await asyncio.to_thread(started.wait, 5.0)
+
+        closing = asyncio.create_task(adapter.close())
+        await asyncio.sleep(0)
+        release.set()
+
+        with pytest.raises(AdapterConnectionError, match="closed while it was still"):
+            await connecting
+        await closing
+
+        self._assert_nothing_held(adapter, sensor_type, before)
+
+    async def test_a_close_part_way_through_its_teardown_blocks_a_new_connect(
+        self, monkeypatch
+    ):
+        """The counter records that a close began, not that it finished.
+
+        `_teardown()` awaits, so a close suspended inside it would otherwise be
+        invisible to a connect starting in that gap, and the rest of the stale
+        teardown would then release what the new connect had just taken. The
+        lifecycle lock is what stops the two straddling each other.
+        """
+        import threading
+
+        self._install_drivers(monkeypatch, "scd40")
+        in_teardown, finish = threading.Event(), threading.Event()
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="scd40", address=0x62))
+        before_connect = dict(i2c_module._shared_busio_refs)
+
+        def _slow_stop():
+            in_teardown.set()
+            finish.wait(5.0)
+
+        adapter._scd4x.stop_periodic_measurement = _slow_stop
+
+        closing = asyncio.create_task(adapter.close())
+        await asyncio.to_thread(in_teardown.wait, 5.0)
+
+        # The close is suspended inside its own teardown. A connect starting
+        # now must not run alongside it.
+        reconnecting = asyncio.create_task(
+            adapter.connect(_config(sensor_type="scd40", address=0x62))
+        )
+        await asyncio.sleep(0.05)
+        assert not reconnecting.done(), "a connect ran inside a close's teardown"
+
+        finish.set()
+        await closing
+        await reconnecting
+
+        assert adapter.is_connected is True
+        assert i2c_module._shared_busio_refs == before_connect, (
+            "the suspended teardown released the later connect's reference"
+        )
+        await adapter.close()
+        assert i2c_module._shared_busio_refs == {}
+
+    async def test_a_close_declares_itself_before_it_waits(self, monkeypatch):
+        """Recording the close after its teardown would reinstate the defect.
+
+        The connect holds the lifecycle lock, so a close cannot tear anything
+        down until the connect finishes. If it also did not record itself
+        first, the connect would see nothing and report success.
+        """
+        import threading
+
+        self._install_drivers(monkeypatch, "ads1115_voltage")
+        started, release = threading.Event(), threading.Event()
+        self._gate(monkeypatch, "after", started, release)
+
+        adapter = I2CAdapter()
+        connecting = asyncio.create_task(
+            adapter.connect(_config(sensor_type="ads1115_voltage"))
+        )
+        await asyncio.to_thread(started.wait, 5.0)
+        closing = asyncio.create_task(adapter.close())
+        await asyncio.sleep(0)
+
+        # The close has not torn anything down — it is waiting for the lock.
+        assert adapter._close_count == 1
+        release.set()
+        with pytest.raises(AdapterConnectionError, match="closed while it was still"):
+            await connecting
+        await closing
+
+    async def test_a_teardown_never_releases_another_adapters_claim(self, monkeypatch):
+        """The property that makes the teardown safe to run from two places.
+
+        Driven on the method rather than through a race, because the lifecycle
+        lock now makes the interleaving that produced it hard to construct —
+        and the ownership check has to hold regardless of how the state arose,
+        since a stale teardown that stole a live claim would admit a third
+        adapter onto a chip another is driving.
+        """
+        _pinned_driver(monkeypatch, chip_mux=0)
+        first = I2CAdapter()
+        await first.connect(_config(sensor_type="ads1115_voltage"))
+        await first.close()
+
+        second = I2CAdapter()
+        await second.connect(_config(sensor_type="ads1115_voltage"))
+        held = dict(i2c_module._ADS1115_CLAIMS)
+        assert held, "the second adapter did not take the claim"
+
+        await first._teardown()
+
+        assert i2c_module._ADS1115_CLAIMS == held, (
+            "a stale teardown released a claim another adapter holds"
+        )
+        assert second.is_connected is True
+        await second.close()
+
+    async def test_a_second_connect_cannot_change_the_first_ones_device(
+        self, monkeypatch
+    ):
+        """Config written to the adapter before the lock is a second race.
+
+        One connect holds the lifecycle lock while its worker is running; a
+        second, for a different address and channel, would overwrite the
+        address, channel and calibration the first is in the middle of using.
+        The worker then opens whatever the second left behind: the wrong
+        device, or the right one on the wrong channel.
+        """
+        import threading
+
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        started, release = threading.Event(), threading.Event()
+        self._gate(monkeypatch, "before", started, release)
+
+        adapter = I2CAdapter()
+        first = asyncio.create_task(
+            adapter.connect(
+                _config(sensor_type="ads1115_voltage", address=0x48, channel=0)
+            )
+        )
+        await asyncio.to_thread(started.wait, 5.0)
+
+        # A second connect for a different chip and channel, while the first
+        # is inside its own initialisation.
+        second = asyncio.create_task(
+            adapter.connect(
+                _config(sensor_type="ads1115_voltage", address=0x49, channel=3)
+            )
+        )
+        await asyncio.sleep(0.05)
+        assert not second.done(), "the second connect ran alongside the first"
+
+        release.set()
+        await first
+
+        # The first connected its own device, on its own channel.
+        assert adapter._address == 0x48
+        assert adapter._channel == 0
+        assert [d.address for d in created] == [0x48]
+
+        # And the second is refused rather than reconnecting in place, so it
+        # takes no further shared-bus reference against the one release the
+        # single close will make.
+        with pytest.raises(AdapterConnectionError, match="already connected"):
+            await second
+        assert i2c_module._shared_busio_refs == {1: 1}
+
+        await adapter.close()
+        assert i2c_module._shared_busio_refs == {}
+        assert i2c_module._ADS1115_CLAIMS == {}
+
+    async def test_a_refused_second_connect_leaves_the_first_readable(
+        self, monkeypatch
+    ):
+        """Refusing must not disturb the adapter that is already working."""
+        _pinned_driver(monkeypatch, chip_mux=0, conversion=0xFFFE)
+        adapter = I2CAdapter()
+        await adapter.connect(
+            _config(sensor_type="ads1115_voltage", address=0x48, channel=0)
+        )
+
+        with pytest.raises(AdapterConnectionError, match="already connected"):
+            await adapter.connect(
+                _config(sensor_type="ads1115_voltage", address=0x49, channel=3)
+            )
+
+        assert adapter.is_connected is True
+        assert adapter._address == 0x48
+        assert adapter._channel == 0
+        assert abs((await adapter.read("s")).value) < 0.01
+        await adapter.close()
+
+    async def test_an_ordinary_connect_is_unaffected(self, monkeypatch):
+        """The guard must not refuse a connect nothing closed."""
+        _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage"))
+        assert adapter.is_connected is True
+        await adapter.close()
+
+    async def test_an_adapter_reconnects_after_a_clean_close(self, monkeypatch):
+        """The close count is a comparison, not a latch."""
+        _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage"))
+        await adapter.close()
+        await adapter.connect(_config(sensor_type="ads1115_voltage"))
+        assert adapter.is_connected is True
+        await adapter.close()

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -1859,6 +1859,11 @@ class TestCloseDuringConnect:
     back. The runtime would then poll a sensor whose bus nobody believes is in
     use.
 
+    Every wait here is bounded. A lifecycle that deadlocks should fail the
+    test rather than hang the run, which is the difference between a defect
+    that is reported and one that is discovered by a timeout somewhere less
+    informative.
+
     Driven for every sensor type the adapter serves, and from both sides of the
     window, because the two orderings fail differently: a close landing after
     the acquisition is undone by the close itself, and one landing before it is
@@ -1937,8 +1942,8 @@ class TestCloseDuringConnect:
         release.set()
 
         with pytest.raises(AdapterConnectionError, match="closed while it was still"):
-            await connecting
-        await closing
+            await asyncio.wait_for(connecting, 5)
+        await asyncio.wait_for(closing, 5)
 
         self._assert_nothing_held(adapter, sensor_type, before)
 
@@ -1978,8 +1983,8 @@ class TestCloseDuringConnect:
         assert not reconnecting.done(), "a connect ran inside a close's teardown"
 
         finish.set()
-        await closing
-        await reconnecting
+        await asyncio.wait_for(closing, 5)
+        await asyncio.wait_for(reconnecting, 5)
 
         assert adapter.is_connected is True
         assert i2c_module._shared_busio_refs == before_connect, (
@@ -2013,8 +2018,8 @@ class TestCloseDuringConnect:
         assert adapter._close_count == 1
         release.set()
         with pytest.raises(AdapterConnectionError, match="closed while it was still"):
-            await connecting
-        await closing
+            await asyncio.wait_for(connecting, 5)
+        await asyncio.wait_for(closing, 5)
 
     async def test_a_teardown_never_releases_another_adapters_claim(self, monkeypatch):
         """The property that makes the teardown safe to run from two places.
@@ -2079,7 +2084,7 @@ class TestCloseDuringConnect:
         assert not second.done(), "the second connect ran alongside the first"
 
         release.set()
-        await first
+        await asyncio.wait_for(first, 5)
 
         # The first connected its own device, on its own channel.
         assert adapter._address == 0x48
@@ -2090,7 +2095,7 @@ class TestCloseDuringConnect:
         # takes no further shared-bus reference against the one release the
         # single close will make.
         with pytest.raises(AdapterConnectionError, match="already connected"):
-            await second
+            await asyncio.wait_for(second, 5)
         assert i2c_module._shared_busio_refs == {1: 1}
 
         await adapter.close()


### PR DESCRIPTION
## What does this PR do?

`I2CAdapter.connect()` runs its hardware initialisation in a worker thread and marked the adapter connected when that thread returned, whatever had happened meanwhile. Two lifecycle races follow from that, and this closes both.

**A close overlapping a connect.** `close()` released what had been taken at that moment while the worker went on taking more, so the connect finished and reported success holding a shared-bus reference `close()` had already given back. The held-reference flag was false by then, so nothing could ever release it again and the cached bus handle was pinned for the life of the process. The same window dropped the ADS1115 chip claim, which is what keeps a second adapter off one multiplexer.

**Two concurrent connects.** Configuration was written straight onto the adapter before any serialisation, so a second connect overwrote the address, channel and calibration that a running worker was in the middle of using. The worker then opened whatever the other left behind: the wrong device, or the right one on the wrong channel.

## How

One lifecycle operation at a time, under a per-adapter lock, with configuration validated into locals first and applied to the adapter only under that lock.

`close()` records itself before it requests the lock. That ordering is load-bearing: the lock means a close cannot tear anything down while a connect holds it, so without the early record the connect would see nothing and report success. Having seen it, the connect gives back everything itself and raises, because a connect that was closed did not connect. It raises rather than returning quietly because `ori/runtime.py` treats a returning `connect()` as success and starts polling immediately.

A second connect on a connected adapter is refused, before any state is touched and before the bus is reached. Reconnecting in place would move a live adapter's device under readings already being taken from it, and would take a second shared-bus reference against the single release the eventual close makes.

Teardown is now shared between `close()` and the closed-connect path, runs under the lock in both, and drops the driver handles as well as releasing them — the driver object holds the bus handle being evicted, so leaving it attached kept the evicted handle alive.

## Scope: this is a contract fix, not a live failure

**Nothing in the runtime reaches either race today.** Adapters are connected sequentially, each is appended to the close list only after `connect()` returns, and that list is the only thing `close()` iterates, so an in-flight adapter is never closed. This is host-tested hardening of a public adapter lifecycle, not a demonstrated failure on a Pi or in the runtime.

If it were ever reached during shutdown, the runtime would treat the new exception as a sensor that failed to connect, and emit a spurious unavailable notice.

## Verification

Eleven mutations, each killed by a named test. They include the close-count guard, the ordering that records a close before its teardown, the lock on each side, the ownership check in the claim release, dropping the driver handle, applying configuration outside the lock, and admitting a second connect.

The tests drive the race from both sides of the window, for every sensor type the adapter serves, because the two orderings fail differently: a close landing after the acquisition is undone by the close itself, and one landing before it is undone only by the connect noticing. Per-type assertions check the resource that type actually takes rather than one shape for all four.

Two boundaries had no test anywhere before this: recording the close before its teardown, and the ownership check that makes the teardown safe to run from two places. The second is the safety-relevant one — a stale teardown that released a live claim would admit a third adapter onto a chip another is driving.

Full suite 4556 passed with 23 skipped, evidence suite 779 passed, adapter suite 121 passed with 4 skipped. `ruff check`, `ruff format --check`, `mypy ori/` and `pyright` clean.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

The ADS1115 claim it restores is the mechanism that stops two adapters driving one multiplexer, and the resulting reading is what a Tier D overcurrent threshold is evaluated against.

## Related issue

Closes #501

#512 covers the held-reference boolean standing for a counted acquisition; its worked example is now unreachable, and the accounting question is not. #513 covers the same lifecycle shape sitting untouched in five sibling adapters, where the contract belongs in the base class rather than copied six times.
