### PR TITLE
fix(hal): certify the ADS1115 window at both ends and point every sample

### DIFF
--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -40,8 +40,16 @@ second sensor on a claimed chip at connect; a second channel is a second chip
 at a second address (ADDR to VDD for `0x49`). The chip's whole configuration,
 not the mux alone, is read back at the start of every measurement, so a gain,
 data rate or conversion mode changed by anything outside the runtime refuses
-the measurement rather than quietly rescaling it. A change that lands part-way
-through a window is caught at the next window, not within that one.
+the measurement rather than quietly rescaling it. It is read back again at the
+end of each window, so a change that is still present when the window closes
+refuses that window rather than the next one. A writer that changes the
+configuration and restores it before the window closes is not caught, and
+cannot be from this side of the bus.
+
+Every sample writes the chip's register pointer for itself, so a foreign read
+of the configuration register cannot turn the rest of a window into the
+configuration word. That costs one sample in thirty-six at 860 SPS against a
+floor of twenty-two, measured on this bench before it was adopted.
 
 A full bus scan (`sudo /usr/sbin/i2cdetect -y 1` — the binary is on the root
 path only) shows `48` and nothing else. `/dev/i2c-1` is present on the image;

--- a/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
+++ b/docs/evidence/2026-09-03-pi4-ads1115-characterisation.md
@@ -135,13 +135,13 @@ and a 21.7 A load reads 0.0 A. Both under-report, which is the direction that
 matters for a current a trip threshold is defined over. Both were measured by
 driving the real 3.0.5 driver over a register-level model of the part.
 
-The check certifies the chip at the start of each window, not through it. A
-write that lands mid-window is not caught until the next one, and a foreign
-pointered read mid-window sends the remaining fast reads back to the config
-word: measured in that model at 10.9 A against 20.9 A. Closing that costs
-either a second readback after the window or a pointered read per sample, and
-the per-sample cost at 1.163 ms has not been measured on the bench. Tracked in
-ori-runtime#503 rather than guessed at here.
+The check certified the chip at the start of each window and not through it,
+which left two ways in. A configuration write landing mid-window was not caught
+until the next window, and a foreign pointered read mid-window sent the
+remaining fast reads back to the config word: measured in that model at 10.9 A
+against 20.9 A. The pointer half is closed outright, on a
+measurement rather than on inspection. The configuration half is narrowed
+rather than closed, and the residue is stated below rather than left implied.
 
 ## Defect 4: a chip at 0x48 that is not an ADS1115 hung the connect
 
@@ -194,7 +194,7 @@ A readback that cannot be performed at all does not quarantine. A dropped
 transaction is not evidence that anything took the chip, and treating it as
 such would turn one bad transfer into an outage lasting until restart.
 
-## What this does not establish
+## What a quarantine does not establish
 
 A quarantine is a refusal to measure, not a protection. A device holding one is
 not protecting that channel, and nothing here restores it: the runtime does not
@@ -203,6 +203,86 @@ a reset would do to a commissioned coil is measured in
 `2026-09-01-pi4-gpio-controller-loss.md`, which also records that a genuine
 watchdog reset was not among the conditions tested. The consequence of a
 withheld measurement having no effect beyond one notice is tracked separately.
+
+## Defect 6: the window was certified only at its start
+
+Recorded 2026-09-04, same bench and part.
+
+A pointered conversion read per sample was the obvious way to close the pointer
+class outright — no sample can then return anything but the conversion register
+— and the objection to it was cost: it writes one extra byte per sample, and
+nothing had established that this fits inside the 1.163 ms conversion interval
+at 860 SPS. So it was measured before it was adopted, paced exactly as the
+adapter paces, over a 2-cycle 50 Hz window:
+
+```text
+fast read (today)        samples 36  elapsed 41.09 ms (ratio 1.0272)
+                         gap mean 1.164 ms  max 1.223  sd 0.010
+pointered every sample   samples 35  elapsed 40.15 ms (ratio 1.0038)
+                         gap mean 1.164 ms  max 1.222  sd 0.011
+floor at 2/3 of nominal 34.4 samples = 22
+```
+
+One sample in thirty-six, an unchanged mean gap, and a whole-window elapsed
+ratio that is nearer nominal rather than further from it. The floor is 22, so
+the cost is well inside it. Adopted.
+
+Confirmed afterwards through the adapter's own sampler rather than a standalone
+loop:
+
+```text
+trial 0: samples=35 elapsed=40.16 ms ratio=1.0039 gap mean=1.164 max=1.829
+trial 1: samples=35 elapsed=40.16 ms ratio=1.0039 gap mean=1.164 max=1.221
+trial 2: samples=35 elapsed=40.16 ms ratio=1.0039 gap mean=1.164 max=1.221
+```
+
+The 1.829 ms outlier in the first trial is one gap of thirty-four on a loaded
+Pi; the window still filled to 35 against a floor of 22.
+
+The scaling moved with it. A pointered read returns the register unsigned,
+because the driver signs it a layer up in the reader this replaces, so the
+adapter now does the two's complement and multiplies by the datasheet's
+full-scale range over 2^15 — not 32767, which is what the driver's own
+arithmetic uses. Checked against that arithmetic on the bench for every gain
+and for the edge values 0x0000, 0x0001, 0x7FFF, 0x8000, 0xFFFF, 0xFFFE, 0x42E3
+and 0x4000: identical to the last place.
+
+The configuration half is narrowed, not closed. A pointered read says nothing
+about a gain or a mode changed part-way through, so the configuration is read
+back again at the end of every window and a window whose chip is **still** on
+someone else's configuration at that point is refused rather than summarised.
+That is what an interfering process which keeps its own settings leaves behind,
+and it was the case measured at 13.9 A against 20.8 A.
+
+What it does not catch is a writer that changes the configuration, lets some
+samples be taken under it, and restores this adapter's configuration before the
+window closes. Both checks then pass and those samples are summarised.
+
+The residue is not a harmless transient, and it does not only under-report.
+The chip converts against whatever range it is on while the adapter scales back
+with the range its own driver object still believes, since nothing told that
+object anything changed. Two effects then pull in opposite directions: the
+affected samples have their amplitude scaled by the ratio of the ranges, and
+the bias shifts with them, which puts a step in the middle of the window that
+adds to the RMS about its mean. Modelled at code level for a foreign gain of
+2/3 over a 15 A signal in a 35-sample window:
+
+```text
+samples under the foreign gain ->  emitted current  (true 15.00 A)
+   4/35                              15.48 A   ( +3.2%)
+  12/35                              15.75 A   ( +5.0%)
+  20/35                              15.10 A   ( +0.7%)
+  28/35                              13.40 A   (-10.6%)
+  34/35                              11.17 A   (-25.6%)
+```
+
+So a brief interference over-reports by a few per cent and a sustained one
+under-reports by a quarter, and neither is refused. A window affected for its
+whole length is the case the end-of-window check does catch.
+
+No amount of additional polling closes this: proving a configuration held for
+the whole of a 40 ms window requires exclusive ownership of the bus, which
+cannot be established from the same bus. It is a wiring and platform property.
 
 ## The adapter as fixed
 

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -93,6 +93,10 @@ except _DRIVER_FAILURE as exc:  # pragma: no cover - exercised on non-Pi hosts
 try:
     import adafruit_ads1x15.ads1x15 as _ads1x15  # type: ignore[import-untyped]
     import adafruit_ads1x15.ads1115 as _ads1115  # type: ignore[import-untyped]
+
+    # Imported to prove the driver package is complete, not to read through:
+    # a sample is taken with the register pointer written explicitly, which
+    # this module's reader does not do.
     import adafruit_ads1x15.analog_in as _analog_in  # type: ignore[import-untyped]
 
     _ADS1115_AVAILABLE = True
@@ -805,6 +809,21 @@ class I2CAdapter(BaseAdapter):
         8: 0x0800,
         16: 0x0A00,
     }
+    # Full-scale range per gain, from the datasheet's PGA table. Carried here
+    # rather than taken from the driver, so a sample can be read with the
+    # pointer written explicitly instead of through the driver's fast path.
+    _ADS1115_PGA_VOLTS = {
+        2 / 3: 6.144,
+        1: 4.096,
+        2: 2.048,
+        4: 1.024,
+        8: 0.512,
+        16: 0.256,
+    }
+    # 2^15, not 32767: the driver divides the full-scale range by
+    # `1 << (bits - 1)`. Verified against its own conversion on the bench for
+    # every gain and every edge value, exact to the last place.
+    _ADS1115_FULL_SCALE_COUNTS = 32768
     _ADS1115_RATE_BITS = {
         8: 0x0000,
         16: 0x0020,
@@ -981,6 +1000,51 @@ class I2CAdapter(BaseAdapter):
         "a reset"
     )
 
+    def _sample_ads1115_volts(self) -> float:
+        """One sample, with the register pointer written for it.
+
+        The driver's continuous read is a fast read that leaves the pointer
+        wherever it was, so anything else on the bus that reads the
+        configuration register turns every remaining sample in the window into
+        the configuration word — a plausible mid-range value no clip check
+        questions. Writing the pointer per sample closes that class outright
+        rather than narrowing it.
+
+        Measured on the bench at 860 SPS before it was adopted: 35 samples
+        against 36 in a 40 ms window, the same 1.164 ms mean gap and 1.22 ms
+        worst gap, and a whole-window elapsed ratio of 1.004 against 1.027.
+        The floor for that window is 22 samples, so the cost is well inside it.
+        """
+        full_scale = self._ADS1115_PGA_VOLTS.get(self._ads.gain)
+        if full_scale is None:
+            raise MeasurementRefusedError(
+                f"I2CAdapter: ADS1115 gain {self._ads.gain!r} is outside the "
+                "datasheet's settings, so a sample cannot be scaled"
+            )
+        # The driver returns the register unsigned and signs it a layer up, in
+        # the reader this replaces, so the two's complement is done here.
+        raw = int(self._ads.get_last_result(False)) & 0xFFFF
+        if raw >= 0x8000:
+            raw -= 0x10000
+        return raw * full_scale / self._ADS1115_FULL_SCALE_COUNTS
+
+    def _refuse_if_configuration_moved(self) -> None:
+        """Refuse, and quarantine the chip, when it is not running what this set."""
+        quarantined = self._ads1115_quarantined()
+        if quarantined is not None:
+            raise MeasurementRefusedError(quarantined)
+        try:
+            fault = self._ads1115_configuration_fault()
+        except Exception as exc:
+            raise MeasurementRefusedError(
+                "I2CAdapter: could not read back the ADS1115 configuration to "
+                f"confirm its channel: {type(exc).__name__}: {exc}"
+            ) from exc
+        if fault is not None:
+            message = f"{fault}{self._REFUSAL_REMEDY}"
+            self._quarantine_ads1115(message)
+            raise MeasurementRefusedError(message)
+
     def _reaffirm_ads1115_channel(self) -> None:
         """Per-measurement: prove the configuration, then re-point the register.
 
@@ -1003,20 +1067,7 @@ class I2CAdapter(BaseAdapter):
         A readback that cannot be performed at all is a bus failure and does
         not latch: it is not evidence that anything took the chip.
         """
-        quarantined = self._ads1115_quarantined()
-        if quarantined is not None:
-            raise MeasurementRefusedError(quarantined)
-        try:
-            fault = self._ads1115_configuration_fault()
-        except Exception as exc:
-            raise MeasurementRefusedError(
-                "I2CAdapter: could not read back the ADS1115 configuration to "
-                f"confirm its channel: {type(exc).__name__}: {exc}"
-            ) from exc
-        if fault is not None:
-            message = f"{fault}{self._REFUSAL_REMEDY}"
-            self._quarantine_ads1115(message)
-            raise MeasurementRefusedError(message)
+        self._refuse_if_configuration_moved()
         self._ads.get_last_result(False)
 
     def _connect_scd40(self) -> None:
@@ -1177,9 +1228,10 @@ class I2CAdapter(BaseAdapter):
         carrying a plausible ampere figure can be emitted from samples that were
         never a measurement.
         """
-        if _analog_in is None:
+        if self._ads is None:
             raise AdapterConnectionError(
-                "I2CAdapter: the ADS1115 driver is not loaded; connect() must run first"
+                "I2CAdapter: no ADS1115 is open on this adapter; connect() must "
+                "run first"
             )
         window = self._window
         if window is None:
@@ -1187,7 +1239,6 @@ class I2CAdapter(BaseAdapter):
                 "I2CAdapter: current calibration was not resolved at connect()"
             )
         self._reaffirm_ads1115_channel()
-        channel = _analog_in.AnalogIn(self._ads, self._channel)
 
         # Monotonic throughout: a wall clock stepped by NTP mid-window would
         # otherwise make an overrun look like a normal window, or the reverse.
@@ -1209,9 +1260,23 @@ class I2CAdapter(BaseAdapter):
                 break
             if now < due:
                 time.sleep(due - now)
-            samples.append(float(channel.voltage))
+            samples.append(self._sample_ads1115_volts())
             due += interval
         elapsed = time.monotonic() - started
+        # Checked again at the end, because the check before the window
+        # certifies the chip only at that instant. This catches a change that
+        # is *still present* at the end, which is what an interfering process
+        # that keeps its own configuration leaves behind.
+        #
+        # It is not whole-window certification. A writer that changes the gain,
+        # lets some samples be taken under it, and restores this adapter's
+        # configuration before the window closes passes both checks, and those
+        # samples are summarised. Detecting that would need exclusive ownership
+        # of the bus, which cannot be established from the same bus — it is a
+        # wiring and platform property, not something more polling can prove.
+        #
+        # The pointer needs no such check: every sample writes it.
+        self._refuse_if_configuration_moved()
 
         try:
             measured = summarise_window(samples, elapsed, window)
@@ -1243,16 +1308,16 @@ class I2CAdapter(BaseAdapter):
     # ── ADS1115 voltage ───────────────────────────────────────────────────────
 
     def _read_ads1115_voltage(self, sensor_id: str) -> SensorReading:
-        if _analog_in is None:
+        if self._ads is None:
             raise AdapterConnectionError(
-                "I2CAdapter: the ADS1115 driver is not loaded; connect() must run first"
+                "I2CAdapter: no ADS1115 is open on this adapter; connect() must "
+                "run first"
             )
         # Not downgraded to AdapterReadError: MeasurementRefusedError is one
         # already, and the subclass is what drives the runtime's degradation
         # state and operator notice. A voltage channel can be a safety input.
         self._reaffirm_ads1115_channel()
-        chan = _analog_in.AnalogIn(self._ads, self._channel)
-        voltage = chan.voltage
+        voltage = self._sample_ads1115_volts()
         return SensorReading(
             sensor_id=sensor_id,
             sensor_type="ads1115_voltage",

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -282,11 +282,12 @@ class _PinnedDriverAnalogIn:
 
     @property
     def voltage(self):
-        # Gain 1: +/-4.096 V over a signed 16-bit range, as the driver scales.
+        # Gain 1: +/-4.096 V over 2^15, which is how the driver scales -- it
+        # divides the full-scale range by `1 << (bits - 1)`, not by 32767.
         raw = self.value
         if raw >= 0x8000:
             raw -= 0x10000
-        return raw * 4.096 / 32767
+        return raw * 4.096 / 32768
 
 
 def _pinned_driver(monkeypatch, **ads_kwargs):
@@ -718,8 +719,7 @@ class TestReadAds1115Current:
         adapter = _connected_ads_adapter("ads1115_current")
         channel = self._waveform_channel(amplitude=math.sqrt(2))
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             reading = await adapter.read("load-current")
 
         assert reading.unit == "ampere"
@@ -738,8 +738,7 @@ class TestReadAds1115Current:
         )
         channel = self._waveform_channel(amplitude=math.sqrt(2))
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             reading = await adapter.read("load-current")
 
         assert reading.value == pytest.approx(10.0, rel=0.05)
@@ -749,8 +748,7 @@ class TestReadAds1115Current:
         channel = MagicMock()
         channel.voltage = 1.65
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             reading = await adapter.read("load-current")
 
         assert reading.value == pytest.approx(0.0, abs=1e-3)
@@ -759,8 +757,7 @@ class TestReadAds1115Current:
         adapter = _connected_ads_adapter("ads1115_current")
         channel = self._waveform_channel(amplitude=1.0)
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             reading = await adapter.read("load-current")
 
         assert reading.metadata["sensitivity_v_per_amp"] == pytest.approx(1 / 30)
@@ -780,8 +777,7 @@ class TestReadAds1115Current:
         channel = MagicMock()
         channel.voltage = 4.09  # hard against the +/-4.096 V full scale
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             with pytest.raises(AdapterReadError, match="clipped"):
                 await adapter.read("load-current")
 
@@ -800,8 +796,7 @@ class TestReadAds1115Current:
 
         type(channel).voltage = property(lambda _self: voltage())
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             with pytest.raises(AdapterReadError, match="fewer than"):
                 await adapter.read("load-current")
 
@@ -819,8 +814,7 @@ class TestReadAds1115Current:
 
         original = channel.__class__.voltage
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
             started = time.monotonic()
             reading = await adapter.read("load-current")
             elapsed = time.monotonic() - started
@@ -836,15 +830,22 @@ class TestReadAds1115Current:
         assert elapsed >= adapter._window.nominal_seconds * 0.9
 
     async def test_channel_used_correctly(self):
+        """The channel is the chip's multiplexer, not an argument per read.
+
+        It is written once at connect and proven from the configuration
+        register before and after every window, so what this asserts is that
+        the configured channel is the one the check demands: single-ended
+        AIN2 is mux code 6.
+        """
         adapter = _connected_ads_adapter("ads1115_current")
         adapter._channel = 2
         channel = self._waveform_channel(amplitude=1.0)
 
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as analog:
-            analog.AnalogIn.return_value = channel
-            await adapter.read("load-current")
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: channel.voltage):
+            reading = await adapter.read("load-current")
 
-        analog.AnalogIn.assert_called_once_with(adapter._ads, 2)
+        assert reading.metadata["channel"] == 2
+        assert (adapter._expected_ads1115_config() >> 12) & 0x7 == 6
 
 
 # ─── read — ADS1115 voltage ───────────────────────────────────────────────────
@@ -853,11 +854,7 @@ class TestReadAds1115Current:
 class TestReadAds1115Voltage:
     async def test_returns_voltage_reading(self):
         adapter = _connected_ads_adapter("ads1115_voltage")
-        mock_chan = MagicMock()
-        mock_chan.voltage = 3.3
-
-        with patch("ori.hal.i2c_adapter._analog_in", create=True) as mock_analog:
-            mock_analog.AnalogIn.return_value = mock_chan
+        with patch.object(adapter, "_sample_ads1115_volts", lambda: 3.3):
             reading = await adapter.read("grid-voltage")
 
         assert reading.sensor_type == "ads1115_voltage"
@@ -2139,4 +2136,179 @@ class TestCloseDuringConnect:
         await adapter.close()
         await adapter.connect(_config(sensor_type="ads1115_voltage"))
         assert adapter.is_connected is True
+        await adapter.close()
+
+
+class TestWindowIntegrity:
+    """What the configuration check does not see between its two ends.
+
+    The check before a window certifies the chip at that instant only. Two
+    things can go wrong inside the window afterwards, and they need different
+    answers: a foreign pointered read moves the chip's register pointer, and a
+    foreign configuration write rescales or halts the conversion.
+    """
+
+    async def test_a_sample_writes_the_pointer_rather_than_trusting_it(
+        self, monkeypatch
+    ):
+        """The fast path returns whatever the pointer is on.
+
+        Moved mid-window, because the check before the window re-points the
+        register itself: a pointer disturbed before the window is put back and
+        proves nothing. Anything else on the bus that reads the configuration
+        register part-way through leaves the pointer there, and with a fast
+        read every remaining sample comes back as the configuration word —
+        2.14 V, a plausible mid-range value the clip check does not question.
+
+        The window is not refused for it and could not be: those samples look
+        like a signal. Writing the pointer per sample removes the question.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        ads = created[0]
+
+        counts = itertools.count()
+        bias, peak = 1.65, 0.5
+
+        def square():
+            i = next(counts)
+            if i == 8:
+                # Another reader on the bus leaves the pointer on CONFIG.
+                ads._pointer = ads.POINTER_CONFIG
+            volts = bias + (peak if i % 2 == 0 else -peak)
+            return int(volts * 32768 / 4.096)
+
+        ads._conversion = square
+
+        reading = await adapter.read("s")
+
+        # 0.5 V RMS over a 1/30 V/A clamp is 15 A. Reading the config word for
+        # most of the window puts it nowhere near that.
+        assert reading.value == pytest.approx(15.0, rel=0.1), reading.value
+        await adapter.close()
+
+    async def test_a_configuration_still_moved_at_the_close_refuses_the_window(
+        self, monkeypatch
+    ):
+        """Samples already taken are rescaled or held; they are not a window.
+
+        The check before the window cannot see this and the pointered read does
+        not address it, so the configuration is read back again at the end. A
+        chip still on someone else's configuration then is refused rather than
+        summarised, which is what an interfering process that keeps its own
+        settings leaves behind.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        ads = created[0]
+
+        counts = itertools.count()
+        bias, peak = 1.65, 0.5
+
+        def square():
+            volts = bias + (peak if next(counts) % 2 == 0 else -peak)
+            if next(counts) > 8:
+                # Part-way through: another writer takes the gain.
+                ads._gain_bits = 0x0000
+            return int(volts * 32768 / 4.096)
+
+        ads._conversion = square
+
+        with pytest.raises(MeasurementRefusedError, match="0x40E3"):
+            await adapter.read("s")
+
+    async def test_a_window_whose_chip_stayed_put_is_still_measured(self, monkeypatch):
+        """The end-of-window check must not refuse an untouched chip."""
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+
+        counts = itertools.count()
+        bias, peak = 1.65, 0.5
+
+        def square():
+            volts = bias + (peak if next(counts) % 2 == 0 else -peak)
+            return int(volts * 32768 / 4.096)
+
+        created[0]._conversion = square
+
+        reading = await adapter.read("s")
+        assert reading.value > 10.0, reading.value
+        await adapter.close()
+
+    async def test_a_configuration_restored_before_the_close_corrupts_silently(
+        self, monkeypatch
+    ):
+        """The limitation, asserted with its consequence rather than described.
+
+        A writer that changes the gain, lets samples be taken under it, and
+        restores this adapter's configuration before the window closes passes
+        both checks. What makes that unsafe rather than merely undetected is
+        that the samples taken meanwhile are wrong: the chip converts against
+        the foreign full-scale range while this adapter scales back with the
+        one its own driver object still believes, because nothing told that
+        object anything changed.
+
+        Modelled at the code level for exactly that reason. A fake that
+        produced the same counts under either gain would pass this test while
+        proving nothing, since the transient would have had no measurement
+        consequence at all.
+
+        Proving a configuration held for a whole 40 ms window needs exclusive
+        ownership of the bus, which cannot be established from the same bus.
+        Written down here so the boundary is visible in the suite rather than
+        only in prose: a change that closes it should make this test fail.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_current", channel=0))
+        ads = created[0]
+
+        full_scale = {0x0200: 4.096, 0x0000: 6.144}  # gain 1, gain 2/3
+        counts = itertools.count()
+        bias, peak = 1.65, 0.5
+
+        def square():
+            i = next(counts)
+            if i == 0:
+                ads._gain_bits = 0x0000  # another writer takes the gain
+            elif i == 32:
+                ads._gain_bits = 0x0200  # and restores it before the close
+            volts = bias + (peak if i % 2 == 0 else -peak)
+            # The chip converts against whatever range it is actually on.
+            return int(volts * 32768 / full_scale[ads._gain_bits])
+
+        ads._conversion = square
+
+        reading = await adapter.read("s")
+
+        # 0.5 V RMS over a 1/30 V/A clamp is 15 A on an untouched chip.
+        assert 8.0 < reading.value < 13.0, (
+            "the window was refused or read correctly, so the limitation this "
+            f"pins has changed and the documents stating it are now wrong: "
+            f"{reading.value}"
+        )
+        await adapter.close()
+
+    async def test_a_sample_is_scaled_the_way_the_driver_scales(self, monkeypatch):
+        """Release-owned arithmetic, pinned to the values it replaces.
+
+        Verified against the driver's own conversion on the bench for every
+        gain and every edge value; these are the two that name themselves in
+        the record, at gain 1.
+        """
+        created = _pinned_driver(monkeypatch, chip_mux=0)
+        adapter = I2CAdapter()
+        await adapter.connect(_config(sensor_type="ads1115_voltage", channel=0))
+        ads = created[0]
+
+        # The fake normalises its source to a callable, as the adapter reads it.
+        ads._conversion = lambda: 0xFFFE  # -2 counts
+        assert adapter._sample_ads1115_volts() == pytest.approx(-0.00025)
+        ads._conversion = lambda: 0x42E3  # the configuration word, as a sample
+        assert adapter._sample_ads1115_volts() == pytest.approx(2.140375)
+        ads._conversion = lambda: 0x7FFF
+        assert adapter._sample_ads1115_volts() == pytest.approx(4.095875)
         await adapter.close()


### PR DESCRIPTION
## What does this PR do?

The ADS1115 configuration check ran once, before a window opened, and certified the chip only at that instant. Two things could go wrong inside the window afterwards, and they need different answers.

**A foreign pointered read.** The driver's continuous read is a fast read that leaves the register pointer wherever it was, so anything else on the bus that reads the configuration register turns every remaining sample in the window into the configuration word — 2.14 V, a plausible mid-range value the clip check does not question. Measured against a register-level model at 10.9 A for a 20.9 A load.

**A foreign configuration write.** A gain or conversion mode changed by something else leaves the samples rescaled or held, and the window was summarised regardless.

## The pointer half is closed, on a measurement

A pointered conversion read per sample means no sample can return anything but the conversion register. The objection was cost: it writes one extra byte per sample and nothing had established that this fits inside the 1.163 ms conversion interval at 860 SPS. So it was measured on the bench before it was adopted, paced exactly as the adapter paces:

```text
fast read (today)        samples 36  elapsed 41.09 ms (ratio 1.0272)  gap mean 1.164  max 1.223
pointered every sample   samples 35  elapsed 40.15 ms (ratio 1.0038)  gap mean 1.164  max 1.222
floor at 2/3 of nominal 34.4 samples = 22
```

One sample in thirty-six, an unchanged mean gap, and a whole-window elapsed ratio nearer nominal rather than further from it. Confirmed afterwards through the adapter's own sampler on the chip rather than a standalone loop.

Taking the sample directly means owning the scaling. The driver returns the register unsigned and signs it a layer up in the reader this replaces, and it divides the full-scale range by two to the fifteenth rather than by 32767. That arithmetic was checked against the driver's own on the bench for every gain and for the edge values `0x0000`, `0x0001`, `0x7FFF`, `0x8000`, `0xFFFF`, `0xFFFE`, `0x42E3` and `0x4000`: identical to the last place.

## The configuration half is narrowed, not closed

The configuration is now read back again at the end of every window, so a chip **still** on someone else's configuration when the window closes is refused rather than summarised. That is what an interfering process which keeps its own settings leaves behind.

It is not whole-window certification, and the documents no longer say it is. A writer that changes the gain, lets samples be taken under it, and restores this adapter's configuration before the window closes passes both checks, and those samples are summarised.

That residue is not harmless, and it does not only under-report. The chip converts against whatever range it is on while this adapter scales back with the range its own driver object still believes. The affected samples have their amplitude scaled, and the bias shifts with them, putting a step in the middle of the window that adds to the RMS about its mean. Modelled at code level for a foreign gain of 2/3 over a 15 A signal:

```text
samples under the foreign gain ->  emitted current  (true 15.00 A)
   4/35                              15.48 A   ( +3.2%)
  12/35                              15.75 A   ( +5.0%)
  28/35                              13.40 A   (-10.6%)
  34/35                              11.17 A   (-25.6%)
```

No amount of additional polling closes it. Proving a configuration held for a whole 40 ms window requires exclusive ownership of the bus, which cannot be established from the same bus — it is a wiring and platform property, the same reasoning that made #502 refuse rather than retry.

So the limitation is asserted in the suite rather than only described. A test drives the write-and-restore sequence and asserts the window is emitted and materially wrong, and it fails from both sides: if the model stops being gain-dependent, and if the gap is ever closed.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

It governs whether the samples a Tier D threshold is evaluated over are the ones the chip was configured to take.

## Verification

Five mutations, each killed by a named test: the fast path restored, the end-of-window check removed, the sign correction dropped, the scale changed to 32767, and the per-sample pointered read reverted.

One of those first survived. My pointer test disturbed the pointer *before* the window, where the per-measurement check puts it back, so switching the sample to the fast path left the suite green. It now disturbs the pointer mid-window, where nothing puts it back.

Full suite 4561 passed with 23 skipped, evidence suite 779 passed, and the adapter module runs 127 passed with 2 skipped on the Pi. `ruff check`, `ruff format --check`, `mypy ori/` and `pyright` clean.

## Testing notes

The window tests that inject sample values now patch the adapter's own sampler rather than the driver's reader, which the adapter no longer uses. They were always about the window arithmetic rather than about how a sample is read, and they used a mock reader before.

`test_channel_used_correctly` previously asserted the channel by watching the driver's reader be constructed. The channel is the chip's multiplexer rather than an argument per read, so it now asserts the configured channel is the one the configuration check demands.

## Related issue

Refs #503 — deliberately not `Closes`. The pointer class is closed and a persistent foreign configuration is refused; transient write-and-restore interference is not, and that is what remains open.
