### PR TITLE
fix(hal): put the connect and close lifecycle contract on BaseAdapter

### DIFF
--- a/ori/hal/base.py
+++ b/ori/hal/base.py
@@ -6,6 +6,8 @@ import enum
 import logging
 import time
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from typing import Any
 
 from ori.network.events import SensorReading
@@ -242,13 +244,160 @@ class BaseAdapter(ABC):
 
     _connected: bool = False
 
+    # Bumped by every close before it can acquire the lifecycle lock, so a
+    # connect can tell that one arrived while its own worker was still
+    # running. Class-level defaults because most adapters do not call
+    # ``super().__init__()``; both become instance attributes on first write.
+    _close_generation: int = 0
+    _lifecycle_lock: "asyncio.Lock | None" = None
+
+    # ── Lifecycle contract ────────────────────────────────────────────────────
+    #
+    # `connect()` does its blocking work off the event loop, and `close()`
+    # releases resources with awaits of its own. Without a shared rule the two
+    # interleave: a close releases what has been taken so far while the
+    # connect's worker goes on taking more, and the adapter ends up believing
+    # it is connected while holding resources nobody else believes are in use.
+    #
+    # The guarantee every adapter gets from `_connecting` and `_closing`:
+    #
+    #   * Only one of connect and close runs at a time, per adapter.
+    #   * A connect that finds itself connected is refused, before it touches
+    #     any state and before it reaches the device. Reconnecting in place
+    #     would take a second resource reference against one release and move
+    #     a live adapter's device under readings already being taken from it.
+    #     **An adapter must therefore validate into locals and assign to
+    #     `self` inside the `_connecting` body.** Assigning before it leaves a
+    #     refused connect having already overwritten the live configuration:
+    #     the adapter stays connected on the old handle while its fields name
+    #     the new target, and `read()` then samples one device and labels the
+    #     reading with another.
+    #   * **A connect that was closed while it was connecting raises**
+    #     `AdapterConnectionError` and leaves the adapter disconnected and
+    #     holding nothing. It does not return successfully, because a connect
+    #     that was closed did not connect.
+    #   * A connect that fails for any reason gives back what it took.
+    #
+    # What the runtime does with that refusal: it connects adapters
+    # sequentially and appends each to its list only after `connect()` returns,
+    # closing only what is in that list, so an in-flight adapter is never
+    # closed in production and the refusal is not reachable there. It is a
+    # contract, held at the boundary, rather than a live bug being papered
+    # over. During shutdown the refusal would surface the same way any other
+    # connect failure does — logged, the adapter not added, the runtime
+    # continuing — which is the correct outcome for an adapter that is being
+    # torn down anyway. `ori/runtime.py` does more than log: it records the
+    # sensor in `_unconnected_sensors`, calls
+    # `_safety_registry.note_sensor_unavailable()` and warns the operator. A
+    # refused connect therefore tells a Tier D pair that its measurement is
+    # unavailable, which is the reason this refusal has to be correct rather
+    # than merely tidy.
+    #
+    # An adapter that cannot meet this must say so in its own docstring rather
+    # than inherit the guarantee silently.
+
+    @property
+    def _lifecycle(self) -> asyncio.Lock:
+        """The per-adapter connect/close lock, created on first use.
+
+        Lazily created rather than set in ``__init__`` because most adapters
+        do not call ``super().__init__()``. There is no race in creating it:
+        the first access happens on the event loop thread before any await.
+        """
+        lock = self._lifecycle_lock
+        if lock is None:
+            lock = asyncio.Lock()
+            # Shadows the class default with an instance attribute, so every
+            # adapter gets its own.
+            self._lifecycle_lock = lock
+        return lock
+
+    @asynccontextmanager
+    async def _connecting(
+        self,
+        description: str,
+        *,
+        release: Callable[[], Awaitable[None]] | None = None,
+    ) -> AsyncIterator[None]:
+        """Run an adapter's connect body under the lifecycle guarantee above.
+
+        Args:
+            description: What is being connected, for the refusal messages.
+            release: Gives back everything the body may have taken. Called
+                when the body raises and when a close arrived while it ran, so
+                it must be idempotent and safe on a partial connect.
+        """
+        # Sampled before the lock is requested, not inside it. A close that
+        # arrives while an earlier connect holds the lock has already declared
+        # itself by the time this one is admitted, and sampling after the wait
+        # would lose that: the second connect would report success for an
+        # adapter a close outstanding before its body ran then tears down.
+        generation = self._close_generation
+        async with self._lifecycle:
+            if self._connected:
+                # Names what was *requested*, not what is held: the base
+                # class does not know an adapter's fields, and claiming to
+                # name the live device while printing the refused one is
+                # worse than not naming it.
+                raise AdapterConnectionError(
+                    f"{self.adapter_name}: already connected; close it before "
+                    f"connecting to {description}"
+                )
+            try:
+                yield
+            except BaseException:
+                await self._release_quietly(release)
+                raise
+
+            if self._close_generation != generation:
+                await self._release_quietly(release)
+                raise AdapterConnectionError(
+                    f"{self.adapter_name}: {description} was closed while it "
+                    "was still connecting"
+                )
+            self._connected = True
+
+    async def _release_quietly(
+        self, release: Callable[[], Awaitable[None]] | None
+    ) -> None:
+        """Give resources back without letting that replace the real failure.
+
+        `release` runs on the failure and abandonment paths, where an
+        exception is already on its way to the caller. If it raised, it would
+        become the exception `connect()` reports — a `RuntimeError` in place of
+        the `AdapterConnectionError` that says what actually went wrong — and
+        the remaining resources would still be held.
+        """
+        if release is None:
+            return
+        try:
+            await release()
+        except Exception:
+            logger.exception(
+                "%s: exception while releasing after a failed connect",
+                self.adapter_name,
+            )
+
+    @asynccontextmanager
+    async def _closing(self) -> AsyncIterator[None]:
+        """Run an adapter's close body under the lifecycle guarantee above.
+
+        The close records itself *before* requesting the lock. A connect
+        holding the lock cannot be interrupted, but it can be told that a
+        close is waiting, and that is what stops it reporting success.
+        """
+        self._close_generation += 1
+        async with self._lifecycle:
+            self._connected = False
+            yield
+
     # ── Abstract methods ──────────────────────────────────────────────────────
 
     @abstractmethod
     async def connect(self, config: dict) -> None:
         """Open the underlying hardware or protocol connection.
 
-        Called once during runtime start-up.  Must set ``_connected = True`` on success.  Raise :exc:`AdapterConnectionError` if the resource cannot be reached, or :exc:`AdapterTimeoutError` if the attempt exceeds the configured deadline.
+        Called once during runtime start-up.  Run the body inside :meth:`_connecting`, which owns ``_connected`` and the lifecycle guarantee above; do not set the flag directly.  Raise :exc:`AdapterConnectionError` if the resource cannot be reached, or :exc:`AdapterTimeoutError` if the attempt exceeds the configured deadline.
 
         Args:
             config: The sensor-level config dict from ``ori.yaml`` (keys such as ``address``, ``channel``, ``port`` vary by adapter type).
@@ -270,8 +419,9 @@ class BaseAdapter(ABC):
     async def close(self) -> None:
         """Release the underlying hardware or protocol connection.
 
-        Called during graceful runtime shutdown.  Must set
-        ``_connected = False``.  Should not raise even if the connection was already lost — log and return cleanly.
+        Called during graceful runtime shutdown.  Run the body inside
+        :meth:`_closing`, which owns ``_connected``; do not clear the flag
+        directly.  Should not raise even if the connection was already lost — log and return cleanly.
         """
 
     # ── Concrete methods (may be overridden) ──────────────────────────────────

--- a/ori/hal/coap_adapter.py
+++ b/ori/hal/coap_adapter.py
@@ -90,52 +90,67 @@ class CoapAdapter(BaseAdapter):
                 "CoapAdapter: 'aiocoap' is not installed. Run: pip install aiocoap"
             )
 
-        self._sensor_id = str(config.get("sensor_id", "")).strip()
-        self._sensor_type = str(config.get("sensor_type", "")).strip()
-        self._uri = str(config.get("uri", "")).strip()
-        self._method = str(config.get("method", "GET")).strip().upper()
-        self._json_path = str(config.get("json_path", "")).strip()
-        self._unit = str(config.get("unit", "")).strip()
-        self._poll_interval_ms = int(
+        # Validated into locals and applied inside the guard. This adapter has
+        # the most to lose from getting it wrong: it awaits a client context
+        # and then starts a background poll task, so a close that overlapped a
+        # connect used to return while both were still live and unreachable.
+        sensor_id = str(config.get("sensor_id", "")).strip()
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        uri = str(config.get("uri", "")).strip()
+        method = str(config.get("method", "GET")).strip().upper()
+        json_path = str(config.get("json_path", "")).strip()
+        unit = str(config.get("unit", "")).strip()
+        poll_interval_ms = int(
             config.get("poll_interval_ms", _DEFAULT_POLL_INTERVAL_MS)
         )
-        self._timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
-        self._payload = self._encode_payload(config.get("payload", ""))
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+        timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
+        payload = self._encode_payload(config.get("payload", ""))
 
         allowed_hosts = config.get("allowed_hosts", []) or []
-        self._allowed_hosts = {
+        allowed = {
             str(host).strip().lower() for host in allowed_hosts if str(host).strip()
         }
 
-        if not self._sensor_type:
+        if not sensor_type:
             raise AdapterConnectionError("CoapAdapter: 'sensor_type' is required")
-        if not self._uri:
+        if not uri:
             raise AdapterConnectionError("CoapAdapter: 'uri' is required")
-        if not self._json_path:
+        if not json_path:
             raise AdapterConnectionError("CoapAdapter: 'json_path' is required")
-        if self._method not in _ALLOWED_METHODS:
+        if method not in _ALLOWED_METHODS:
             raise AdapterConnectionError(
                 f"CoapAdapter: method must be one of {sorted(_ALLOWED_METHODS)}"
             )
-        if self._poll_interval_ms < 100:
+        if poll_interval_ms < 100:
             raise AdapterConnectionError("CoapAdapter: poll_interval_ms must be >= 100")
-        if self._timeout_s <= 0:
+        if timeout_s <= 0:
             raise AdapterConnectionError("CoapAdapter: timeout_s must be > 0")
-        self._validate_target()
 
-        try:
-            self._context = await _aiocoap.Context.create_client_context()
-        except Exception as exc:
-            raise AdapterConnectionError(
-                f"CoapAdapter: failed to create aiocoap client context: {exc}"
-            ) from exc
+        async with self._connecting(f"'{uri}'", release=self._teardown):
+            self._sensor_id = sensor_id
+            self._sensor_type = sensor_type
+            self._uri = uri
+            self._method = method
+            self._json_path = json_path
+            self._unit = unit
+            self._poll_interval_ms = poll_interval_ms
+            self._timeout_s = timeout_s
+            self._payload = payload
+            self._allowed_hosts = allowed
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+            self._validate_target()
 
-        self._connected = True
-        self._poll_task = asyncio.create_task(
-            self._poll_loop(),
-            name=f"coap-poll:{self._sensor_id or self._sensor_type}",
-        )
+            try:
+                self._context = await _aiocoap.Context.create_client_context()
+            except Exception as exc:
+                raise AdapterConnectionError(
+                    f"CoapAdapter: failed to create aiocoap client context: {exc}"
+                ) from exc
+
+            self._poll_task = asyncio.create_task(
+                self._poll_loop(),
+                name=f"coap-poll:{sensor_id or sensor_type}",
+            )
 
     async def read(self, sensor_id: str) -> SensorReading:
         if not self._connected:
@@ -159,9 +174,17 @@ class CoapAdapter(BaseAdapter):
         )
 
     async def close(self) -> None:
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
+        """Stop the poll loop and drop the context, finished or not.
+
+        Both are started inside the connect body, so a connect abandoned
+        part-way through has to give back whichever of them it reached.
+        """
         task = self._poll_task
         self._poll_task = None
-        self._connected = False
         if task is not None and not task.done():
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)

--- a/ori/hal/growatt_adapter.py
+++ b/ori/hal/growatt_adapter.py
@@ -76,23 +76,19 @@ class GrowattAdapter(BaseAdapter):
                 f"Supported: {sorted(_SUPPORTED)}"
             )
 
-        self._sensor_type = sensor_type
-        self._host = str(config.get("host", "")).strip()
-        self._serial = str(config.get("serial", "")).strip()
-        self._port = int(config.get("port", _DEFAULT_PORT))
-        self._breaker = HardwareCircuitBreaker(
-            getattr(self, "adapter_name", type(self).__name__), config
-        )
+        host = str(config.get("host", "")).strip()
+        serial = str(config.get("serial", "")).strip()
+        port = int(config.get("port", _DEFAULT_PORT))
 
-        if not self._host:
+        if not host:
             raise AdapterConnectionError(
                 "GrowattAdapter: 'host' is required in sensor config."
             )
-        if not self._serial:
+        if not serial:
             raise AdapterConnectionError(
                 "GrowattAdapter: 'serial' is required in sensor config."
             )
-        if self._port <= 0:
+        if port <= 0:
             raise AdapterConnectionError("GrowattAdapter: 'port' must be > 0.")
 
         if not _PYSOLARMAN_AVAILABLE:
@@ -101,13 +97,26 @@ class GrowattAdapter(BaseAdapter):
                 "Run: pip install pysolarmanv5"
             )
 
-        # Lazy connect on first read.
-        self._connected = True
+        # Lazy connect on first read. Nothing is awaited above, so no close
+        # can interleave with it, but the guarantee is taken from
+        # `BaseAdapter` rather than rested on that: a later await added here
+        # would silently reopen the race.
+        async with self._connecting(f"'{host}:{port}'"):
+            self._sensor_type = sensor_type
+            self._host = host
+            self._serial = serial
+            self._port = port
+            self._breaker = HardwareCircuitBreaker(
+                getattr(self, "adapter_name", type(self).__name__), config
+            )
 
     async def close(self) -> None:
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
         client = self._client
         self._client = None
-        self._connected = False
         if client is None:
             return
 

--- a/ori/hal/http_adapter.py
+++ b/ori/hal/http_adapter.py
@@ -62,33 +62,43 @@ class HttpAdapter(BaseAdapter):
                 "HttpAdapter: 'httpx' is not installed. Run: pip install httpx"
             )
 
-        self._sensor_id = str(config.get("sensor_id", "")).strip()
-        self._sensor_type = str(config.get("sensor_type", "")).strip()
-        self._url = str(config.get("url", "")).strip()
-        self._json_path = str(config.get("json_path", "")).strip()
-        self._unit = str(config.get("unit", "")).strip()
-        self._poll_interval_ms = int(
+        # Validated into locals and applied inside the guard, so a refused
+        # connect cannot replace the live URL and sensor type while the
+        # adapter stays connected and its poll loop keeps running.
+        sensor_id = str(config.get("sensor_id", "")).strip()
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        url = str(config.get("url", "")).strip()
+        json_path = str(config.get("json_path", "")).strip()
+        unit = str(config.get("unit", "")).strip()
+        poll_interval_ms = int(
             config.get("poll_interval_ms", _DEFAULT_POLL_INTERVAL_MS)
         )
-        self._timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+        timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
 
-        if not self._sensor_type:
+        if not sensor_type:
             raise AdapterConnectionError("HttpAdapter: 'sensor_type' is required")
-        if not self._url:
+        if not url:
             raise AdapterConnectionError("HttpAdapter: 'url' is required")
-        if not self._json_path:
+        if not json_path:
             raise AdapterConnectionError("HttpAdapter: 'json_path' is required")
-        if self._poll_interval_ms < 100:
+        if poll_interval_ms < 100:
             raise AdapterConnectionError("HttpAdapter: poll_interval_ms must be >= 100")
-        if self._timeout_s <= 0:
+        if timeout_s <= 0:
             raise AdapterConnectionError("HttpAdapter: timeout_s must be > 0")
 
-        self._connected = True
-        self._poll_task = asyncio.create_task(
-            self._poll_loop(),
-            name=f"http-poll:{self._sensor_id or self._sensor_type}",
-        )
+        async with self._connecting(f"'{url}'", release=self._teardown):
+            self._sensor_id = sensor_id
+            self._sensor_type = sensor_type
+            self._url = url
+            self._json_path = json_path
+            self._unit = unit
+            self._poll_interval_ms = poll_interval_ms
+            self._timeout_s = timeout_s
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+            self._poll_task = asyncio.create_task(
+                self._poll_loop(),
+                name=f"http-poll:{sensor_id or sensor_type}",
+            )
 
     async def read(self, sensor_id: str) -> SensorReading:
         if not self._connected:
@@ -112,9 +122,13 @@ class HttpAdapter(BaseAdapter):
         )
 
     async def close(self) -> None:
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
+        """Stop the poll loop, whether the connect finished or not."""
         task = self._poll_task
         self._poll_task = None
-        self._connected = False
         if task is not None and not task.done():
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)

--- a/ori/hal/i2c_adapter.py
+++ b/ori/hal/i2c_adapter.py
@@ -574,18 +574,14 @@ class I2CAdapter(BaseAdapter):
         self._bme280_params: Any = None  # bme280 calibration params
         self._ads: Any = None  # ADS1115 instance
         self._scd4x: Any = None  # SCD4X instance
-        # Whether this adapter holds a reference on the shared busio.I2C. The
-        # count is shared, so releasing one this adapter never took would evict
-        # a handle another adapter is still reading through.
-        self._holds_shared_bus: bool = False
-        # Incremented by every close(), before it waits for anything, so a
-        # connect already past its own sampling point can still see it.
-        self._close_count: int = 0
-        # One lifecycle operation at a time. `_teardown()` awaits, so without
-        # this a close suspended part-way through it is invisible to a connect
-        # starting in that gap, and the rest of the stale teardown then
-        # releases what the new connect had just taken.
-        self._lifecycle = asyncio.Lock()
+        # How many references on the shared busio.I2C this adapter holds. A
+        # boolean here disagreed with the cache's count the moment one adapter
+        # acquired twice: the single release cleared the flag, and the second
+        # reference became unreleasable by anything, pinning the cached handle
+        # for the life of the process. Counting keeps the property the boolean
+        # was there for — an adapter cannot release a reference it never took,
+        # because it has none to give back.
+        self._shared_bus_holds: int = 0
 
     # ── Lifecycle ─────────────────────────────────────────────────────────────
 
@@ -633,17 +629,8 @@ class I2CAdapter(BaseAdapter):
             calibration = _resolve_calibration(config)
             window = _window_spec(calibration)
 
-        async with self._lifecycle:
-            if self._connected:
-                # Refused before any state is touched and before the bus is
-                # reached. Reconnecting in place would take a second shared-bus
-                # reference against one release, and would move a live
-                # adapter's device under readings already being taken from it.
-                raise AdapterConnectionError(
-                    f"I2CAdapter: already connected to '{self._sensor_type}' at "
-                    f"address 0x{self._address:02X} on bus {self._bus_number}; "
-                    "close it before connecting again"
-                )
+        description = f"'{sensor_type}' at address 0x{address:02X} on bus {bus_number}"
+        async with self._connecting(description, release=self._teardown):
             self._sensor_id = sensor_id
             self._sensor_type = sensor_type
             self._address = address
@@ -651,51 +638,20 @@ class I2CAdapter(BaseAdapter):
             self._channel = channel
             self._calibration = calibration
             self._window = window
-            await self._connect_locked(sensor_type, config)
+            try:
+                await asyncio.to_thread(self._connect_sync, sensor_type)
+            except AdapterConnectionError:
+                raise
+            except Exception as exc:
+                raise AdapterConnectionError(
+                    f"I2CAdapter: failed to connect to '{sensor_type}' at "
+                    f"address 0x{self._address:02X} on bus {self._bus_number}: "
+                    f"{exc}"
+                ) from exc
 
-    async def _connect_locked(self, sensor_type: str, config: dict) -> None:
-        # Sampled inside the lock, so a close that has already run in full is
-        # counted here rather than mistaken for one that arrived later.
-        closes_before = self._close_count
-        connected = False
-        try:
-            await asyncio.to_thread(self._connect_sync, sensor_type)
-            connected = True
-        except AdapterConnectionError:
-            raise
-        except Exception as exc:
-            raise AdapterConnectionError(
-                f"I2CAdapter: failed to connect to '{sensor_type}' at "
-                f"address 0x{self._address:02X} on bus {self._bus_number}: {exc}"
-            ) from exc
-        finally:
-            # The runtime logs a failed connect and moves on without calling
-            # close(), so a connect that raises has to give back what it took
-            # on the way in. A leaked reference keeps the cached bus handle
-            # alive past its last real user, and the next connect is then
-            # handed a stale one.
-            if not connected:
-                self._release_shared_bus()
-
-        if self._close_count != closes_before:
-            # A close() arrived while this connect held the lock. It could not
-            # tear anything down yet, but it has declared itself, and the
-            # worker thread went on taking more meanwhile. Reporting success
-            # would leave an adapter that believes it is connected while a
-            # close already waiting tears it down, and the runtime would poll
-            # it. The connect gives everything back itself and refuses,
-            # because a connect that was closed did not connect.
-            await self._teardown()
-            raise AdapterConnectionError(
-                f"I2CAdapter: '{sensor_type}' at address "
-                f"0x{self._address:02X} on bus {self._bus_number} was closed "
-                "while it was still connecting"
+            self._breaker = HardwareCircuitBreaker(
+                getattr(self, "adapter_name", type(self).__name__), config
             )
-
-        self._breaker = HardwareCircuitBreaker(
-            getattr(self, "adapter_name", type(self).__name__), config
-        )
-        self._connected = True
 
     def _connect_sync(self, sensor_type: str) -> None:
         """Blocking I2C initialisation — runs in executor."""
@@ -865,15 +821,14 @@ class I2CAdapter(BaseAdapter):
     def _acquire_shared_bus(self) -> Any:
         """Take a reference on the shared bus, and record that this one holds it."""
         i2c = _get_shared_busio_i2c(self._bus_number)
-        self._holds_shared_bus = True
+        self._shared_bus_holds += 1
         return i2c
 
     def _release_shared_bus(self) -> None:
-        """Give back this adapter's reference, once, if it took one."""
-        if not self._holds_shared_bus:
-            return
-        self._holds_shared_bus = False
-        _release_shared_busio_i2c(self._bus_number)
+        """Give back every reference this adapter took, and none it did not."""
+        while self._shared_bus_holds > 0:
+            self._shared_bus_holds -= 1
+            _release_shared_busio_i2c(self._bus_number)
 
     def _ads1115_quarantined(self) -> str | None:
         """Why this chip is refused for the life of the process, if it is."""
@@ -1125,12 +1080,8 @@ class I2CAdapter(BaseAdapter):
         a worker thread can see that it was closed and give back what it took
         after this ran.
         """
-        self._close_count += 1
-        async with self._lifecycle:
-            try:
-                await self._teardown()
-            finally:
-                self._connected = False
+        async with self._closing():
+            await self._teardown()
 
     async def health_check(self) -> bool:
         """Return ``True`` when connected and the device handle is open."""

--- a/ori/hal/lorawan_adapter.py
+++ b/ori/hal/lorawan_adapter.py
@@ -116,18 +116,19 @@ class LoraWanAdapter(MqttCachedAdapter):
                 "LoraWanAdapter: 'topic' is required (e.g. v3/<app>@ttn/devices/<dev>/up)"
             )
 
-        self._sensor_type = sensor_type
-        self._topic = topic
-        self._value_path = value_path
-        self._quality_path = str(config.get("quality_path", "")).strip()
-        self._unit = unit
+        async with self._connecting(f"'{topic}'", release=self._close_mqtt):
+            self._sensor_type = sensor_type
+            self._topic = topic
+            self._value_path = value_path
+            self._quality_path = str(config.get("quality_path", "")).strip()
+            self._unit = unit
 
-        await self._connect_mqtt(
-            config=config,
-            topics=[topic],
-            default_port=_DEFAULT_PORT,
-            listener_name=f"lorawan-listener:{topic}",
-        )
+            await self._connect_mqtt(
+                config=config,
+                topics=[topic],
+                default_port=_DEFAULT_PORT,
+                listener_name=f"lorawan-listener:{topic}",
+            )
 
     async def _handle_message(self, topic: str, payload: Any) -> None:
         parsed = self._parse_payload(payload)
@@ -206,9 +207,6 @@ class LoraWanAdapter(MqttCachedAdapter):
                     "raw_payload": payload,
                 },
             )
-
-    async def close(self) -> None:
-        await self._close_mqtt()
 
     @staticmethod
     def _parse_payload(payload: Any) -> dict[str, Any]:

--- a/ori/hal/mqtt_adapter.py
+++ b/ori/hal/mqtt_adapter.py
@@ -92,18 +92,19 @@ class MqttAdapter(MqttCachedAdapter):
         if not topic:
             raise AdapterConnectionError("MqttAdapter: 'topic' is required")
 
-        self._sensor_type = sensor_type
-        self._topic = topic
-        self._value_path = str(config.get("value_path", "value")).strip()
-        self._quality_path = str(config.get("quality_path", "")).strip()
-        self._unit = str(config.get("unit", "")).strip()
+        async with self._connecting(f"'{topic}'", release=self._close_mqtt):
+            self._sensor_type = sensor_type
+            self._topic = topic
+            self._value_path = str(config.get("value_path", "value")).strip()
+            self._quality_path = str(config.get("quality_path", "")).strip()
+            self._unit = str(config.get("unit", "")).strip()
 
-        await self._connect_mqtt(
-            config=config,
-            topics=[topic],
-            default_port=_DEFAULT_PORT,
-            listener_name=f"mqtt-listener:{topic}",
-        )
+            await self._connect_mqtt(
+                config=config,
+                topics=[topic],
+                default_port=_DEFAULT_PORT,
+                listener_name=f"mqtt-listener:{topic}",
+            )
 
     async def _handle_message(self, topic: str, payload: Any) -> None:
         parsed = self._parse_payload(payload)
@@ -164,9 +165,6 @@ class MqttAdapter(MqttCachedAdapter):
                     "raw_payload": payload,
                 },
             )
-
-    async def close(self) -> None:
-        await self._close_mqtt()
 
     @staticmethod
     def _parse_payload(payload: Any) -> dict[str, Any]:

--- a/ori/hal/mqtt_base.py
+++ b/ori/hal/mqtt_base.py
@@ -393,7 +393,6 @@ class MqttCachedAdapter(BaseAdapter):
             self._client = await client.__aenter__()
             for topic in topics:
                 await self._client.subscribe(topic)
-            self._connected = True
             self._listener_task = asyncio.create_task(
                 self._listen_loop(),
                 name=listener_name or f"mqtt-listener:{self._broker_host}:{self._port}",
@@ -405,9 +404,21 @@ class MqttCachedAdapter(BaseAdapter):
                 f"{self._broker_host}:{self._port}: {exc}"
             ) from exc
 
-    async def _close_mqtt(self) -> None:
-        self._connected = False
+    async def close(self) -> None:
+        """Close for the whole MQTT family, under the lifecycle contract.
 
+        Every subclass had the same two-line `close()`; it lives here once so
+        that the guarantee cannot be adopted by some of them and not others.
+        """
+        async with self._closing():
+            await self._close_mqtt()
+
+    async def _close_mqtt(self) -> None:
+        """Give back the listener and the client, finished or not.
+
+        Called from `close()` and as the `release` of an abandoned connect, so
+        it must be idempotent and safe on a partial connect.
+        """
         task = self._listener_task
         self._listener_task = None
         if task is not None and not task.done():

--- a/ori/hal/mqtt_perception_adapter.py
+++ b/ori/hal/mqtt_perception_adapter.py
@@ -50,15 +50,16 @@ class MqttPerceptionAdapter(MqttCachedAdapter):
                 "MqttPerceptionAdapter: 'topic' is required in sensor config."
             )
 
-        self._sensor_type = sensor_type
-        self._topic = topic
+        async with self._connecting(f"'{topic}'", release=self._close_mqtt):
+            self._sensor_type = sensor_type
+            self._topic = topic
 
-        await self._connect_mqtt(
-            config=config,
-            topics=[topic],
-            default_port=_DEFAULT_PORT,
-            listener_name=f"perception-listener:{topic}",
-        )
+            await self._connect_mqtt(
+                config=config,
+                topics=[topic],
+                default_port=_DEFAULT_PORT,
+                listener_name=f"perception-listener:{topic}",
+            )
 
     async def _handle_message(self, topic: str, payload: Any) -> None:
         parsed = self._parse_payload(payload)
@@ -112,9 +113,6 @@ class MqttPerceptionAdapter(MqttCachedAdapter):
                     "port": self._port,
                 },
             )
-
-    async def close(self) -> None:
-        await self._close_mqtt()
 
     def _parse_payload(self, payload: Any) -> dict[str, Any]:
         if isinstance(payload, (bytes, bytearray)):

--- a/ori/hal/opcua_adapter.py
+++ b/ori/hal/opcua_adapter.py
@@ -54,33 +54,41 @@ class OpcUaAdapter(BaseAdapter):
                 "OpcUaAdapter: 'asyncua' is not installed. Run: pip install asyncua"
             )
 
-        self._sensor_type = str(config.get("sensor_type", "")).strip()
-        self._url = str(config.get("url", "")).strip()
-        self._node_id = str(config.get("node_id", "")).strip()
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+        sensor_type = str(config.get("sensor_type", "")).strip()
+        url = str(config.get("url", "")).strip()
+        node_id = str(config.get("node_id", "")).strip()
 
-        if not self._sensor_type:
+        if not sensor_type:
             raise AdapterConnectionError("OpcUaAdapter: 'sensor_type' is required")
-        if not self._url:
+        if not url:
             raise AdapterConnectionError("OpcUaAdapter: 'url' is required")
-        if not self._node_id:
+        if not node_id:
             raise AdapterConnectionError("OpcUaAdapter: 'node_id' is required")
 
-        try:
+        async with self._connecting(
+            f"'{url}' node '{node_id}'", release=self._teardown
+        ):
+            self._sensor_type = sensor_type
+            self._url = url
+            self._node_id = node_id
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
             try:
-                client = _AsyncUaClient(url=self._url)
-            except TypeError:
-                client = _AsyncUaClient(self._url)
-            await client.connect()
-            self._client = client
-            self._node = client.get_node(self._node_id)
-            self._connected = True
-        except Exception as exc:
-            await self.close()
-            raise AdapterConnectionError(
-                f"OpcUaAdapter: failed to connect to '{self._url}' "
-                f"node '{self._node_id}': {exc}"
-            ) from exc
+                try:
+                    client = _AsyncUaClient(url=url)
+                except TypeError:
+                    client = _AsyncUaClient(url)
+                await client.connect()
+                self._client = client
+                self._node = client.get_node(node_id)
+            except Exception as exc:
+                # `_teardown`, not `close()`: the guard already holds the
+                # lifecycle lock, so calling `close()` here would deadlock on
+                # it, and would also record a close this connect did not
+                # receive.
+                raise AdapterConnectionError(
+                    f"OpcUaAdapter: failed to connect to '{url}' "
+                    f"node '{node_id}': {exc}"
+                ) from exc
 
     async def read(self, sensor_id: str) -> SensorReading:
         if not _ASYNCUA_AVAILABLE:
@@ -119,10 +127,14 @@ class OpcUaAdapter(BaseAdapter):
             )
 
     async def close(self) -> None:
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
+        """Drop the client, whether the connect finished or not."""
         client = self._client
         self._client = None
         self._node = None
-        self._connected = False
 
         if client is None:
             return

--- a/ori/hal/psutil_adapter.py
+++ b/ori/hal/psutil_adapter.py
@@ -88,17 +88,24 @@ class PsutilAdapter(BaseAdapter):
                 f"PsutilAdapter: unsupported sensor_type '{sensor_type}'. "
                 f"Supported: {sorted(_SUPPORTED)}"
             )
-        self._sensor_id = config.get("sensor_id", "")
-        self._sensor_type = sensor_type
-        self._config = dict(config)
-        self._breaker = HardwareCircuitBreaker(
-            getattr(self, "adapter_name", type(self).__name__), config
-        )
-        self._connected = True
+        sensor_id = config.get("sensor_id", "")
+        # Nothing is awaited and `close()` releases nothing, so this adapter
+        # has no race to lose; it takes the guarantee from `BaseAdapter` so
+        # that the contract is one rule rather than one per adapter, and
+        # applies its configuration inside the guard so a refused connect
+        # leaves the live one alone.
+        async with self._connecting(f"'{sensor_type}'"):
+            self._sensor_id = sensor_id
+            self._sensor_type = sensor_type
+            self._config = dict(config)
+            self._breaker = HardwareCircuitBreaker(
+                getattr(self, "adapter_name", type(self).__name__), config
+            )
 
     async def close(self) -> None:
         """Release resources (no-op for psutil — marks as disconnected)."""
-        self._connected = False
+        async with self._closing():
+            pass
 
     async def health_check(self) -> bool:
         """Return ``True`` if psutil is importable and adapter is connected."""

--- a/ori/hal/serial_adapter.py
+++ b/ori/hal/serial_adapter.py
@@ -238,14 +238,17 @@ class SerialAdapter(BaseAdapter):
                 f"Supported: {sorted(_SUPPORTED)}"
             )
 
-        self._sensor_type = sensor_type
-        self._port = config.get("port", "")
-        if not self._port:
+        # Validated into locals and applied to the adapter only inside the
+        # guard: assigning first would leave a refused connect having already
+        # replaced the live port, slave id and sensor type while the adapter
+        # stayed connected on the old handle.
+        port = config.get("port", "")
+        if not port:
             raise AdapterConnectionError(
                 "SerialAdapter: 'port' is required in sensor config (e.g. /dev/ttyUSB0)"
             )
 
-        self._baudrate = resolve_baud_rate(
+        baudrate = resolve_baud_rate(
             has_canonical="baud_rate" in config,
             canonical=config.get("baud_rate"),
             has_legacy="baudrate" in config,
@@ -253,27 +256,46 @@ class SerialAdapter(BaseAdapter):
             default=_DEFAULT_BAUDRATE,
             adapter_name="SerialAdapter",
         )
-        self._bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
-        self._parity = str(config.get("parity", _DEFAULT_PARITY))
-        self._stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))
-        self._timeout = float(config.get("timeout", _DEFAULT_TIMEOUT))
-        self._slave_id = int(config.get("slave_id", _DEFAULT_SLAVE_ID))
+        bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
+        parity = str(config.get("parity", _DEFAULT_PARITY))
+        stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))
+        timeout = float(config.get("timeout", _DEFAULT_TIMEOUT))
+        slave_id = int(config.get("slave_id", _DEFAULT_SLAVE_ID))
         reg = config.get("register")
-        self._register = int(reg) if reg is not None else None
+        register = int(reg) if reg is not None else None
 
+        async with self._connecting(f"'{port}'", release=self._teardown):
+            self._sensor_type = sensor_type
+            self._port = port
+            self._baudrate = baudrate
+            self._bytesize = bytesize
+            self._parity = parity
+            self._stopbits = stopbits
+            self._timeout = timeout
+            self._slave_id = slave_id
+            self._register = register
+            try:
+                await asyncio.to_thread(self._open_port)
+            except AdapterConnectionError:
+                raise
+            except Exception as exc:
+                raise AdapterConnectionError(
+                    f"SerialAdapter: failed to open '{self._port}': {exc}"
+                ) from exc
+
+            self._breaker = HardwareCircuitBreaker(
+                getattr(self, "adapter_name", type(self).__name__), config
+            )
+
+    async def _teardown(self) -> None:
+        """Give back the port, whether the connect finished or not."""
         try:
-            await asyncio.to_thread(self._open_port)
-        except AdapterConnectionError:
-            raise
-        except Exception as exc:
-            raise AdapterConnectionError(
-                f"SerialAdapter: failed to open '{self._port}': {exc}"
-            ) from exc
-
-        self._breaker = HardwareCircuitBreaker(
-            getattr(self, "adapter_name", type(self).__name__), config
-        )
-        self._connected = True
+            if self._serial is not None and self._serial.is_open:
+                await asyncio.to_thread(self._serial.close)
+        except Exception:
+            logger.warning("SerialAdapter: exception during close on '%s'", self._port)
+        finally:
+            self._serial = None
 
     def _open_port(self) -> None:
         if serial is None:
@@ -290,15 +312,14 @@ class SerialAdapter(BaseAdapter):
         )
 
     async def close(self) -> None:
-        """Close the serial port."""
-        try:
-            if self._serial is not None and self._serial.is_open:
-                await asyncio.to_thread(self._serial.close)
-        except Exception:
-            logger.warning("SerialAdapter: exception during close on '%s'", self._port)
-        finally:
-            self._serial = None
-            self._connected = False
+        """Close the serial port.
+
+        Runs under the lifecycle contract on `BaseAdapter`: recorded before the
+        lock is requested, so a connect still opening the port sees that it was
+        closed and gives the port back rather than reporting success.
+        """
+        async with self._closing():
+            await self._teardown()
 
     async def health_check(self) -> bool:
         """Return ``True`` if the serial port is open."""

--- a/ori/hal/smart_adapter.py
+++ b/ori/hal/smart_adapter.py
@@ -235,10 +235,15 @@ class SmartAdapter(BaseAdapter):
                 "SmartAdapter: 'device' is required (e.g. /dev/sda, /dev/nvme0n1)"
             )
 
-        self._sensor_type = sensor_type
-        self._device = device
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
-        self._connected = True
+        # Nothing is awaited here and `close()` releases nothing, so this
+        # adapter has no race to lose; it takes the guarantee from
+        # `BaseAdapter` so that the contract is one rule rather than five, and
+        # applies its configuration inside the guard so that a refused connect
+        # leaves the live one alone.
+        async with self._connecting(f"'{device}'"):
+            self._sensor_type = sensor_type
+            self._device = device
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
 
         if not _PYSMART_AVAILABLE:
             logger.info(
@@ -283,7 +288,8 @@ class SmartAdapter(BaseAdapter):
             )
 
     async def close(self) -> None:
-        self._connected = False
+        async with self._closing():
+            pass
 
     def _read_metrics_sync(self) -> dict[str, float | None]:
         # Try pySMART first, then fallback to smartctl subprocess.

--- a/ori/hal/solarman_modbus_adapter.py
+++ b/ori/hal/solarman_modbus_adapter.py
@@ -98,18 +98,18 @@ class SolarmanModbusAdapter(BaseAdapter):
                 "must be numeric."
             )
 
-        self._host = str(config.get("host", "")).strip()
-        self._serial = str(config.get("serial", "")).strip()
-        self._port = int(config.get("port", profile.default_port))
-        if not self._host:
+        host = str(config.get("host", "")).strip()
+        serial = str(config.get("serial", "")).strip()
+        port = int(config.get("port", profile.default_port))
+        if not host:
             raise AdapterConnectionError(
                 "SolarmanModbusAdapter: 'host' is required in sensor config."
             )
-        if not self._serial:
+        if not serial:
             raise AdapterConnectionError(
                 "SolarmanModbusAdapter: 'serial' logger serial is required."
             )
-        if self._port <= 0:
+        if port <= 0:
             raise AdapterConnectionError(
                 "SolarmanModbusAdapter: 'port' must be greater than zero."
             )
@@ -127,15 +127,26 @@ class SolarmanModbusAdapter(BaseAdapter):
                 profile.status,
             )
 
-        self._profile = profile
-        self._sensor_type = sensor_type
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
-        self._connected = True
+        # Nothing is awaited above, so no close can interleave with it, but the
+        # guarantee is taken from `BaseAdapter` rather than rested on that: a
+        # later await added here would silently reopen the race. The
+        # configuration is applied inside the guard so that a refused connect
+        # leaves the live one alone.
+        async with self._connecting(f"'{host}:{port}'"):
+            self._host = host
+            self._serial = serial
+            self._port = port
+            self._profile = profile
+            self._sensor_type = sensor_type
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
 
     async def close(self) -> None:
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
         client = self._client
         self._client = None
-        self._connected = False
         if client is None:
             return
 

--- a/ori/hal/usb_serial_adapter.py
+++ b/ori/hal/usb_serial_adapter.py
@@ -166,12 +166,14 @@ class UsbSerialAdapter(BaseAdapter):
                 f"UsbSerialAdapter: unsupported sensor_type '{sensor_type}'. "
                 f"Supported: {sorted(_SUPPORTED)}"
             )
-        self._sensor_type = sensor_type
-
-        self._device_path = str(config.get("device_path", "")).strip()
-        if not self._device_path and bool(config.get("auto_detect_device_path", False)):
-            self._device_path = _find_direct_serial_device()
-        if not self._device_path:
+        # Validated into locals and applied to the adapter only inside the
+        # guard: assigning first would leave a refused connect having already
+        # replaced the live device path, slave id and sensor type while the
+        # adapter stayed connected on the old handle.
+        device_path = str(config.get("device_path", "")).strip()
+        if not device_path and bool(config.get("auto_detect_device_path", False)):
+            device_path = _find_direct_serial_device()
+        if not device_path:
             termux_devices = await asyncio.to_thread(_list_termux_usb_devices_sync)
             if termux_devices:
                 devices = ", ".join(termux_devices)
@@ -187,7 +189,7 @@ class UsbSerialAdapter(BaseAdapter):
                 "UsbSerialAdapter: 'device_path' is required (e.g. /dev/ttyUSB0)"
             )
 
-        self._baud_rate = resolve_baud_rate(
+        baud_rate = resolve_baud_rate(
             has_canonical="baud_rate" in config,
             canonical=config.get("baud_rate"),
             has_legacy="baudrate" in config,
@@ -195,25 +197,33 @@ class UsbSerialAdapter(BaseAdapter):
             default=_DEFAULT_BAUD_RATE,
             adapter_name="UsbSerialAdapter",
         )
-        self._bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
-        self._parity = str(config.get("parity", _DEFAULT_PARITY))
-        self._stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))
-        self._timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
-        self._slave_id = int(config.get("slave_id", _DEFAULT_SLAVE_ID))
-        self._transport = _transport_for_path(self._device_path)
+        bytesize = int(config.get("bytesize", _DEFAULT_BYTESIZE))
+        parity = str(config.get("parity", _DEFAULT_PARITY))
+        stopbits = int(config.get("stopbits", _DEFAULT_STOPBITS))
+        timeout_s = float(config.get("timeout_s", _DEFAULT_TIMEOUT_S))
+        slave_id = int(config.get("slave_id", _DEFAULT_SLAVE_ID))
+        transport = _transport_for_path(device_path)
 
-        self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+        async with self._connecting(f"'{device_path}'", release=self._teardown):
+            self._sensor_type = sensor_type
+            self._device_path = device_path
+            self._baud_rate = baud_rate
+            self._bytesize = bytesize
+            self._parity = parity
+            self._stopbits = stopbits
+            self._timeout_s = timeout_s
+            self._slave_id = slave_id
+            self._transport = transport
+            self._breaker = HardwareCircuitBreaker(self.adapter_name, config)
+            try:
+                await asyncio.to_thread(self._open_port_sync)
+            except AdapterConnectionError:
+                raise
+            except Exception as exc:
+                raise AdapterConnectionError(
+                    f"UsbSerialAdapter: failed to open '{self._device_path}': {exc}"
+                ) from exc
 
-        try:
-            await asyncio.to_thread(self._open_port_sync)
-        except AdapterConnectionError:
-            raise
-        except Exception as exc:
-            raise AdapterConnectionError(
-                f"UsbSerialAdapter: failed to open '{self._device_path}': {exc}"
-            ) from exc
-
-        self._connected = True
         logger.info(
             "UsbSerialAdapter: connected device_path=%s transport=%s sensor_type=%s",
             self._device_path,
@@ -272,6 +282,12 @@ class UsbSerialAdapter(BaseAdapter):
             )
 
     async def close(self) -> None:
+        """Close the port under the lifecycle contract on `BaseAdapter`."""
+        async with self._closing():
+            await self._teardown()
+
+    async def _teardown(self) -> None:
+        """Give back the port, whether the connect finished or not."""
         try:
             if self._serial is not None and self._serial.is_open:
                 await asyncio.to_thread(self._serial.close)
@@ -282,7 +298,6 @@ class UsbSerialAdapter(BaseAdapter):
             )
         finally:
             self._serial = None
-            self._connected = False
 
     def _open_port_sync(self) -> None:
         if _serial_module is None:

--- a/ori/hal/victron_adapter.py
+++ b/ori/hal/victron_adapter.py
@@ -46,20 +46,22 @@ class VictronAdapter(MqttCachedAdapter):
                 f"Supported: {sorted(_SUPPORTED)}"
             )
 
-        self._sensor_type = sensor_type
-        self._portal_id = str(config.get("portal_id", "")).strip()
-        if not self._portal_id:
+        portal_id = str(config.get("portal_id", "")).strip()
+        if not portal_id:
             raise AdapterConnectionError(
                 "VictronAdapter: 'portal_id' is required in sensor config."
             )
 
-        topics = [self._topic_for_sensor(sensor) for sensor in sorted(_SUPPORTED)]
-        await self._connect_mqtt(
-            config=config,
-            topics=topics,
-            default_port=_DEFAULT_PORT,
-            listener_name=f"victron-listener:{self._portal_id}",
-        )
+        async with self._connecting(f"portal '{portal_id}'", release=self._close_mqtt):
+            self._sensor_type = sensor_type
+            self._portal_id = portal_id
+            topics = [self._topic_for_sensor(sensor) for sensor in sorted(_SUPPORTED)]
+            await self._connect_mqtt(
+                config=config,
+                topics=topics,
+                default_port=_DEFAULT_PORT,
+                listener_name=f"victron-listener:{portal_id}",
+            )
 
     async def _handle_message(self, topic: str, payload: Any) -> None:
         value, raw_payload = self.parse_numeric_payload(payload)
@@ -102,9 +104,6 @@ class VictronAdapter(MqttCachedAdapter):
                     "raw_payload": raw_payload,
                 },
             )
-
-    async def close(self) -> None:
-        await self._close_mqtt()
 
     def _topic_for_sensor(self, sensor_type: str) -> str:
         suffix, _unit = _SENSOR_MAP[sensor_type]

--- a/ori/hal/zigbee_adapter.py
+++ b/ori/hal/zigbee_adapter.py
@@ -120,18 +120,19 @@ class ZigbeeAdapter(MqttCachedAdapter):
                 "ZigbeeAdapter: 'topic' is required (e.g. zigbee2mqtt/living-room)"
             )
 
-        self._sensor_type = sensor_type
-        self._topic = topic
-        self._value_path = value_path
-        self._quality_path = str(config.get("quality_path", "")).strip()
-        self._unit = unit
+        async with self._connecting(f"'{topic}'", release=self._close_mqtt):
+            self._sensor_type = sensor_type
+            self._topic = topic
+            self._value_path = value_path
+            self._quality_path = str(config.get("quality_path", "")).strip()
+            self._unit = unit
 
-        await self._connect_mqtt(
-            config=config,
-            topics=[topic],
-            default_port=_DEFAULT_PORT,
-            listener_name=f"zigbee-listener:{topic}",
-        )
+            await self._connect_mqtt(
+                config=config,
+                topics=[topic],
+                default_port=_DEFAULT_PORT,
+                listener_name=f"zigbee-listener:{topic}",
+            )
 
     async def _handle_message(self, topic: str, payload: Any) -> None:
         parsed = self._parse_payload(payload)
@@ -204,9 +205,6 @@ class ZigbeeAdapter(MqttCachedAdapter):
                     "raw_payload": payload,
                 },
             )
-
-    async def close(self) -> None:
-        await self._close_mqtt()
 
     @staticmethod
     def _parse_payload(payload: Any) -> dict[str, Any]:

--- a/tests/test_hal_lifecycle_contract.py
+++ b/tests/test_hal_lifecycle_contract.py
@@ -27,8 +27,10 @@ the race silently.
 from __future__ import annotations
 
 import asyncio
+import sys
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -260,6 +262,11 @@ class TestTheGuaranteeItself:
         assert probe.opened == 1
 
 
+def _module_of(adapter_class: type) -> Any:
+    """The module an adapter is defined in, for patching its driver flags."""
+    return sys.modules[adapter_class.__module__]
+
+
 # Each entry: the adapter, a first config, a second naming a different target,
 # and the attributes a refused second connect must not have changed. The
 # drivers are stubbed so the real `connect()` runs without hardware.
@@ -378,10 +385,16 @@ ADAPTER_CASES = [
 @pytest.fixture
 def stub_drivers(monkeypatch):
     """Let every adapter's real `connect()` run without hardware."""
-    import ori.hal.growatt_adapter as growatt
-    import ori.hal.serial_adapter as serial_module
-    import ori.hal.solarman_modbus_adapter as solarman
-    import ori.hal.usb_serial_adapter as usb
+    # Each adapter's module is reached through the class already imported at
+    # the top of this file, rather than imported a second time under an alias.
+    serial_module = _module_of(SerialAdapter)
+    usb = _module_of(UsbSerialAdapter)
+    growatt = _module_of(GrowattAdapter)
+    solarman = _module_of(SolarmanModbusAdapter)
+    coap = _module_of(CoapAdapter)
+    http = _module_of(HttpAdapter)
+    opcua = _module_of(OpcUaAdapter)
+    mqtt_base = sys.modules["ori.hal.mqtt_base"]
 
     monkeypatch.setattr(serial_module, "_SERIAL_AVAILABLE", True)
     monkeypatch.setattr(SerialAdapter, "_open_port", lambda self: None)
@@ -390,11 +403,6 @@ def stub_drivers(monkeypatch):
     monkeypatch.setattr(UsbSerialAdapter, "_open_port_sync", lambda self: None)
     monkeypatch.setattr(growatt, "_PYSOLARMAN_AVAILABLE", True)
     monkeypatch.setattr(solarman, "_PYSOLARMAN_AVAILABLE", True)
-
-    import ori.hal.coap_adapter as coap
-    import ori.hal.http_adapter as http
-    import ori.hal.mqtt_base as mqtt_base
-    import ori.hal.opcua_adapter as opcua
 
     async def _noop(self, *args, **kwargs):
         return None
@@ -547,4 +555,7 @@ class TestEveryAdapterInherits:
         one = adapter_class()
         another = adapter_class()
         assert one._lifecycle is not another._lifecycle
-        assert one._lifecycle is one._lifecycle
+        # Created on first use, so the second access must return the same lock
+        # rather than a fresh one that serialises nothing.
+        first_access = one._lifecycle
+        assert one._lifecycle is first_access

--- a/tests/test_hal_lifecycle_contract.py
+++ b/tests/test_hal_lifecycle_contract.py
@@ -1,0 +1,550 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The lifecycle guarantee on `BaseAdapter`, driven against every adapter.
+
+`connect()` does its blocking work off the event loop and `close()` releases
+with awaits of its own, so the two can interleave: a close releases what has
+been taken so far while the connect's worker goes on taking more, and the
+adapter ends up believing it is connected while holding resources nobody else
+believes are in use.
+
+ori-platform/ori-runtime#501 fixed that in `I2CAdapter` with a per-adapter lock
+and counter. #513 moved the rule to `BaseAdapter`, because copying a counter
+into six files multiplies the surface that has to stay correct and gives each
+adapter its own chance to get it subtly wrong. These tests drive the guarantee
+against each adapter rather than one representative, so an adapter that stops
+meeting it fails here by name.
+
+Not every adapter had the defect. Only `SerialAdapter` and `UsbSerialAdapter`
+awaited during `connect()`; `SmartAdapter` awaits nothing, and `GrowattAdapter`
+and `SolarmanModbusAdapter` already captured the client into a local before
+yielding, so their close released only what it had taken. They take the shared
+guarantee anyway: an await added to any of them later would otherwise reopen
+the race silently.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from ori.hal.base import AdapterConnectionError, BaseAdapter
+from ori.hal.coap_adapter import CoapAdapter
+from ori.hal.growatt_adapter import GrowattAdapter
+from ori.hal.http_adapter import HttpAdapter
+from ori.hal.i2c_adapter import I2CAdapter
+from ori.hal.lorawan_adapter import LoraWanAdapter
+from ori.hal.mqtt_adapter import MqttAdapter
+from ori.hal.mqtt_perception_adapter import MqttPerceptionAdapter
+from ori.hal.opcua_adapter import OpcUaAdapter
+from ori.hal.psutil_adapter import PsutilAdapter
+from ori.hal.serial_adapter import SerialAdapter
+from ori.hal.smart_adapter import SmartAdapter
+from ori.hal.solarman_modbus_adapter import SolarmanModbusAdapter
+from ori.hal.usb_serial_adapter import UsbSerialAdapter
+from ori.hal.victron_adapter import VictronAdapter
+from ori.hal.zigbee_adapter import ZigbeeAdapter
+
+# Every concrete adapter in `ori/hal/`. The list is asserted complete against
+# the package below, so a new adapter cannot be added without appearing here.
+ADAPTERS = [
+    pytest.param(I2CAdapter, id="i2c"),
+    pytest.param(SerialAdapter, id="serial"),
+    pytest.param(UsbSerialAdapter, id="usb_serial"),
+    pytest.param(SmartAdapter, id="smart"),
+    pytest.param(GrowattAdapter, id="growatt"),
+    pytest.param(SolarmanModbusAdapter, id="solarman_modbus"),
+    pytest.param(PsutilAdapter, id="psutil"),
+    pytest.param(HttpAdapter, id="http"),
+    pytest.param(CoapAdapter, id="coap"),
+    pytest.param(OpcUaAdapter, id="opcua"),
+    pytest.param(MqttAdapter, id="mqtt"),
+    pytest.param(MqttPerceptionAdapter, id="mqtt_perception"),
+    pytest.param(LoraWanAdapter, id="lorawan"),
+    pytest.param(VictronAdapter, id="victron"),
+    pytest.param(ZigbeeAdapter, id="zigbee"),
+]
+
+
+def test_every_adapter_in_the_package_is_covered():
+    """The contract is universal, so the list that proves it must be too.
+
+    `BaseAdapter` states the guarantee for every subclass. An adapter added
+    later would inherit that claim silently unless something notices, so the
+    package is enumerated rather than trusted.
+    """
+    import importlib
+    import inspect
+    import pkgutil
+
+    import ori.hal as hal_package
+
+    covered = {param.values[0] for param in ADAPTERS}
+    found: set[type] = set()
+    for module in pkgutil.iter_modules(hal_package.__path__):
+        imported = importlib.import_module(f"ori.hal.{module.name}")
+        for _, obj in inspect.getmembers(imported, inspect.isclass):
+            if (
+                issubclass(obj, BaseAdapter)
+                and obj is not BaseAdapter
+                and not inspect.isabstract(obj)
+                and obj.__module__ == imported.__name__
+            ):
+                found.add(obj)
+
+    assert found - covered == set(), sorted(c.__name__ for c in found - covered)
+
+
+class _Probe(BaseAdapter):
+    """A minimal adapter that uses the contract and nothing else.
+
+    The guarantee is a property of `BaseAdapter`, so it is asserted here
+    without any hardware library, driver or simulation in the way.
+    """
+
+    def __init__(self) -> None:
+        self.opened = 0
+        self.released = 0
+        self.release_gate: asyncio.Event | None = None
+        self.opening = asyncio.Event()
+
+    async def connect(self, config: dict) -> None:
+        async with self._connecting("the probe", release=self._release):
+            self.opening.set()
+            if self.release_gate is not None:
+                await self.release_gate.wait()
+            self.opened += 1
+
+    async def read(self, sensor_id: str):  # pragma: no cover - never called
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        async with self._closing():
+            await self._release()
+
+    async def _release(self) -> None:
+        self.released += 1
+
+
+class TestTheGuaranteeItself:
+    @pytest.mark.asyncio
+    async def test_a_close_during_connect_leaves_it_disconnected(self):
+        probe = _Probe()
+        probe.release_gate = asyncio.Event()
+
+        connecting = asyncio.create_task(probe.connect({}))
+        await probe.opening.wait()
+        closing = asyncio.create_task(probe.close())
+        await asyncio.sleep(0)
+
+        probe.release_gate.set()
+        with pytest.raises(AdapterConnectionError, match="closed while it was still"):
+            await asyncio.wait_for(connecting, 5)
+        await asyncio.wait_for(closing, 5)
+
+        assert probe.is_connected is False
+        assert probe.released >= 1
+
+    @pytest.mark.asyncio
+    async def test_a_close_declares_itself_before_it_waits(self):
+        """A close waiting on the lock is what the connect must be able to see."""
+        probe = _Probe()
+        probe.release_gate = asyncio.Event()
+
+        connecting = asyncio.create_task(probe.connect({}))
+        await probe.opening.wait()
+        closing = asyncio.create_task(probe.close())
+        await asyncio.sleep(0)
+
+        assert probe._close_generation == 1
+
+        probe.release_gate.set()
+        with pytest.raises(AdapterConnectionError):
+            await asyncio.wait_for(connecting, 5)
+        await asyncio.wait_for(closing, 5)
+
+    @pytest.mark.asyncio
+    async def test_a_connect_queued_behind_another_still_sees_the_close(self):
+        """Why the generation is sampled before the lock, not inside it.
+
+        Three-way: one connect holds the lock, a second queues behind it, and
+        a close is then requested. The close declares itself immediately, but
+        cannot act until both connects release the lock. A second connect that
+        sampled the generation *after* winning the lock would compare against
+        a value the close had already bumped, find them equal, and report
+        success for an adapter that a close outstanding before its body ran is
+        about to tear down.
+        """
+        probe = _Probe()
+        probe.release_gate = asyncio.Event()
+
+        first = asyncio.create_task(probe.connect({}))
+        await probe.opening.wait()
+
+        second = asyncio.create_task(probe.connect({}))
+        # Let the second reach the lock, so it has sampled before the close.
+        for _ in range(4):
+            await asyncio.sleep(0)
+
+        closing = asyncio.create_task(probe.close())
+        await asyncio.sleep(0)
+        probe.release_gate.set()
+
+        with pytest.raises(AdapterConnectionError, match="closed while it was still"):
+            await asyncio.wait_for(first, 5)
+        with pytest.raises(AdapterConnectionError, match="closed while it was still"):
+            await asyncio.wait_for(second, 5)
+        await asyncio.wait_for(closing, 5)
+
+        assert probe.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_a_release_that_raises_does_not_replace_the_real_failure(self):
+        """The caller must see why the connect failed, not why cleanup did."""
+
+        class _BadRelease(_Probe):
+            async def _release(self) -> None:
+                self.released += 1
+                raise RuntimeError("cleanup exploded")
+
+            async def connect(self, config: dict) -> None:
+                async with self._connecting("the probe", release=self._release):
+                    raise AdapterConnectionError("the real reason")
+
+        probe = _BadRelease()
+        with pytest.raises(AdapterConnectionError, match="the real reason"):
+            await probe.connect({})
+        assert probe.released == 1
+        assert probe.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_a_connect_that_fails_gives_back_what_it_took(self):
+        class _Failing(_Probe):
+            async def connect(self, config: dict) -> None:
+                async with self._connecting("the probe", release=self._release):
+                    raise AdapterConnectionError("boom")
+
+        probe = _Failing()
+        with pytest.raises(AdapterConnectionError, match="boom"):
+            await probe.connect({})
+        assert probe.released == 1
+        assert probe.is_connected is False
+
+    @pytest.mark.asyncio
+    async def test_a_successful_connect_releases_nothing(self):
+        probe = _Probe()
+        await probe.connect({})
+        assert probe.is_connected is True
+        assert probe.released == 0
+
+    @pytest.mark.asyncio
+    async def test_the_lock_serialises_two_connects(self):
+        """The second waits rather than interleaving, then is refused."""
+        probe = _Probe()
+        probe.release_gate = asyncio.Event()
+
+        first = asyncio.create_task(probe.connect({}))
+        await probe.opening.wait()
+        second = asyncio.create_task(probe.connect({}))
+        await asyncio.sleep(0)
+
+        assert not second.done()
+        probe.release_gate.set()
+        await asyncio.wait_for(first, 5)
+        with pytest.raises(AdapterConnectionError, match="already connected"):
+            await asyncio.wait_for(second, 5)
+        assert probe.opened == 1
+
+
+# Each entry: the adapter, a first config, a second naming a different target,
+# and the attributes a refused second connect must not have changed. The
+# drivers are stubbed so the real `connect()` runs without hardware.
+ADAPTER_CASES = [
+    pytest.param(
+        SerialAdapter,
+        {"sensor_type": "voltage", "port": "/dev/ttyUSB0", "slave_id": 1},
+        {"sensor_type": "current", "port": "/dev/ttyUSB9", "slave_id": 42},
+        ("_sensor_type", "_port", "_slave_id"),
+        id="serial",
+    ),
+    pytest.param(
+        UsbSerialAdapter,
+        {"sensor_type": "usb_power", "device_path": "/dev/ttyUSB0", "slave_id": 1},
+        {"sensor_type": "usb_voltage", "device_path": "/dev/ttyUSB9", "slave_id": 42},
+        ("_sensor_type", "_device_path", "_slave_id"),
+        id="usb_serial",
+    ),
+    pytest.param(
+        SmartAdapter,
+        {"sensor_type": "drive_temp_celsius", "device": "/dev/sda"},
+        {"sensor_type": "power_on_hours", "device": "/dev/sdz"},
+        ("_sensor_type", "_device"),
+        id="smart",
+    ),
+    pytest.param(
+        GrowattAdapter,
+        {"sensor_type": "growatt_pv_power", "host": "10.0.0.1", "serial": "AAA"},
+        {"sensor_type": "growatt_grid_power", "host": "10.0.0.2", "serial": "BBB"},
+        ("_sensor_type", "_host", "_serial"),
+        id="growatt",
+    ),
+    pytest.param(
+        SolarmanModbusAdapter,
+        {
+            "sensor_type": "deye_grid_power",
+            "profile": "deye_hybrid",
+            "host": "10.0.0.1",
+            "serial": "AAA",
+        },
+        {
+            "sensor_type": "deye_battery_soc",
+            "profile": "deye_hybrid",
+            "host": "10.0.0.2",
+            "serial": "BBB",
+        },
+        ("_sensor_type", "_host", "_serial"),
+        id="solarman_modbus",
+    ),
+    pytest.param(
+        PsutilAdapter,
+        {"sensor_type": "cpu_temp", "sensor_id": "a"},
+        {"sensor_type": "battery_percent", "sensor_id": "b"},
+        ("_sensor_type", "_sensor_id"),
+        id="psutil",
+    ),
+    pytest.param(
+        HttpAdapter,
+        {"sensor_type": "power", "url": "http://h/1", "json_path": "v"},
+        {"sensor_type": "voltage", "url": "http://h/2", "json_path": "w"},
+        ("_sensor_type", "_url", "_json_path"),
+        id="http",
+    ),
+    pytest.param(
+        CoapAdapter,
+        {"sensor_type": "power", "uri": "coap://h/1", "json_path": "v"},
+        {"sensor_type": "voltage", "uri": "coap://h/2", "json_path": "w"},
+        ("_sensor_type", "_uri", "_json_path"),
+        id="coap",
+    ),
+    pytest.param(
+        OpcUaAdapter,
+        {"sensor_type": "power", "url": "opc.tcp://h:1", "node_id": "ns=2;i=1"},
+        {"sensor_type": "voltage", "url": "opc.tcp://h:2", "node_id": "ns=2;i=2"},
+        ("_sensor_type", "_url", "_node_id"),
+        id="opcua",
+    ),
+    pytest.param(
+        MqttAdapter,
+        {"sensor_type": "power", "topic": "a/1"},
+        {"sensor_type": "voltage", "topic": "a/2"},
+        ("_sensor_type", "_topic"),
+        id="mqtt",
+    ),
+    pytest.param(
+        MqttPerceptionAdapter,
+        {"sensor_type": "ppe_hardhat_violation_score", "topic": "p/1"},
+        {"sensor_type": "ppe_vest_violation_score", "topic": "p/2"},
+        ("_sensor_type", "_topic"),
+        id="mqtt_perception",
+    ),
+    pytest.param(
+        LoraWanAdapter,
+        {"sensor_type": "lorawan_humidity", "topic": "l/1"},
+        {"sensor_type": "lorawan_battery_percent", "topic": "l/2"},
+        ("_sensor_type", "_topic"),
+        id="lorawan",
+    ),
+    pytest.param(
+        ZigbeeAdapter,
+        {"sensor_type": "battery_percent", "topic": "z/1"},
+        {"sensor_type": "contact", "topic": "z/2"},
+        ("_sensor_type", "_topic"),
+        id="zigbee",
+    ),
+    pytest.param(
+        VictronAdapter,
+        {"sensor_type": "victron_battery_soc", "portal_id": "AAA"},
+        {"sensor_type": "victron_battery_power", "portal_id": "BBB"},
+        ("_sensor_type", "_portal_id"),
+        id="victron",
+    ),
+]
+
+
+@pytest.fixture
+def stub_drivers(monkeypatch):
+    """Let every adapter's real `connect()` run without hardware."""
+    import ori.hal.growatt_adapter as growatt
+    import ori.hal.serial_adapter as serial_module
+    import ori.hal.solarman_modbus_adapter as solarman
+    import ori.hal.usb_serial_adapter as usb
+
+    monkeypatch.setattr(serial_module, "_SERIAL_AVAILABLE", True)
+    monkeypatch.setattr(SerialAdapter, "_open_port", lambda self: None)
+    monkeypatch.setattr(usb, "_PYSERIAL_AVAILABLE", True)
+    monkeypatch.setattr(usb, "_serial_module", object())
+    monkeypatch.setattr(UsbSerialAdapter, "_open_port_sync", lambda self: None)
+    monkeypatch.setattr(growatt, "_PYSOLARMAN_AVAILABLE", True)
+    monkeypatch.setattr(solarman, "_PYSOLARMAN_AVAILABLE", True)
+
+    import ori.hal.coap_adapter as coap
+    import ori.hal.http_adapter as http
+    import ori.hal.mqtt_base as mqtt_base
+    import ori.hal.opcua_adapter as opcua
+
+    async def _noop(self, *args, **kwargs):
+        return None
+
+    monkeypatch.setattr(http, "_HTTPX_AVAILABLE", True)
+    monkeypatch.setattr(http, "_httpx", object())
+    monkeypatch.setattr(HttpAdapter, "_poll_loop", _noop)
+
+    monkeypatch.setattr(coap, "_AIOCOAP_AVAILABLE", True)
+
+    class _Context:
+        @staticmethod
+        async def create_client_context():
+            return object()
+
+    monkeypatch.setattr(coap, "_aiocoap", SimpleNamespace(Context=_Context))
+    monkeypatch.setattr(CoapAdapter, "_poll_loop", _noop)
+    monkeypatch.setattr(CoapAdapter, "_validate_target", lambda self: None)
+    monkeypatch.setattr(CoapAdapter, "_shutdown_context", _noop)
+
+    class _UaClient:
+        def __init__(self, url):
+            self.url = url
+
+        async def connect(self):
+            return None
+
+        async def disconnect(self):
+            return None
+
+        def get_node(self, node_id):
+            return node_id
+
+    monkeypatch.setattr(opcua, "_ASYNCUA_AVAILABLE", True)
+    monkeypatch.setattr(opcua, "_AsyncUaClient", _UaClient)
+
+    # The MQTT family's broker work is `_connect_mqtt`; what is under test is
+    # whether each subclass runs its body inside the guard.
+    monkeypatch.setattr(mqtt_base, "_AIOMQTT_AVAILABLE", True)
+    monkeypatch.setattr(mqtt_base.MqttCachedAdapter, "_connect_mqtt", _noop)
+    monkeypatch.setattr(mqtt_base.MqttCachedAdapter, "_close_mqtt", _noop)
+
+
+class TestEveryAdapterInherits:
+    """Driven through each adapter's real `connect()`, not through the base class.
+
+    An earlier version of these tests called `adapter._connecting(...)`
+    directly and asserted on `inspect.getsource`. That re-tested `BaseAdapter`
+    six times under six ids and proved nothing about any adapter: the contract
+    could be dead-coded out of one of them and the whole suite still passed.
+    """
+
+    @pytest.mark.parametrize(
+        ("adapter_class", "first", "second", "guarded"), ADAPTER_CASES
+    )
+    @pytest.mark.asyncio
+    async def test_a_second_connect_is_refused(
+        self, stub_drivers, adapter_class, first, second, guarded
+    ):
+        adapter = adapter_class()
+        await adapter.connect(dict(first))
+        assert adapter.is_connected is True
+
+        with pytest.raises(AdapterConnectionError, match="already connected"):
+            await adapter.connect(dict(second))
+
+    @pytest.mark.parametrize(
+        ("adapter_class", "first", "second", "guarded"), ADAPTER_CASES
+    )
+    @pytest.mark.asyncio
+    async def test_a_refused_connect_changes_nothing(
+        self, stub_drivers, adapter_class, first, second, guarded
+    ):
+        """The refusal must fire before the adapter's configuration moves.
+
+        Assigning first leaves the adapter connected on the old handle while
+        its fields name the new target, so `read()` samples one device and
+        labels the reading with another.
+        """
+        adapter = adapter_class()
+        await adapter.connect(dict(first))
+        before = {name: getattr(adapter, name) for name in guarded}
+        breaker_before = adapter._breaker
+
+        with pytest.raises(AdapterConnectionError):
+            await adapter.connect(dict(second))
+
+        assert {name: getattr(adapter, name) for name in guarded} == before
+        assert adapter._breaker is breaker_before
+        assert adapter.is_connected is True
+
+    @pytest.mark.parametrize(
+        ("adapter_class", "first", "second", "guarded"), ADAPTER_CASES
+    )
+    @pytest.mark.asyncio
+    async def test_connect_after_close_is_admitted(
+        self, stub_drivers, adapter_class, first, second, guarded
+    ):
+        """The refusal is about a *live* adapter, not a spent one."""
+        adapter = adapter_class()
+        await adapter.connect(dict(first))
+        await adapter.close()
+        assert adapter.is_connected is False
+
+        await adapter.connect(dict(second))
+
+        assert adapter.is_connected is True
+        assert getattr(adapter, guarded[1]) == second[guarded[1].lstrip("_")]
+
+    @pytest.mark.parametrize(
+        ("adapter_class", "first", "second", "guarded"), ADAPTER_CASES
+    )
+    @pytest.mark.asyncio
+    async def test_a_close_during_connect_refuses_and_disconnects(
+        self, stub_drivers, adapter_class, first, second, guarded
+    ):
+        """The race, through the adapter's own `connect()`."""
+        adapter = adapter_class()
+        gate = asyncio.Event()
+        original = type(adapter)._connecting
+
+        def gated(self, description, *, release=None):
+            @asynccontextmanager
+            async def run():
+                async with original(self, description, release=release):
+                    await gate.wait()
+                    yield
+
+            return run()
+
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(type(adapter), "_connecting", gated)
+        try:
+            task = asyncio.create_task(adapter.connect(dict(first)))
+            await asyncio.sleep(0)
+            closing = asyncio.create_task(adapter.close())
+            await asyncio.sleep(0)
+            gate.set()
+            with pytest.raises(AdapterConnectionError, match="closed while"):
+                await asyncio.wait_for(task, 5)
+            await asyncio.wait_for(closing, 5)
+        finally:
+            monkeypatch.undo()
+
+        assert adapter.is_connected is False
+
+    @pytest.mark.parametrize("adapter_class", ADAPTERS)
+    @pytest.mark.asyncio
+    async def test_the_lifecycle_lock_is_per_adapter(self, adapter_class):
+        one = adapter_class()
+        another = adapter_class()
+        assert one._lifecycle is not another._lifecycle
+        assert one._lifecycle is one._lifecycle

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -131,7 +131,7 @@ def _connected_ads_adapter(
     adapter._ads = MagicMock()
     # The config readback before every measurement: the configured channel
     # single-ended (mux 4 + n), PGA gain 1, continuous, 860 SPS, comparator off.
-    adapter._holds_shared_bus = True
+    adapter._shared_bus_holds = 1
     adapter._ads.gain = 1
     adapter._ads.data_rate = 860
     adapter._ads._read_register.side_effect = lambda *_a, **_k: (
@@ -151,7 +151,7 @@ def _connected_scd40_adapter() -> I2CAdapter:
     adapter = I2CAdapter()
     adapter._connected = True
     adapter._sensor_type = "scd40"
-    adapter._holds_shared_bus = True
+    adapter._shared_bus_holds = 1
     adapter._breaker = HardwareCircuitBreaker("I2CAdapter", {})
     adapter._scd4x = MagicMock()
     return adapter
@@ -1491,7 +1491,7 @@ class TestAds1115ChannelSelection:
         adapter = I2CAdapter()
         with pytest.raises(AdapterConnectionError):
             await adapter.connect(config)
-        assert not adapter._holds_shared_bus
+        assert adapter._shared_bus_holds == 0
         expected = 1 if holder is not None else 0
         assert i2c_module._shared_busio_refs.get(1, 0) == expected
         if holder is not None:
@@ -2012,7 +2012,7 @@ class TestCloseDuringConnect:
         await asyncio.sleep(0)
 
         # The close has not torn anything down — it is waiting for the lock.
-        assert adapter._close_count == 1
+        assert adapter._close_generation == 1
         release.set()
         with pytest.raises(AdapterConnectionError, match="closed while it was still"):
             await asyncio.wait_for(connecting, 5)
@@ -2312,3 +2312,92 @@ class TestWindowIntegrity:
         ads._conversion = lambda: 0x7FFF
         assert adapter._sample_ads1115_volts() == pytest.approx(4.095875)
         await adapter.close()
+
+
+class TestSharedBusReferenceAccounting:
+    """ori-platform/ori-runtime#512.
+
+    The adapter tracked whether it held a reference on the shared `busio.I2C`
+    with a boolean while the cache counted references. The two disagreed the
+    moment one adapter acquired twice: the single release cleared the flag and
+    the second reference became unreleasable by anything, pinning the cached
+    handle for the life of the process so the next connect on that bus was
+    handed a stale one.
+    """
+
+    @pytest.fixture
+    def counting_bus(self, monkeypatch):
+        def fake(bus_number: int):
+            i2c_module._shared_busio_refs[bus_number] = (
+                i2c_module._shared_busio_refs.get(bus_number, 0) + 1
+            )
+            return MagicMock()
+
+        monkeypatch.setattr(i2c_module, "_get_shared_busio_i2c", fake)
+        i2c_module._shared_busio_refs.clear()
+        yield i2c_module._shared_busio_refs
+        i2c_module._shared_busio_refs.clear()
+
+    def test_acquiring_twice_and_releasing_returns_the_count(self, counting_bus):
+        """`connect, connect, close` must leave the count where it started."""
+        adapter = I2CAdapter()
+        adapter._bus_number = 1
+        before = counting_bus.get(1, 0)
+
+        adapter._acquire_shared_bus()
+        adapter._acquire_shared_bus()
+        assert counting_bus[1] == before + 2
+
+        adapter._release_shared_bus()
+        assert counting_bus.get(1, 0) == before
+
+    def test_the_adapters_accounting_matches_the_cache(self, counting_bus):
+        adapter = I2CAdapter()
+        adapter._bus_number = 1
+        for expected in (1, 2, 3):
+            adapter._acquire_shared_bus()
+            assert adapter._shared_bus_holds == expected == counting_bus[1]
+
+    def test_an_adapter_cannot_release_a_reference_it_did_not_take(
+        self, counting_bus, monkeypatch
+    ):
+        """Asserted directly, not inferred from the counting.
+
+        This is the property the boolean existed for: releasing one this
+        adapter never took would evict a handle another adapter is still
+        reading through.
+        """
+        holder = I2CAdapter()
+        holder._bus_number = 1
+        holder._acquire_shared_bus()
+
+        released: list[int] = []
+        monkeypatch.setattr(
+            i2c_module, "_release_shared_busio_i2c", lambda bus: released.append(bus)
+        )
+
+        freeloader = I2CAdapter()
+        freeloader._bus_number = 1
+        freeloader._release_shared_bus()
+        freeloader._release_shared_bus()
+
+        assert released == []
+        assert counting_bus[1] == 1
+        assert freeloader._shared_bus_holds == 0
+
+    @pytest.mark.asyncio
+    async def test_a_second_connect_while_connected_is_refused(self):
+        """The recorded choice: refuse, rather than tear down and reopen.
+
+        Reconnecting in place would take a second reference against one
+        release and move a live adapter's device under readings already being
+        taken from it.
+        """
+        adapter = I2CAdapter()
+        adapter._connected = True
+        adapter._sensor_type = "ads1115_voltage"
+        adapter._address = 0x48
+        adapter._bus_number = 1
+
+        with pytest.raises(AdapterConnectionError, match="already connected"):
+            await adapter.connect(_config(sensor_type="ads1115_voltage"))


### PR DESCRIPTION
## What does this PR do?

`connect()` runs its blocking initialisation in a worker thread and `close()` releases resources with awaits of its own, so the two interleave: a close releases what has been taken so far while the worker goes on taking more, and the adapter ends up believing it is connected while holding resources nobody else believes are in use.

#501 fixed that inside `I2CAdapter` with a per-adapter lock and a close counter. Copying it into every other adapter would multiply the surface that has to stay correct and give each one its own chance to get it subtly wrong, so the rule moves to `BaseAdapter` as `_connecting` and `_closing`, and `I2CAdapter`'s mechanism is replaced by it rather than left alongside.

### Every adapter is migrated, not a subset

`BaseAdapter` states the guarantee for all of its subclasses, so a partial migration leaves the rest inheriting a claim that is not true of them. `HttpAdapter`, `CoapAdapter`, `OpcUaAdapter`, `PsutilAdapter` and the whole MQTT family still set `_connected` directly, and a second `connect()` on any of them succeeded and overwrote the live adapter's configuration:

```text
True two http://127.0.0.1:10 True
```

All sixteen concrete adapters now use the guards, and a test enumerates `ori/hal/` with `pkgutil` and fails if a concrete `BaseAdapter` subclass is missing from the covered list, so a new adapter cannot inherit the guarantee silently.

`CoapAdapter` gains the most: it awaits a client context and then starts a background poll task, and its `close()` returned while both were still live and unreachable if a close overlapped a connect. `OpcUaAdapter` called `close()` from inside `connect()` on failure, which under the contract would deadlock on the lifecycle lock and record a close it never received; it tears down directly now. The five MQTT subclasses had one identical `close()` each, which now lives once on `MqttCachedAdapter`.

### The guarantee, stated where it is implemented

One lifecycle operation at a time per adapter. A connect that finds itself connected is refused before it touches state or reaches the device. A connect that was closed while it was connecting raises `AdapterConnectionError` and leaves the adapter disconnected and holding nothing, because a connect that was closed did not connect. A connect that fails for any reason gives back what it took.

The runtime consequence is written down too: a refused connect is not only logged, it records the sensor in `_unconnected_sensors` and calls `note_sensor_unavailable()`, so it tells a Tier D pair its measurement is gone. That is why the refusal has to be correct rather than merely tidy.

**An adapter must validate into locals and assign to `self` inside the `_connecting` body.** Assigning before it leaves a refused connect having already overwritten the live configuration: the adapter stays connected on the old handle while its fields name the new target, and `read()` then samples one device and labels the reading with another. `I2CAdapter` already did this; nothing else did.

**The close generation is sampled before the lock is requested**, not after it is won. A close arriving while an earlier connect holds the lock has already declared itself, and sampling after the wait loses that: a second connect queued behind the first would compare against a value the close had already bumped, find them equal, and report success for an adapter that close is about to tear down.

**A `release` that raises no longer replaces the failure that caused it.** It runs where an exception is already on its way to the caller, so it is logged rather than propagated; otherwise the caller sees a `RuntimeError` from cleanup in place of the `AdapterConnectionError` that says what went wrong, and the remaining resources are still held.

### The issue's adapter list was checked, not taken

#513 said five siblings shared the shape. Parsing each one's `connect` and `close` on `main`, two did:

| adapter | awaits during `connect` | at risk |
| --- | --- | --- |
| `serial_adapter` | yes | **yes** |
| `usb_serial_adapter` | yes | **yes** |
| `smart_adapter` | none | no |
| `growatt_adapter` | none | no |
| `solarman_modbus_adapter` | none | no |

Without a suspension point in `connect`, no close can interleave with it. `smart_adapter` awaits nothing in either method; `growatt_adapter` and `solarman_modbus_adapter` capture the client into a local and clear `self._client` before yielding, so their close releases only what it took. All of them adopt the contract anyway, because an `await` added to any of them later would otherwise reopen the race silently. The issue body has been corrected.

### #512, riding along

`I2CAdapter` tracked whether it held a reference on the shared `busio.I2C` with a boolean while the cache counted references. The two disagreed the moment one adapter acquired twice:

```text
after two acquires : refs {1: 2}, holds True
after one release  : refs {1: 1}, holds False   <- nobody can release this
```

The second reference became unreleasable by anything, pinning the cached handle for the life of the process so the next connect on that bus was handed a stale one. The adapter now counts what it holds and gives all of it back, which keeps the property the boolean was there for — it still cannot release a reference it never took, because it has none to give back. A second connect on a connected adapter is refused rather than tearing down first: reconnecting in place would take a second reference against one release and move a live adapter's device under readings already being taken from it.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

The HAL supplies the readings a Tier D condition is evaluated over, and a refused connect tells a safety pair its measurement is unavailable.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

[skip-cap-matrix] The capability matrix describes what the runtime can do, and this changes how adapters manage their own lifecycle rather than adding, removing or altering a capability. No row's claim becomes true or false.

## Related issue

Closes #512
Closes #513

## Testing notes

`tests/test_hal_lifecycle_contract.py` drives every adapter's **real** `connect()` with stubbed drivers, not the base class under six ids. An earlier version of these tests called `adapter._connecting(...)` directly and asserted on `inspect.getsource`; the contract could be dead-coded out of an adapter while keeping the literal source text and the whole suite still passed. It does not now: that mutation fails three named `growatt` tests.

Thirteen mutations, each killed by its own named test: the close-generation check removed, the generation sampled inside the lock rather than before it, the already-connected refusal removed, the release-on-exception removed, the release guard made to propagate, the lifecycle lock shared across a class, the contract dead-coded out of an adapter, configuration assigned before the guard again, `HttpAdapter` reverted to setting the flag itself, an adapter removed from the covered list, the CoAP teardown dropping its context shutdown, the shared-bus release giving back only one reference, and the duplicate-key refusal removed.

Two of those are earlier states of this change. `HttpAdapter` setting its own flag is the case an independent review reproduced against the unmigrated adapter; assigning before the guard is the state the first version of this PR shipped in for five adapters.

Concurrency was attacked directly rather than by inspection: close during connect at every await point, two concurrent connects, connect during close, three concurrent closes, close before any connect and twice more, a `release` that raises, `CancelledError` mid-open, repeated connect/close cycles, reuse after a failed connect, and the three-way connect/connect/close interleaving that the generation sample point exists for.

Full suite 5514 passed with 30 skipped; the lifecycle and I2C suites are 79 and 130. `ruff check`, `ruff format --check`, `mypy ori/` across 162 source files, `pyright` 0 errors on every changed file, and `pre-commit` are clean.

Host-only. No Raspberry Pi and no hardware: every driver is stubbed, so nothing here is HIL-proven. The shared-bus counter's `+=`/`-=` are written from a worker thread and read on the loop thread; the lifecycle lock serialises them, but that is established by inspection rather than by a stress test.
