### PR TITLE
feat(safety): escalate a measurement loss that does not resolve

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1926,3 +1926,54 @@ so a regression in the activation checks can no longer produce a false
 `protected` and a lying caller is refused. Drivability remains a constant, and
 the re-read status is still written only by the branch the earlier check gates.
 The gain is real and it is narrower than "every conjunct is independent".
+## 2026-09-05 — A withheld measurement escalates; it is never answered by a restart
+
+A device that cannot establish a trustworthy measurement reports it, degrades
+its health, and marks the affected safety pairs. What it must not do is treat
+its own liveness as the remedy. Two responses suggest themselves and both are
+rejected, on their own merits and not as a matter of sequencing.
+
+**A timed self-restart is rejected.** A restart clears the measurement
+quarantine and reconfigures the device while the competing writer may still be
+there, which is precisely the contest the quarantine refuses; losing it
+intermittently produces a plausible number rather than a refusal. It also makes
+the process boundary meaningless — the quarantine is process-scoped because a
+person is expected to intervene, and an automatic restart turns that into a
+retry loop with extra steps. And it repeats a mistake already withdrawn once: a
+restart taken to recover one sensor removes protection for every other active
+safety pair on the device for its duration, and a restart loop never restores
+it. Sensors are inputs; the protected thing is the commissioned zone-and-profile
+pair, and a restart takes all of them down together.
+
+**Coupling watchdog feeding to measurement health is rejected.** Withholding
+the feed does not report a problem, it resets the controller.
+`docs/evidence/2026-09-01-pi4-gpio-controller-loss.md` measured that a reset
+clears the driving pad and de-energises the coil, and states that a genuine
+watchdog reset was not among the conditions tested. What de-energising does to
+the protected circuit is commissioned per channel, and for a zone whose mapping
+makes `de_energised` the closed state, a watchdog reset reconnects the load at
+the exact moment the runtime cannot measure whether that is safe.
+
+**What is adopted instead is escalation, and escalation restores nothing.** A
+loss still present after a bounded period is re-notified on a slow cadence and
+escalates to the secondary contact: immediate to the primary, a primary
+reminder at six hours, the secondary at twelve, then daily. It is Tier A
+throughout, invents no physical authority, and travels the structural
+policy-exempt outbox so an entitlement cap cannot silence it. There is no
+give-up: a still-unprotected channel must not become permanently silent, so the
+schedule ends on credible recovery and on nothing else that is implemented
+today. The cadence is release-owned rather than site-configurable, because a
+setting would let a deployment configure a persistent loss into silence.
+
+**No text anywhere may describe escalation as restoring protection.** It tells a
+person that a channel is unprotected. It does not protect it.
+
+**Any reset-based response comes later, and only once platform qualification
+and HIL proof establish what a reset does to every relevant actuator, and
+commissioning establishes what that actuator state does to the site circuit.**
+That is the qualification fixture's work, not a runtime patch.
+
+This decision stands on its own and does not close
+`ori-platform/ori-runtime#510`, whose remaining scope is the pair-scoped
+supervision mechanism, its health and evidence state, the reset qualification
+boundary, and the connect-time contention case.

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -273,6 +273,62 @@ MEASUREMENT_WINDOWS_TO_RECOVER = 5
 # delivered or durably queued. Paced by the poll interval, and bounded so a
 # broken alert path does not retry forever on every refused window.
 MEASUREMENT_NOTIFY_MAX_ATTEMPTS = 5
+
+# The escalation schedule for a measurement loss that does not resolve, in
+# elapsed milliseconds since the degradation began.
+#
+# A device that cannot establish a trustworthy measurement said so once and
+# then waited indefinitely for a person. The first notice is not the problem;
+# the silence after it is, because a channel that is not being measured is a
+# channel nothing is protecting, and the operator has no reminder that it is
+# still in that state.
+#
+#   immediate   the primary contact, on the transition into degraded
+#   6 hours     the primary contact again
+#   12 hours    the secondary contact, or the primary where none is configured
+#   daily       the same escalation contact, indefinitely
+#
+# **There is no give-up.** A still-unprotected channel must not become
+# permanently silent, so nothing here stops on a message count or a delivery
+# cost. It stops when the sensor produces credible measurements again. Two
+# further stop conditions are sanctioned and neither is implemented: removal
+# of the affected safety pair, which belongs with the active-pair supervision
+# design, and a locally audited maintenance acknowledgement with a short
+# expiry, which needs an inbound, audited authority surface of its own. Until
+# they exist, recovery is the only way this stops, and an operator who has
+# accepted the fault keeps being reminded of it.
+#
+# Release-owned rather than site-configurable, deliberately. A setting here
+# would let a deployment configure a persistent measurement loss into silence,
+# which is the condition this schedule exists to prevent. Measure real pilot
+# message volume first; any later configuration must be a surface that cannot
+# disable, indefinitely defer, or remove the escalation.
+#
+# The cadence keeps message volume to two primary messages and then one daily
+# escalation, rather than repeating to everybody every day.
+MEASUREMENT_REMINDER_AFTER_MS = 6 * 60 * 60 * 1000
+MEASUREMENT_ESCALATE_AFTER_MS = 12 * 60 * 60 * 1000
+MEASUREMENT_ESCALATION_REPEAT_MS = 24 * 60 * 60 * 1000
+
+
+def measurement_notice_stage_due(elapsed_ms: int) -> int:
+    """Which notice the schedule owes at this point in a degradation.
+
+    Stage 0 is the notice sent on the transition itself. The schedule is a
+    function of elapsed time alone, never of what was delivered, so a reminder
+    that could not be sent is superseded by the next stage rather than
+    cancelling it.
+    """
+    if elapsed_ms < MEASUREMENT_REMINDER_AFTER_MS:
+        return 0
+    if elapsed_ms < MEASUREMENT_ESCALATE_AFTER_MS:
+        return 1
+    repeats = (elapsed_ms - MEASUREMENT_ESCALATE_AFTER_MS) // (
+        MEASUREMENT_ESCALATION_REPEAT_MS
+    )
+    return 2 + int(repeats)
+
+
 STALE_SENSOR_MAX_CHECK_INTERVAL_S = 30.0
 HEALTH_SOCKET_DEFAULT_PATH = "/run/ori/health.sock"
 
@@ -360,6 +416,7 @@ class OriRuntime:
         self._last_policy_refresh_transient_audit_ms: dict[str, int] = {}
         self._primary_alert_channel: str = "sms"
         self._operator_contact: str = ""
+        self._secondary_contact: str = ""
         self._sensor_poll_interval_ms: dict[str, int] = {}
         self._sensor_last_seen_ms: dict[str, int] = {}
         self._stale_sensor_active: set[str] = set()
@@ -374,6 +431,8 @@ class OriRuntime:
         self._unconnected_sensors: set[str] = set()
         self._measurement_unnotified: set[str] = set()
         self._measurement_notify_attempts: dict[str, int] = {}
+        self._measurement_degraded_since: dict[str, int] = {}
+        self._measurement_notice_stage: dict[str, int] = {}
         self._runtime_started_at_ms: int = 0
         self._configured_sensors: list[Any] = []
         self._connected_sensor_ids: set[str] = set()
@@ -865,6 +924,7 @@ class OriRuntime:
         primary_alert_channel = config.actions.primary_alert_channel
         self._primary_alert_channel = primary_alert_channel
         self._operator_contact = _operator_contact
+        self._secondary_contact = _secondary_contact
         self._configure_alert_outbox(config.actions.alert_outbox)
         alert_sender = AlertFailoverSender(
             primary_channel=primary_alert_channel,
@@ -1250,22 +1310,7 @@ class OriRuntime:
         self._stale_sensor_active = set()
         self._measurement_refusals = {}
         self._measurement_valid_streak = {}
-        # Restored rather than cleared. The alert fires on the transition into
-        # degradation, so an in-memory set emptied by every start would make a
-        # crash-looping runtime re-send the same warning after each restart.
-        restored = (
-            await self._state_store.get_measurement_degradation()
-            if self._state_store is not None
-            else {}
-        )
-        self._measurement_degraded = set(restored)
-        # A degradation whose warning never got out is still owed one. Losing
-        # that distinction would make the crash that prevented the alert the
-        # reason it is never sent.
-        self._measurement_unnotified = {
-            sensor_id for sensor_id, notified in restored.items() if not notified
-        }
-        self._measurement_notify_attempts = {}
+        await self._restore_measurement_state()
         self._last_alert_timestamps_by_channel = {}
         self._last_alert_timestamps_by_trigger = {}
 
@@ -3354,11 +3399,197 @@ class OriRuntime:
                         stale_after_ms=stale_after_ms,
                     )
 
+            await self._escalate_persistent_measurement_loss()
+
             try:
                 await asyncio.wait_for(self._shutdown_event.wait(), timeout=interval)
                 break
             except asyncio.TimeoutError:
                 pass
+
+    async def _restore_measurement_state(self) -> None:
+        """Rebuild every measurement-degradation fact from the state store.
+
+        Restored rather than cleared. The notice fires on the transition into
+        degradation, so an in-memory set emptied by every start would make a
+        crash-looping runtime re-send the same warning after each restart, and
+        a schedule reset by every start would postpone every escalation
+        forever on the same device.
+
+        One seam, called at startup and driven directly by the tests that
+        prove a restart behaves, so the durable join cannot drift from what
+        startup actually does.
+        """
+        restored = (
+            await self._state_store.get_measurement_degradation()
+            if self._state_store is not None
+            else {}
+        )
+        schedule = (
+            await self._state_store.get_measurement_notice_schedule()
+            if self._state_store is not None
+            else {}
+        )
+        self._measurement_degraded = set(restored)
+        self._measurement_degraded_since = {
+            sensor_id: since for sensor_id, (since, _) in schedule.items()
+        }
+        self._measurement_notice_stage = {
+            sensor_id: stage for sensor_id, (_, stage) in schedule.items()
+        }
+        # A degradation whose notice never got out is still owed one. Losing
+        # that distinction would make the crash that prevented the alert the
+        # reason it is never sent.
+        self._measurement_unnotified = {
+            sensor_id for sensor_id, notified in restored.items() if not notified
+        }
+        self._measurement_notify_attempts = {}
+
+    async def _escalate_persistent_measurement_loss(self) -> None:
+        """Re-notify, and escalate, while a measurement loss persists.
+
+        The first notice fires on the transition and is not repeated, so a
+        device that cannot establish a trustworthy measurement said so once
+        and then waited indefinitely for a person. This is what keeps saying
+        it.
+
+        It restores nothing. A channel that is not being measured is not being
+        protected, and telling somebody about it does not change that; the
+        notice exists so an operator can act, not so the device can claim to
+        have handled it.
+        """
+        now = now_ms()
+        for sensor_id in sorted(self._measurement_degraded):
+            since = self._measurement_degraded_since.get(sensor_id)
+            if since is None:
+                # Degraded with no recorded start. Anchor it here rather than
+                # treating it as owed every stage at once.
+                self._measurement_degraded_since[sensor_id] = now
+                continue
+            due = measurement_notice_stage_due(now - since)
+            if due <= self._measurement_notice_stage.get(sensor_id, 0):
+                continue
+            await self._send_measurement_escalation(
+                sensor_id=sensor_id,
+                stage=due,
+                elapsed_ms=now - since,
+                first_notice_delivered=sensor_id not in self._measurement_unnotified,
+            )
+
+    def _measurement_escalation_recipient(self, stage: int) -> str:
+        """Who a given stage is addressed to.
+
+        Stages 0 and 1 are the primary contact; from stage 2 the escalation
+        goes to the secondary contact, and to the primary again only where no
+        secondary is configured. A device with one contact is not left silent
+        because it has nobody to escalate to.
+        """
+        if stage >= 2 and self._secondary_contact:
+            return self._secondary_contact
+        return self._operator_contact
+
+    async def _send_measurement_escalation(
+        self,
+        *,
+        sensor_id: str,
+        stage: int,
+        elapsed_ms: int,
+        first_notice_delivered: bool,
+    ) -> None:
+        """Send one scheduled stage, and record it only if it got out.
+
+        The escalation runs whether or not the notice on the transition ever
+        reached anybody. An undelivered first notice is the case where an
+        operator knows least, so blocking the schedule on it would silence the
+        device precisely when its contact is unreachable — and the initial
+        notice's own retries are bounded, so the block would be permanent.
+        What changes is the wording: a stage that cannot assume the first
+        notice arrived states the fault rather than recalling one.
+        """
+        recipient = self._measurement_escalation_recipient(stage)
+        if self._alert_sender is None or not recipient:
+            logger.warning(
+                "[sensor] measurement escalation for %s not sent: "
+                "no alert sender or no recipient for stage %d",
+                sensor_id,
+                stage,
+            )
+            return
+        hours = elapsed_ms // (60 * 60 * 1000)
+        opening = (
+            f"Sensor {sensor_id} has still not produced a valid measurement "
+            f"after {hours} hours."
+            if first_notice_delivered
+            else (
+                f"Sensor {sensor_id} has not produced a valid measurement for "
+                f"{hours} hours. An earlier notice about it could not be "
+                "delivered."
+            )
+        )
+        message = (
+            f"{opening} Readings are not being published for it, and any "
+            "protection depending on them is not running. Nothing has been "
+            "restored. Check the sensor wiring and signal."
+        )
+        # Structural rather than policy-gated, for the same reason as the
+        # notice on the transition, and addressed to the escalation contact.
+        delivered = await self._send_or_queue_safety_alert(
+            message=message,
+            trigger_name=f"measurement_degraded_persists:{sensor_id}",
+            alert_sender=self._alert_sender,
+            recipient=recipient,
+        )
+        if not delivered:
+            # Left un-recorded so this stage is retried on the next pass, and
+            # superseded without ceremony when the next stage falls due. A
+            # reminder that could not be sent never cancels the escalation
+            # after it.
+            return
+        # Advanced in memory whether or not the write below lands, so a store
+        # that is failing does not turn every pass of the loop into another
+        # message. A restart then repeats at most this one stage.
+        self._measurement_notice_stage[sensor_id] = stage
+        recorded = True
+        if self._state_store is not None:
+            try:
+                # One write, not two, and an upsert rather than an update.
+                # Recording only the stage would leave the disk saying a later
+                # stage was sent while still saying nobody was notified, so
+                # the next start would send the notice for the transition all
+                # over again. And the row may not exist at all: the write that
+                # records the degradation is allowed to fail transiently, so
+                # an escalation can be the first one to land. It carries the
+                # in-memory start so a reconstructed row dates the loss to
+                # when it happened rather than to when the disk caught up.
+                await self._state_store.record_measurement_notice_delivered(
+                    sensor_id,
+                    stage,
+                    degraded_since=self._measurement_degraded_since.get(
+                        sensor_id, now_ms()
+                    ),
+                )
+            except Exception:
+                recorded = False
+                logger.exception(
+                    "[sensor] could not persist notice stage %d for %s; "
+                    "a restart may repeat this reminder",
+                    stage,
+                    sensor_id,
+                )
+        if recorded:
+            # Cleared only once the disk agrees. Clearing it on a failed write
+            # would leave memory saying the operator has been told and disk
+            # saying they have not, and the restart would resolve that
+            # disagreement by messaging them again.
+            self._measurement_unnotified.discard(sensor_id)
+            self._measurement_notify_attempts.pop(sensor_id, None)
+        logger.warning(
+            "[sensor] measurement loss for %s persists after %d hours; "
+            "stage %d notice sent",
+            sensor_id,
+            hours,
+            stage,
+        )
 
     async def _note_measurement_accepted(self, sensor_id: str) -> None:
         """A window that was a measurement. Counts toward clearing degradation."""
@@ -3379,6 +3610,8 @@ class OriRuntime:
         self._measurement_notify_attempts.pop(sensor_id, None)
         self._measurement_refusals.pop(sensor_id, None)
         self._measurement_valid_streak.pop(sensor_id, None)
+        self._measurement_degraded_since.pop(sensor_id, None)
+        self._measurement_notice_stage.pop(sensor_id, None)
         logger.info(
             "[sensor] %s measurement recovered after %d consecutive valid windows",
             sensor_id,
@@ -3417,6 +3650,8 @@ class OriRuntime:
             return
         self._measurement_degraded.add(sensor_id)
         self._measurement_unnotified.add(sensor_id)
+        self._measurement_degraded_since.setdefault(sensor_id, now_ms())
+        self._measurement_notice_stage[sensor_id] = 0
         # Recorded before the alert is attempted, and without letting a store
         # failure escape the poll loop: this runs inside an `except` clause, so
         # an exception here would not be caught by the handler below it and
@@ -3503,14 +3738,14 @@ class OriRuntime:
             "published for it, and any protection depending on them is not "
             "running. Check the sensor wiring and signal."
         )
+        # Structural rather than policy-gated. A notice that a protection is
+        # absent must not be suppressed by an entitlement cap: suppressing it
+        # leaves an operator believing a measurement is being taken that is
+        # not, which is the fact this notice exists to carry.
         return bool(
-            await self._send_or_queue_alert(
-                channel=self._primary_alert_channel,
+            await self._send_or_queue_safety_alert(
                 message=message,
-                recipient=self._operator_contact,
-                action_tier="A",
                 trigger_name=f"measurement_degraded:{sensor_id}",
-                original_ts=now_ms(),
                 alert_sender=self._alert_sender,
             )
         )
@@ -4178,6 +4413,7 @@ class OriRuntime:
         message: str,
         trigger_name: str,
         alert_sender: AlertFailoverSender,
+        recipient: str = "",
     ) -> bool:
         """Mandatory notices: delivery or durable queue, structurally outside
         DevicePolicy — no external-alert gate is consulted and no
@@ -4188,9 +4424,14 @@ class OriRuntime:
         suppressing it leaves an operator believing something is being watched
         that is not. The safety registry's sink is one. A configured sensor
         that never connected is the other, and it qualifies for the same
-        reason — the runtime cannot measure what it was told to measure.
+        reason — the runtime cannot measure what it was told to measure. A
+        persistent measurement loss is the third, and its escalation is why
+        `recipient` exists: from the second stage the notice is addressed to
+        the secondary contact, and it must stay on this route to get there.
+        An entitlement cap that silenced the escalation would leave exactly
+        the operator who has not acted still not knowing.
         Never reachable from skills or ordinary action execution."""
-        recipient = self._operator_contact
+        recipient = recipient or self._operator_contact
         if not recipient:
             logger.warning(
                 "[safety] notice not sent: operator_contact is not configured"

--- a/ori/state/store.py
+++ b/ori/state/store.py
@@ -627,6 +627,13 @@ CREATE TABLE IF NOT EXISTS sensor_measurement_state (
     -- collapsing them means a restart restores an unreported sensor as
     -- already reported, and the warning is suppressed permanently.
     notified_at   INTEGER,
+    -- When this degradation began, and how far its notification schedule has
+    -- run. The schedule advances on elapsed time rather than on delivery, so
+    -- a reminder that could not be sent never cancels the escalation after
+    -- it; both are persisted so a restart neither resets the clock nor
+    -- repeats a stage the operator already has.
+    degraded_since INTEGER,
+    notice_stage  INTEGER NOT NULL DEFAULT 0,
     updated_at    INTEGER NOT NULL
 );
 
@@ -898,6 +905,13 @@ class StateStore:
         ]
         for col, typedef in _new_reasoning_cols:
             self._add_column_if_missing_on_conn(conn, "reasoning_log", col, typedef)
+        for col, typedef in (
+            ("degraded_since", "INTEGER"),
+            ("notice_stage", "INTEGER NOT NULL DEFAULT 0"),
+        ):
+            self._add_column_if_missing_on_conn(
+                conn, "sensor_measurement_state", col, typedef
+            )
         self._add_column_if_missing_on_conn(
             conn,
             "action_log",
@@ -6047,6 +6061,116 @@ class StateStore:
         ).fetchall()
         return {str(row[0]): row[1] is not None for row in rows}
 
+    async def get_measurement_notice_schedule(self) -> dict[str, tuple[int, int]]:
+        """Per degraded sensor, when it began and which notice stage it reached.
+
+        Restored at startup so the escalation schedule survives a restart: the
+        clock is not reset, and a stage already delivered is not repeated.
+        """
+        return await self._run_read(self._get_measurement_notice_schedule_sync)
+
+    def _get_measurement_notice_schedule_sync(
+        self, conn: sqlite3.Connection
+    ) -> dict[str, tuple[int, int]]:
+        rows = conn.execute(
+            "SELECT sensor_id, degraded_since, updated_at, notice_stage "
+            "FROM sensor_measurement_state WHERE degraded = 1"
+        ).fetchall()
+        # `degraded_since` is absent on a row written before this column
+        # existed. Falling back to `updated_at` dates the degradation to the
+        # last write rather than inventing "now", so an upgrade does not
+        # restart the schedule from zero for a sensor already long degraded.
+        return {
+            str(row[0]): (
+                int(row[1] if row[1] is not None else row[2]),
+                int(row[3] or 0),
+            )
+            for row in rows
+        }
+
+    async def set_measurement_notice_stage(self, sensor_id: str, stage: int) -> None:
+        """Record the highest notification stage this degradation has reached."""
+        await self._run_write(self._set_measurement_notice_stage_sync, sensor_id, stage)
+
+    def _set_measurement_notice_stage_sync(self, sensor_id: str, stage: int) -> None:
+        assert self._conn is not None
+        self._conn.execute(
+            "UPDATE sensor_measurement_state SET notice_stage = ?, updated_at = ? "
+            "WHERE sensor_id = ?",
+            (int(stage), now_ms(), sensor_id),
+        )
+        self._conn.commit()
+
+    async def record_measurement_notice_delivered(
+        self, sensor_id: str, stage: int, *, degraded_since: int
+    ) -> None:
+        """Record a delivered notice: the degradation, the stage, and that it went.
+
+        One statement, one commit. Written separately, a crash between them
+        leaves the disk saying a later stage was sent while still saying
+        nobody was notified, and the next start sends the notice for the
+        transition all over again — which is the duplicate message this state
+        exists to prevent.
+
+        An upsert rather than an update, because the row may not exist. The
+        write that records the degradation can itself fail — the store is
+        allowed to be transiently unavailable, and a failure there is logged
+        and does not stop polling — so a later escalation can be the first
+        write that lands. An `UPDATE` would match nothing, raise nothing, and
+        leave the runtime believing the operator had been told about a
+        degradation the disk has no record of at all: the next start would
+        find no degraded sensor and forget the measurement loss entirely.
+
+        `degraded_since` comes from the runtime's in-memory value so a
+        reconstructed row carries the real start of the loss rather than the
+        moment the disk caught up, and the schedule does not restart. Where
+        the row already exists, its own start and `notified_at` are kept: the
+        latter marks *that* the operator has been told, not when they were
+        last told, and the stage carries the schedule's own position.
+        """
+        await self._run_write(
+            self._record_measurement_notice_delivered_sync,
+            sensor_id,
+            stage,
+            degraded_since,
+        )
+
+    def _record_measurement_notice_delivered_sync(
+        self, sensor_id: str, stage: int, degraded_since: int
+    ) -> None:
+        assert self._conn is not None
+        now = now_ms()
+        cursor = self._conn.execute(
+            """
+            INSERT INTO sensor_measurement_state
+                (sensor_id, degraded, notified_at, degraded_since,
+                 notice_stage, updated_at)
+            VALUES (?, 1, ?, ?, ?, ?)
+            ON CONFLICT(sensor_id) DO UPDATE SET
+                degraded = 1,
+                notified_at = COALESCE(
+                    sensor_measurement_state.notified_at, excluded.notified_at
+                ),
+                degraded_since = COALESCE(
+                    sensor_measurement_state.degraded_since, excluded.degraded_since
+                ),
+                notice_stage = excluded.notice_stage,
+                updated_at = excluded.updated_at
+            """,
+            (sensor_id, now, int(degraded_since), int(stage), now),
+        )
+        if cursor.rowcount != 1:
+            # Unreachable while the statement above is an upsert, which always
+            # affects exactly one row. It is here so that a return to a plain
+            # `UPDATE` fails closed rather than silently: that statement
+            # matches nothing when the row is absent, raises nothing, and the
+            # caller would mark an operator as told about a degradation the
+            # disk has no record of. Nothing written means nothing recorded,
+            # and the caller keeps the obligation.
+            self._conn.rollback()
+            raise RuntimeError(f"measurement notice for {sensor_id!r} was not recorded")
+        self._conn.commit()
+
     async def set_measurement_degraded(self, sensor_id: str, *, notified: bool) -> None:
         """Record a degradation, and separately whether it has been reported."""
         await self._run_write(self._set_measurement_degraded_sync, sensor_id, notified)
@@ -6057,10 +6181,16 @@ class StateStore:
         self._conn.execute(
             """
             INSERT INTO sensor_measurement_state
-                (sensor_id, degraded, notified_at, updated_at)
-            VALUES (?, 1, ?, ?)
+                (sensor_id, degraded, notified_at, degraded_since, updated_at)
+            VALUES (?, 1, ?, ?, ?)
             ON CONFLICT(sensor_id) DO UPDATE SET
                 degraded = 1,
+                -- The start of the degradation, not of the latest write: the
+                -- escalation schedule is measured from when measurement was
+                -- lost, so a second write must not move it forward.
+                degraded_since = COALESCE(
+                    sensor_measurement_state.degraded_since, excluded.degraded_since
+                ),
                 -- Once reported, stays reported. A later write that has not
                 -- itself notified must not reopen the alert.
                 notified_at = COALESCE(
@@ -6068,7 +6198,7 @@ class StateStore:
                 ),
                 updated_at = excluded.updated_at
             """,
-            (sensor_id, now if notified else None, now),
+            (sensor_id, now if notified else None, now, now),
         )
         self._conn.commit()
 
@@ -6081,11 +6211,13 @@ class StateStore:
         self._conn.execute(
             """
             INSERT INTO sensor_measurement_state
-                (sensor_id, degraded, notified_at, updated_at)
-            VALUES (?, 0, NULL, ?)
+                (sensor_id, degraded, notified_at, degraded_since, updated_at)
+            VALUES (?, 0, NULL, NULL, ?)
             ON CONFLICT(sensor_id) DO UPDATE SET
                 degraded = 0,
                 notified_at = NULL,
+                degraded_since = NULL,
+                notice_stage = 0,
                 updated_at = excluded.updated_at
             """,
             (sensor_id, now_ms()),

--- a/tests/test_ac_measurement.py
+++ b/tests/test_ac_measurement.py
@@ -8,11 +8,38 @@ the decision to accept or refuse a window can be driven exactly.
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import math
+import sys
+from typing import Any, cast
 
 import pytest
 
+from ori.actions.alert_failover import AlertFailoverSender
 from ori.hal.ac_measurement import WindowRefusedError, WindowSpec, summarise_window
+
+
+@contextlib.contextmanager
+def _frozen_at(elapsed_ms: int):
+    """Hold `ori.runtime.now_ms` at one instant.
+
+    The schedule is a function of elapsed time, so every escalation test has
+    to say what time it is. The module is resolved through `sys.modules`
+    rather than imported a second time under an alias, since this file
+    already imports from it.
+    """
+    # `sys.modules` is typed as a plain module, so the attribute this needs to
+    # swap is invisible to the checker; resolved through it rather than
+    # imported a second time under an alias.
+    module = cast(Any, sys.modules["ori.runtime"])
+    original = module.now_ms
+    module.now_ms = lambda: int(elapsed_ms)
+    try:
+        yield
+    finally:
+        module.now_ms = original
+
 
 SPEC = WindowSpec(
     mains_frequency_hz=50.0,
@@ -363,7 +390,7 @@ class _EscalationHarness:
         self.runtime._measurement_notice_stage = {"load-current": 0}
         self.runtime._measurement_notify_attempts = {}
         self.runtime._state_store = None
-        self.runtime._alert_sender = object()
+        self.runtime._alert_sender = cast(AlertFailoverSender, object())
         self.runtime._operator_contact = "+2340000000000"
         self.runtime._secondary_contact = secondary
         self.runtime._primary_alert_channel = "sms"
@@ -388,14 +415,8 @@ class _EscalationHarness:
         self.runtime._send_or_queue_alert = _policy_gated  # type: ignore[method-assign]
 
     async def tick(self, at_hours: float) -> None:
-        import ori.runtime as runtime_module
-
-        original = runtime_module.now_ms
-        runtime_module.now_ms = lambda: int(at_hours * 60 * 60 * 1000)
-        try:
+        with _frozen_at(int(at_hours * 60 * 60 * 1000)):
             await self.runtime._escalate_persistent_measurement_loss()
-        finally:
-            runtime_module.now_ms = original
 
 
 def test_the_schedule_is_a_function_of_elapsed_time_alone():
@@ -546,15 +567,12 @@ async def test_the_reminder_never_claims_anything_was_restored():
 async def test_the_staleness_loop_drives_the_escalation():
     """The join, not the mechanism.
 
-    Everything above calls `_escalate_persistent_measurement_loss` directly,
-    so removing its one call site left the whole suite green while a
-    persistent measurement loss went back to being reported once and then
-    forgotten.
+    Every other escalation test reaches
+    `_escalate_persistent_measurement_loss` directly, so none of them
+    observes that anything calls it. Without this one, deleting its call site
+    would leave a persistent measurement loss reported once and then
+    forgotten while the rest of the suite stayed green.
     """
-    import asyncio
-
-    import ori.runtime as runtime_module
-
     harness = _EscalationHarness()
     runtime = harness.runtime
     runtime._sensor_poll_interval_ms = {}
@@ -562,12 +580,11 @@ async def test_the_staleness_loop_drives_the_escalation():
     runtime._stale_sensor_active = set()
     runtime._shutdown_event = asyncio.Event()
 
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(12 * 60 * 60 * 1000):
         task = asyncio.create_task(
             runtime._sensor_staleness_loop(
-                alert_sender=object(), check_interval_s=3600.0
+                alert_sender=cast(AlertFailoverSender, object()),
+                check_interval_s=3600.0,
             )
         )
         for _ in range(20):
@@ -576,8 +593,6 @@ async def test_the_staleness_loop_drives_the_escalation():
                 break
         runtime._shutdown_event.set()
         await asyncio.wait_for(task, 5)
-    finally:
-        runtime_module.now_ms = original
 
     assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
 
@@ -665,8 +680,6 @@ async def test_the_runtime_restores_the_schedule_and_sends_the_stage_that_is_due
     would let the durable join drift from what a restart actually does and
     the test would not notice.
     """
-    import ori.runtime as runtime_module
-
     store = await _store(tmp_path)
     await store.set_measurement_degraded("load-current", notified=True)
     began = (await store.get_measurement_notice_schedule())["load-current"][0]
@@ -683,12 +696,8 @@ async def test_the_runtime_restores_the_schedule_and_sends_the_stage_that_is_due
     assert runtime._measurement_notice_stage == {"load-current": 1}
     assert runtime._measurement_unnotified == set()
 
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(began + 12 * 60 * 60 * 1000):
         await runtime._escalate_persistent_measurement_loss()
-    finally:
-        runtime_module.now_ms = original
 
     # Stage 1 was sent before the restart and is not repeated; stage 2 is due
     # and goes to the secondary contact.
@@ -709,8 +718,6 @@ async def test_a_delivered_escalation_stops_the_initial_notice_being_retried(
     warning again — to the primary, about a fault the secondary already has,
     at the cost of another message.
     """
-    import ori.runtime as runtime_module
-
     store = await _store(tmp_path)
     # The transition: degraded, and the notice did not get out.
     await store.set_measurement_degraded("load-current", notified=False)
@@ -722,12 +729,8 @@ async def test_a_delivered_escalation_stops_the_initial_notice_being_retried(
     await runtime._restore_measurement_state()
     assert runtime._measurement_unnotified == {"load-current"}
 
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(began + 12 * 60 * 60 * 1000):
         await runtime._escalate_persistent_measurement_loss()
-    finally:
-        runtime_module.now_ms = original
 
     assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
     assert runtime._measurement_unnotified == set()
@@ -769,7 +772,7 @@ async def test_the_notice_on_the_transition_is_policy_exempt() -> None:
     from ori.runtime import OriRuntime
 
     runtime = OriRuntime.__new__(OriRuntime)
-    runtime._alert_sender = object()
+    runtime._alert_sender = cast(AlertFailoverSender, object())
     runtime._operator_contact = "+2340000000000"
     runtime._primary_alert_channel = "sms"
     structural: list[str] = []
@@ -830,8 +833,6 @@ async def test_a_failed_record_leaves_the_operator_still_owed_the_notice(
     owed the notice on the transition, so the initial retry keeps owning this
     sensor rather than the runtime believing a message got out that did not.
     """
-    import ori.runtime as runtime_module
-
     store = await _store(tmp_path)
     await store.set_measurement_degraded("load-current", notified=False)
     began = (await store.get_measurement_notice_schedule())["load-current"][0]
@@ -846,12 +847,8 @@ async def test_a_failed_record_leaves_the_operator_still_owed_the_notice(
 
     store.record_measurement_notice_delivered = _fails  # type: ignore[method-assign]
 
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(began + 12 * 60 * 60 * 1000):
         await runtime._escalate_persistent_measurement_loss()
-    finally:
-        runtime_module.now_ms = original
 
     assert len(harness.sent) == 1
     assert runtime._measurement_unnotified == {"load-current"}
@@ -868,8 +865,6 @@ async def test_a_failing_store_does_not_turn_every_pass_into_another_message(
     Otherwise a store that is failing makes the loop resend the same stage on
     every pass, which is a message flood rather than a bounded repeat.
     """
-    import ori.runtime as runtime_module
-
     store = await _store(tmp_path)
     await store.set_measurement_degraded("load-current", notified=True)
     began = (await store.get_measurement_notice_schedule())["load-current"][0]
@@ -884,14 +879,10 @@ async def test_a_failing_store_does_not_turn_every_pass_into_another_message(
 
     store.record_measurement_notice_delivered = _fails  # type: ignore[method-assign]
 
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(began + 12 * 60 * 60 * 1000):
         await runtime._escalate_persistent_measurement_loss()
         await runtime._escalate_persistent_measurement_loss()
         await runtime._escalate_persistent_measurement_loss()
-    finally:
-        runtime_module.now_ms = original
 
     assert len(harness.sent) == 1
     await store.close()
@@ -910,8 +901,6 @@ async def test_an_escalation_reconstructs_a_row_the_first_write_never_created(
     a degradation the disk has never heard of; the next start finds no
     degraded sensor and forgets the measurement loss entirely.
     """
-    import ori.runtime as runtime_module
-
     store = await _store(tmp_path)
     harness = _EscalationHarness()
     runtime = harness.runtime
@@ -926,12 +915,8 @@ async def test_an_escalation_reconstructs_a_row_the_first_write_never_created(
     assert await store.get_measurement_degradation() == {}
 
     # The store recovers, and the twelve-hour escalation is delivered.
-    original = runtime_module.now_ms
-    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
-    try:
+    with _frozen_at(began + 12 * 60 * 60 * 1000):
         await runtime._escalate_persistent_measurement_loss()
-    finally:
-        runtime_module.now_ms = original
 
     assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
     await store.close()

--- a/tests/test_ac_measurement.py
+++ b/tests/test_ac_measurement.py
@@ -159,6 +159,9 @@ class _Runtime:
         self.runtime._measurement_degraded = set()
         self.runtime._measurement_unnotified = set()
         self.runtime._measurement_notify_attempts = {}
+        self.runtime._measurement_degraded_since = {}
+        self.runtime._measurement_notice_stage = {}
+        self.runtime._secondary_contact = ""
         self.runtime._alert_sender = None
         self.runtime._state_store = None
         self.runtime._operator_contact = "+2340000000000"
@@ -337,3 +340,632 @@ async def test_repeated_writes_are_idempotent(tmp_path) -> None:
         await store.clear_measurement_degraded("load-current")
     assert await store.get_measurement_degradation() == {}
     await store.close()
+
+
+# ─── Persistent measurement loss escalates (ori-platform/ori-runtime#510) ──────
+
+
+class _EscalationHarness:
+    """The escalation schedule, driven directly off `OriRuntime`.
+
+    A device that could not establish a trustworthy measurement said so once
+    and then waited indefinitely for a person. These drive what keeps saying
+    it, and to whom.
+    """
+
+    def __init__(self, *, secondary: str = "+2349999999999") -> None:
+        from ori.runtime import OriRuntime
+
+        self.runtime = OriRuntime.__new__(OriRuntime)
+        self.runtime._measurement_degraded = {"load-current"}
+        self.runtime._measurement_unnotified = set()
+        self.runtime._measurement_degraded_since = {"load-current": 0}
+        self.runtime._measurement_notice_stage = {"load-current": 0}
+        self.runtime._measurement_notify_attempts = {}
+        self.runtime._state_store = None
+        self.runtime._alert_sender = object()
+        self.runtime._operator_contact = "+2340000000000"
+        self.runtime._secondary_contact = secondary
+        self.runtime._primary_alert_channel = "sms"
+        self.sent: list[tuple[str, str]] = []
+        self.deliverable = True
+
+        async def _send(**kwargs: object) -> bool:
+            if not self.deliverable:
+                return False
+            self.sent.append((str(kwargs["recipient"]), str(kwargs["message"])))
+            return True
+
+        # The structural, policy-exempt route. An entitlement cap must not be
+        # able to silence a notice that a channel is not being measured.
+        self.runtime._send_or_queue_safety_alert = _send  # type: ignore[method-assign]
+
+        async def _policy_gated(**kwargs: object) -> bool:
+            raise AssertionError(
+                "measurement escalation must not use the policy-gated path"
+            )
+
+        self.runtime._send_or_queue_alert = _policy_gated  # type: ignore[method-assign]
+
+    async def tick(self, at_hours: float) -> None:
+        import ori.runtime as runtime_module
+
+        original = runtime_module.now_ms
+        runtime_module.now_ms = lambda: int(at_hours * 60 * 60 * 1000)
+        try:
+            await self.runtime._escalate_persistent_measurement_loss()
+        finally:
+            runtime_module.now_ms = original
+
+
+def test_the_schedule_is_a_function_of_elapsed_time_alone():
+    """Stage 0 immediate, 1 at six hours, 2 at twelve, then daily."""
+    from ori.runtime import measurement_notice_stage_due as due
+
+    hour = 60 * 60 * 1000
+    assert due(0) == 0
+    assert due(5 * hour) == 0
+    assert due(6 * hour) == 1
+    assert due(11 * hour) == 1
+    assert due(12 * hour) == 2
+    assert due(35 * hour) == 2
+    assert due(36 * hour) == 3
+    assert due(60 * hour) == 4
+    # No terminal stage: a still-unprotected channel never becomes silent.
+    assert due(365 * 24 * hour) > 300
+
+
+async def test_a_reminder_goes_to_the_primary_contact_at_six_hours():
+    harness = _EscalationHarness()
+
+    await harness.tick(1)
+    assert harness.sent == []
+
+    await harness.tick(6)
+    assert [recipient for recipient, _ in harness.sent] == ["+2340000000000"]
+
+
+async def test_the_escalation_goes_to_the_secondary_contact_at_twelve_hours():
+    harness = _EscalationHarness()
+    await harness.tick(6)
+    harness.sent.clear()
+
+    await harness.tick(12)
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+
+
+async def test_the_escalation_repeats_daily_to_the_secondary_contact():
+    harness = _EscalationHarness()
+    await harness.tick(12)
+    harness.sent.clear()
+
+    await harness.tick(35)
+    assert harness.sent == []
+
+    await harness.tick(36)
+    await harness.tick(60)
+
+    assert [recipient for recipient, _ in harness.sent] == [
+        "+2349999999999",
+        "+2349999999999",
+    ]
+
+
+async def test_a_device_with_no_secondary_contact_still_escalates():
+    """One contact is not a reason to go silent about an unprotected channel."""
+    harness = _EscalationHarness(secondary="")
+
+    await harness.tick(12)
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2340000000000"]
+
+
+async def test_a_stage_is_resent_until_it_gets_out():
+    harness = _EscalationHarness()
+    harness.deliverable = False
+
+    await harness.tick(6)
+    assert harness.sent == []
+    assert harness.runtime._measurement_notice_stage["load-current"] == 0
+
+    harness.deliverable = True
+    await harness.tick(7)
+
+    assert len(harness.sent) == 1
+
+
+async def test_an_undelivered_reminder_does_not_cancel_the_next_escalation():
+    """The schedule advances on time, not on delivery.
+
+    Otherwise a device whose six-hour reminder could not be sent would never
+    reach the twelve-hour escalation, and the one operator who was already
+    unreachable would be the only one ever told.
+    """
+    harness = _EscalationHarness()
+    harness.deliverable = False
+    await harness.tick(6)
+    assert harness.sent == []
+
+    harness.deliverable = True
+    await harness.tick(12)
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+
+
+async def test_the_escalation_runs_even_when_the_first_notice_never_got_out():
+    """The case where the operator knows least must not be the silent one.
+
+    The notice on the transition has bounded retries, so blocking the
+    schedule until it succeeds makes the block permanent once they are spent:
+    a device whose primary contact is unreachable would never reach the
+    secondary at all.
+    """
+    harness = _EscalationHarness()
+    harness.runtime._measurement_unnotified = {"load-current"}
+
+    await harness.tick(12)
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+
+
+async def test_a_stage_states_the_fault_when_the_first_notice_was_not_delivered():
+    """It cannot recall a notice nobody received."""
+    harness = _EscalationHarness()
+    harness.runtime._measurement_unnotified = {"load-current"}
+
+    await harness.tick(12)
+
+    message = harness.sent[0][1]
+    assert "could not be delivered" in message
+    assert "still not produced" not in message
+
+
+async def test_a_degradation_with_no_recorded_start_is_anchored_not_flooded():
+    harness = _EscalationHarness()
+    harness.runtime._measurement_degraded_since = {}
+
+    await harness.tick(48)
+
+    assert harness.sent == []
+    assert harness.runtime._measurement_degraded_since["load-current"] == 48 * 3600000
+
+
+async def test_the_reminder_never_claims_anything_was_restored():
+    harness = _EscalationHarness()
+
+    await harness.tick(12)
+
+    message = harness.sent[0][1]
+    assert "Nothing has been restored" in message
+    assert "not running" in message
+    for word in ("restored protection", "resolved", "recovered", "fixed"):
+        assert word not in message.lower().replace("nothing has been restored", "")
+
+
+async def test_the_staleness_loop_drives_the_escalation():
+    """The join, not the mechanism.
+
+    Everything above calls `_escalate_persistent_measurement_loss` directly,
+    so removing its one call site left the whole suite green while a
+    persistent measurement loss went back to being reported once and then
+    forgotten.
+    """
+    import asyncio
+
+    import ori.runtime as runtime_module
+
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._sensor_poll_interval_ms = {}
+    runtime._sensor_last_seen_ms = {}
+    runtime._stale_sensor_active = set()
+    runtime._shutdown_event = asyncio.Event()
+
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: 12 * 60 * 60 * 1000
+    try:
+        task = asyncio.create_task(
+            runtime._sensor_staleness_loop(
+                alert_sender=object(), check_interval_s=3600.0
+            )
+        )
+        for _ in range(20):
+            await asyncio.sleep(0)
+            if harness.sent:
+                break
+        runtime._shutdown_event.set()
+        await asyncio.wait_for(task, 5)
+    finally:
+        runtime_module.now_ms = original
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+
+
+async def test_the_notice_schedule_survives_a_reopen(tmp_path) -> None:
+    """A restart must not restart the escalation clock.
+
+    Without persistence a crash-looping device postpones every escalation
+    forever: each start re-anchors the degradation to now, and the six-hour
+    reminder is never due.
+    """
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=True)
+    await store.set_measurement_notice_stage("load-current", 2)
+    schedule = await store.get_measurement_notice_schedule()
+    began, stage = schedule["load-current"]
+    await store.close()
+
+    reopened = await _store(tmp_path)
+    try:
+        assert await reopened.get_measurement_notice_schedule() == {
+            "load-current": (began, 2)
+        }
+    finally:
+        await reopened.close()
+    assert stage == 2
+
+
+async def test_a_second_degradation_write_does_not_move_the_start(tmp_path) -> None:
+    """The schedule is measured from when measurement was lost."""
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=False)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+
+    await store.set_measurement_degraded("load-current", notified=True)
+
+    assert (await store.get_measurement_notice_schedule())["load-current"][0] == began
+    await store.close()
+
+
+async def test_recovery_clears_the_schedule(tmp_path) -> None:
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=True)
+    await store.set_measurement_notice_stage("load-current", 3)
+
+    await store.clear_measurement_degraded("load-current")
+
+    assert await store.get_measurement_notice_schedule() == {}
+    await store.close()
+
+
+async def test_a_row_written_before_the_schedule_columns_dates_from_its_last_write(
+    tmp_path,
+) -> None:
+    """An upgrade must not restart the schedule for an already-degraded sensor.
+
+    A row from before these columns existed carries no start, so it is dated
+    to its last write rather than to now. Dating it to now would postpone
+    every escalation by the age of the degradation, on exactly the devices
+    that have been unprotected longest.
+    """
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=True)
+    legacy_updated_at = 1_700_000_000_000
+    store._conn.execute(  # type: ignore[union-attr]
+        "UPDATE sensor_measurement_state SET degraded_since = NULL, "
+        "notice_stage = 0, updated_at = ? WHERE sensor_id = ?",
+        (legacy_updated_at, "load-current"),
+    )
+    store._conn.commit()  # type: ignore[union-attr]
+
+    assert await store.get_measurement_notice_schedule() == {
+        "load-current": (legacy_updated_at, 0)
+    }
+    await store.close()
+
+
+async def test_the_runtime_restores_the_schedule_and_sends_the_stage_that_is_due(
+    tmp_path,
+) -> None:
+    """Store write, reopen, restoration through the startup seam, next stage.
+
+    Driven through `_restore_measurement_state`, the same call startup makes,
+    rather than by reassigning the fields it sets. Rebuilding them by hand
+    would let the durable join drift from what a restart actually does and
+    the test would not notice.
+    """
+    import ori.runtime as runtime_module
+
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=True)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+    await store.set_measurement_notice_stage("load-current", 1)
+    await store.close()
+
+    reopened = await _store(tmp_path)
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._state_store = reopened
+    await runtime._restore_measurement_state()
+
+    assert runtime._measurement_degraded == {"load-current"}
+    assert runtime._measurement_notice_stage == {"load-current": 1}
+    assert runtime._measurement_unnotified == set()
+
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
+    try:
+        await runtime._escalate_persistent_measurement_loss()
+    finally:
+        runtime_module.now_ms = original
+
+    # Stage 1 was sent before the restart and is not repeated; stage 2 is due
+    # and goes to the secondary contact.
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+    assert (await reopened.get_measurement_notice_schedule())["load-current"][1] == 2
+    await reopened.close()
+
+
+async def test_a_delivered_escalation_stops_the_initial_notice_being_retried(
+    tmp_path,
+) -> None:
+    """Failed initial, delivered secondary, restart, further refusal.
+
+    The initial notice to the primary contact never got out, so the
+    degradation is recorded un-notified. The twelve-hour escalation reaches
+    the secondary contact. If only the stage were recorded, a restart would
+    find the degradation still marked un-notified and send the initial
+    warning again — to the primary, about a fault the secondary already has,
+    at the cost of another message.
+    """
+    import ori.runtime as runtime_module
+
+    store = await _store(tmp_path)
+    # The transition: degraded, and the notice did not get out.
+    await store.set_measurement_degraded("load-current", notified=False)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._state_store = store
+    await runtime._restore_measurement_state()
+    assert runtime._measurement_unnotified == {"load-current"}
+
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
+    try:
+        await runtime._escalate_persistent_measurement_loss()
+    finally:
+        runtime_module.now_ms = original
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+    assert runtime._measurement_unnotified == set()
+    await store.close()
+
+    # Restart, and a further refused window.
+    reopened = await _store(tmp_path)
+    restarted = _EscalationHarness()
+    restarted.runtime._state_store = reopened
+    await restarted.runtime._restore_measurement_state()
+
+    assert restarted.runtime._measurement_unnotified == set()
+
+    initial_notices: list[str] = []
+
+    async def _initial(**kwargs: object) -> bool:
+        initial_notices.append(str(kwargs.get("sensor_id")))
+        return True
+
+    restarted.runtime._emit_measurement_degraded_warning = _initial  # type: ignore[method-assign]
+    restarted.runtime._measurement_refusals = {"load-current": 9}
+    restarted.runtime._measurement_valid_streak = {}
+    await restarted.runtime._note_measurement_refusal(
+        sensor_id="load-current", detail="still refused"
+    )
+
+    assert initial_notices == []
+
+
+async def test_the_notice_on_the_transition_is_policy_exempt() -> None:
+    """An entitlement cap must not silence it.
+
+    `DevicePolicy` can suppress an ordinary Tier A alert at a monthly cap.
+    Suppressing this one leaves an operator believing a measurement is being
+    taken that is not, which is the fact the notice exists to carry, so it
+    takes the structural route that consults no policy and moves no
+    policy-counted counter.
+    """
+    from ori.runtime import OriRuntime
+
+    runtime = OriRuntime.__new__(OriRuntime)
+    runtime._alert_sender = object()
+    runtime._operator_contact = "+2340000000000"
+    runtime._primary_alert_channel = "sms"
+    structural: list[str] = []
+
+    async def _structural(**kwargs: object) -> bool:
+        structural.append(str(kwargs["trigger_name"]))
+        return True
+
+    async def _policy_gated(**kwargs: object) -> bool:
+        raise AssertionError(
+            "the measurement degradation notice must not consult DevicePolicy"
+        )
+
+    runtime._send_or_queue_safety_alert = _structural  # type: ignore[method-assign]
+    runtime._send_or_queue_alert = _policy_gated  # type: ignore[method-assign]
+
+    sent = await runtime._emit_measurement_degraded_warning(
+        sensor_id="load-current", refusals=3
+    )
+
+    assert sent is True
+    assert structural == ["measurement_degraded:load-current"]
+
+
+async def test_the_stage_and_the_notified_mark_are_written_together(tmp_path) -> None:
+    """One transaction, so a crash cannot land half of it.
+
+    Written as two statements, an interruption between them leaves the disk
+    saying a later stage was sent while still saying nobody was notified, and
+    the next start sends the notice for the transition again.
+    """
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=False)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+    assert await store.get_measurement_degradation() == {"load-current": False}
+
+    await store.record_measurement_notice_delivered(
+        "load-current", 2, degraded_since=began
+    )
+
+    await store.close()
+    reopened = await _store(tmp_path)
+    try:
+        assert await reopened.get_measurement_degradation() == {"load-current": True}
+        assert (await reopened.get_measurement_notice_schedule())["load-current"][
+            1
+        ] == 2
+    finally:
+        await reopened.close()
+
+
+async def test_a_failed_record_leaves_the_operator_still_owed_the_notice(
+    tmp_path,
+) -> None:
+    """The split failure, forced: the write does not land at all.
+
+    Neither disk fact moves, and the in-memory set still says the operator is
+    owed the notice on the transition, so the initial retry keeps owning this
+    sensor rather than the runtime believing a message got out that did not.
+    """
+    import ori.runtime as runtime_module
+
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=False)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._state_store = store
+    await runtime._restore_measurement_state()
+
+    async def _fails(sensor_id: str, stage: int, *, degraded_since: int) -> None:
+        raise RuntimeError("disk gone")
+
+    store.record_measurement_notice_delivered = _fails  # type: ignore[method-assign]
+
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
+    try:
+        await runtime._escalate_persistent_measurement_loss()
+    finally:
+        runtime_module.now_ms = original
+
+    assert len(harness.sent) == 1
+    assert runtime._measurement_unnotified == {"load-current"}
+    assert await store.get_measurement_degradation() == {"load-current": False}
+    assert (await store.get_measurement_notice_schedule())["load-current"][1] == 0
+    await store.close()
+
+
+async def test_a_failing_store_does_not_turn_every_pass_into_another_message(
+    tmp_path,
+) -> None:
+    """The stage advances in memory even when the write fails.
+
+    Otherwise a store that is failing makes the loop resend the same stage on
+    every pass, which is a message flood rather than a bounded repeat.
+    """
+    import ori.runtime as runtime_module
+
+    store = await _store(tmp_path)
+    await store.set_measurement_degraded("load-current", notified=True)
+    began = (await store.get_measurement_notice_schedule())["load-current"][0]
+
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._state_store = store
+    await runtime._restore_measurement_state()
+
+    async def _fails(sensor_id: str, stage: int, *, degraded_since: int) -> None:
+        raise RuntimeError("disk gone")
+
+    store.record_measurement_notice_delivered = _fails  # type: ignore[method-assign]
+
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
+    try:
+        await runtime._escalate_persistent_measurement_loss()
+        await runtime._escalate_persistent_measurement_loss()
+        await runtime._escalate_persistent_measurement_loss()
+    finally:
+        runtime_module.now_ms = original
+
+    assert len(harness.sent) == 1
+    await store.close()
+
+
+async def test_an_escalation_reconstructs_a_row_the_first_write_never_created(
+    tmp_path,
+) -> None:
+    """Transient store failure, recovery, delivered escalation, restart.
+
+    The write that records the degradation is allowed to fail — a store
+    failure is logged and must not stop polling — so the disk can hold no row
+    at all while the runtime knows perfectly well that the sensor is
+    degraded. If a later escalation writes with an `UPDATE`, it matches
+    nothing, raises nothing, and the runtime marks the operator as told about
+    a degradation the disk has never heard of; the next start finds no
+    degraded sensor and forgets the measurement loss entirely.
+    """
+    import ori.runtime as runtime_module
+
+    store = await _store(tmp_path)
+    harness = _EscalationHarness()
+    runtime = harness.runtime
+    runtime._state_store = store
+
+    # The transition happened, and the store was unavailable for it.
+    began = 1_700_000_000_000
+    runtime._measurement_degraded = {"load-current"}
+    runtime._measurement_degraded_since = {"load-current": began}
+    runtime._measurement_notice_stage = {"load-current": 0}
+    runtime._measurement_unnotified = {"load-current"}
+    assert await store.get_measurement_degradation() == {}
+
+    # The store recovers, and the twelve-hour escalation is delivered.
+    original = runtime_module.now_ms
+    runtime_module.now_ms = lambda: began + 12 * 60 * 60 * 1000
+    try:
+        await runtime._escalate_persistent_measurement_loss()
+    finally:
+        runtime_module.now_ms = original
+
+    assert [recipient for recipient, _ in harness.sent] == ["+2349999999999"]
+    await store.close()
+
+    reopened = await _store(tmp_path)
+    try:
+        restarted = _EscalationHarness()
+        restarted.runtime._state_store = reopened
+        await restarted.runtime._restore_measurement_state()
+
+        # The loss is still known, dated to when it happened rather than to
+        # when the disk caught up, and the operator is not owed the notice
+        # for the transition a second time.
+        assert restarted.runtime._measurement_degraded == {"load-current"}
+        assert restarted.runtime._measurement_degraded_since == {"load-current": began}
+        assert restarted.runtime._measurement_notice_stage == {"load-current": 2}
+        assert restarted.runtime._measurement_unnotified == set()
+    finally:
+        await reopened.close()
+
+
+async def test_a_write_for_an_absent_row_creates_it(tmp_path) -> None:
+    """The upsert never lands on nothing.
+
+    A plain `UPDATE` here matches no row, raises nothing, and reports success
+    for a write that changed nothing. The row is created instead, so the
+    degradation the caller is recording a notice about exists on disk
+    afterwards whether or not it did before.
+    """
+    store = await _store(tmp_path)
+    try:
+        await store.record_measurement_notice_delivered(
+            "never-degraded", 2, degraded_since=1_700_000_000_000
+        )
+        assert await store.get_measurement_degradation() == {"never-degraded": True}
+    finally:
+        await store.close()


### PR DESCRIPTION
## What does this PR do?

A device that cannot establish a trustworthy measurement said so once and then waited indefinitely for a person. The notice on the transition into degradation fires deliberately once, so a persistent fault does not become a message flood; after it, the device is silent. An operator who does not act is left with a device that is up, reporting degraded to anyone who asks, and protecting nothing.

### The schedule

The primary contact immediately, a primary reminder at six hours, the secondary contact at twelve, then daily to the secondary — the primary again where no secondary is configured, because one contact is not a reason to go silent about an unprotected channel. That is two primary messages and then one daily escalation, rather than repeating to everybody every day.

**It advances on elapsed time, not on delivery.** A reminder that could not be sent is superseded by the next stage rather than cancelling it. The escalation also runs when the notice on the transition never got out at all: that is the case where an operator knows least, the initial notice's retries are bounded, and blocking on it would make the silence permanent once they are spent. A stage that cannot assume the first notice arrived states the fault rather than recalling one.

**There is no give-up.** A still-unprotected channel must not become permanently silent, so nothing stops on a message count or a delivery cost; the schedule ends when the sensor produces credible measurements again. Two further stop conditions are sanctioned and neither is implemented here: removal of the affected safety pair belongs with the active-pair supervision design, and a locally audited maintenance acknowledgement needs an inbound, audited authority surface of its own. Until they exist, an operator who has accepted a fault keeps being reminded of it.

**The cadence is release-owned, not site-configurable.** A setting would let a deployment configure a persistent measurement loss into silence, which is the condition the schedule exists to prevent. Pilot message volume should be measured first; any later configuration must be a surface that cannot disable, indefinitely defer, or remove the escalation.

### Nothing here can be suppressed by an entitlement cap

Both the notice on the transition and every escalation take the structural, policy-exempt outbox rather than the ordinary alert path. `DevicePolicy` can suppress an ordinary Tier A alert at a monthly cap, and suppressing this one leaves an operator believing a measurement is being taken that is not — the fact these notices exist to carry. The structural path now accepts a recipient so an escalation can address the secondary contact without leaving it.

### The durable state, and why it is one write

A delivered escalation is a delivered notice, and both facts are recorded in **one upsert, one commit**.

Recording only the stage leaves the degradation marked un-notified, so a restart sends the notice for the transition all over again — to the primary contact, about a fault the secondary has already been told about. Written as two statements, an interruption between them lands exactly that state on disk.

It is an upsert rather than an update because **the row may not exist**. The write that records the degradation is itself allowed to fail — a store failure is logged and must not stop polling — so the disk can hold no row at all while the runtime knows the sensor is degraded, and a later escalation is then the first write to land. An `UPDATE` would match nothing, raise nothing, and leave the runtime believing the operator had been told about a degradation the disk has never heard of; the next start would find no degraded sensor and forget the measurement loss entirely.

The write carries the in-memory `degraded_since`, so a reconstructed row dates the loss to when it happened rather than to when the disk caught up, and the schedule does not restart.

Two ordering rules follow from what a failed write should cost. The in-memory un-notified set is cleared **only** once the write succeeds, because memory saying the operator has been told while disk says otherwise is resolved on the next start by messaging them again. The stage advances in memory **regardless**, because a store that is failing would otherwise make the loop resend the same stage on every pass; a store failure then costs at most one repeated escalation after a restart.

Restoration is one seam that startup calls and the restart tests drive, so the durable join cannot drift from what a restart actually does. A row written before these columns existed is dated to its last write rather than to now, so an upgrade does not restart the schedule on the devices that have been unprotected longest.

### Escalation restores nothing

No text in the code, the messages or the documentation says otherwise. It tells a person that a channel is unprotected; it does not protect it.

`DECISIONS.md` records why neither a timed restart nor watchdog-health coupling is adopted — a restart clears the measurement quarantine while the competing writer may still be there and takes every other safety pair down with it, and withholding a watchdog feed resets the controller rather than reporting anything, which for a zone whose mapping makes `de_energised` the closed state reconnects the load at the moment the runtime cannot measure whether that is safe. That decision stands on its own and does not close this issue.

## Type of change

- [x] `feat` — new feature
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

It governs whether an operator is told that a channel is not being measured, and therefore not being protected.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

[skip-cap-matrix] The matrix's alert-delivery and safety-notice rows describe what the runtime sends and under what authority, and both remain true: this is Tier A throughout, on the existing structural outbox, and introduces no capability. What changes is the cadence of a notice already described there.

## Related issue

Refs #510

This does not close it. The pair-scoped supervision mechanism, its health and evidence state, the reset qualification boundary, and the connect-time contention case are all still open, and the maintenance-acknowledgement stop condition is designed but unimplemented.

## Testing notes

Twelve mutations, each killed by its own named test: the escalation never called from the loop, a delivered stage not clearing the in-memory set, the stage not persisted with the notified mark, the restoration seam collapsing the notified distinction, the escalation returned to the policy-gated path, the notice on the transition returned to it, the escalation blocked again on an undelivered first notice, the wording ignoring whether the first notice landed, two separate writes with an interruption between them, a bare `UPDATE` that matches no row, the reconstructed row dated to now, and the schedule terminating after the first escalation.

Two of those are worth naming. Removing the escalation's call site from the staleness loop left every other test green, because they reach the escalation directly; `test_the_staleness_loop_drives_the_escalation` drives the real loop. And nothing asserted the notice on the transition was policy-exempt until a test stubbed `_send_or_queue_alert` to raise if anything reached it.

One mutation deliberately survives: disabling the `rowcount != 1` guard changes nothing, because an upsert always affects exactly one row. It is documented in place as unreachable by construction, kept so that a return to an `UPDATE` fails closed rather than silently, and that return is caught by its own mutation.

Durability is proven through the store and then through the runtime: write, reopen, restore through the startup seam, next due stage. Including a second degradation write not moving the start, recovery clearing the schedule, the legacy `updated_at` fallback, a failed write leaving the operator still owed the notice, a failing store not turning every pass into another message, and a transient failure of the initial write followed by a delivered escalation and a restart.

Full suite 5546 passed with 30 skipped; the measurement suite is 49. `ruff check`, `ruff format --check`, `mypy ori/` across 162 source files, `pyright` 0 errors on the changed files, and `pre-commit` are clean.

Host-only. No hardware and no phone: the alert transports are stubbed, so delivery is proven to the outbox boundary and no further.
