### PR TITLE
test(runtime): wait for the state and for startup before stopping

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,9 @@ exercising the real code paths and reach no pin.
 
 from __future__ import annotations
 
+import asyncio
 import os
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -87,3 +89,148 @@ def no_real_gpio(monkeypatch: pytest.MonkeyPatch) -> None:
     for name in _OUTPUT_CLASSES:
         if hasattr(gpiozero, name):
             monkeypatch.setattr(gpiozero, name, FakeGPIODevice)
+
+
+def _mark_startup_complete(runtime: Any) -> "asyncio.Event":
+    """An event set when `start()` finishes its last step.
+
+    `start()` ends by awaiting the shutdown event, and
+    `_send_setup_success_notifications` is the last step it takes before doing
+    so, which makes wrapping that step an exact marker rather than a guess.
+    The shutdown event itself is not one: several background loops await it
+    too, so a waiter on it says nothing about whether startup is done.
+
+    If that step is ever renamed this fails loudly with `AttributeError`
+    rather than silently going back to racing.
+    """
+    complete = asyncio.Event()
+    original = runtime._send_setup_success_notifications
+
+    async def _marked(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await original(*args, **kwargs)
+        finally:
+            complete.set()
+
+    runtime._send_setup_success_notifications = _marked
+    return complete
+
+
+async def run_runtime_until(
+    runtime: Any,
+    reached: Callable[[], bool],
+    *,
+    description: str,
+    timeout: float = 15.0,
+) -> None:
+    """Start a runtime, wait for a state and for startup, then stop it.
+
+    The pattern this replaces slept for a fixed interval and then stopped:
+
+    ```python
+    async def _stop():
+        await asyncio.sleep(0.1)
+        await runtime.stop()
+
+    await asyncio.gather(runtime.start(), _stop())
+    ```
+
+    The sleep is a guess that startup got far enough. When it has not — a
+    loaded runner, a slower interpreter — the stop tears down a half-built
+    runtime, and the failure does not surface at the test that caused it: it
+    surfaces wherever startup happened to be, as an assertion inside an
+    unrelated component. One of these failed in CI as a bare `AssertionError`
+    sixty lines into the state store, from a pull request that does not touch
+    the file containing the test.
+
+    **Waiting for the asserted state is not enough on its own.** That state
+    becomes true partway through startup, and `start()` still has adapter
+    connections, background services, the webhook, the health socket and
+    reconciliation ahead of it. Stopping there closes resources those later
+    steps are still using — the same race, entered by observation instead of
+    by a guess. So this waits for the state, and then for startup to finish,
+    and only then stops.
+
+    Both waits earn their place. The state wait is what fails with a useful
+    message when the thing the test asserts on never happens; the startup wait
+    is what makes the teardown safe. Neither substitutes for the other, and
+    the assertions still hold afterwards because what they read — log records,
+    recorded calls — persists past the moment it first became true.
+    """
+    complete = _mark_startup_complete(runtime)
+
+    async def _stop_when_safe() -> None:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        while not reached():
+            if loop.time() > deadline:
+                raise AssertionError(
+                    f"startup did not reach {description} within {timeout}s"
+                )
+            await asyncio.sleep(0.02)
+        await asyncio.wait_for(complete.wait(), timeout=timeout)
+        await runtime.stop()
+
+    await asyncio.gather(runtime.start(), _stop_when_safe())
+
+
+def logged(caplog: Any, fragment: str) -> bool:
+    """Whether a log record containing `fragment` has been emitted yet."""
+    return any(fragment in record.message for record in caplog.records)
+
+
+async def run_runtime_full_startup(runtime: Any, *, timeout: float = 15.0) -> None:
+    """Start a runtime, let startup finish completely, then stop it.
+
+    For tests whose subject is the lifecycle itself, or which assert that
+    something did *not* happen: there is no partial state to wait for, and an
+    absence cannot be waited for at all.
+    """
+    await run_runtime_until(
+        runtime,
+        lambda: True,
+        description="the end of startup",
+        timeout=timeout,
+    )
+
+
+SLOW_STARTUP_PROBE_ENV = "ORI_SLOW_STARTUP_PROBE"
+
+# Opt-in harness for the fix in ori-platform/ori-runtime#468. A test that waits
+# for a state rather than an interval must keep passing when startup is slower
+# than the interval it used to guess with, and a run on a fast machine is not
+# evidence of that:
+#
+#     ORI_SLOW_STARTUP_PROBE=1 python3 -m pytest tests/test_runtime.py
+#
+# It slows an early startup phase and a late one. Slowing only the early phase
+# moves every wait later together, so a teardown that fires at a partial state
+# still lands before the steps that would notice it; the late delay is what
+# puts a stop between the state a test waits for and the startup work that
+# follows it.
+#
+# In-tree and opt-in rather than a recipe in a pull request, so the check can
+# be run again by whoever next doubts one of these tests.
+if os.environ.get(SLOW_STARTUP_PROBE_ENV) == "1":
+    from ori.runtime import OriRuntime as _ProbeRuntime
+    from ori.state.store import StateStore as _ProbeStore
+
+    _PROBE_DELAY_S = 0.6
+    _probe_original_open = _ProbeStore.open
+    _probe_original_health_socket = _ProbeRuntime._start_health_socket_if_enabled
+
+    @pytest.fixture(autouse=True)
+    def slow_startup_probe(monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _slow_open(self: Any, *args: Any, **kwargs: Any) -> Any:
+            result = await _probe_original_open(self, *args, **kwargs)
+            await asyncio.sleep(_PROBE_DELAY_S)
+            return result
+
+        async def _slow_late(self: Any, *args: Any, **kwargs: Any) -> Any:
+            await asyncio.sleep(_PROBE_DELAY_S)
+            return await _probe_original_health_socket(self, *args, **kwargs)
+
+        monkeypatch.setattr(_ProbeStore, "open", _slow_open)
+        monkeypatch.setattr(
+            _ProbeRuntime, "_start_health_socket_if_enabled", _slow_late
+        )

--- a/tests/test_external_watchdog.py
+++ b/tests/test_external_watchdog.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from ori.runtime import OriRuntime
+from tests.conftest import run_runtime_full_startup
 
 
 def _patch_external(monkeypatch):
@@ -102,11 +103,10 @@ async def test_disabled_by_default(tmp_path: Path, monkeypatch):
     mocked_external_loop = AsyncMock()
     monkeypatch.setattr(runtime, "_external_watchdog_loop", mocked_external_loop)
 
-    async def _stop():
-        await asyncio.sleep(0.15)
-        await runtime.stop()
-
-    await asyncio.gather(runtime.start(), _stop())
+    # An absence cannot be waited for, so this waits for the end of startup:
+    # if the external watchdog loop were going to be started, it would have
+    # been by then.
+    await run_runtime_full_startup(runtime)
     assert mocked_external_loop.await_count == 0
 
 

--- a/tests/test_led_indicator.py
+++ b/tests/test_led_indicator.py
@@ -113,7 +113,26 @@ async def test_status_loop_ticks_and_closes():
     task = asyncio.create_task(
         runtime._status_signaling_loop(indicator=indicator, tick_ms=50)
     )
-    await asyncio.sleep(0.12)
+    # Waits for the loop to have ticked rather than for an interval that ought
+    # to contain a tick: the tick cadence is not a promise about when a loaded
+    # runner gets there. Counted by wrapping `tick`, because the indicator
+    # exposes no count of its own.
+    ticks = 0
+    original_tick = indicator.tick
+
+    def _counted_tick() -> None:
+        nonlocal ticks
+        ticks += 1
+        original_tick()
+
+    indicator.tick = _counted_tick  # type: ignore[method-assign]
+
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 15.0
+    while ticks == 0:
+        if loop.time() > deadline:
+            raise AssertionError("the status loop never ticked the indicator")
+        await asyncio.sleep(0.01)
     await runtime.stop()
     await task
     assert indicator.available is False

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -64,6 +64,11 @@ from ori.security.remote_commands.throttle import RemoteCommandThrottleDecision
 from ori.skills.signing import canonical_signed_payload
 from ori.state.store import StateStore
 from tests.commissioning.signing import commission_relay
+from tests.conftest import (
+    logged,
+    run_runtime_full_startup,
+    run_runtime_until,
+)
 
 try:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -72,6 +77,24 @@ except Exception:  # pragma: no cover - environment without cryptography support
     Ed25519PrivateKey = None
     Encoding = None
     PublicFormat = None
+
+
+async def _end_loop_once_warned(runtime, *, timeout: float = 15.0) -> None:
+    """Let the staleness loop exit once it has emitted its warning.
+
+    This test drives `_sensor_staleness_loop` directly and never starts the
+    runtime, so the loop's own exit condition is the shutdown event rather
+    than `stop()`. Waiting for the warning rather than for an interval is the
+    same correction: the loop's check cadence is not a promise about when the
+    alert lands.
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while runtime._send_or_queue_alert.await_count == 0:
+        if loop.time() > deadline:
+            raise AssertionError("the staleness loop never emitted a warning")
+        await asyncio.sleep(0.02)
+    runtime._shutdown_event.set()
 
 
 def _capability_config(
@@ -1484,11 +1507,11 @@ class TestLocalSLMWiring:
 
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
-        await asyncio.gather(runtime.start(), _stop())
+        await run_runtime_until(
+            runtime,
+            lambda: "local_llm" in captured,
+            description="building the elevator",
+        )
         assert captured["local_llm"] is sentinel
         assert captured["gateway_reasoner"] is None
 
@@ -1704,12 +1727,18 @@ class TestAdapterProtocol:
 
         runtime = OriRuntime(config_path=str(cfg))
 
-        async def _stop():
-            await asyncio.sleep(0.5)
+        # No state to wait for: `start()` is expected to raise before it
+        # reaches any of it. The stop is a backstop so that a start which
+        # unexpectedly succeeds fails as a timeout rather than hanging.
+        async def _stop_if_it_did_not_raise():
+            try:
+                await asyncio.wait_for(runtime._shutdown_event.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                pass
             await runtime.stop()
 
         with pytest.raises(ConfigValidationError, match="unknown_proto"):
-            await asyncio.gather(runtime.start(), _stop())
+            await asyncio.gather(runtime.start(), _stop_if_it_did_not_raise())
 
 
 class TestLifecycle:
@@ -1719,11 +1748,7 @@ class TestLifecycle:
 
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _auto_stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
-        await asyncio.gather(runtime.start(), _auto_stop())
+        await run_runtime_full_startup(runtime)
         # If we reach here, start() returned cleanly after stop()
 
     async def test_stop_is_idempotent(self, minimal_config, monkeypatch):
@@ -1731,12 +1756,9 @@ class TestLifecycle:
         _patch_external(monkeypatch)
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _double_stop():
-            await asyncio.sleep(0.05)
-            await runtime.stop()
-            await runtime.stop()  # second call — must be a no-op
-
-        await asyncio.gather(runtime.start(), _double_stop())
+        await run_runtime_full_startup(runtime)
+        # Second call, after startup has finished and the first stop returned.
+        await runtime.stop()  # must be a no-op
 
     def test_resolve_dispatcher_approval_timeout_uses_max_declared(self):
         skills_cfg = [
@@ -1779,12 +1801,20 @@ class TestLifecycle:
         runtime1 = OriRuntime(config_path=str(cfg_path))
         runtime2 = OriRuntime(config_path=str(cfg_path))
 
-        async def _run_once(runtime: OriRuntime):
-            async def _stop():
-                await asyncio.sleep(0.1)
-                await runtime.stop()
+        def _handler_installed() -> bool:
+            return any(
+                isinstance(h, RotatingFileHandler)
+                and Path(getattr(h, "baseFilename", "")).resolve()
+                == custom_log.resolve()
+                for h in logging.getLogger().handlers
+            )
 
-            await asyncio.gather(runtime.start(), _stop())
+        async def _run_once(runtime: OriRuntime):
+            await run_runtime_until(
+                runtime,
+                _handler_installed,
+                description="installing the rotating file handler",
+            )
 
         await _run_once(runtime1)
         await _run_once(runtime2)
@@ -1848,12 +1878,12 @@ class TestLifecycle:
         )
         monkeypatch.setattr("ori.actions.relay.RelayAction.connect", mocked_connect)
 
-        async def _stop():
-            await asyncio.sleep(0.2)
-            await runtime.stop()
-
         with caplog.at_level(logging.WARNING):
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: logged(caplog, "deployment_type=phone with relay configured"),
+                description="logging that the phone deployment skipped the relay",
+            )
 
         assert mocked_connect.await_count == 0
         assert any(
@@ -1936,12 +1966,12 @@ class TestStartupLogs:
         _treat_scratch_skills_as_packaged(monkeypatch)
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
         with caplog.at_level(logging.INFO):
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: logged(caplog, "[skill]"),
+                description="logging the loaded skills",
+            )
 
         skill_lines = [r.message for r in caplog.records if "[skill]" in r.message]
         assert any("test-skill" in line for line in skill_lines), (
@@ -1959,12 +1989,12 @@ class TestStartupLogs:
         _patch_external(monkeypatch)
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
         with caplog.at_level(logging.INFO):
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: logged(caplog, "event loop ready"),
+                description="logging that the event loop is ready",
+            )
 
         messages = [r.message for r in caplog.records]
         assert any("event loop ready" in m for m in messages), (
@@ -2159,7 +2189,16 @@ class TestShutdown:
             completed.append(True)
 
         async def _inject_and_stop():
-            await asyncio.sleep(0.05)
+            # Injected once startup has a dispatcher to replace, rather than
+            # after a guessed interval: replacing it earlier races the
+            # construction this test depends on.
+            loop = asyncio.get_running_loop()
+            deadline = loop.time() + 15.0
+            while runtime._dispatcher is None:
+                if loop.time() > deadline:
+                    raise AssertionError("startup never built a dispatcher")
+                await asyncio.sleep(0.02)
+
             tier_d_task = asyncio.create_task(_tier_d_work())
 
             class _FakeDispatcher:
@@ -2168,8 +2207,9 @@ class TestShutdown:
 
             runtime._dispatcher = _FakeDispatcher()
             await runtime.stop()
-            # Give the drained task time to finish
-            await asyncio.sleep(0.25)
+            # `stop()` drains the task rather than abandoning it, so awaiting
+            # it here observes the drain rather than waiting out its duration.
+            await tier_d_task
 
         await asyncio.gather(runtime.start(), _inject_and_stop())
         assert completed == [True], "Tier D task was abandoned before completion"
@@ -2185,12 +2225,12 @@ class TestWatchdog:
 
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
         with caplog.at_level(logging.WARNING):
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: logged(caplog, "watchdog"),
+                description="warning that the watchdog device is absent",
+            )
 
         watchdog_warnings = [r.message for r in caplog.records]
         assert watchdog_warnings, "Expected watchdog 'not found' warning in logs"
@@ -2217,12 +2257,12 @@ class TestWatchdog:
 
         runtime = OriRuntime(config_path=str(minimal_config))
 
-        async def _stop():
-            await asyncio.sleep(0.1)
-            await runtime.stop()
-
         with caplog.at_level(logging.INFO):
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: m_open.call_args is not None,
+                description="opening the watchdog device",
+            )
 
         # Assert watchdog device was opened for writing
         m_open.assert_called_with("/dev/watchdog", "wb", buffering=0)
@@ -2657,16 +2697,12 @@ class TestSensorPolling:
         runtime._send_or_queue_alert = AsyncMock(return_value=True)
         alert_sender = AsyncMock()
 
-        async def _stop():
-            await asyncio.sleep(0.05)
-            await runtime.stop()
-
         await asyncio.gather(
             runtime._sensor_staleness_loop(
                 alert_sender=alert_sender,
                 check_interval_s=0.01,
             ),
-            _stop(),
+            _end_loop_once_warned(runtime),
         )
 
         runtime._send_or_queue_alert.assert_awaited_once()
@@ -3198,12 +3234,11 @@ class TestWebhookServerStartup:
         fake_instance = _FakeServer()
 
         with patch("ori.runtime.SMSWebhookServer", return_value=fake_instance) as cls:
-
-            async def _stop():
-                await asyncio.sleep(0.1)
-                await runtime.stop()
-
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: cls.call_args is not None,
+                description="constructing the SMS webhook server",
+            )
 
         cls.assert_called_once()
         assert cls.call_args.kwargs["allowed_source_cidrs"] == ["127.0.0.1/32"]
@@ -3301,12 +3336,11 @@ class TestWebhookServerStartup:
         fake_instance = _FakeServer()
 
         with patch("ori.runtime.SMSWebhookServer", return_value=fake_instance) as cls:
-
-            async def _stop():
-                await asyncio.sleep(0.1)
-                await runtime.stop()
-
-            await asyncio.gather(runtime.start(), _stop())
+            await run_runtime_until(
+                runtime,
+                lambda: cls.call_args is not None,
+                description="constructing the SMS webhook server",
+            )
 
         cls.assert_called_once()
         assert cls.call_args.kwargs["host"] == "127.0.0.1"
@@ -3381,12 +3415,10 @@ class TestWebhookServerStartup:
 
         runtime = OriRuntime(config_path=str(cfg))
         with patch("ori.runtime.SMSWebhookServer") as cls:
-
-            async def _stop():
-                await asyncio.sleep(0.1)
-                await runtime.stop()
-
-            await asyncio.gather(runtime.start(), _stop())
+            # An absence cannot be waited for, so this waits for the end of
+            # startup: if the webhook were going to be constructed, it would
+            # have been by then.
+            await run_runtime_full_startup(runtime)
 
         cls.assert_not_called()
 

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1734,6 +1734,9 @@ class TestAdapterProtocol:
             try:
                 await asyncio.wait_for(runtime._shutdown_event.wait(), timeout=5.0)
             except asyncio.TimeoutError:
+                # The expected path: `start()` raised, so nothing ever set the
+                # shutdown event and the wait timed out. Fall through and stop
+                # anyway, which is a no-op on a runtime that never started.
                 pass
             await runtime.stop()
 
@@ -2209,7 +2212,9 @@ class TestShutdown:
             await runtime.stop()
             # `stop()` drains the task rather than abandoning it, so awaiting
             # it here observes the drain rather than waiting out its duration.
-            await tier_d_task
+            # Bounded, so a drain that never happens fails as a timeout rather
+            # than hanging the suite.
+            await asyncio.wait_for(tier_d_task, timeout=5.0)
 
         await asyncio.gather(runtime.start(), _inject_and_stop())
         assert completed == [True], "Tier D task was abandoned before completion"

--- a/tests/test_startup_race_guard.py
+++ b/tests/test_startup_race_guard.py
@@ -1,0 +1,188 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""No test may stop a runtime after guessing that startup got far enough.
+
+The shape this refuses:
+
+```python
+async def _stop():
+    await asyncio.sleep(0.1)
+    await runtime.stop()
+
+await asyncio.gather(runtime.start(), _stop())
+```
+
+The sleep is a guess. When startup is slower than the guess — a loaded runner,
+a slower interpreter — the stop tears down a half-built runtime, and the
+failure surfaces wherever startup happened to be rather than at the test that
+caused it. One of these failed in CI as a bare `AssertionError` sixty lines
+into the state store, from a pull request that does not touch the file
+containing the test, and the time it costs is spent by whoever is unlucky
+rather than by whoever wrote it.
+
+A longer sleep makes it rarer and the suite slower and leaves the same failure
+available on a slower machine. `tests/conftest.py::run_runtime_until` waits for
+the state the test is about to assert on instead.
+
+This guard exists because fixing the twelve that existed does not stop the
+thirteenth being written, in this module or any other. It reads the whole test
+tree, so a new one anywhere fails here rather than intermittently somewhere
+else.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_ROOT = Path(__file__).resolve().parent
+
+
+def _is_sleep(node: ast.AST) -> bool:
+    """Whether this awaits a sleep, however the duration is written.
+
+    Matching a literal duration would refuse `asyncio.sleep(0.1)` and admit
+    `asyncio.sleep(_DELAY)`, which is the same guess with a name on it. The
+    duration is not what makes it wrong; waiting for one at all is.
+
+    Both spellings count: `asyncio.sleep(...)` and a bare `sleep(...)` from
+    `from asyncio import sleep`.
+    """
+    if not isinstance(node, ast.Await) or not isinstance(node.value, ast.Call):
+        return False
+    func = node.value.func
+    if isinstance(func, ast.Attribute):
+        return func.attr == "sleep"
+    return isinstance(func, ast.Name) and func.id == "sleep"
+
+
+def _awaits_a_stop(node: ast.AST) -> bool:
+    """Whether this subtree awaits something's `.stop()`."""
+    for child in ast.walk(node):
+        if (
+            isinstance(child, ast.Await)
+            and isinstance(child.value, ast.Call)
+            and isinstance(child.value.func, ast.Attribute)
+            and child.value.func.attr == "stop"
+        ):
+            return True
+    return False
+
+
+def _guessing_sleeps(function: ast.AST) -> list[int]:
+    """Line numbers of straight-line sleeps in a function that then stops.
+
+    A sleep inside a loop is a poll interval, not a guess: the surrounding
+    loop is what waits for the state, and it carries its own deadline. Only a
+    sleep on the straight-line path is asserting that a duration is long
+    enough.
+    """
+    if not _awaits_a_stop(function):
+        return []
+
+    own: list[ast.AST] = []
+    nested: set[int] = set()
+    for node in ast.walk(function):
+        # A nested `async def _stop()` is its own function and is reported
+        # under its own name; walking into it here would report the same
+        # sleep twice, once for the helper and once for the test around it.
+        if node is not function and isinstance(
+            node, (ast.AsyncFunctionDef, ast.FunctionDef, ast.Lambda)
+        ):
+            for inner in ast.walk(node):
+                nested.add(id(inner))
+    for node in ast.walk(function):
+        if id(node) not in nested:
+            own.append(node)
+
+    looped: set[int] = set()
+    for node in own:
+        if isinstance(node, (ast.While, ast.For, ast.AsyncFor)):
+            for inner in ast.walk(node):
+                looped.add(id(inner))
+
+    return [
+        node.lineno
+        for node in own
+        if isinstance(node, ast.Await) and _is_sleep(node) and id(node) not in looped
+    ]
+
+
+def _offenders() -> list[str]:
+    found: list[str] = []
+    for path in sorted(TESTS_ROOT.rglob("test_*.py")):
+        if path.name == Path(__file__).name:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                continue
+            for line in _guessing_sleeps(node):
+                found.append(
+                    f"{path.relative_to(TESTS_ROOT.parent)}:{line} "
+                    f"in {node.name}() — sleeps, then stops a runtime"
+                )
+    return found
+
+
+def test_no_test_stops_a_runtime_after_a_fixed_sleep() -> None:
+    offenders = _offenders()
+    assert offenders == [], (
+        "These wait for time to pass and then stop a runtime, which races "
+        "startup. Wait for the state being asserted on instead — "
+        "`tests/conftest.py::run_runtime_until`:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_the_guard_recognises_the_shape_it_refuses() -> None:
+    """A guard that cannot fail is not a guard.
+
+    Asserted directly, because the suite passing tells us nothing about
+    whether this would notice a thirteenth.
+    """
+    guessing = ast.parse(
+        "async def _stop():\n    await asyncio.sleep(0.1)\n    await runtime.stop()\n"
+    ).body[0]
+    polling = ast.parse(
+        "async def _stop():\n"
+        "    while not ready():\n"
+        "        await asyncio.sleep(0.02)\n"
+        "    await runtime.stop()\n"
+    ).body[0]
+    unrelated = ast.parse(
+        "async def _drive():\n    await asyncio.sleep(0.1)\n    task.cancel()\n"
+    ).body[0]
+
+    nested = ast.parse(
+        "async def test_x():\n"
+        "    async def _stop():\n"
+        "        await asyncio.sleep(0.1)\n"
+        "        await runtime.stop()\n"
+        "    await asyncio.gather(runtime.start(), _stop())\n"
+    ).body[0]
+
+    named = ast.parse(
+        "async def _stop():\n"
+        "    await asyncio.sleep(_STARTUP_DELAY)\n"
+        "    await runtime.stop()\n"
+    ).body[0]
+    aliased = ast.parse(
+        "async def _stop():\n    await sleep(0.1)\n    await runtime.stop()\n"
+    ).body[0]
+    computed = ast.parse(
+        "async def _stop():\n"
+        "    await asyncio.sleep(_base * 2)\n"
+        "    await runtime.stop()\n"
+    ).body[0]
+
+    assert _guessing_sleeps(guessing) == [2]
+    # Reported once, under the helper that sleeps, not again under the test.
+    assert _guessing_sleeps(nested) == []
+    # A name on the duration is the same guess. So is importing `sleep`
+    # directly, and so is computing the interval.
+    assert _guessing_sleeps(named) == [2]
+    assert _guessing_sleeps(aliased) == [2]
+    assert _guessing_sleeps(computed) == [2]
+    assert _guessing_sleeps(polling) == []
+    assert _guessing_sleeps(unrelated) == []


### PR DESCRIPTION
## What does this PR do?

Sixteen tests slept for a fixed interval and then stopped a runtime:

```python
async def _stop():
    await asyncio.sleep(0.1)
    await runtime.stop()

await asyncio.gather(runtime.start(), _stop())
```

The sleep is a guess that startup got far enough. When it has not — a loaded runner, a slower interpreter — the stop tears down a half-built runtime, and the failure does not surface at the test that caused it: it surfaces wherever startup happened to be, as an assertion inside an unrelated component. One failed in CI as a bare `AssertionError` sixty lines into the state store, from a pull request that does not touch the file containing the test, so the time it costs is spent by whoever is unlucky rather than by whoever wrote it.

The issue counted twelve. An AST sweep of the tree found **sixteen**, across three modules, including shapes the `gather(start(), _stop())` grep does not match.

### Waiting for the asserted state is necessary and not sufficient

That state becomes true partway through startup, and `start()` still has adapter connections, background services, the webhook, the health socket and reconciliation ahead of it. `stop()` closes the state store, so stopping there closes it under steps still using it. Observing an early state and then stopping is the same race entered a different way.

Every one of these tests therefore goes through one shared helper in `tests/conftest.py`, which waits for the state, **then** for startup to finish, and only then stops. Both waits earn their place: the state wait is what fails with a useful message when the thing being asserted never happens, and the startup wait is what makes the teardown safe. The assertions still hold afterwards, because what they read — log records, recorded calls — persists past the moment it first became true.

The end of startup is marked by wrapping `_send_setup_success_notifications`, the last step `start()` takes before parking on the shutdown event. The shutdown event itself is not a marker: several background loops await it too, so a waiter on it says nothing about whether startup is done.

Two shapes need something else. A test whose subject is the lifecycle itself, or which asserts that something did *not* happen, has no partial state to wait for and cannot wait for an absence, so it waits only for the end of startup. A test that drives a single loop directly rather than `start()` waits for that loop's own observable and ends it through the shutdown event.

### The seventeenth

Fixing the sixteen that exist does not stop the next one being written, here or in another module. `tests/test_startup_race_guard.py` reads the whole test tree and refuses the shape.

It rejects any straight-line sleep before a runtime stop, **however the duration is written**: matching a literal would refuse `asyncio.sleep(0.1)` and admit `asyncio.sleep(_DELAY)`, which is the same guess with a name on it, and a bare `sleep()` imported from `asyncio` is the same guess again. A sleep inside a loop is a poll interval, and the loop around it carries the deadline. The guard carries its own tests, including those three evasions, because a guard that cannot fail is not a guard.

The guard is textual, so it cannot see a helper that stops at a partial state without sleeping. That is why there is one shared helper rather than one per module: the rule the guard enforces is about the shape, and the way to keep the guarantee is to give every test the same implementation.

## Type of change

- [x] `test` — tests only

No production code changes. `ori/` is untouched.

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] PR description explains **why**, not just what

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

[skip-cap-matrix] Tests only; no capability-impacting file is touched and no matrix row's claim changes.

## Related issue

Closes #468

## Testing notes

The issue asks that each converted test be verified against a startup slowed past its old sleep, since a passing run on a fast machine is not evidence. That harness is in-tree and opt-in rather than a recipe in this description:

```bash
ORI_SLOW_STARTUP_PROBE=1 python3 -m pytest tests/test_runtime.py
```

It slows an early startup phase and a late one. Slowing only the early phase moves every wait later together, so a teardown firing at a partial state still lands before the steps that would notice it; the late delay is what puts a stop between the state a test waits for and the startup work that follows.

It measurably does something: `tests/test_runtime.py` goes from 10.05s to 48.50s under it. **All 226 tests across the runtime-driving modules pass** — `test_runtime.py`, `test_external_watchdog.py`, `test_led_indicator.py`, `safety/test_runtime_wiring.py`, `commissioning/test_runtime_startup.py`, `test_ac_measurement.py` and the guard. Restoring one converted test to its fixed sleep reproduces the documented failure under the same harness, as a bare `AssertionError`.

**One property is argued rather than demonstrated, and is worth stating plainly.** Removing the wait for the end of startup, so the helper stops at the partial state, does not fail any test in the suite even with the late delay: these configurations do not reach a store-using startup step after the state each test waits for. The wait stays because the helper is shared and the guarantee should not depend on which configuration a test happens to use.

Full suite 5548 passed with 30 skipped. `ruff check`, `ruff format --check`, `mypy ori/` across 162 source files and `pre-commit` are clean. `pyright` reports 74 on `tests/test_runtime.py`; `main` reports the same 74 for the same files, so this branch adds none, and `pyright ori/` — the gated scope — is 0.

## Not fixed here

The issue states that production does not have this race, because "the runtime registers its signal handlers after the startup phase these tests interrupt". They are registered at `ori/runtime.py:1291`, and `start()` continues to line 1645 through adapter connects, the SMS webhook, telemetry export and the gateway responders. A real `SIGTERM` can therefore land mid-startup, where `stop()` closes the state store under steps still using it. That is a runtime question rather than a test one, it does not change this fix, and it wants its own issue.
