### PR TITLE
fix(commissioning): distinguish an unconfigured anchor from a wrong one

### DIFF
--- a/docs/COMMISSIONING.md
+++ b/docs/COMMISSIONING.md
@@ -236,6 +236,32 @@ reproduced by a released line. Each of those modes has to be observed at the
 panel and recorded. What the release does establish is that the operation holds
 the output only for the command and the operator's observation of it.
 
+The ceremony commands run as their own process, started from a shell. Only
+the runtime service loads the environment file, through `EnvironmentFile=`, so
+a shell does not inherit the anchor and the commands verify against nothing:
+the delivery is refused `unknown_signer` at `key_selection`, which is the
+contract's verdict when no key can be selected.
+
+Pass the anchor to the command, and pass nothing else:
+
+```bash
+anchor=$(sed -n 's/^ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64=//p' \
+  /etc/ori/runtime.env | tr -d "\"'")
+ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64="$anchor" \
+  ori commissioning deliver --path /etc/ori/ori.yaml --binding ./binding.json
+```
+
+**Do not source that file.** It is the delivery channel for
+`GATEWAY_SHARED_SECRET`, `ORI_CUSTODY_SECRET`, `ORI_EVIDENCE_DEVICE_SECRET`,
+the remote-command secrets and the telemetry API key. `set -a; . file` would
+export every one of them into the interactive shell and each child it starts,
+to obtain a value that is a public key. It also reads the file as shell rather
+than as a systemd environment file, which is a different grammar: systemd
+performs no expansion, so a value containing `$` or a backtick means one thing
+to the service and another to the shell.
+
+For a user install the file is `~/.config/ori/runtime.env`.
+
 `commissioning deliver` stages the verified document beside `ori.yaml`; the
 provisional record appears when the runtime next starts. So a freshly delivered
 binding needs one runtime start before `commissioning prove-command` can see it,

--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -30,7 +30,9 @@ from ori.config import (
 from ori.gateway.mqtt_security import parse_gateway_broker_endpoint
 from ori.network.events import SensorReading
 from ori.security.commissioning.anchors import (
+    COMMISSIONING_ANCHOR_ENV,
     AnchorError,
+    CommissioningAnchors,
     anchor_collision,
     load_commissioning_anchors,
     provisioning_anchor,
@@ -934,12 +936,12 @@ async def _commissioning_deliver(
 
     if anchor_collision(anchors, prov):
         # Decided before any document is read, exactly as at configuration load.
-        raise _refused("key_selection", "anchor_collision")
+        raise _refused("key_selection", "anchor_collision", anchors=anchors)
 
     try:
         document = parse_document(text)
     except BindingRefusedError as refusal:
-        raise _refused(refusal.stage, refusal.reason) from None
+        raise _refused(refusal.stage, refusal.reason, anchors=anchors) from None
 
     if in_force is not None and is_the_binding_in_force(document, in_force):
         return {
@@ -972,7 +974,7 @@ async def _commissioning_deliver(
     try:
         accepted = verify_binding_envelope(document, context)
     except BindingRefusedError as refusal:
-        raise _refused(refusal.stage, refusal.reason) from None
+        raise _refused(refusal.stage, refusal.reason, anchors=anchors) from None
 
     target = Path(config_path).resolve().parent / BINDING_RELATIVE_PATH
     payload = text.encode("utf-8")
@@ -1139,7 +1141,9 @@ def _declared_gpio_pin(config: Config) -> int | None:
     return int(pin) if pin is not None else None
 
 
-def _refused(stage: str, reason: str) -> BridgeError:
+def _refused(
+    stage: str, reason: str, *, anchors: CommissioningAnchors | None = None
+) -> BridgeError:
     """A refused binding, reported the way this bridge reports a rejected document.
 
     `config validate` already answers an invalid document with `ok: false` and
@@ -1147,15 +1151,34 @@ def _refused(stage: str, reason: str) -> BridgeError:
     operator handed the tool something the contract does not accept. The code
     is the contract's reason and the stage rides alongside it, because a
     refusal only proves a check ran if every earlier stage passed.
+
+    `unknown_signer` over an unconfigured anchor is the contract's verdict and
+    stays so; what changes is the detail. Absence and mismatch are one reason
+    with two remedies, and only the operator can be told them apart.
+
+    The remedy names one variable and scopes it to one command. The service
+    environment file is the delivery channel for the gateway, custody and
+    telemetry secrets too, so telling an operator to source it would export
+    every one of them into their shell and its children to obtain a public key.
     """
-    return BridgeError(
-        code=reason,
-        detail=(
-            f"binding refused at {stage}; the binding in force is unchanged "
-            "and nothing was written"
-        ),
-        stage=stage,
+    detail = (
+        f"binding refused at {stage}; the binding in force is unchanged "
+        "and nothing was written"
     )
+    if reason == "unknown_signer" and anchors is not None and not anchors.configured:
+        detail += (
+            f". No commissioning anchor is configured in this process's "
+            f"environment: {COMMISSIONING_ANCHOR_ENV} is unset, so no key "
+            "could be selected and the document's signer was never compared. "
+            "The installer writes the anchor to the service environment file "
+            "(/etc/ori/runtime.env, or ~/.config/ori/runtime.env for a user "
+            "install), which a shell does not inherit. Read that one variable "
+            f"out and pass it to this command alone, as {COMMISSIONING_ANCHOR_ENV}"
+            "=... before the command. Do not source the file: it also carries "
+            "the gateway, custody and telemetry secrets, and a systemd "
+            "environment file is not shell"
+        )
+    return BridgeError(code=reason, detail=detail, stage=stage)
 
 
 def _write_staged_binding(target: Path, payload: bytes) -> None:

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -883,6 +883,188 @@ def test_cli_bridge_commissioning_deliver_refuses_by_stage_and_writes_nothing(
     assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
 
 
+def _deliver_refusal(tmp_path, monkeypatch, capsys) -> dict:
+    config_path = _commissioning_config(tmp_path)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    return payload["error"]
+
+
+def test_cli_bridge_commissioning_deliver_names_an_unconfigured_anchor(
+    tmp_path, monkeypatch, capsys
+):
+    """An absent anchor keeps the contract's verdict and says where it lives.
+
+    The stage and reason are what `commissioned-safety-binding/v1` requires
+    when no key can be selected, so neither moves. An operator reading only
+    `unknown_signer` would go looking at the signing key, when what is missing
+    is the anchor this process never inherited.
+    """
+    from ori.security.commissioning.anchors import (
+        COMMISSIONING_ANCHOR_ENV,
+        COMMISSIONING_ANCHOR_PREVIOUS_ENV,
+    )
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_ENV, raising=False)
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_PREVIOUS_ENV, raising=False)
+
+    error = _deliver_refusal(tmp_path, monkeypatch, capsys)
+
+    assert error["code"] == "unknown_signer"
+    assert error["stage"] == "key_selection"
+    assert COMMISSIONING_ANCHOR_ENV in error["detail"]
+    assert "/etc/ori/runtime.env" in error["detail"]
+    assert "a shell does not inherit" in error["detail"]
+    assert not (tmp_path / BINDING_RELATIVE_PATH).exists()
+
+
+def test_cli_bridge_commissioning_deliver_separates_an_absent_anchor_from_a_wrong_one(
+    tmp_path, monkeypatch, capsys
+):
+    """One reason, two remedies; a detail that served both would name neither.
+
+    Merging the two messages passes every assertion about the verdict, so the
+    distinguishing property is asserted directly: the configured-but-wrong
+    detail must not carry the guidance that only an absent anchor earns.
+    """
+    from ori.security.commissioning.anchors import (
+        COMMISSIONING_ANCHOR_ENV,
+        COMMISSIONING_ANCHOR_PREVIOUS_ENV,
+    )
+
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_ENV, raising=False)
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_PREVIOUS_ENV, raising=False)
+    absent = _deliver_refusal(tmp_path, monkeypatch, capsys)
+
+    # The anchor configured is not the key that signed the document.
+    _anchor(monkeypatch, seed="6" * 64)
+    mismatched = _deliver_refusal(tmp_path, monkeypatch, capsys)
+
+    assert absent["code"] == mismatched["code"] == "unknown_signer"
+    assert absent["stage"] == mismatched["stage"] == "key_selection"
+    assert absent["detail"] != mismatched["detail"]
+    assert COMMISSIONING_ANCHOR_ENV not in mismatched["detail"]
+    assert "runtime.env" not in mismatched["detail"]
+    assert mismatched["detail"] == (
+        "binding refused at key_selection; the binding in force is unchanged "
+        "and nothing was written"
+    )
+
+
+def test_cli_bridge_commissioning_deliver_guidance_is_confined_to_unknown_signer(
+    tmp_path, monkeypatch, capsys
+):
+    """Only the verdict an absent anchor causes earns the anchor's remedy.
+
+    An unconfigured anchor is the state, not the verdict. Attaching the
+    guidance to every refusal decided while it happens to be unset would send
+    an operator to the environment file over a document that names the wrong
+    device, which sourcing it would not fix.
+    """
+    from ori.security.commissioning.anchors import (
+        COMMISSIONING_ANCHOR_ENV,
+        COMMISSIONING_ANCHOR_PREVIOUS_ENV,
+    )
+
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_ENV, raising=False)
+    monkeypatch.delenv(COMMISSIONING_ANCHOR_PREVIOUS_ENV, raising=False)
+
+    config_path = _commissioning_config(tmp_path)
+    envelope = _bench_envelope()
+    # `device_id` is decided before `key_selection`, so this refusal is reached
+    # with the anchor still unconfigured.
+    envelope["binding"]["device_id"] = "not-this-device"
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(envelope), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    error = payload["error"]
+    assert error["code"] == "wrong_device"
+    assert error["stage"] == "device_id"
+    assert COMMISSIONING_ANCHOR_ENV not in error["detail"]
+    assert "runtime.env" not in error["detail"]
+
+
+def test_commissioning_doc_says_the_ceremony_commands_need_their_own_anchor(tmp_path):
+    """The remedy the refusal names must be written down where an installer looks."""
+    doc = (
+        Path(__file__).resolve().parents[1] / "docs" / "COMMISSIONING.md"
+    ).read_text()
+
+    assert "a shell does not inherit the anchor" in doc
+    # The table of what an installation carries already names both paths, so
+    # asserting those would pass with this guidance absent. What is new is the
+    # remedy: reading out one variable and scoping it to one command.
+    assert "sed -n 's/^ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64=//p'" in doc
+    assert 'ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64="$anchor"' in doc
+    assert "**Do not source that file.**" in doc
+    assert "~/.config/ori/runtime.env" in doc
+
+
+def test_the_anchor_remedy_never_tells_an_operator_to_source_the_env_file():
+    """The service environment file carries secrets, so the remedy is one key.
+
+    `set -a; . file` exports the gateway, custody and telemetry secrets into
+    the operator's shell and every child it starts, to obtain a value that is
+    a public key. It also reads a systemd environment file as shell, which is
+    a different grammar. Asserted over both surfaces the remedy appears on,
+    because fixing one and leaving the other is the shape of this defect.
+    """
+    from ori.security.commissioning.anchors import CommissioningAnchors
+
+    doc = (
+        Path(__file__).resolve().parents[1] / "docs" / "COMMISSIONING.md"
+    ).read_text()
+    remedy = cli_bridge._refused(
+        "key_selection",
+        "unknown_signer",
+        anchors=CommissioningAnchors(current=None, previous=None),
+    ).detail
+
+    # The runnable form is what gets copied. The doc may name the
+    # anti-pattern generically in order to warn against it, and does.
+    for surface, text in (("doc", doc), ("refusal detail", remedy)):
+        for runnable in (
+            "set -a; . /etc/ori/runtime.env",
+            "set -a; . ~/.config/ori/runtime.env",
+            "source /etc/ori/runtime.env",
+            "source ~/.config/ori/runtime.env",
+        ):
+            assert runnable not in text, f"{surface}: {runnable}"
+
+    assert "Do not source the file" in remedy
+    assert "gateway, custody and telemetry secrets" in remedy
+    assert "**Do not source that file.**" in doc
+
+
 def test_cli_bridge_commissioning_deliver_refuses_an_undemonstrated_zone_when_hardened(
     tmp_path, monkeypatch, capsys
 ):


### PR DESCRIPTION
## What does this PR do?

A delivery run from a shell finds no commissioning anchor. Only the runtime service loads the environment file that carries it, through `EnvironmentFile=`, and `commissioning deliver` is a separate process started from a shell that does not inherit it.

The verdict is right and the diagnosis is not. `commissioned-safety-binding/v1` says absence of the current anchor with a binding present is `unknown_signer` at `key_selection`, because no key can be selected — so the stage and reason stay exactly as they are. What an installer does with that is go looking at the signing key, when the anchor is one process away. The first thing anyone does with a new device is deliver a binding, so the most likely first outcome today is a refusal pointing at the wrong thing.

Only the detail changes. An absent anchor names the variable, says where the installer writes it, and says how to pass it. An anchor that is configured but does not match keeps the message it had.

**The remedy names one variable and scopes it to one command.** The service environment file is also the delivery channel for `GATEWAY_SHARED_SECRET`, `ORI_CUSTODY_SECRET`, `ORI_EVIDENCE_DEVICE_SECRET`, the remote-command secrets and the telemetry API key. Telling an operator to source it would export every one of them into their interactive shell and each child it starts, in order to obtain a value that is a public key. Sourcing also reads a systemd environment file as shell, which is a different grammar — systemd performs no expansion, so a value containing `$` or a backtick means one thing to the service and another to the shell.

`unknown_signer` has three producers. Two are the operator-facing delivery path and both report through the same helper, so the distinction is made there rather than at one call site. The third, `verify_firmware_profile`, has no production caller and is driven only by the golden corpus.

The guidance is confined to `unknown_signer`. A refusal decided for another reason while the anchor happens to be unset — a document naming the wrong device, say — must not send an operator to the environment file, because sourcing it would not fix that.

## Type of change

- [x] `fix` — bug fix
- [x] `docs` — documentation only
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability behaviour changes. The verdict, its stage and its reason are identical before and after; only the human-readable detail accompanying an existing refusal differs.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

## Related issue

Closes #471

## Testing notes

Host-tested only. No installer has run these commands on a device, and the two device-only risks recorded against #470 — the anchor may not be in the installer's environment, and the staged file inherits umask — are untouched by this and remain for the bench visit.

Each boundary was mutated and the named test confirmed to fail for the property it names: dropping the condition, widening it to every `unknown_signer`, widening it to every refusal, dropping the anchors argument at the reporting site, removing the variable name from the detail, removing the file location, and changing the verdict instead of the detail.

One line is knowingly not covered. Passing the anchors to the parse-stage refusal is inert, because `parse_document` raises only `parses`/`malformed` and never `unknown_signer`; it is defensive breadth that no behavioural test can reach.

The extraction in `docs/COMMISSIONING.md` was run against an environment file holding quoted and unquoted values: it reads the anchor in both forms, and the gateway, custody and telemetry variables remain unset in the shell afterwards.
