### PR TITLE
build(mobile): identify an Android payload's ABI from its ELF header

### DIFF
--- a/scripts/build-android-runtime-mobile.sh
+++ b/scripts/build-android-runtime-mobile.sh
@@ -6,6 +6,14 @@
 # provisioning. The resulting files are real ELF executables named
 # libori_runtime_exec.so so Android extracts them into nativeLibraryDir where
 # the APK can execute them without violating Android W^X rules.
+#
+# The name is a packaging requirement and not a description: nothing loads
+# these as shared libraries, they are exec'd as processes. Android only
+# populates nativeLibraryDir from APK entries matching lib/<abi>/*.so.
+#
+# Every check the consuming APK's release gate makes is made here too, so a
+# payload that would be refused at packaging fails at the point it was built,
+# where the toolchain that produced it is still at hand.
 
 set -euo pipefail
 
@@ -13,6 +21,16 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CRATE_DIR="${ROOT}/mobile/ori-runtime-mobile"
 OUT="${ORI_ANDROID_RUNTIME_PAYLOAD_OUT:-${ROOT}/dist/android-runtime-payloads}"
 TARGET_DIR="${CARGO_TARGET_DIR:-${ROOT}/mobile/target}"
+
+# Pinned rather than left to cargo-ndk's default, so an upgrade of the tool
+# cannot move it silently. 21 is at or below every consuming APK's minSdk, so
+# one binary serves all of them; a binary built for a lower API level runs on
+# higher ones, not the reverse.
+PLATFORM="${ORI_ANDROID_RUNTIME_PAYLOAD_PLATFORM:-21}"
+
+# Debug symbols are a third of the artefact and nothing on the device reads
+# them. Set to 0 to keep them when a crash needs symbolising.
+STRIP="${ORI_ANDROID_RUNTIME_PAYLOAD_STRIP:-1}"
 
 if ! command -v cargo >/dev/null 2>&1; then
   echo "ERROR: cargo is required to build ori-runtime-mobile." >&2
@@ -24,16 +42,50 @@ if ! cargo ndk --version >/dev/null 2>&1; then
   exit 1
 fi
 
+# The NDK's strip. cargo-ndk finds its NDK through several variables and can
+# build when none of them is set, so looking only at ANDROID_NDK_HOME would
+# leave a build stripped or not depending on the caller's environment, with
+# the artefact differing from what this script says it produces.
+LLVM_STRIP=""
+for ndk_root in \
+  "${ANDROID_NDK_HOME:-}" \
+  "${ANDROID_NDK_ROOT:-}" \
+  "${NDK_HOME:-}" \
+  "${ANDROID_HOME:-}"/ndk/* \
+  "${ANDROID_SDK_ROOT:-}"/ndk/* \
+  "${HOME}"/Library/Android/sdk/ndk/*; do
+  [ -n "${ndk_root}" ] && [ -d "${ndk_root}" ] || continue
+  for candidate in "${ndk_root}"/toolchains/llvm/prebuilt/*/bin/llvm-strip; do
+    if [ -x "${candidate}" ]; then
+      LLVM_STRIP="${candidate}"
+      break 2
+    fi
+  done
+done
+
+# Refused rather than warned. The payload is correct unstripped, but silently
+# producing one artefact when the run was asked for another is how a size and
+# a digest stop meaning what a report says they mean.
+if [ "${STRIP}" = "1" ] && [ -z "${LLVM_STRIP}" ]; then
+  echo "ERROR: stripping was requested and no llvm-strip was found." >&2
+  echo "  Set ANDROID_NDK_HOME, or pass ORI_ANDROID_RUNTIME_PAYLOAD_STRIP=0" >&2
+  echo "  to keep symbols deliberately." >&2
+  exit 1
+fi
+
 mkdir -p "${OUT}"
 
 build_one() {
   local abi="$1"
   local triple="$2"
+  local elf_class="$3"
+  local elf_machine="$4"
   echo "Building ori-runtime-mobile for ${abi} (${triple})"
   (
     cd "${CRATE_DIR}"
     CARGO_TARGET_DIR="${TARGET_DIR}" cargo ndk \
       -t "${abi}" \
+      -P "${PLATFORM}" \
       build \
       --release \
       --locked
@@ -49,16 +101,83 @@ build_one() {
   mkdir -p "${dest_dir}"
   cp "${source}" "${dest}"
   chmod 0755 "${dest}"
-  if ! file "${dest}" | grep -q "ELF"; then
-    echo "ERROR: payload is not an ELF executable: ${dest}" >&2
-    exit 1
+
+  local symbols="unstripped"
+  if [ "${STRIP}" = "1" ]; then
+    "${LLVM_STRIP}" "${dest}"
+    symbols="stripped"
   fi
-  shasum -a 256 "${dest}"
+
+  verify_payload "${dest}" "${elf_class}" "${elf_machine}"
+  # Reported per artefact, so a digest is never read alongside a size the run
+  # did not produce.
+  echo "  ${abi}: ${symbols}"
+  digest "${dest}"
 }
 
-build_one "arm64-v8a" "aarch64-linux-android"
-build_one "armeabi-v7a" "armv7-linux-androideabi"
-build_one "x86_64" "x86_64-linux-android"
+# One unsigned byte from the ELF header at a given offset.
+elf_byte() {
+  od -An -tu1 -j "$2" -N1 "$1" | tr -d ' \n'
+}
+
+# Every one of these corresponds to a refusal in the consuming APK's release
+# gate. A payload failing any of them would be refused at packaging.
+verify_payload() {
+  local path="$1" want_class="$2" want_machine="$3"
+  local class data m_lo m_hi machine
+
+  if [ "$(head -c 4 "${path}" | od -An -tx1 | tr -d ' \n')" != "7f454c46" ]; then
+    echo "ERROR: payload does not begin with ELF magic: ${path}" >&2
+    exit 1
+  fi
+
+  # Decided from the ELF header, never from `file`'s prose. The prose nests:
+  # an arm64 binary is described "ARM aarch64", so a substring test for the
+  # 32-bit "ARM" accepts it and the wrong payload reaches the armeabi-v7a
+  # slot, failing only once it is on a 32-bit handset.
+  class="$(elf_byte "${path}" 4)"        # EI_CLASS: 1 = 32-bit, 2 = 64-bit
+  data="$(elf_byte "${path}" 5)"         # EI_DATA: 1 = little-endian
+  if [ "${data}" != "1" ]; then
+    echo "ERROR: payload is not little-endian; every Android ABI here is: ${path}" >&2
+    exit 1
+  fi
+  m_lo="$(elf_byte "${path}" 18)"
+  m_hi="$(elf_byte "${path}" 19)"
+  machine=$(( m_hi * 256 + m_lo ))       # e_machine
+
+  if [ "${class}" != "${want_class}" ]; then
+    echo "ERROR: payload is ELF class ${class}, expected ${want_class}: ${path}" >&2
+    exit 1
+  fi
+  if [ "${machine}" != "${want_machine}" ]; then
+    echo "ERROR: payload is e_machine ${machine}, expected ${want_machine}: ${path}" >&2
+    exit 1
+  fi
+
+  # The placeholder the consuming repo ships to keep its own build green is a
+  # shell script. Handing one over would pass an ELF check nowhere and this
+  # everywhere.
+  if grep -q "system/bin/sh" "${path}" 2>/dev/null; then
+    echo "ERROR: payload contains a shell interpreter line: ${path}" >&2
+    exit 1
+  fi
+  if grep -q "ORI_ANDROID_RUNTIME_PAYLOAD_SHIM" "${path}" 2>/dev/null; then
+    echo "ERROR: payload carries the placeholder marker: ${path}" >&2
+    exit 1
+  fi
+}
+
+digest() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1"
+  else
+    sha256sum "$1"
+  fi
+}
+
+build_one "arm64-v8a" "aarch64-linux-android" 2 183
+build_one "armeabi-v7a" "armv7-linux-androideabi" 1 40
+build_one "x86_64" "x86_64-linux-android" 2 62
 
 cat <<EOF
 

--- a/tests/test_runtime_mobile_payload_contract.py
+++ b/tests/test_runtime_mobile_payload_contract.py
@@ -3,6 +3,8 @@
 
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE = ROOT / "mobile" / "ori-runtime-mobile" / "src" / "main.rs"
 CARGO = ROOT / "mobile" / "ori-runtime-mobile" / "Cargo.toml"
@@ -72,7 +74,77 @@ def test_android_runtime_payload_builds_all_release_abis():
     assert "libori_runtime_exec.so" in script
     assert "cargo ndk" in script
     assert "--locked" in script
-    assert 'grep -q "ELF"' in script
+
+
+def test_android_runtime_payload_pins_the_api_level():
+    """cargo-ndk's default is its own to change; the payload's floor is not.
+
+    The flag is `-P`. Lowercase `-p` reaches cargo as `--package` and fails
+    with `unknown package`, which is why it is asserted rather than assumed.
+    """
+    script = BUILD_SCRIPT.read_text()
+
+    assert '-P "${PLATFORM}"' in script
+    assert "ORI_ANDROID_RUNTIME_PAYLOAD_PLATFORM" in script
+
+
+def test_android_runtime_payload_refuses_what_the_apk_gate_refuses():
+    """A payload the consuming APK would refuse must fail where it was built.
+
+    The consuming release gate refuses a payload lacking ELF magic, carrying a
+    shell interpreter line, or carrying the placeholder marker. Each is checked
+    here so the failure names the toolchain that produced it rather than
+    surfacing at packaging in another repository.
+    """
+    script = BUILD_SCRIPT.read_text()
+
+    assert "7f454c46" in script
+    assert "system/bin/sh" in script
+    assert "ORI_ANDROID_RUNTIME_PAYLOAD_SHIM" in script
+
+
+def test_android_runtime_payload_identifies_an_abi_by_elf_header():
+    """The ABI is decided from the header, never from `file`'s prose.
+
+    The prose nests: an arm64 binary is described "ARM aarch64", so a
+    substring test for the 32-bit "ARM" accepts it. That puts an arm64 payload
+    in the armeabi-v7a slot, where it packages cleanly and fails only once it
+    reaches a 32-bit handset.
+    """
+    script = BUILD_SCRIPT.read_text()
+
+    # EI_CLASS at offset 4, EI_DATA at 5, e_machine at 18.
+    assert 'elf_byte "${path}" 4' in script
+    assert 'elf_byte "${path}" 5' in script
+    assert 'elf_byte "${path}" 18' in script
+    assert "e_machine" in script
+
+    # EM_AARCH64 183, EM_ARM 40, EM_X86_64 62, with the 64/32-bit class.
+    assert 'build_one "arm64-v8a" "aarch64-linux-android" 2 183' in script
+    assert 'build_one "armeabi-v7a" "armv7-linux-androideabi" 1 40' in script
+    assert 'build_one "x86_64" "x86_64-linux-android" 2 62' in script
+
+    # A guard reading the description would reintroduce the nesting.
+    assert "want_arch" not in script
+
+
+def test_android_runtime_payload_refuses_to_silently_skip_stripping():
+    """An artefact must not differ from what the run was asked to produce.
+
+    Stripping that quietly turns itself off when a tool is missing makes a
+    reported size and digest describe a build nobody asked for. Absent tooling
+    refuses; keeping symbols stays available, deliberately.
+    """
+    script = BUILD_SCRIPT.read_text()
+
+    assert "ERROR: stripping was requested and no llvm-strip was found." in script
+    assert "ORI_ANDROID_RUNTIME_PAYLOAD_STRIP=0" in script
+    # cargo-ndk resolves its NDK from several variables and can build with
+    # none of them set, so one variable is not where the toolchain lives.
+    for variable in ("ANDROID_NDK_ROOT", "NDK_HOME", "ANDROID_SDK_ROOT"):
+        assert variable in script
+    # Reported per artefact rather than assumed for the run.
+    assert "${abi}: ${symbols}" in script
 
 
 def test_rust_supply_chain_guard_checks_lockfile_and_forbidden_sources():
@@ -83,3 +155,100 @@ def test_rust_supply_chain_guard_checks_lockfile_and_forbidden_sources():
     assert "forbidden git source" in guard
     assert "forbidden non-registry source" in guard
     assert "Android runtime payload build must use cargo --locked" in guard
+
+
+def _run_verifier(tmp_path, payload: bytes, want_class: int, want_machine: int):
+    """Drive the script's own verifier over a payload, and report its verdict.
+
+    The script's functions are extracted and executed rather than reimplemented,
+    so this tests the shipped logic. A test that asserted only that the header
+    offsets appear in the source would pass with every comparison removed.
+    """
+    import subprocess
+
+    target = tmp_path / "payload.bin"
+    target.write_bytes(payload)
+    harness = tmp_path / "harness.sh"
+    harness.write_text(
+        "set -euo pipefail\n"
+        f'eval "$(sed -n \'/^elf_byte()/,/^}}/p;/^verify_payload()/,/^}}/p\' "{BUILD_SCRIPT}")"\n'
+        f'verify_payload "{target}" "{want_class}" "{want_machine}"\n'
+    )
+    return subprocess.run(
+        ["bash", str(harness)], capture_output=True, text=True
+    ).returncode
+
+
+def _elf_header(elf_class: int, machine: int, *, data: int = 1) -> bytes:
+    """The leading bytes of an ELF the verifier reads, and nothing more."""
+    header = bytearray(64)
+    header[0:4] = b"\x7fELF"
+    header[4] = elf_class
+    header[5] = data
+    header[18] = machine & 0xFF
+    header[19] = (machine >> 8) & 0xFF
+    return bytes(header)
+
+
+AARCH64 = (2, 183)
+ARM32 = (1, 40)
+X86_64 = (2, 62)
+
+
+@pytest.mark.parametrize(
+    "payload_abi,slot_abi,accepted",
+    [
+        (AARCH64, AARCH64, True),
+        (ARM32, ARM32, True),
+        (X86_64, X86_64, True),
+        # The reported bypass: `file` describes arm64 as "ARM aarch64", so a
+        # substring test for the 32-bit "ARM" accepted it into this slot.
+        (AARCH64, ARM32, False),
+        (ARM32, AARCH64, False),
+        (X86_64, AARCH64, False),
+        (AARCH64, X86_64, False),
+        (ARM32, X86_64, False),
+        (X86_64, ARM32, False),
+    ],
+)
+def test_the_verifier_accepts_only_its_own_abi(
+    tmp_path, payload_abi, slot_abi, accepted
+):
+    """Every ABI substitution, in both directions."""
+    rc = _run_verifier(tmp_path, _elf_header(*payload_abi), *slot_abi)
+    assert (rc == 0) is accepted
+
+
+@pytest.mark.parametrize(
+    "payload,slot",
+    [
+        # The machine matches and only the class does not. No pair of the three
+        # real ABIs differs this way, so without these the class check decides
+        # nothing and could be removed unnoticed.
+        ((1, 183), AARCH64),
+        ((2, 40), ARM32),
+        ((1, 62), X86_64),
+    ],
+)
+def test_the_verifier_checks_the_elf_class_on_its_own(tmp_path, payload, slot):
+    """A payload naming the right machine at the wrong width is still wrong."""
+    assert _run_verifier(tmp_path, _elf_header(*payload), *slot) != 0
+
+
+def test_the_verifier_refuses_a_payload_that_is_not_an_elf(tmp_path):
+    assert _run_verifier(tmp_path, b"#!/system/bin/sh\nexit 0\n", *AARCH64) != 0
+
+
+def test_the_verifier_refuses_a_big_endian_payload(tmp_path):
+    """e_machine is read as two bytes, so its byte order has to be known."""
+    assert _run_verifier(tmp_path, _elf_header(*AARCH64, data=2), *AARCH64) != 0
+
+
+def test_the_verifier_refuses_an_elf_carrying_the_placeholder_marker(tmp_path):
+    payload = _elf_header(*AARCH64) + b"ORI_ANDROID_RUNTIME_PAYLOAD_SHIM"
+    assert _run_verifier(tmp_path, payload, *AARCH64) != 0
+
+
+def test_the_verifier_refuses_an_elf_carrying_a_shell_interpreter_line(tmp_path):
+    payload = _elf_header(*AARCH64) + b"#!/system/bin/sh\n"
+    assert _run_verifier(tmp_path, payload, *AARCH64) != 0


### PR DESCRIPTION
## What does this PR do?

Fixes an ABI guard bypass in the Android payload build script, and closes the gaps that let the bypass survive its own test.

### The bypass

The verifier decided an artefact's architecture from `file`'s description, matched as a substring. That prose nests:

```
file(arm64) = ELF 64-bit LSB pie executable, ARM aarch64
```

The 32-bit check looked for `ARM`, which is a prefix of `ARM aarch64`, so an arm64 payload passed the `armeabi-v7a` check. It would then package cleanly into the 32-bit slot and fail only once it reached a 32-bit handset — the worst place for it to fail, since packaging, staging and every host check all pass.

The ABI is now read from the ELF header: `EI_CLASS` at offset 4, `EI_DATA` at 5, and `e_machine` at 18, checked against the pairs the three targets actually have. Byte order is checked because `e_machine` is two bytes and its order has to be known before it can be read. Every substitution is now refused in both directions, including the pairs that differ only in width.

### Why the old check had a test and the bypass survived anyway

There was an architecture test. It used x86-64 against aarch64, where neither description is a prefix of the other, so it passed while establishing nothing about the case that mattered. Two further gaps came out of mutating the guard properly rather than trusting that green run:

The contract assertions were substring greps over the script's source. Deleting the comparisons entirely left them passing, because the offsets were still mentioned. The verifier's own functions are now extracted and executed against synthesised ELF headers, so the shipped logic is what runs. The headers are built in the test rather than committed, so this needs no NDK and no artefact.

Even then, removing the class check alone survived, because all three real ABIs differ in `e_machine` as well and the class never decided anything. The cases where the machine matches and only the width differs are now covered, so each half of the identity holds on its own.

### Stripping

Stripping was conditional on finding a tool and warned when it could not, which meant a run could quietly produce an unstripped artefact while its report described a stripped one. A size and a digest have to describe the build that was asked for, so a missing tool now refuses; keeping symbols stays available deliberately through `ORI_ANDROID_RUNTIME_PAYLOAD_STRIP=0`.

The toolchain is looked up the several ways the build tool itself resolves one, because it can build successfully with none of them set — so looking at a single variable would leave the artefact depending on the caller's environment. Each payload now reports whether it was stripped, on its own line above its digest.

### API level

Pinned rather than left to the build tool's default, which belongs to that tool and can move on an upgrade. It is passed as `-P`; the lowercase spelling reaches cargo as `--package` and fails with `unknown package`.

## Type of change

- [x] `fix` — bug fix

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime capability changes. This is build tooling: no file under `ori/` is touched, and nothing here runs on a device.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable. Only `scripts/` and `tests/`.

## Related issue

Refs #536, which carries the publishing route these artefacts still have no way to travel. This PR produces and verifies payloads; it publishes nothing, and obtaining one still means running the script by hand.

## Testing notes

Host-verified on macOS with NDK 27.2.12479018. A clean rebuild produces three stripped PIE executables reproducing byte for byte across runs:

```
arm64-v8a    14f2dfb5e14c914a…  ELF 64-bit LSB pie, ARM aarch64   2.4M
armeabi-v7a  53de2d9b60d4f861…  ELF 32-bit LSB pie, ARM EABI5     1.6M
x86_64       dd53a727be6acf52…  ELF 64-bit LSB pie, x86-64        2.7M
```

Both 64-bit targets already carry sixteen-kilobyte page alignment from the NDK's defaults, so no link argument is needed for Android 15 and later; the 32-bit target is four-kilobyte aligned, which is correct because that page size support is 64-bit only.

Seven mutations on the guards, each killed by the test naming the property it breaks: the armv7 slot accepting any ARM class, the class check removed, the machine check removed, stripping silently skipped, the API level unpinned, the placeholder marker check dropped, and the strip state going unreported.

Reproducibility was checked on one machine only, which is worth stating because #536's digest criterion depends on it holding across machines. Nothing here establishes that the payload executes on a handset: the packaging path was exercised end to end with a placeholder binary, and the real payload has not been run in its place.
