### PR TITLE
ci(types): hold the pyright count against a committed baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,31 @@ jobs:
       # managers entered synchronously. Scoped to `ori/` because the test tree
       # still carries stub-typing diagnostics; widening it is #358's remaining
       # half. A ratchet only holds if the clean half is enforced.
+      # `scripts/` is inside the ratchet's total, so it is gated at zero here
+      # too. Gating only `ori/` would leave diagnostics added under `scripts/`
+      # payable by removing some from `tests/`, which is the absorption the
+      # ratchet exists to prevent one directory over.
       - name: Type check production code (pyright)
         if: matrix.python-version == '3.12'
-        run: pyright ori/
+        run: pyright ori/ scripts/
+
+      # mypy needs no ratchet: it is already clean over both trees, so it gets
+      # the stronger control. Ordered before the ratchet so a type regression
+      # names the tree it is in rather than arriving as a moved count, and
+      # scoped to one interpreter because the analysis version is pinned in
+      # config and running it three times measures the same thing three times.
+      - name: Type check the test tree (mypy)
+        if: matrix.python-version == '3.12'
+        run: python -m mypy tests/
+
+      # The test tree is not zero and paying it down is separate work. This
+      # stops the number growing while that waits, which a per-author habit
+      # does not: a count nothing prints is a count no reviewer sees. Strict
+      # in both directions, because a baseline left above the real count is
+      # headroom someone later spends without noticing.
+      - name: Hold the pyright count against its baseline (ratchet)
+        if: matrix.python-version == '3.12'
+        run: python scripts/pyright_ratchet.py
 
       - name: Pre-commit (lint + format + hygiene)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,6 +203,13 @@ ignore = ["E501"]
 # duplicate is invisible in a total and makes the count untrackable.
 include = ["ori", "tests", "scripts"]
 extraPaths = ["scripts"]
+# Pinned, because the count is compared against a committed baseline and an
+# unpinned analysis environment makes that number a property of whoever ran it.
+# Typeshed declares some members under `sys.platform == "linux"` only, so the
+# same tree reports one more diagnostic on macOS than on Linux; the interpreter
+# version moves it too. These are the values the baseline was measured at.
+pythonPlatform = "Linux"
+pythonVersion = "3.12"
 
 [tool.mypy]
 python_version = "3.11"

--- a/pyright-baseline.json
+++ b/pyright-baseline.json
@@ -1,0 +1,11 @@
+{
+  "total": 478,
+  "by_area": {
+    "tests": 334,
+    "tests/commissioning": 14,
+    "tests/evidence": 6,
+    "tests/firmware": 86,
+    "tests/remote_commands": 38
+  },
+  "note": "pyright error count over the trees pyright analyses (ori, tests, scripts; skills/ is outside its include). Lower it whenever the real count falls. Raising it needs --allow-raise and is a decision, not a step. `pyright ori/ scripts/` is separately gated at zero, so a rise there cannot be absorbed by a fall in tests/. The count depends on pythonPlatform and pythonVersion, both pinned in pyproject.toml."
+}

--- a/scripts/pyright_ratchet.py
+++ b/scripts/pyright_ratchet.py
@@ -1,0 +1,242 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hold the pyright count over the analysed trees at or below a baseline.
+
+`pyright ori/ scripts/` is gated at zero and stays that way. The test tree is
+not zero, and paying it down is separate work; what this stops is the number
+growing while that work waits. A count nothing prints is a number no reviewer
+sees, and a rule every author has to remember is the control that fails when
+someone is in a hurry.
+
+The ratchet is strict in both directions. A rise fails, which is the point. A
+fall fails too, asking for the baseline to be lowered, because a baseline left
+above the real count is headroom someone later spends without noticing.
+
+That strictness has a cost, and it is the reason the alternative exists: every
+change that moves the count in either direction carries a one-line baseline
+commit, two such changes conflict on that line, deleting a test file becomes a
+failure until the baseline follows, and a pyright upgrade moves the number for
+everyone until someone re-measures. The alternative — failing only on a rise —
+trades those for headroom that accumulates silently and is spent by whoever
+comes next.
+
+The count is a property of the analysis environment as much as of the code, so
+`pythonPlatform` and `pythonVersion` are pinned in `pyproject.toml`. Without
+that the same tree reports a different number on macOS and Linux and no single
+committed value is correct on both.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import Counter
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BASELINE_PATH = REPO_ROOT / "pyright-baseline.json"
+
+BASELINE_NOTE = (
+    "pyright error count over the trees pyright analyses (ori, tests, scripts; "
+    "skills/ is outside its include). Lower it whenever the real count falls. "
+    "Raising it needs --allow-raise and is a decision, not a step. "
+    "`pyright ori/ scripts/` is separately gated at zero, so a rise there "
+    "cannot be absorbed by a fall in tests/. The count depends on "
+    "pythonPlatform and pythonVersion, both pinned in pyproject.toml."
+)
+
+
+def run_pyright() -> dict:
+    """Every diagnostic pyright reports for the analysed trees, as JSON.
+
+    Invoked through this interpreter rather than whatever `pyright` is first on
+    PATH: a globally installed copy of another version reports another number,
+    and the whole mechanism rests on the count being the pinned one.
+    """
+    try:
+        completed = subprocess.run(
+            [sys.executable, "-m", "pyright", "--outputjson"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError as exc:  # pragma: no cover - environment failure
+        sys.stderr.write(f"could not run pyright: {exc}\n")
+        raise SystemExit(2) from exc
+
+    # A non-zero exit is the normal case: it means diagnostics exist. Only
+    # unparseable output means pyright itself failed.
+    try:
+        report: dict = json.loads(completed.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(
+            "pyright did not produce JSON. It may not be installed in this "
+            "environment, or it failed before analysing.\n"
+        )
+        sys.stderr.write(completed.stdout[-2000:])
+        sys.stderr.write(completed.stderr[-2000:])
+        raise SystemExit(2) from None
+    return report
+
+
+def error_diagnostics(report: dict) -> list[dict]:
+    return [
+        diagnostic
+        for diagnostic in report.get("generalDiagnostics", [])
+        if diagnostic.get("severity") == "error"
+    ]
+
+
+def relative(raw: str) -> str:
+    try:
+        return str(Path(raw).resolve().relative_to(REPO_ROOT))
+    except (ValueError, OSError):
+        return raw or "unknown"
+
+
+def by_area(diagnostics: list[dict]) -> dict[str, int]:
+    counts: Counter[str] = Counter()
+    for diagnostic in diagnostics:
+        counts[str(Path(relative(diagnostic.get("file") or "")).parent)] += 1
+    return dict(sorted(counts.items()))
+
+
+def read_baseline() -> dict:
+    if not BASELINE_PATH.exists():
+        sys.stderr.write(f"no baseline at {BASELINE_PATH.name}; run --update\n")
+        raise SystemExit(2)
+    baseline: dict = json.loads(BASELINE_PATH.read_text())
+    return baseline
+
+
+def write_baseline(diagnostics: list[dict]) -> None:
+    BASELINE_PATH.write_text(
+        json.dumps(
+            {
+                "total": len(diagnostics),
+                "by_area": by_area(diagnostics),
+                "note": BASELINE_NOTE,
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+
+
+def describe_change(
+    diagnostics: list[dict], recorded_areas: dict[str, int]
+) -> list[str]:
+    """The areas that moved, so a failure names where to look.
+
+    The whole distribution would be nearly the same before and after a small
+    rise, which is what makes a bare breakdown useless for finding one.
+    """
+    current = by_area(diagnostics)
+    lines: list[str] = []
+    for area in sorted(set(current) | set(recorded_areas)):
+        now, before = current.get(area, 0), recorded_areas.get(area, 0)
+        if now != before:
+            lines.append(f"    {before:>5} -> {now:<5}  {area}")
+    if not lines:
+        lines.append("    (no area changed; the recorded breakdown may be stale)")
+    return lines
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="pyright count ratchet")
+    parser.add_argument(
+        "--update", action="store_true", help="record the current count"
+    )
+    parser.add_argument(
+        "--allow-raise",
+        action="store_true",
+        help="with --update, permit recording a higher count",
+    )
+    parser.add_argument(
+        "--list", action="store_true", help="print every diagnostic and exit"
+    )
+    args = parser.parse_args(argv)
+
+    report = run_pyright()
+    diagnostics = error_diagnostics(report)
+    total = len(diagnostics)
+
+    # Two counts that disagree mean one is being read wrong, and a report with
+    # no summary is not a report this can check. Neither is compared.
+    summary = report.get("summary")
+    if not isinstance(summary, dict) or "errorCount" not in summary:
+        sys.stderr.write("pyright reported no error summary; refusing to compare.\n")
+        return 2
+    if int(summary["errorCount"]) != total:
+        sys.stderr.write(
+            f"pyright reported {summary['errorCount']} errors in its summary "
+            f"but {total} diagnostics; refusing to compare an ambiguous count.\n"
+        )
+        return 2
+
+    if args.list:
+        for diagnostic in diagnostics:
+            line = int(diagnostic.get("range", {}).get("start", {}).get("line", 0)) + 1
+            rule = diagnostic.get("rule") or "unclassified"
+            message = str(diagnostic.get("message", "")).splitlines()[0]
+            print(f"{relative(diagnostic.get('file') or '')}:{line}  {rule}  {message}")
+        return 0
+
+    baseline = read_baseline()
+    recorded = int(baseline["total"])
+    recorded_areas = {
+        str(k): int(v) for k, v in (baseline.get("by_area") or {}).items()
+    }
+
+    if args.update:
+        if total > recorded and not args.allow_raise:
+            print(
+                f"refusing to raise the baseline from {recorded} to {total}. "
+                "A rise is a decision, not a step:",
+                file=sys.stderr,
+            )
+            print(
+                *describe_change(diagnostics, recorded_areas), sep="\n", file=sys.stderr
+            )
+            print(
+                "  Fix them, or pass --allow-raise to record the rise deliberately.",
+                file=sys.stderr,
+            )
+            return 1
+        write_baseline(diagnostics)
+        direction = "raised" if total > recorded else "lowered"
+        if total == recorded:
+            direction = "unchanged at"
+        print(f"baseline {direction} {total}")
+        return 0
+
+    if total != recorded:
+        verb = "rose" if total > recorded else "fell"
+        delta = f"+{total - recorded}" if total > recorded else f"-{recorded - total}"
+        print(
+            f"pyright diagnostics {verb}: {total}, baseline {recorded} ({delta}).",
+            file=sys.stderr,
+        )
+        print(*describe_change(diagnostics, recorded_areas), sep="\n", file=sys.stderr)
+        if total > recorded:
+            print(
+                "  List them with: python scripts/pyright_ratchet.py --list",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                "  Lower the baseline so the difference cannot be spent later:\n"
+                "    python scripts/pyright_ratchet.py --update",
+                file=sys.stderr,
+            )
+        return 1
+
+    print(f"pyright diagnostics: {total}, baseline {recorded}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_pyright_ratchet.py
+++ b/tests/test_pyright_ratchet.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""The ratchet that holds the pyright count against a committed baseline.
+
+Driven as a module rather than by running pyright: a test that shelled out to
+the checker would take minutes and would fail whenever the tree's real count
+moved, which is the thing the baseline exists to absorb.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts import pyright_ratchet
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+BASELINE = REPO_ROOT / "pyright-baseline.json"
+
+
+def _diagnostic(
+    severity: str = "error",
+    rule: str = "reportArgumentType",
+    path: str = "tests/x.py",
+) -> dict:
+    return {
+        "file": str(REPO_ROOT / path),
+        "severity": severity,
+        "rule": rule,
+        "message": "something",
+        "range": {"start": {"line": 0}},
+    }
+
+
+def _report(diagnostics: list[dict]) -> dict:
+    return {
+        "generalDiagnostics": diagnostics,
+        "summary": {
+            "errorCount": len([d for d in diagnostics if d["severity"] == "error"])
+        },
+    }
+
+
+def _fixed(monkeypatch: pytest.MonkeyPatch, diagnostics: list[dict]) -> None:
+    monkeypatch.setattr(pyright_ratchet, "run_pyright", lambda: _report(diagnostics))
+
+
+def _running_steps() -> list[dict]:
+    """Every step of the test job that CI actually runs.
+
+    Parsed rather than grepped: a step commented out, deleted, or disabled with
+    `if: false` still leaves its text in the file, so a substring assertion
+    passes over a workflow that enforces nothing.
+    """
+    workflow = yaml.safe_load(CI.read_text())
+    steps = []
+    for job in workflow["jobs"].values():
+        for step in job.get("steps") or []:
+            condition = str(step.get("if", "")).strip().lower()
+            if condition in {"false", "${{ false }}"}:
+                continue
+            steps.append(step)
+    return steps
+
+
+def _run_lines() -> list[str]:
+    return [str(step.get("run", "")).strip() for step in _running_steps()]
+
+
+# --------------------------------------------------------------------------
+# Counting
+# --------------------------------------------------------------------------
+
+
+def test_only_errors_are_counted() -> None:
+    """A warning is not a diagnostic this holds, so it cannot consume headroom."""
+    report = {
+        "generalDiagnostics": [
+            _diagnostic("error"),
+            _diagnostic("warning"),
+            _diagnostic("information"),
+        ]
+    }
+    assert len(pyright_ratchet.error_diagnostics(report)) == 1
+
+
+def test_the_committed_baseline_records_a_total_and_a_breakdown() -> None:
+    baseline = json.loads(BASELINE.read_text())
+    assert isinstance(baseline["total"], int) and baseline["total"] >= 0
+    assert baseline["by_area"]
+    assert sum(baseline["by_area"].values()) == baseline["total"]
+    assert baseline["note"].strip()
+
+
+def test_the_committed_baseline_is_free_of_gated_trees() -> None:
+    """`ori/` and `scripts/` are gated at zero, so neither may appear here.
+
+    A diagnostic recorded under a gated tree would mean the baseline had
+    absorbed something the zero gate is supposed to refuse.
+    """
+    baseline = json.loads(BASELINE.read_text())
+    for area in baseline["by_area"]:
+        assert not area.startswith("ori"), area
+        assert not area.startswith("scripts"), area
+
+
+@pytest.mark.parametrize(
+    "total,recorded,expected",
+    [(478, 478, 0), (479, 478, 1), (477, 478, 1)],
+)
+def test_the_ratchet_is_strict_in_both_directions(
+    monkeypatch: pytest.MonkeyPatch, total: int, recorded: int, expected: int
+) -> None:
+    """Unspent headroom is a rise someone else gets for free later."""
+    _fixed(monkeypatch, [_diagnostic() for _ in range(total)])
+    monkeypatch.setattr(
+        pyright_ratchet, "read_baseline", lambda: {"total": recorded, "by_area": {}}
+    )
+    assert pyright_ratchet.main([]) == expected
+
+
+@pytest.mark.parametrize("summary", [None, {}, {"warningCount": 0}, "not a dict"])
+def test_a_report_without_an_error_summary_is_refused(
+    monkeypatch: pytest.MonkeyPatch, summary
+) -> None:
+    """A count whose meaning is not established is not compared to anything."""
+    monkeypatch.setattr(
+        pyright_ratchet,
+        "run_pyright",
+        lambda: {"generalDiagnostics": [_diagnostic()], "summary": summary},
+    )
+    monkeypatch.setattr(pyright_ratchet, "read_baseline", lambda: {"total": 1})
+    assert pyright_ratchet.main([]) == 2
+
+
+def test_a_summary_disagreeing_with_the_diagnostics_is_refused(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        pyright_ratchet,
+        "run_pyright",
+        lambda: {"generalDiagnostics": [_diagnostic()], "summary": {"errorCount": 400}},
+    )
+    monkeypatch.setattr(pyright_ratchet, "read_baseline", lambda: {"total": 400})
+    assert pyright_ratchet.main([]) == 2
+
+
+# --------------------------------------------------------------------------
+# The failure has to say where to look
+# --------------------------------------------------------------------------
+
+
+def test_a_rise_names_the_area_that_moved(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The area that changed, not the distribution of everything.
+
+    A small rise leaves the overall breakdown almost identical, so printing it
+    whole tells an author nothing about the diagnostics they just added.
+    """
+    diagnostics = [_diagnostic(path="tests/x.py") for _ in range(334)]
+    diagnostics += [_diagnostic(path="tests/firmware/y.py") for _ in range(88)]
+    _fixed(monkeypatch, diagnostics)
+    monkeypatch.setattr(
+        pyright_ratchet,
+        "read_baseline",
+        lambda: {"total": 420, "by_area": {"tests": 334, "tests/firmware": 86}},
+    )
+
+    assert pyright_ratchet.main([]) == 1
+
+    err = capsys.readouterr().err
+    assert "422" in err and "420" in err and "+2" in err
+    assert "--list" in err
+    # Only the area that moved, named with both counts.
+    assert "86 -> 88" in err and "tests/firmware" in err
+    assert "tests\n" not in err.replace("tests/firmware", "")
+
+
+def test_a_fall_says_to_lower_the_baseline_rather_than_to_look_for_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _fixed(monkeypatch, [_diagnostic() for _ in range(470)])
+    monkeypatch.setattr(
+        pyright_ratchet,
+        "read_baseline",
+        lambda: {"total": 478, "by_area": {"tests": 478}},
+    )
+
+    assert pyright_ratchet.main([]) == 1
+
+    err = capsys.readouterr().err
+    assert "-8" in err
+    assert "--update" in err
+    assert "--list" not in err
+
+
+# --------------------------------------------------------------------------
+# --update is the only mutating path
+# --------------------------------------------------------------------------
+
+
+def test_update_refuses_to_raise_the_baseline(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The remediation a failure prints must not be a way to bank a rise.
+
+    A fall is a hard failure whose printed fix is `--update`. An author whose
+    branch removed some diagnostics and added others would otherwise run what
+    they were told to run and record the net rise without seeing it.
+    """
+    target = tmp_path / "baseline.json"
+    target.write_text(json.dumps({"total": 478, "by_area": {"tests": 478}}))
+    monkeypatch.setattr(pyright_ratchet, "BASELINE_PATH", target)
+    _fixed(monkeypatch, [_diagnostic() for _ in range(600)])
+
+    assert pyright_ratchet.main(["--update"]) == 1
+    assert json.loads(target.read_text())["total"] == 478
+    assert "refusing to raise" in capsys.readouterr().err
+
+
+def test_update_records_a_rise_only_when_asked_deliberately(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    target = tmp_path / "baseline.json"
+    target.write_text(json.dumps({"total": 478, "by_area": {"tests": 478}}))
+    monkeypatch.setattr(pyright_ratchet, "BASELINE_PATH", target)
+    _fixed(monkeypatch, [_diagnostic() for _ in range(600)])
+
+    assert pyright_ratchet.main(["--update", "--allow-raise"]) == 0
+    assert json.loads(target.read_text())["total"] == 600
+
+
+def test_update_lowers_without_ceremony(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Lowering is the direction that needs no permission."""
+    target = tmp_path / "baseline.json"
+    target.write_text(json.dumps({"total": 478, "by_area": {"tests": 478}}))
+    monkeypatch.setattr(pyright_ratchet, "BASELINE_PATH", target)
+    _fixed(monkeypatch, [_diagnostic() for _ in range(400)])
+
+    assert pyright_ratchet.main(["--update"]) == 0
+    recorded = json.loads(target.read_text())
+    assert recorded["total"] == 400
+    assert recorded["by_area"] == {"tests": 400}
+
+
+def test_a_missing_baseline_is_an_error_rather_than_an_empty_one(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Treating absence as zero would fail every run; as infinity, none."""
+    monkeypatch.setattr(pyright_ratchet, "BASELINE_PATH", tmp_path / "absent.json")
+    _fixed(monkeypatch, [_diagnostic()])
+    with pytest.raises(SystemExit) as raised:
+        pyright_ratchet.main([])
+    assert raised.value.code == 2
+
+
+def test_list_prints_every_diagnostic_and_changes_nothing(
+    monkeypatch: pytest.MonkeyPatch, tmp_path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    target = tmp_path / "baseline.json"
+    target.write_text(json.dumps({"total": 1, "by_area": {"tests": 1}}))
+    monkeypatch.setattr(pyright_ratchet, "BASELINE_PATH", target)
+    _fixed(monkeypatch, [_diagnostic(), _diagnostic(path="tests/firmware/y.py")])
+
+    assert pyright_ratchet.main(["--list"]) == 0
+
+    out = capsys.readouterr().out
+    assert "tests/x.py:1" in out and "tests/firmware/y.py:1" in out
+    assert "reportArgumentType" in out
+    assert json.loads(target.read_text())["total"] == 1
+
+
+# --------------------------------------------------------------------------
+# What CI enforces, read from the workflow rather than from its text
+# --------------------------------------------------------------------------
+
+
+def test_ci_runs_the_ratchet() -> None:
+    assert "python scripts/pyright_ratchet.py" in _run_lines()
+
+
+def test_ci_gates_every_tree_the_ratchet_counts_at_zero() -> None:
+    """A rise in a gated tree must not be absorbable by a fall in the test tree.
+
+    The ratchet holds one total across `ori`, `tests` and `scripts`, so on its
+    own it would let one tree pay for another. The zero gate has to cover every
+    counted tree except the one the baseline exists for, or the absorption it
+    forbids simply moves to whichever tree the gate missed.
+    """
+    import tomllib
+
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_bytes().decode())
+    counted = set(pyproject["tool"]["pyright"]["include"])
+
+    gate = next((line for line in _run_lines() if line.startswith("pyright ")), None)
+    assert gate is not None, "no pyright zero gate runs in CI"
+    gated = set(gate.removeprefix("pyright ").split())
+
+    assert counted - {tree.rstrip("/") for tree in gated} == {"tests"}
+
+
+def test_ci_gates_the_test_tree_with_mypy_rather_than_a_ratchet() -> None:
+    """The explicit decision #532 asks for, asserted where it is enforced.
+
+    mypy is already clean over both trees, so it takes a gate at zero instead
+    of a baseline. A ratchet exists to hold a number that cannot yet be zero;
+    using one where zero is achievable would license a first regression.
+    """
+    runs = _run_lines()
+    assert "python -m mypy ori/" in runs
+    assert "python -m mypy tests/" in runs
+    assert not any("mypy" in line and "ratchet" in line for line in runs)
+
+
+def test_the_analysis_environment_is_pinned() -> None:
+    """The count is a property of the environment as much as of the code.
+
+    Unpinned, the same tree reports a different number on macOS and Linux, and
+    no single committed value is correct on both: one platform reads a fall and
+    the other a rise, forever.
+    """
+    import tomllib
+
+    pyright = tomllib.loads((REPO_ROOT / "pyproject.toml").read_bytes().decode())[
+        "tool"
+    ]["pyright"]
+
+    assert pyright["pythonPlatform"] == "Linux"
+    assert pyright["pythonVersion"]


### PR DESCRIPTION
## What does this PR do?

`pyright ori/` was gated at zero and CI enforced it. The test tree was gated by nothing, so every change could add diagnostics there and nobody would see it. In one session three separate changes each added between one and five, and each was caught only because the author happened to compare against `main` before pushing. That is a habit, and habits are the control that fails when someone is in a hurry.

This holds the count over the trees pyright analyses against a committed baseline, and fails CI when it moves. Paying down the existing count is separate work and deliberately not here.

### Strict in both directions, and what that costs

A rise fails, which is the point. A fall fails too, asking for the baseline to be lowered, because a baseline left standing above the real count is headroom the next change spends without noticing.

The issue asked for the baseline to lower automatically — the step rewriting it, or a periodic job — on the grounds that a number only a human can lower stops tracking reality. This does neither, and the amended decision is recorded on the issue. The property being protected is still held, and held harder: a gap between the baseline and the real count cannot survive one CI run, and the person who closes it is the person who caused it.

The mechanism was rejected on cost, not principle. Lowering autonomously means a workflow with write access to the default branch, pushing commits to keep a lint number current. This repository gates release protections, signs its release bundles and runs a supply-chain guard; a type-diagnostic count is not worth opening that surface. The costs of what shipped are real and stated in the script rather than left to be discovered: a one-line baseline commit whenever the count moves, a conflict when two changes move it at once, a test-file deletion failing until the baseline follows, and a pyright upgrade moving the number for everyone until someone re-measures. If that proves worse in practice than the headroom it prevents, failing on a rise and warning on a fall is a smaller change than adding a bot.

### The count is a property of the environment, so the environment is pinned

Typeshed declares some members under `sys.platform == "linux"` only — `psutil.sensors_temperatures` among them — so the same tree reported 479 diagnostics on macOS and 478 on Linux. With a two-directional ratchet no single committed value is correct on both: one platform reads a rise and the other a fall, forever. `pythonPlatform` and `pythonVersion` are now pinned in `pyproject.toml`, and both platforms agree at 478.

The count also depends on the installed dependency set, which a pin cannot fix. A sparse environment reports far more, and correctly fails rather than passing falsely.

### Why `scripts/` joins the zero gate

The ratchet holds one total across `ori`, `tests` and `scripts`. Gating only `ori/` would leave diagnostics added under `scripts/` payable by removing some from `tests/` — the absorption the acceptance criterion forbids, one directory over, in a tree that holds the release-bundle builder and the signing scripts. `pyright ori/ scripts/` is already zero, so the gate costs nothing today and refuses the trade tomorrow.

### `--update` cannot bank a rise

Recording a higher count needs `--allow-raise`. A fall is the failure that prints `--update` as its remedy, so a change that removed some diagnostics and added others would otherwise record the net rise by doing exactly what it was told.

### The mypy decision

The issue asks for it explicitly. mypy is already clean over both trees, so it takes a gate at zero rather than a baseline: a ratchet exists to hold a number that cannot yet be zero, and using one where zero is reachable would license a first regression. The gate is ordered before the ratchet so a type regression names the tree it is in rather than arriving as a moved count.

## Type of change

- [x] `test` — tests only

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no runtime capability changes. No file under `ori/` is touched; this is CI configuration and a build-time check.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

Not applicable. `.github/`, `pyproject.toml`, `scripts/` and `tests/` only.

## Related issue

Closes #532.

## Testing notes

Verified in `python:3.12-bookworm` with `pip install --require-hashes -r requirements/dev.txt`, which is the dependency set CI installs: `mypy ori/` clean, `mypy tests/` clean over 189 files, `pyright ori/ scripts/` zero, and the ratchet reading 478 against its baseline with a zero exit. macOS reports the same 478 under the pin.

Exit codes were checked unpiped, because a pipe would report the last command's status rather than the ratchet's: 0 at the baseline, 1 on a rise, 1 on a fall, 2 on a missing baseline or an unusable report.

Twelve mutations, each killed by the test naming the property it breaks — including the two forms that disable every gate while leaving its text in the workflow: `if: false` on each step, and commenting out each `run:` line. The workflow assertions parse the YAML and compare the steps CI would actually run, because a substring search over the file passes over a workflow that enforces nothing. The expected gate set is derived from `pyproject`'s `include` rather than written out, so adding a fourth analysed tree without gating it fails.

The failure prints only the areas whose counts moved. A whole-distribution breakdown is nearly identical before and after a small rise, which is what makes one useless for finding it.
