### PR TITLE
fix(runtime): order a stop signal against startup instead of racing it

### DIFF
--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -449,6 +449,9 @@ class OriRuntime:
         self._firmware_command_service: FirmwareCommandService | None = None
         self._firmware_liveness_scheduler: FirmwareLivenessScheduler | None = None
         self._telemetry_exporter: HttpTelemetryExporter | None = None
+        # Startup and stop must not run at once; these order them.
+        self._startup_complete = False
+        self._stop_requested_during_startup = False
         self._evidence_attestor: FirstPartyEvidenceAttestor | None = None
         self._evidence_inbound_subscriber: MqttEvidenceInboundSubscriber | None = None
         self._evidence_outbound_publisher: MqttEvidenceOutboundPublisher | None = None
@@ -1295,11 +1298,14 @@ class OriRuntime:
         )
 
         # ── Register signal handlers ──────────────────────────────────────────
+        # Registered here rather than at the end of startup, because a device
+        # that cannot be stopped for the whole of startup is worse than one
+        # that stops untidily, and startup includes adapter connects that can
+        # block on hardware. What the handler does depends on how far startup
+        # has got: see `_request_stop`.
         loop = asyncio.get_running_loop()
-        loop.add_signal_handler(
-            signal.SIGTERM, lambda: asyncio.create_task(self.stop())
-        )
-        loop.add_signal_handler(signal.SIGINT, lambda: asyncio.create_task(self.stop()))
+        loop.add_signal_handler(signal.SIGTERM, self._request_stop)
+        loop.add_signal_handler(signal.SIGINT, self._request_stop)
         if hasattr(signal, "SIGHUP"):
             loop.add_signal_handler(
                 signal.SIGHUP, lambda: asyncio.create_task(self.reload_skills())
@@ -1499,6 +1505,9 @@ class OriRuntime:
                     name="status-signaling",
                 )
             )
+        if await self._stop_if_requested_during_startup():
+            return
+
         webhook_task = await self._start_sms_webhook_if_enabled(config)
         if webhook_task is not None:
             self._background_tasks.append(webhook_task)
@@ -1608,6 +1617,9 @@ class OriRuntime:
                     )
                 )
 
+        if await self._stop_if_requested_during_startup():
+            return
+
         await self._start_firmware_mqtt_operator_if_enabled(config)
 
         node_heartbeat = _build_runtime_node_heartbeat_publisher(
@@ -1622,6 +1634,9 @@ class OriRuntime:
                     name="runtime-node-heartbeat",
                 )
             )
+
+        if await self._stop_if_requested_during_startup():
+            return
 
         await self._start_health_socket_if_enabled(config)
 
@@ -1640,6 +1655,9 @@ class OriRuntime:
         if status_indicator is not None:
             status_indicator.set_runtime_state(RuntimeHealthState.NORMAL)
 
+        if await self._stop_if_requested_during_startup():
+            return
+
         await self._send_setup_success_notifications(config, alert_sender)
 
         # Block here until stop() sets the shutdown event
@@ -1649,7 +1667,71 @@ class OriRuntime:
                     self._safety_registry.run_retry_loop(self._shutdown_event)
                 )
             )
+        if await self._complete_startup():
+            await self.stop()
+            return
+
         await self._shutdown_event.wait()
+
+    async def _complete_startup(self) -> bool:
+        """Hand the stop signal from startup's checkpoints to the handler.
+
+        Returns True when a request arrived during startup and is this
+        caller's to honour.
+
+        The flag is raised before the request is read, so a signal landing
+        between the two is taken by the handler rather than falling into an
+        instant that neither path owns. Reading first and raising after would
+        leave exactly that gap, and a stop dropped there is a device that
+        ignores its operator once per boot.
+        """
+        self._startup_complete = True
+        return self._stop_requested_during_startup and not self._shutdown_event.is_set()
+
+    def _request_stop(self) -> None:
+        """Handle SIGTERM or SIGINT, deciding what the signal means right now.
+
+        After startup has finished, a signal stops the runtime, which is the
+        whole of its meaning. During startup it cannot: `stop()` closes the
+        state store, the adapters and every server, and startup is still
+        constructing and using them. Running the two concurrently is how a
+        resource is closed under a step that is mid-way through using it, and
+        the failure surfaces deep inside whichever step lost the race.
+
+        So during startup the request is recorded and startup unwinds at its
+        next checkpoint, which serialises the two rather than making `stop()`
+        defensive against every order they could interleave in.
+
+        A second signal is taken as an instruction rather than a repetition.
+        Startup can block in an adapter connect that never answers, which is
+        exactly when an operator sends the first signal and exactly when no
+        checkpoint is coming. An operator who has asked twice is left with a
+        way out, at the cost of the untidy teardown the first signal avoids.
+        """
+        if self._startup_complete or self._stop_requested_during_startup:
+            if not self._startup_complete:
+                logger.warning(
+                    "[runtime] second stop signal during startup; tearing down "
+                    "now without waiting for a checkpoint"
+                )
+            asyncio.create_task(self.stop())
+            return
+        self._stop_requested_during_startup = True
+        logger.info(
+            "[runtime] stop requested during startup; unwinding at the next "
+            "checkpoint. Signal again to tear down immediately."
+        )
+
+    async def _stop_if_requested_during_startup(self) -> bool:
+        """A startup checkpoint: stop here if a signal asked us to.
+
+        Returns True when the caller should abandon the rest of startup.
+        """
+        if not self._stop_requested_during_startup:
+            return False
+        logger.info("[runtime] startup interrupted by a stop request")
+        await self.stop()
+        return True
 
     async def stop(self) -> None:
         """Graceful shutdown. Called by SIGTERM/SIGINT signal handlers."""

--- a/tests/test_sigterm_during_startup.py
+++ b/tests/test_sigterm_during_startup.py
@@ -1,0 +1,417 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+
+"""What a stop signal means depends on how far startup has got.
+
+After startup, it stops the runtime. During startup it cannot: `stop()` closes
+the state store, the adapters and every server while startup is still building
+and using them, so the two are serialised rather than allowed to interleave.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from ori.runtime import OriRuntime
+
+
+def _runtime() -> OriRuntime:
+    runtime = OriRuntime(config_path="ori.yaml")
+    runtime._shutdown_event = asyncio.Event()
+    return runtime
+
+
+@pytest.mark.asyncio
+async def test_a_signal_during_startup_does_not_tear_down_immediately() -> None:
+    """The request is recorded; nothing is closed while startup still runs."""
+    runtime = _runtime()
+    stopped: list[str] = []
+    runtime.stop = lambda: stopped.append("stop")  # type: ignore[method-assign]
+
+    runtime._request_stop()
+
+    assert runtime._stop_requested_during_startup is True
+    assert stopped == []
+
+
+@pytest.mark.asyncio
+async def test_a_signal_after_startup_stops_the_runtime() -> None:
+    """Once startup is done the signal means what it plainly means."""
+    runtime = _runtime()
+    runtime._startup_complete = True
+    stopped: list[str] = []
+
+    async def _stop() -> None:
+        stopped.append("stop")
+
+    runtime.stop = _stop  # type: ignore[method-assign]
+
+    runtime._request_stop()
+    await asyncio.sleep(0)
+
+    assert stopped == ["stop"]
+
+
+@pytest.mark.asyncio
+async def test_a_second_signal_during_startup_tears_down_without_a_checkpoint() -> None:
+    """Startup can block where no checkpoint is coming, so asking twice works.
+
+    An adapter connect against hardware that never answers is exactly when an
+    operator sends the first signal and exactly when the first signal cannot
+    be honoured. The second is taken as an instruction, not a repetition.
+    """
+    runtime = _runtime()
+    stopped: list[str] = []
+
+    async def _stop() -> None:
+        stopped.append("stop")
+
+    runtime.stop = _stop  # type: ignore[method-assign]
+
+    runtime._request_stop()
+    assert stopped == []
+
+    runtime._request_stop()
+    await asyncio.sleep(0)
+
+    assert stopped == ["stop"]
+
+
+@pytest.mark.asyncio
+async def test_a_checkpoint_passes_through_when_nothing_asked_to_stop() -> None:
+    runtime = _runtime()
+    assert await runtime._stop_if_requested_during_startup() is False
+
+
+@pytest.mark.asyncio
+async def test_a_checkpoint_stops_and_tells_startup_to_abandon() -> None:
+    runtime = _runtime()
+    stopped: list[str] = []
+
+    async def _stop() -> None:
+        stopped.append("stop")
+
+    runtime.stop = _stop  # type: ignore[method-assign]
+    runtime._stop_requested_during_startup = True
+
+    assert await runtime._stop_if_requested_during_startup() is True
+    assert stopped == ["stop"]
+
+
+def test_startup_checks_the_request_at_several_points() -> None:
+    """One checkpoint would leave the rest of startup racing the teardown.
+
+    Read from the source rather than counted in a comment, so removing one
+    fails here. The window each closes is the phase it precedes; a single
+    checkpoint would only narrow the race, not order the two operations.
+    """
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "ori" / "runtime.py").read_text()
+    start = source.index("async def start(")
+    end = source.index("def _request_stop(")
+    body = source[start:end]
+
+    assert body.count("await self._stop_if_requested_during_startup()") >= 4
+
+
+def test_startup_acts_on_the_handoff_rather_than_only_calling_it() -> None:
+    """`start()` must stop when the handoff says a request is its to honour.
+
+    Calling the handoff and discarding its answer leaves the runtime parked on
+    an event that the deferred request never sets, so a stop asked for during
+    startup would hang the process instead of ending it. Read from the source
+    because driving `start()` needs a device's worth of configuration.
+    """
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "ori" / "runtime.py").read_text()
+
+    assert (
+        "if await self._complete_startup():\n            await self.stop()\n            return"
+        in source
+    )
+
+
+def test_the_signal_handler_is_not_wired_straight_to_stop() -> None:
+    """The handler routes on startup state; wiring it to `stop()` is the defect.
+
+    `loop.add_signal_handler(SIGTERM, lambda: create_task(self.stop()))` is
+    what ran teardown concurrently with startup.
+    """
+    from pathlib import Path
+
+    source = (Path(__file__).resolve().parents[1] / "ori" / "runtime.py").read_text()
+
+    assert "loop.add_signal_handler(signal.SIGTERM, self._request_stop)" in source
+    assert "loop.add_signal_handler(signal.SIGINT, self._request_stop)" in source
+    assert "signal.SIGTERM, lambda: asyncio.create_task(self.stop())" not in source
+
+
+@pytest.mark.asyncio
+async def test_a_request_made_during_startup_is_honoured_at_the_handoff() -> None:
+    """A stop asked for during startup is not lost when startup finishes."""
+    runtime = _runtime()
+    runtime._stop_requested_during_startup = True
+
+    assert await runtime._complete_startup() is True
+    assert runtime._startup_complete is True
+
+
+@pytest.mark.asyncio
+async def test_the_handoff_claims_nothing_when_no_stop_was_requested() -> None:
+    runtime = _runtime()
+
+    assert await runtime._complete_startup() is False
+    assert runtime._startup_complete is True
+
+
+@pytest.mark.asyncio
+async def test_the_handoff_does_not_stop_a_runtime_already_stopping() -> None:
+    """A teardown already under way is not started a second time."""
+    runtime = _runtime()
+    runtime._stop_requested_during_startup = True
+    runtime._shutdown_event.set()
+
+    assert await runtime._complete_startup() is False
+
+
+@pytest.mark.asyncio
+async def test_the_handoff_opens_the_handler_before_reading_the_request() -> None:
+    """No instant may be owned by neither the checkpoints nor the handler.
+
+    Reading the request before raising the flag would leave a gap: a signal
+    arriving in it is deferred by a handler that no later checkpoint will
+    reach. This asserts the flag is already up while the request is read, by
+    signalling from inside the read.
+    """
+    runtime = _runtime()
+    observed: list[bool] = []
+
+    class _Watching:
+        def __bool__(self) -> bool:
+            # The handler's view at the moment the request is consulted.
+            observed.append(runtime._startup_complete)
+            return False
+
+    runtime._stop_requested_during_startup = _Watching()  # type: ignore[assignment]
+
+    await runtime._complete_startup()
+
+    assert observed == [True]
+
+
+@pytest.mark.asyncio
+async def test_stop_survives_a_runtime_that_never_started() -> None:
+    """The ordering is the fix, but a partial teardown must still not raise."""
+    runtime = OriRuntime(config_path="ori.yaml")
+
+    await runtime.stop()
+
+    assert runtime._shutdown_event.is_set()
+
+
+# --------------------------------------------------------------------------
+# The real thing: a signal delivered during a real start()
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def startable_config(tmp_path: Path) -> Path:
+    """A minimal valid ori.yaml whose startup runs on any machine."""
+    skill_dir = tmp_path / "skills" / "test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.yaml").write_text(
+        textwrap.dedent("""\
+            name: test-skill
+            version: 0.1.0
+            author: test
+            sensors_required:
+              - type: cpu_percent
+            triggers:
+              - name: high_cpu
+                condition: "value > 90"
+                action_tier: A
+                cooldown_seconds: 0
+                escalate_to: local_slm
+            actions:
+              available:
+                - name: alert_whatsapp
+                  tier: A
+              defaults:
+                high_cpu: [alert_whatsapp]
+        """),
+        encoding="utf-8",
+    )
+    cfg = tmp_path / "ori.yaml"
+    cfg.write_text(
+        textwrap.dedent(f"""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors:
+              - id: cpu-sensor
+                type: cpu_percent
+                protocol: psutil
+                poll_interval_ms: 100
+            skills:
+              - name: test-skill
+                version: "0.1.0"
+                config: {{}}
+            reasoning:
+              default_tier: local
+              local_model: ""
+              model_path: ""
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+              relay:
+                enabled: false
+            skills_dir: {str(tmp_path / "skills")}
+            database:
+              path: {str(tmp_path / "ori_state.db")}
+            logging:
+              level: INFO
+              file: {str(tmp_path / "ori.log")}
+        """),
+        encoding="utf-8",
+    )
+    return cfg
+
+
+# Three real startup steps, at increasing depth. Named rather than counted, so
+# a rename fails here instead of silently testing one phase three times.
+EARLY = "_restore_measurement_state"
+MIDDLE = "_start_sms_webhook_if_enabled"
+LATE = "_reconcile_pending_attestations"
+
+
+async def _start_with_signal_at(
+    runtime: OriRuntime, monkeypatch: pytest.MonkeyPatch, step: str
+) -> list[str]:
+    """Run a real `start()`, signalling when `step` runs, and trace the order.
+
+    The trace records every startup step that ran after the signal and the
+    moment the state store was closed. A teardown that overlapped startup
+    would put the close before a step, which is the failure #530 describes and
+    the one a test calling private helpers cannot see.
+    """
+    trace: list[str] = []
+
+    for name in (EARLY, MIDDLE, LATE):
+        original = getattr(OriRuntime, name)
+
+        def _traced(self, *args, _name=name, _original=original, **kwargs):
+            trace.append(f"step:{_name}")
+            if _name == step:
+                self._request_stop()
+            return _original(self, *args, **kwargs)
+
+        monkeypatch.setattr(OriRuntime, name, _traced)
+
+    real_stop = OriRuntime.stop
+
+    async def _traced_stop(self):
+        trace.append("stop")
+        return await real_stop(self)
+
+    monkeypatch.setattr(OriRuntime, "stop", _traced_stop)
+
+    await asyncio.wait_for(runtime.start(), timeout=30.0)
+    return trace
+
+
+@pytest.mark.parametrize("step", [EARLY, MIDDLE, LATE])
+@pytest.mark.asyncio
+async def test_a_signal_during_a_real_startup_stops_without_overlapping_it(
+    startable_config: Path, monkeypatch: pytest.MonkeyPatch, step: str
+) -> None:
+    """A real `start()`, signalled at three depths, must never tear down early.
+
+    The property is ordering, not merely that nothing raised: `stop()` closes
+    the state store and the adapters, and every startup step that runs after
+    that is using something already closed. So the teardown must come after
+    the last step, at every depth the signal can arrive.
+    """
+    runtime = OriRuntime(config_path=str(startable_config))
+
+    trace = await _start_with_signal_at(runtime, monkeypatch, step)
+
+    assert "stop" in trace, "the signal did not lead to a teardown"
+    assert f"step:{step}" in trace, "the step that signals never ran"
+    # Nothing from startup may run once the teardown has begun.
+    after_stop = trace[trace.index("stop") + 1 :]
+    assert [entry for entry in after_stop if entry.startswith("step:")] == []
+    assert runtime._shutdown_event.is_set()
+
+
+@pytest.mark.asyncio
+async def test_a_signal_early_in_a_real_startup_skips_the_later_phases(
+    startable_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Unwinding means abandoning the rest, not finishing it first.
+
+    A signal at the first phase that still ran the webhook, the health socket
+    and reconciliation would have deferred the stop rather than honoured it,
+    and would leave those resources built purely to be torn down.
+    """
+    runtime = OriRuntime(config_path=str(startable_config))
+
+    trace = await _start_with_signal_at(runtime, monkeypatch, EARLY)
+
+    # The first checkpoint after the signal is the one before the webhook, so
+    # neither the middle nor the late phase may run. Asserting only the late
+    # one would pass with that checkpoint deleted, because a later checkpoint
+    # would catch the same signal a phase further on.
+    assert f"step:{MIDDLE}" not in trace
+    assert f"step:{LATE}" not in trace
+    assert trace.index("stop") < len(trace)
+
+
+@pytest.mark.asyncio
+async def test_a_real_startup_with_no_signal_reaches_its_last_phase(
+    startable_config: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The counterpart: without a signal the checkpoints stop nothing.
+
+    Without this, every assertion above would be satisfied by a runtime whose
+    startup never got past its first phase for some unrelated reason.
+    """
+    runtime = OriRuntime(config_path=str(startable_config))
+
+    async def _stop_once_started() -> None:
+        for _ in range(1500):
+            if runtime._startup_complete:
+                await runtime.stop()
+                return
+            await asyncio.sleep(0.02)
+        raise AssertionError("startup never completed")
+
+    trace: list[str] = []
+    for name in (EARLY, MIDDLE, LATE):
+        original = getattr(OriRuntime, name)
+
+        def _traced(self, *args, _name=name, _original=original, **kwargs):
+            trace.append(f"step:{_name}")
+            return _original(self, *args, **kwargs)
+
+        monkeypatch.setattr(OriRuntime, name, _traced)
+
+    await asyncio.wait_for(
+        asyncio.gather(runtime.start(), _stop_once_started()), timeout=30.0
+    )
+
+    assert [f"step:{EARLY}", f"step:{MIDDLE}", f"step:{LATE}"] == [
+        entry for entry in trace if entry.startswith("step:")
+    ]


### PR DESCRIPTION
## What does this PR do?

`start()` registers its signal handlers about 350 lines before it parks on the shutdown event, and each handler created a task running `stop()`. A `SIGTERM` arriving anywhere in that window ran teardown concurrently with the rest of startup.

The 350 lines in between connect the HAL adapters and start the SMS webhook, the telemetry exporter, the gateway export responder and heartbeat subscriber, the firmware command egress and liveness scheduler, the node heartbeat and the health socket, then drain pending firmware confirmations, reconcile pending attestations and send the setup notifications. `stop()` closes the state store, closes every adapter, and closes the gateway, heartbeat, firmware and health-socket servers — while startup is still constructing and using them.

The same shape in the test suite surfaced as a bare `AssertionError` sixty lines into the state store, from a pull request that did not touch the file containing the test. On a device the equivalent would surface during the shutdown of a runtime that was still starting: the hardest case to reproduce, and the one least likely to be diagnosed from a log.

### What the defect is, and what it is not

`stop()` on a runtime that never started already completes without raising, so this is not missing null checks. The defect is that the two operations run at once. That is why they are now **ordered** rather than made mutually defensive: making `stop()` safe against every state startup could be halfway through means enumerating those states, and the enumeration is what goes stale.

### The decision

**After startup**, a signal stops the runtime. That is the whole of its meaning and it is unchanged.

**During startup**, the request is recorded and startup unwinds at its next checkpoint. Four checkpoints sit at phase boundaries, so the work abandoned is the phase the signal arrived in rather than all of startup.

Registering the handlers at the end of `start()` instead was considered and rejected: it trades this window for a worse one. A device that cannot be stopped for the whole of startup is worse than one that stops untidily, and startup includes adapter connects that can block on hardware.

**A second signal tears down immediately**, without waiting for a checkpoint. Startup can block in an adapter connect that never answers — exactly when an operator sends the first signal, and exactly when no checkpoint is coming. An operator who has asked twice is left with a way out, at the cost of the untidy teardown the first signal exists to avoid. This is the answer to the acceptance criterion about startup blocking on hardware that never responds.

**The handoff at the end of startup leaves no gap.** The completion flag is raised before the request is read, so a signal arriving between the two is taken by the handler rather than falling into an instant that neither path owns. Reading first and raising after would leave exactly that gap, and a stop dropped there is a device that ignores its operator once per boot.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability is added, removed or degraded. A signal that previously raced startup now waits for it; what the runtime can do is unchanged.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D path is added or altered. The teardown drains in-flight Tier D tasks exactly as before; only when it may begin has changed.

## Related issue

Closes #530.

Its final criterion asked that #468's claim about production be corrected wherever it was repeated. The claim is not in the tree, so #468's body carries the correction, with the original struck rather than removed.

## Testing notes

Host-tested. Five tests run a real `OriRuntime.start()` against a real configuration and inject the signal at three depths — the measurement-state restore, the SMS webhook, and attestation reconciliation. They assert the ordering property rather than the absence of an exception: a trace records every startup step and the teardown, and no startup step may appear after the teardown begins.

Mutating the handler back to its original form — a task running `stop()` on every signal — is killed by those tests at every depth. Under helper-level tests alone it would have been caught only by an assertion about the source.

Fourteen mutations in total, each killed by the test naming the property it breaks: the handler restored, a first signal tearing down at once, a second signal read as a repetition, a signal after startup deferred forever, a checkpoint that never stops, a checkpoint that stops but lets startup continue, one checkpoint instead of several, the handoff dropping a request, the handoff restarting a teardown already under way, the flag raised after the request is read, and `start()` calling the handoff without acting on its answer.

Removing a single checkpoint is caught behaviourally rather than only by a count, because an early signal must stop before the middle phase rather than merely before the last one.

The tests point the runtime's log at the temporary directory, so they need no writable checkout and leave nothing behind.
