### PR TITLE
fix(security): refuse a trust anchor whose private key this repository publishes

### DIFF
--- a/ori/security/commissioning/anchors.py
+++ b/ori/security/commissioning/anchors.py
@@ -16,6 +16,8 @@ import os
 from dataclasses import dataclass
 from typing import Any, Mapping
 
+from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
+
 COMMISSIONING_ANCHOR_ENV = "ORI_COMMISSIONING_ANCHOR_PUBLIC_KEY_B64"
 COMMISSIONING_ANCHOR_PREVIOUS_ENV = "ORI_COMMISSIONING_ANCHOR_PREVIOUS_PUBLIC_KEY_B64"
 
@@ -44,6 +46,17 @@ def _decode_anchor(name: str, text: str) -> bytes:
         raise AnchorError(f"{name} does not hold a 32-byte Ed25519 public key")
     if base64.b64encode(raw).decode("ascii") != text:
         raise AnchorError(f"{name} is not canonically encoded")
+    if raw in PUBLISHED_TEST_KEYS:
+        raise AnchorError(
+            f"{name} names a key whose private seed is published test "
+            "material in this repository, so anyone holding a clone can forge a "
+            "binding this device would accept -- including one claiming both "
+            "proof legs, which licenses autonomous actuation. Generate a "
+            "commissioning key that has never left the producer and write its "
+            "public half here instead. This is refused at every deployment "
+            "profile: a development runtime drives the same relay as a "
+            "production one."
+        )
     return raw
 
 
@@ -98,7 +111,12 @@ def provisioning_anchor(
         raw = base64.b64decode(text, validate=True)
     except (binascii.Error, ValueError):
         return None
-    return raw if len(raw) == 32 else None
+    if len(raw) != 32 or raw in PUBLISHED_TEST_KEYS:
+        # A published key is not authority, so it is not a provisioning anchor
+        # either. The path that verifies with it refuses loudly; here it reads
+        # as absent, because an absent anchor cannot collide with one.
+        return None
+    return raw
 
 
 def anchor_collision(

--- a/ori/security/config_signatures.py
+++ b/ori/security/config_signatures.py
@@ -16,6 +16,7 @@ import re
 from dataclasses import dataclass
 from typing import Any
 
+from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
 from ori.utils.bool_utils import is_truthy
 
 CONFIG_SIGNATURE_SCHEMA = "ori.config_signature.v1"
@@ -141,6 +142,7 @@ def verify_config_signature_if_needed(
         signature=signature,
         public_key_b64=trust_anchor,
         payload=canonical_config_signature_payload(raw_config),
+        anchor_env=policy.trust_anchor_env,
     )
     return ConfigSignatureVerification(
         verified=True,
@@ -187,6 +189,7 @@ def _verify_ed25519_signature(
     signature: str,
     public_key_b64: str,
     payload: bytes,
+    anchor_env: str,
 ) -> None:
     _, signature_b64 = signature.split(":", 1)
     try:
@@ -208,6 +211,17 @@ def _verify_ed25519_signature(
         raise ConfigSignatureError(
             "config signature trust anchor is not base64"
         ) from exc
+
+    if public_key_bytes in PUBLISHED_TEST_KEYS:
+        raise ConfigSignatureError(
+            f"{anchor_env} names a key whose private seed is published test "
+            "material in this repository, so anyone holding a clone can sign a "
+            "configuration this runtime would accept as verified -- including "
+            "one that moves "
+            "device.rated_capacity_amps, the Tier D threshold input, or declares "
+            "a relay pin. Generate a signing key that has never left the producer "
+            "and write its public half here instead."
+        )
 
     try:
         from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey

--- a/ori/security/published_test_keys.py
+++ b/ori/security/published_test_keys.py
@@ -1,0 +1,57 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""Public keys whose private seeds are published test material in this repository.
+
+A trust anchor is an authority only while its private half is secret. Every seed under
+`tests/`, in vectors, fixtures and source literals alike, is committed, so a signature from one of these keys proves
+nothing about who produced the document. They exist to drive verifiers against
+known material, and configuring one on a device makes that device accept forged
+documents from anyone holding a clone.
+
+`tests/test_published_test_keys.py` re-derives this set from tracked files, so
+a newly committed seed cannot quietly escape it.
+
+The set is **append-only**. A seed rotated out of the working tree stays in
+history, so the key it derives stays forgeable and must stay refused. Nothing
+here is ever removed, and no test asserts the set contains only what the
+current tree publishes -- such a test would force exactly that removal. Over-
+refusal costs nothing: these are 32-byte values, and a genuine key collides
+with one at 2**-256.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import Final
+
+PUBLISHED_TEST_KEYS_B64: Final[tuple[str, ...]] = (
+    "0EqyMnQrtKs6E2i9RhXk5tAiSrcaAWuvhSCjMsl3hzc=",
+    "11l5O7wTooGagnx2rbb7qKSa7gB/SfLQmS2ZuCWtLEg=",
+    "5zTqbCtiV95yNV5HKqBaTEh+a0Y8Ap7TBt8vAbVja1g=",
+    "A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg=",
+    "E9mQinCSWZLtVGAH0n9Q2mi6chfvYqw8ynhFKf8QRxw=",
+    "F0VTtFbd38aQjsqxwQH+arIeK6oGF3lbfUOmNIKZP9U=",
+    "F8t5+ytBIPKx7GXkGY1uCLKOgT/rAeSkAIObheGAgM4=",
+    "IVL40Zt5HSRFMkLhXy6rbLfP+ntqXtMAl5YOBpiB2xI=",
+    "Ivwpd5Lwtv/Av8/bftsMCqFOAlo2XsDjQuhuOCnLdLY=",
+    "JUO5L/EJVRFHatyDadtt3JM2ZaEZeN2hQE7hBmypVZ0=",
+    "Kay64UG8yvCyLhqU000LxzYeUm0L/hLIl5S8kyKWbdc=",
+    "My6+jSfLcyOzpAHBwTtd1kvMwOEOzaHCtdEaA3eaheU=",
+    "NLTZBDFWy23PC+sKKUm3VZyUDSvLbb6MU6mzAnjjp0Y=",
+    "O2onvM62pC1io6jQKm8Nc2UyFXcd4kOmOsBIoYtZ2ik=",
+    "T9CZzNR9eJPf6ewkQU7LDZtUICMqrTDZHEZb4zy+ZcQ=",
+    "aEYOvvOxOBZOx/2GEOlYAN91mPcPLy6n21FyrHTrwUQ=",
+    "dqFZIESm5PURJlvKc6YE2QsFKdHfYCvjChmpJXZg0fU=",
+    "fVnFYj3UCnSqTVoyrGRdOz+V2urkwiviVHbdakhvc4I=",
+    "gUci3nHFsU50jf8yKuf3xBXO5Vh2ZJUpLNbEwKap3yg=",
+    "oJql9HpnWYAv+VX43C0qFKXJnSO+l/hkEn/5ODRVpPA=",
+    "skkdlQKuKGMKK6yy4MdFEP/N0yjDNP8+E5PnWy0x59w=",
+    "xoImN8fTEOxXYnvgC6JZ0lN0n0qvZERwz/vlOjX3MkI=",
+    "yFOtDwzSthmuqSzuxP1Wok1kmdWEznklfkXP2BObYKc=",
+    "ylfu0w5KcnTvTGSPVvWPiAsg0solcl2eXBPIPAjAmus=",
+    "zRSzf5VulTGU/3+3Oz2B3MVh1hp1OAlLfD4aZD7l86o=",
+)
+
+PUBLISHED_TEST_KEYS: Final[frozenset[bytes]] = frozenset(
+    base64.b64decode(key) for key in PUBLISHED_TEST_KEYS_B64
+)

--- a/tests/commissioning/signing.py
+++ b/tests/commissioning/signing.py
@@ -4,7 +4,8 @@
 
 Test tooling only. The real producer is ori-cli; this exists so the runtime's
 consumer can be exercised against documents whose signing key the test
-controls, using the corpus's published test seed or a fresh one.
+controls. The seed is generated per run and never committed: the runtime
+refuses every key whose private half this repository publishes.
 """
 
 from __future__ import annotations
@@ -12,6 +13,7 @@ from __future__ import annotations
 import base64
 import copy
 import json
+import secrets
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +23,14 @@ from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 
 from ori.security.commissioning.anchors import COMMISSIONING_ANCHOR_ENV
 from ori.security.commissioning.binding import canonical_bytes
+
+#: Generated per run and never committed. A seed written into a tracked file
+#: is published, and the runtime refuses every key derived from one.
+EPHEMERAL_SEED: str = secrets.token_hex(32)
+
+#: A second real key, for asserting that a valid anchor which did not sign
+#: the document is refused as an unknown signer rather than as a bad anchor.
+EPHEMERAL_SEED_OTHER: str = secrets.token_hex(32)
 
 
 def private_key(seed_hex: str) -> Ed25519PrivateKey:
@@ -179,7 +189,7 @@ def commission_relay(
     sensor_id: str,
     gpio_pin: int = 26,
     active_high: bool = False,
-    seed_hex: str = "7" * 64,
+    seed_hex: str = EPHEMERAL_SEED,
     **overrides: Any,
 ) -> Path:
     """Write an accepted binding beside *config_path* and configure its anchor.

--- a/tests/commissioning/test_anchors.py
+++ b/tests/commissioning/test_anchors.py
@@ -17,6 +17,7 @@ from ori.security.commissioning.anchors import (
     anchor_collision,
     load_commissioning_anchors,
 )
+from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
 
 
 def _key() -> bytes:
@@ -115,3 +116,39 @@ def test_collision_is_compared_as_key_material_across_generations() -> None:
     assert anchor_collision(anchors, previous)
     assert not anchor_collision(anchors, None)
     assert not anchor_collision(load_commissioning_anchors({}), provisioning)
+
+
+def test_a_published_test_key_is_refused_as_the_current_anchor() -> None:
+    """Its private seed ships in this repository, so it authenticates nobody."""
+    published = _b64(next(iter(PUBLISHED_TEST_KEYS)))
+    with pytest.raises(AnchorError) as refusal:
+        load_commissioning_anchors({COMMISSIONING_ANCHOR_ENV: published})
+    assert COMMISSIONING_ANCHOR_ENV in str(refusal.value)
+    assert "private seed is published" in str(refusal.value)
+
+
+def test_a_published_test_key_is_refused_in_the_previous_slot() -> None:
+    """A verify-only generation still accepts documents, so it is not exempt."""
+    published = _b64(next(iter(PUBLISHED_TEST_KEYS)))
+    with pytest.raises(AnchorError) as refusal:
+        load_commissioning_anchors(
+            {
+                COMMISSIONING_ANCHOR_ENV: _b64(_key()),
+                COMMISSIONING_ANCHOR_PREVIOUS_ENV: published,
+            }
+        )
+    assert COMMISSIONING_ANCHOR_PREVIOUS_ENV in str(refusal.value)
+
+
+def test_every_published_test_key_is_refused() -> None:
+    """One refused key does not establish that the set is consulted."""
+    for raw in PUBLISHED_TEST_KEYS:
+        with pytest.raises(AnchorError):
+            load_commissioning_anchors({COMMISSIONING_ANCHOR_ENV: _b64(raw)})
+
+
+def test_a_key_that_was_never_published_is_still_accepted() -> None:
+    """The guard refuses published material, not every key it has not seen."""
+    fresh = _key()
+    anchors = load_commissioning_anchors({COMMISSIONING_ANCHOR_ENV: _b64(fresh)})
+    assert anchors.current == fresh

--- a/tests/commissioning/test_control_leg.py
+++ b/tests/commissioning/test_control_leg.py
@@ -22,12 +22,13 @@ from ori.security.commissioning.binding import (
     verify_binding_envelope,
 )
 from tests.commissioning.signing import (
+    EPHEMERAL_SEED,
     local_gpio_binding,
     public_key_b64,
     sign_envelope,
 )
 
-SEED = "7" * 64
+SEED = EPHEMERAL_SEED
 DEVICE = "bench-01"
 SENSOR = "load-current"
 

--- a/tests/commissioning/test_proof_operation.py
+++ b/tests/commissioning/test_proof_operation.py
@@ -37,12 +37,13 @@ from ori.security.commissioning.proof_operation import (
 )
 from ori.state.store import StateStore
 from tests.commissioning.signing import (
+    EPHEMERAL_SEED,
     local_gpio_binding,
     public_key_b64,
     sign_envelope,
 )
 
-SEED = "7" * 64
+SEED = EPHEMERAL_SEED
 DEVICE = "bench-01"
 SENSOR = "load-current"
 PIN = 26

--- a/tests/commissioning/test_runtime_startup.py
+++ b/tests/commissioning/test_runtime_startup.py
@@ -33,12 +33,14 @@ from ori.security.commissioning.loader import (
 )
 from ori.state.store import StateStore
 from tests.commissioning.signing import (
+    EPHEMERAL_SEED,
+    EPHEMERAL_SEED_OTHER,
     local_gpio_binding,
     public_key_b64,
     sign_envelope,
 )
 
-SEED = "5" * 64
+SEED = EPHEMERAL_SEED
 DEVICE = "bench-runtime-01"
 SENSOR = "cpu-sensor"
 
@@ -192,7 +194,7 @@ async def test_a_refused_binding_is_reported_by_stage_and_licenses_nothing(
 ) -> None:
     _patch_external(monkeypatch)
     # The anchor configured is not the key that signed the document.
-    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64("6" * 64))
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(EPHEMERAL_SEED_OTHER))
     _write_binding(tmp_path)
     runtime = OriRuntime(config_path=str(_write_config(tmp_path)))
     observed: dict[str, Any] = {}
@@ -632,3 +634,27 @@ async def test_a_binding_file_that_breaks_the_decoder_does_not_stop_the_runtime(
     assert block["last_verdict"]["reason"] == "malformed"
     assert block["actuation_licensed"] is False
     assert observed["health"]["status"] == "degraded"
+
+
+async def test_a_published_anchor_stops_the_start_before_any_binding_is_read(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Startup loads anchors independently of the bridge, so it is covered here.
+
+    The refusal lands where `anchor_collision` does -- at configuration load,
+    before a binding is opened -- because a forgeable authority is not a
+    property of any particular document.
+    """
+    import base64
+
+    from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
+
+    _patch_external(monkeypatch)
+    published = base64.b64encode(next(iter(PUBLISHED_TEST_KEYS))).decode("ascii")
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, published)
+    _write_binding(tmp_path)
+    runtime = OriRuntime(config_path=str(_write_config(tmp_path)))
+
+    with pytest.raises(ConfigValidationError) as refusal:
+        await _start_expecting_refusal(runtime)
+    assert "private seed is published" in str(refusal.value)

--- a/tests/safety/test_runtime_wiring.py
+++ b/tests/safety/test_runtime_wiring.py
@@ -24,12 +24,13 @@ from ori.security.commissioning.anchors import COMMISSIONING_ANCHOR_ENV
 from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
 from ori.security.commissioning.profiles import load_profile_set
 from tests.commissioning.signing import (
+    EPHEMERAL_SEED,
     local_gpio_binding,
     public_key_b64,
     sign_envelope,
 )
 
-SEED = "5" * 64
+SEED = EPHEMERAL_SEED
 DEVICE = "bench-runtime-01"
 SENSOR = "cpu-sensor"
 

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -754,7 +754,11 @@ def _commissioning_config(
 
 def _bench_envelope(**overrides):
     """A binding with both proof legs unless a test overrides one."""
-    from tests.commissioning.signing import local_gpio_binding, sign_envelope
+    from tests.commissioning.signing import (
+        EPHEMERAL_SEED,
+        local_gpio_binding,
+        sign_envelope,
+    )
 
     overrides.setdefault("proof_method", "actuate_and_observe")
     overrides.setdefault("control_proof_method", "commanded_and_observed")
@@ -765,14 +769,20 @@ def _bench_envelope(**overrides):
         active_high=False,
         **overrides,
     )
-    return sign_envelope(binding, "7" * 64)
+    return sign_envelope(binding, EPHEMERAL_SEED)
 
 
-def _anchor(monkeypatch, seed: str = "7" * 64) -> None:
+def _other_seed() -> str:
+    from tests.commissioning.signing import EPHEMERAL_SEED_OTHER
+
+    return EPHEMERAL_SEED_OTHER
+
+
+def _anchor(monkeypatch, seed: str | None = None) -> None:
     from ori.security.commissioning.anchors import COMMISSIONING_ANCHOR_ENV
-    from tests.commissioning.signing import public_key_b64
+    from tests.commissioning.signing import EPHEMERAL_SEED, public_key_b64
 
-    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(seed))
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(seed or EPHEMERAL_SEED))
 
 
 def test_cli_bridge_commissioning_inventory_reports_the_candidate_set(tmp_path, capsys):
@@ -858,7 +868,7 @@ def test_cli_bridge_commissioning_deliver_refuses_by_stage_and_writes_nothing(
 
     config_path = _commissioning_config(tmp_path)
     # The anchor configured is not the key that signed the document.
-    _anchor(monkeypatch, seed="6" * 64)
+    _anchor(monkeypatch, seed=_other_seed())
     source = tmp_path / "binding.json"
     source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
 
@@ -953,7 +963,7 @@ def test_cli_bridge_commissioning_deliver_separates_an_absent_anchor_from_a_wron
     absent = _deliver_refusal(tmp_path, monkeypatch, capsys)
 
     # The anchor configured is not the key that signed the document.
-    _anchor(monkeypatch, seed="6" * 64)
+    _anchor(monkeypatch, seed=_other_seed())
     mismatched = _deliver_refusal(tmp_path, monkeypatch, capsys)
 
     assert absent["code"] == mismatched["code"] == "unknown_signer"
@@ -1566,3 +1576,43 @@ def test_an_exiting_command_is_not_swallowed(
     monkeypatch.setattr(cli_bridge, "_commissioning_inventory", exiting)
     with pytest.raises(SystemExit):
         cli_bridge.run_bridge(["commissioning", "inventory", "--path", "ori.yaml"])
+
+
+def test_cli_bridge_commissioning_deliver_refuses_a_published_anchor(
+    tmp_path, monkeypatch, capsys
+):
+    """`deliver` loads anchors on its own path, so it needs its own coverage.
+
+    Nothing is staged: an operator who reached this refusal has an anchor whose
+    private half anyone can read, and accepting the document would license
+    actuation on a forgeable authority.
+    """
+    import base64
+
+    from ori.security.commissioning.anchors import COMMISSIONING_ANCHOR_ENV
+    from ori.security.commissioning.loader import BINDING_RELATIVE_PATH
+    from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
+
+    published = base64.b64encode(next(iter(PUBLISHED_TEST_KEYS))).decode("ascii")
+    monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, published)
+
+    config_path = _commissioning_config(tmp_path)
+    source = tmp_path / "binding.json"
+    source.write_text(json.dumps(_bench_envelope()), encoding="utf-8")
+
+    rc = cli_bridge.main(
+        [
+            "commissioning",
+            "deliver",
+            "--path",
+            str(config_path),
+            "--binding",
+            str(source),
+        ]
+    )
+    payload = _read_stdout_json(capsys)
+
+    assert rc == 2 and payload["ok"] is False
+    assert payload["error"]["code"] == "anchor_error"
+    assert "private seed is published" in payload["error"]["detail"]
+    assert not (tmp_path / BINDING_RELATIVE_PATH).exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -997,6 +997,63 @@ class TestLoadExample:
         )
         assert cfg.security["config_signature"]["signed_at_ms"] == 1_800_000_000_000
 
+    def test_config_load_refuses_a_signature_from_a_published_key(
+        self, tmp_path, monkeypatch
+    ):
+        """A published key must not admit a configuration through the real loader.
+
+        `device.rated_capacity_amps` scales the Tier D trip point, and production
+        posture requires a verified signature -- so a key anyone can sign with
+        would satisfy a mandated control while moving where the runtime trips.
+        """
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
+
+        published = Ed25519PrivateKey.from_private_bytes(bytes.fromhex("5" * 64))
+        raw_public = published.public_key().public_bytes(
+            serialization.Encoding.Raw, serialization.PublicFormat.Raw
+        )
+        assert raw_public in PUBLISHED_TEST_KEYS, "this test needs a refused key"
+        monkeypatch.setenv(
+            "ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64",
+            base64.b64encode(raw_public).decode("ascii"),
+        )
+
+        yaml_path = _write_yaml(
+            tmp_path,
+            _sign_config_yaml(
+                """
+                device:
+                  id: dev-01
+                  name: Test
+                  location: Lagos
+                  rated_capacity_amps: 400.0
+                sensors: []
+                skills: []
+                reasoning: {}
+                gateway: {}
+                actions:
+                  primary_alert_channel: sms
+                  sms:
+                    enabled: false
+                  relay:
+                    enabled: false
+                    gpio_pin: 26
+                security:
+                  config_signature:
+                    require_signed: true
+                """,
+                published,
+            ),
+        )
+
+        with pytest.raises(ConfigValidationError) as refusal:
+            Config.load(yaml_path)
+        assert "private seed is published" in str(refusal.value)
+        assert "ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64" in str(refusal.value)
+
     def test_signed_config_is_checked_before_env_expansion(self, tmp_path, monkeypatch):
         private_key, public_key_b64 = _ed25519_keypair()
         monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)

--- a/tests/test_published_test_keys.py
+++ b/tests/test_published_test_keys.py
@@ -1,0 +1,291 @@
+# Copyright 2026 Ori Nexus Systems LTD
+# SPDX-License-Identifier: Apache-2.0
+"""The refused set must cover every private seed this repository publishes.
+
+The scan is over tracked files rather than one directory, because a seed is
+published wherever it is committed: a JSON vector, a fixture, or a Python
+literal are all equally readable by anyone with a clone. It also covers seeds
+nobody committed but everybody can guess -- a single hex digit repeated, and the
+first thirty-two integers -- because those are forgeable whether or not this
+repository happens to spell them today.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import re
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from ori.security.published_test_keys import PUBLISHED_TEST_KEYS
+
+_ROOT = Path(__file__).resolve().parent.parent
+_HEX64 = re.compile(r"^[0-9a-fA-F]{64}$")
+_B64_32 = re.compile(r"^[A-Za-z0-9+/]{43}=$")
+_REPEATED_HEX = re.compile(r"""["']([0-9a-fA-F])["'] ?\* ?64""")
+_REPEATED_BYTE = re.compile(r'b["\']\\x([0-9a-fA-F]{2})["\'] ?\* ?32')
+_FROM_HEX = re.compile(r'bytes\.fromhex\(\s*["\']([0-9a-fA-F]{64})["\']\s*\)')
+_RANGE_32 = re.compile(r"bytes\(range\(32\)\)")
+
+
+def _tracked_files() -> list[Path]:
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-z"],
+            cwd=_ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        # Failing loudly matters: the vacuity guard below only means anything
+        # if this actually ran. A container bind-mounting the repo under a
+        # different uid trips git's safe.directory and exits 128.
+        raise AssertionError(
+            "cannot list tracked files, so the published-seed scan cannot run: "
+            f"`git ls-files` failed in {_ROOT} ({exc}). This needs a git "
+            "checkout; in a container, mark the mount safe.directory."
+        ) from exc
+    return [_ROOT / name for name in result.stdout.split("\0") if name]
+
+
+def _seeds_in_json(text: str) -> set[bytes]:
+    """A 32-byte value under a field whose name says seed."""
+    try:
+        document = json.loads(text)
+    except ValueError:
+        return set()
+    found: set[bytes] = set()
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                walk(value, f"{path}/{key}")
+        elif isinstance(node, list):
+            for index, value in enumerate(node):
+                walk(value, f"{path}[{index}]")
+        elif isinstance(node, str) and "seed" in path.lower():
+            if _HEX64.match(node):
+                found.add(bytes.fromhex(node))
+            elif _B64_32.match(node):
+                try:
+                    raw = base64.b64decode(node, validate=True)
+                except ValueError:
+                    return None
+                if len(raw) == 32:
+                    found.add(raw)
+
+    walk(document, "")
+    return found
+
+
+def _seeds_in_source(text: str) -> set[bytes]:
+    """The literal forms this repository actually uses to spell a seed."""
+    found: set[bytes] = set()
+    for digit in _REPEATED_HEX.findall(text):
+        found.add(bytes.fromhex(digit * 64))
+    for pair in _REPEATED_BYTE.findall(text):
+        found.add(bytes([int(pair, 16)]) * 32)
+    for value in _FROM_HEX.findall(text):
+        found.add(bytes.fromhex(value))
+    if _RANGE_32.search(text):
+        found.add(bytes(range(32)))
+    return found
+
+
+_ANY_HEX64 = re.compile(r"\b[0-9a-fA-F]{64}\b")
+_ANY_B64_32 = re.compile(r"\b[A-Za-z0-9+/]{43}=")
+
+
+def _key_material(text: str) -> set[bytes]:
+    """Every 32-byte value spelled anywhere in this text, whatever it is called."""
+    found: set[bytes] = set()
+    for token in _ANY_HEX64.findall(text):
+        found.add(bytes.fromhex(token))
+    for token in _ANY_B64_32.findall(text):
+        try:
+            raw = base64.b64decode(token, validate=True)
+        except ValueError:
+            continue
+        if len(raw) == 32:
+            found.add(raw)
+    return found
+
+
+def _paired_seeds(material: set[bytes]) -> set[bytes]:
+    """Values whose derived public key is written down in the same corpus.
+
+    That pairing is what separates a seed from a digest: a published test seed
+    is committed beside the key it derives, because that is what makes it usable
+    to verify against. A sha256 digest derives a key that appears nowhere.
+    """
+    return {candidate for candidate in material if public_key(candidate) in material}
+
+
+@lru_cache(maxsize=1)
+def published_seeds() -> frozenset[bytes]:
+    """Every seed a clone of this repository hands you, plus the guessable ones."""
+    seeds: set[bytes] = {bytes.fromhex(digit * 64) for digit in "0123456789abcdef"}
+    seeds.add(bytes(range(32)))
+    material: set[bytes] = set()
+    for path in _tracked_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            # Undecodable means no readable literal; a binary blob carrying a
+            # seed would be a different finding than this scan is looking for.
+            continue
+        seeds |= _seeds_in_source(text)
+        seeds |= _seeds_in_json(text)
+        material |= _key_material(text)
+    # Any 32-byte value whose derived public key is also written down here was
+    # published to be verified against, whatever field or format spelled it.
+    # A digest derives a key that appears nowhere, so this admits seeds without
+    # sweeping in every sha256 in the tree.
+    seeds |= _paired_seeds(material)
+    return frozenset(seeds)
+
+
+def public_key(seed: bytes) -> bytes:
+    return (
+        Ed25519PrivateKey.from_private_bytes(seed)
+        .public_key()
+        .public_bytes(Encoding.Raw, PublicFormat.Raw)
+    )
+
+
+GUESSABLE = {bytes.fromhex(digit * 64) for digit in "0123456789abcdef"} | {
+    bytes(range(32))
+}
+
+
+def test_the_file_scan_contributes_seeds_of_its_own() -> None:
+    """A scan that silently read nothing would still return GUESSABLE and pass.
+
+    Asserting a total would not catch that, so this asserts what only reading
+    tracked files can supply.
+    """
+    from_files = published_seeds() - GUESSABLE
+    assert len(from_files) >= 8
+
+
+def test_the_default_test_signer_is_refused() -> None:
+    """A scan of tests/vectors alone missed this one, and it was the default.
+
+    It signed commissioning documents across the test tree, so a runtime that
+    accepted it accepted documents from anyone holding a clone.
+    """
+    assert public_key(bytes.fromhex("7" * 64)) in PUBLISHED_TEST_KEYS
+
+
+def test_every_published_seed_derives_a_refused_key() -> None:
+    missing = sorted(
+        base64.b64encode(public_key(seed)).decode("ascii")
+        for seed in published_seeds()
+        if public_key(seed) not in PUBLISHED_TEST_KEYS
+    )
+    assert not missing, (
+        "these keys have published or guessable private seeds and would be "
+        f"accepted as trust anchors: {missing}. Add them to "
+        "PUBLISHED_TEST_KEYS_B64 in ori/security/published_test_keys.py."
+    )
+
+
+def test_the_refused_set_carries_only_thirty_two_byte_keys() -> None:
+    """A typo'd entry would decode to something no anchor can ever equal."""
+    assert all(len(key) == 32 for key in PUBLISHED_TEST_KEYS)
+
+
+def test_a_published_key_cannot_verify_a_configuration_signature() -> None:
+    """The config anchor carries the Tier D threshold input, so it is not exempt.
+
+    `device.rated_capacity_amps` scales the Tier D trip point, and production
+    posture requires a verified signature -- a mandated gate that a key anyone
+    can sign with would satisfy.
+    """
+    from ori.security.config_signatures import (
+        ConfigSignatureError,
+        _verify_ed25519_signature,
+    )
+
+    seed = bytes.fromhex("5" * 64)
+    signing = Ed25519PrivateKey.from_private_bytes(seed)
+    payload = b"a configuration this runtime would otherwise trust"
+
+    with pytest.raises(ConfigSignatureError) as refusal:
+        _verify_ed25519_signature(
+            signature="ed25519:" + base64.b64encode(signing.sign(payload)).decode(),
+            public_key_b64=base64.b64encode(public_key(seed)).decode(),
+            payload=payload,
+            anchor_env="ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64",
+        )
+    assert "private seed is published" in str(refusal.value)
+    assert "ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64" in str(refusal.value)
+
+
+def test_a_published_key_is_not_read_as_a_provisioning_anchor() -> None:
+    from ori.security.commissioning.anchors import provisioning_anchor
+
+    security = {"config_signature": {"trust_anchor_env": "ORI_TEST_PROV_ANCHOR"}}
+    published = base64.b64encode(next(iter(PUBLISHED_TEST_KEYS))).decode("ascii")
+    assert provisioning_anchor(security, {"ORI_TEST_PROV_ANCHOR": published}) is None
+
+
+def test_the_source_scan_reads_every_seed_form_this_repository_uses() -> None:
+    """Proven against synthetic text, not repository contents.
+
+    Every seed committed today is either a repeated hex digit or lives in a
+    vector file, so no tracked file distinguishes a working scan from a broken
+    one. These assert the logic directly, so a future seed in a new place is
+    caught rather than discovered by an attacker.
+    """
+    assert bytes.fromhex("3" * 64) in _seeds_in_source('SEED = "3" * 64')
+    assert bytes.fromhex("3" * 64) in _seeds_in_source("SEED = '3'*64")
+    assert bytes([0x22]) * 32 in _seeds_in_source('key = b"\\x22" * 32')
+    assert bytes(range(32)) in _seeds_in_source("key = bytes(range(32))")
+    novel = "9f" + "0" * 62
+    assert bytes.fromhex(novel) in _seeds_in_source(f'seed = bytes.fromhex("{novel}")')
+    assert _seeds_in_source("nothing to see here") == set()
+
+
+def test_the_json_scan_reads_hex_and_base64_under_a_seed_named_field() -> None:
+    novel = bytes.fromhex("ab" + "0" * 62)
+    assert novel in _seeds_in_json(json.dumps({"signing_seed_hex": novel.hex()}))
+    assert novel in _seeds_in_json(
+        json.dumps({"nested": {"key_seed": base64.b64encode(novel).decode()}})
+    )
+    assert _seeds_in_json(json.dumps({"public_key_hex": novel.hex()})) == set()
+    assert _seeds_in_json("not json at all") == set()
+
+
+def test_a_seed_is_found_by_its_derived_key_whatever_spelled_it() -> None:
+    """The scan must not depend on a field name or a file format.
+
+    A seed committed in Markdown, in a shell script, or under a JSON key that
+    does not say "seed" is published just the same. What makes it findable is
+    that the key it derives is written down beside it, which is what makes a
+    published test key usable in the first place.
+    """
+    seed = bytes.fromhex("c7" + "3d" * 31)
+    spelled_beside_its_key = (
+        f"the bench signer is {seed.hex()} and its anchor is "
+        f"{base64.b64encode(public_key(seed)).decode()}"
+    )
+    material = _key_material(spelled_beside_its_key)
+    assert seed in material and public_key(seed) in material
+    assert seed in _paired_seeds(material)
+
+
+def test_a_lone_value_with_no_matching_key_is_not_treated_as_a_seed() -> None:
+    """Otherwise every sha256 digest in the tree would be refused as a key."""
+    digest = bytes.fromhex("ab" * 32)
+    material = _key_material(f"sha256:{digest.hex()}")
+    assert digest in material
+    assert _paired_seeds(material) == set()


### PR DESCRIPTION
## What this changes

A trust anchor is authority only while its private half is secret. This repository commits Ed25519 seeds as test material, and three verification paths across two trust boundaries accepted a public key derived from one: the commissioning anchor, loaded independently at runtime startup and by `commissioning deliver`, and the configuration-signature trust anchor.

The refusal is unconditional at every deployment profile rather than a warning in development, because a development runtime drives the same relay as a production one. It covers the verify-only previous commissioning slot, which still accepts documents.

Coordinated disclosure: GHSA-rv38-92xc-7xq8, published 2026-09-07. Developed and reviewed in the advisory's private fork; this is the public landing of that reviewed change.

## Demonstrated, then closed

Both exposures were driven through real entry points rather than internal helpers.

With the commissioning guard reverted, `commissioning deliver` on a binding signed by a committed seed returns `"state": "in_force", "unproven_zones": []` and stages the file. With the guard in place it returns `anchor_error` and stages nothing.

With the configuration guard reverted, `Config.load` succeeds on a `require_signed: true` document carrying `device.rated_capacity_amps: 400.0` and a declared relay pin, reporting `verified: true` and `signer_id: forger`. With the guard in place it refuses, and `tests/test_config.py::TestLoadExample::test_config_load_refuses_a_signature_from_a_published_key` fails with `DID NOT RAISE` when the guard is mutated away — the right reason, at the production admission boundary.

## Availability, which is upgrade-breaking

What a device loses depends on which anchor holds a published key.

A published **commissioning** anchor refuses startup outright. That costs detection and alerting as well as actuation, and under systemd it restart-loops. This matches how a malformed anchor already behaves, and the alternative — starting unprotected on a forgeable authority — is worse.

A published **configuration-signature** anchor refuses when a signed configuration is required or present. A deployment running unsigned in development may never reach that verification and gets no signal from this boundary until `require_signed` is turned on, so the configured anchor value has to be audited directly rather than inferred from a clean start.

## The refused set is append-only

A seed rotated out of the working tree stays in history, so the key it derives stays forgeable and must stay refused. No test asserts the set contains only what the current tree publishes — such a test forces exactly the removal that reopens the hole. Over-refusal costs nothing at `2**-256`.

The set is re-derived from tracked files by test, from three sources: seed-named JSON fields, source literals, and any 32-byte value whose derived public key is written down beside it. The third admits a seed in any format or field name — Markdown, shell, a base64 literal, a JSON key that does not say "seed" — without sweeping in the ~2500 digests a blanket rule would.

## Verification

| | |
| --- | --- |
| full pytest | 5712 passed, 30 skipped |
| `ruff check` / `ruff format --check` | clean |
| `mypy ori/` | clean, 164 files |
| pyright ratchet | 478, baseline 478 |
| `pre-commit run --files` | all hooks passed |
| mutations | 11 killed by the test that names the property |

Three mutations survive: narrowing the scan to `tests/vectors`, and disabling either the source or the JSON scanner. The three sources are fully redundant on current repository contents — source literals find 14 seeds, JSON fields 15, derived pairing 18, with no seed unique to any one of them — so removing any single source loses nothing. Each scanner's logic is covered directly by unit tests against synthetic text, and those mutations do kill.

## Not fixed here

Two sibling boundaries accept published material and are not regressions from this change:

- `ori/skills/signing.py` accepts a skill signed by a committed seed when `ORI_HUB_ROOT_PUBLIC_KEY_B64` names its public half. A forged community skill reaches Tier B triggers with `requires_approval: false`. Tier D is provenance-gated to first-party and community hooks do not execute, so the ceiling is Tier B/C.
- `ori/gateway/firmware_commands.py` accepts a committed seed as a *private* signing seed. The refused set holds public keys and cannot help; that boundary needs a seed-side check.

Both want their own issues.

## Scope boundary

The guard sits at the environment-loading boundary. `VerifierContext` built from another source would bypass it silently, which is why the 244-case binding corpus still verifies documents signed by published keys — as it must, since that is what a conformance corpus is for. The only production construction is fed from the two guarded loaders.
## Clean-checkout verification of 0ed2595

Actions are unavailable in an advisory private fork, so the CI gate list was reproduced from a fresh clone of this fork at exactly `0ed2595`, in an isolated venv built from hash-locked requirements. Release signing was deliberately not attempted: this fork has no release authority, and the fixed release is made from the public origin in the coordinated window.

```
HEAD        : 0ed2595c383762d88314752f6dce4cb60a4113bd
tree clean  : 0 modified
date        : 2026-09-07T11:37:45Z
host        : Darwin 25.6.0 arm64
python      : 3.12.13        pip        : 26.2.1
ruff        : 0.16.5         mypy       : 2.3.1 (compiled)
pytest      : 9.1.1          pyright    : 1.1.411
pre-commit  : 4.6.2          git        : 2.50.1
```

| gate | result |
| --- | --- |
| install hash-locked dev requirements (`--require-hashes`) | PASS |
| install package (`--no-deps -e .`) | PASS |
| `scripts/check_workflows.py` | PASS — `Supply-chain guard: OK` |
| `scripts/check_rust_supply_chain.sh` | PASS — `Rust supply-chain guard: OK` |
| `scripts/test-refresh-evidence-vectors.sh` | PASS |
| `scripts/test-refresh-telemetry-refusal-fixture.sh` | PASS |
| `scripts/typecheck-boundaries.sh` | PASS |
| `mypy ori/` | PASS |
| `mypy tests/` | PASS |
| `pyright ori/ scripts/` | PASS |
| `scripts/pyright_ratchet.py` | PASS — 478, baseline 478 |
| `scripts/guard-capability-matrix.sh origin/main 0ed2595` | PASS |
| Guard Tier Escalation Invariants | PASS |
| Guard Skill Capability Invariants | PASS |
| `pre-commit run --all-files` | PASS |
| full suite | PASS — **5712 passed, 30 skipped** |
| build wheel and sdist | PASS |
| `published_test_keys.py` present in the built wheel | PASS |

The capability-matrix guard was checked for a vacuous pass rather than taken at its word: it saw 12 changed files, not zero, and none match its capability-impacting patterns (`ori/reasoning/`, `ori/actions/`, `ori/runtime.py`, `ori/skills/loader.py`, `ori/config.py`), so it passed for the right reason. This change touches `ori/security/`, which that guard does not gate.

Build products: `ori_runtime-2.5.0rc7-py3-none-any.whl` (814,991 bytes) and `ori_runtime-2.5.0rc7.tar.gz` (1,194,877 bytes).

### What this does not cover

**Platform and interpreter.** CI runs `ubuntu-latest` across Python 3.11, 3.12 and 3.13. This ran on macOS `arm64` with 3.12 only, so the Linux rows and the 3.11/3.13 rows are unverified here. The suite is hermetic and the change is pure-Python with no platform-conditional code, but that is reasoning, not evidence.

**Release-only steps.** The wheelhouse disclosure audit and release bundle assembly from `ci.yml` were not run; they need a Linux wheelhouse build. Package build validation was done with `python -m build` instead, which proves the sdist and wheel assemble and that the new module ships.

**Release signing.** Not attempted, by design.
