### PR TITLE
chore(release): prepare v2.5.0-rc.8

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -82,3 +82,22 @@ candidate or release is cut.
   not driven and registers no relay action. Every logged physical action
   records the `binding_seq` in force, and health reports the actuator's coil
   state and last command.
+
+## Security
+
+- A trust anchor whose private key this repository publishes is refused, at
+  every deployment profile. This repository commits Ed25519 seeds as test
+  material, and three verification paths across two trust boundaries accepted a
+  public key derived from one: the commissioning anchor, loaded independently
+  at runtime startup and by `commissioning deliver`, and the
+  configuration-signature trust anchor. A device configured with such a key
+  accepted documents signed by anyone holding a clone — a commissioned binding
+  claiming both proof legs, which licenses actuation through the commissioned
+  seam, or a signed configuration carrying `device.rated_capacity_amps`, the
+  input that scales the Tier D trip point. The refusal covers the verify-only
+  previous commissioning slot, and `provisioning_anchor` reads such a key as
+  absent. A device carrying one now refuses to start rather than starting on a
+  forgeable authority, which is upgrade-breaking and costs detection as well as
+  actuation; rotate to a key that has never left the producer. No installer,
+  document or example ever configured one. Coordinated as
+  `GHSA-rv38-92xc-7xq8`.

--- a/docs/releases/v2.5.0.md
+++ b/docs/releases/v2.5.0.md
@@ -2,7 +2,7 @@
 
 ## Release Type
 
-Minor release, in progress. `v2.5.0-rc.7` is the current candidate.
+Minor release, in progress. `v2.5.0-rc.8` is the current candidate.
 
 **Do not install a candidate on anything you depend on.** A candidate is
 published to be exercised on hardware, and this one exists because a class of
@@ -47,6 +47,7 @@ installed.
 | `v2.5.0-rc.5` | published | the GPIO packaging candidate; installed on the bench Pi against the system `python3.13`, where the release venv resolves `LGPIOFactory` by default from `lgpio` staged inside the release tree, with nothing resolving from outside it |
 | `v2.5.0-rc.6` | published | the evidence exchange candidate; its Pi wheelhouse carries `pyftdi`, whose scripts pip byte-compiles into `venv/bin/__pycache__`, and the shebang relocation refuses that directory, so the bundle cannot be installed on a Pi in either scope. With the relocation fix substituted into the installer, the same bundle installed under user scope and carried checkpoints to a LAN gateway with envelope auth |
 | `v2.5.0-rc.7` | published | the evidence exchange candidate re-cut with the installer fix and the shutdown checkpoint fix; installed on the bench Pi against stock `python3.13` through the verified bootstrap with the Pi wheelhouse, went through the whole systemd-host runbook as published — clean-host install, reboot, uninstall — and is the release a deliberately failing upgrade was rolled back onto |
+| `v2.5.0-rc.8` | published | the security candidate, cut to carry the refusal of a trust anchor whose private key this repository publishes (`GHSA-rv38-92xc-7xq8`). Upgrade-breaking for a device configured with such a key: it refuses to start until the anchor is rotated |
 
 `v2.5.0-rc.1` produced no artifacts and must not be installed. Nothing was
 built, signed or published from it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ori-runtime"
-version = "2.5.0rc7"
+version = "2.5.0rc8"
 description = "Offline-first agentic IoT runtime — give physical devices the ability to reason"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
Cuts `v2.5.0-rc.8` as a security candidate for GHSA-rv38-92xc-7xq8, which is published.

Version to `2.5.0rc8`, the advisory's fix recorded under a `Security` heading in the unreleased notes, and the candidate table in `docs/releases/v2.5.0.md` extended with the rc.8 row.

The release note states the upgrade-breaking consequence plainly: a device configured with a published anchor refuses to start until the anchor is rotated, and that costs detection as well as actuation. It also records that no installer, document or example ever configured one, so this is a guard against a misconfiguration rather than a shipped default.

Scope is the release cut only. The queued documentation work — `SECURITY.md`'s supported-platform table and the installer's platform tuples — stays out of a security release deliberately.