### PR TITLE
fix(installer): grant the service account the device groups its unit needs

### DIFF
--- a/docs/RASPBERRY_PI_SUPPORT.md
+++ b/docs/RASPBERRY_PI_SUPPORT.md
@@ -296,6 +296,50 @@ exit code: it succeeds for any factory at all, including the experimental
 fallback. Steps 1 and 2 can pass on a device whose Ori install still cannot
 drive a pin.
 
+## Device access is granted by the unit, not by the account
+
+On the certified Trixie 64-bit image, `/dev/gpiochip0` is `root:gpio` and
+`/dev/i2c-1` is `root:i2c`, both mode 0660, so a system install running as its
+own service account opens neither by default. Ownership and mode come from udev
+rules and vary between images and distributions; read the nodes on the device
+rather than assuming these values. A system unit renders
+
+```ini
+SupplementaryGroups=gpio i2c
+```
+
+naming only the groups the host's group database actually defines, because
+systemd refuses to start a unit that names a group that does not exist. The
+grant lives in the unit rather than in the account because the installer adopts
+an existing account exactly as found; a group added with `usermod -aG` would
+outlive both the unit and the uninstall.
+
+Be clear about what this grant is and is not. A defined `gpio` group is not
+evidence that a gpiochip exists or that it is owned by that group — the name
+resolving is only what systemd requires to start the unit. The grant is a
+standing one, decided at install time and covering every node those groups own,
+not only the two named above. It is deliberately wider than the installed
+configuration needs: the installer writes `relay.enabled: false` with no pin, so
+nothing at install time declares which devices this deployment will drive.
+
+A user-scope install gets no such directive: it already runs as someone with
+their own groups. `DeviceAllow=` is not used, because the unit sets neither
+`PrivateDevices=` nor a closed device policy; adding it alone would narrow
+nothing.
+
+Step 3 above runs under `sudo`, so it passes whatever the service account can
+do. Check the identity that actually runs:
+
+```bash
+systemctl show ori-runtime -p User -p SupplementaryGroups
+grep ^Groups: /proc/$(systemctl show ori-runtime -p MainPID --value)/status
+getent group gpio i2c
+```
+
+`/dev/gpiochip0` may also carry an ACL for the desktop login user. That entry
+does not cover the service account, so a `getfacl` line naming a human is not
+evidence the service can open the chip.
+
 ## Before a demo
 
 Anything that must physically actuate has to be proven on the device, under a

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import contextlib
 import fcntl
+import grp
 import json
 import os
 import pwd
@@ -872,6 +873,11 @@ def _health_bridge_response(
     return "healthy", health
 
 
+#: Groups owning the device nodes a runtime drives. Granted through the unit,
+#: never through the account: the installer adopts an account exactly as found.
+DEVICE_GROUPS: tuple[str, ...] = ("gpio", "i2c")
+
+
 class SystemdServiceManager:
     """Shell-free systemd lifecycle adapter with explicit unit scope."""
 
@@ -1113,6 +1119,7 @@ class SystemdServiceManager:
         section = ""
         users: list[str] = []
         targets: list[str] = []
+        groups: list[str] = []
         for raw_line in rendered.splitlines():
             if raw_line.rstrip().endswith("\\"):
                 raise LinuxInstallError(
@@ -1129,6 +1136,8 @@ class SystemdServiceManager:
             key, value = line.split("=", 1)
             if section == "Service" and key.strip() == "User":
                 users.append(value.strip())
+            if section == "Service" and key.strip() == "SupplementaryGroups":
+                groups.append(value.strip())
             if section == "Install" and key.strip() == "WantedBy":
                 targets.append(value.strip())
         expected_target = (
@@ -1146,6 +1155,19 @@ class SystemdServiceManager:
             raise LinuxInstallError(
                 "service_start_failed", "service unit identity does not match profile"
             )
+        if self._profile.scope == "user" and groups:
+            raise LinuxInstallError(
+                "service_start_failed",
+                "service unit grants device groups outside a system profile",
+            )
+        for line in groups:
+            for name in line.split():
+                if name not in DEVICE_GROUPS:
+                    raise LinuxInstallError(
+                        "service_start_failed",
+                        f"service unit names a group that is not a device "
+                        f"group: {name!r}",
+                    )
 
     def _systemctl(self) -> list[str]:
         return (
@@ -1175,6 +1197,21 @@ class SystemdServiceManager:
         return result
 
 
+def host_device_groups(
+    resolver: Callable[[str], object] | None = None,
+) -> tuple[str, ...]:
+    """The device groups this host defines, in a stable order."""
+    lookup = resolver if resolver is not None else grp.getgrnam
+    present: list[str] = []
+    for name in DEVICE_GROUPS:
+        try:
+            lookup(name)
+        except KeyError:
+            continue
+        present.append(name)
+    return tuple(present)
+
+
 def render_systemd_unit(
     template: str,
     *,
@@ -1183,6 +1220,7 @@ def render_systemd_unit(
     data_dir: Path,
     config_path: Path,
     env_file: Path,
+    device_groups: Sequence[str] = (),
 ) -> str:
     """Render a shell-free unit without mixing user and system semantics."""
     paths = {
@@ -1214,21 +1252,32 @@ def render_systemd_unit(
             "systemd config path must be inside the writable data directory",
         )
 
-    if "@ORI_USER_DIRECTIVE@" not in rendered or "@ORI_WANTED_BY@" not in rendered:
-        raise LinuxInstallError(
-            "service_start_failed", "service template is missing profile markers"
-        )
+    for marker in ("@ORI_USER_DIRECTIVE@", "@ORI_DEVICE_GROUPS@", "@ORI_WANTED_BY@"):
+        if marker not in rendered:
+            raise LinuxInstallError(
+                "service_start_failed", f"service template is missing {marker}"
+            )
     if profile.scope == "user":
         user_directive = ""
         wanted_by = "default.target"
+        groups_directive = ""
     elif profile.scope == "system" and profile.service_user is not None:
         user_directive = f"User={profile.service_user}"
         wanted_by = "multi-user.target"
+        names = list(device_groups)
+        for name in names:
+            if name not in DEVICE_GROUPS:
+                raise LinuxInstallError(
+                    "service_start_failed",
+                    f"device group name is not a device group: {name!r}",
+                )
+        groups_directive = f"SupplementaryGroups={' '.join(names)}" if names else ""
     else:
         raise LinuxInstallError(
             "service_start_failed", "service profile is inconsistent"
         )
     rendered = rendered.replace("@ORI_USER_DIRECTIVE@", user_directive)
+    rendered = rendered.replace("@ORI_DEVICE_GROUPS@", groups_directive)
     rendered = rendered.replace("@ORI_WANTED_BY@", wanted_by)
     if re.search(r"@[A-Z0-9_]+@", rendered):
         raise LinuxInstallError(
@@ -2471,6 +2520,7 @@ def install_composed_release(
         data_dir=layout.data,
         config_path=config_path,
         env_file=env_file,
+        device_groups=host_device_groups(),
     )
     release_preparer = preparer or OfflineReleasePreparer(bundle=bundle)
     verifier = health_verifier or RuntimeHealthVerifier(

--- a/packaging/systemd/ori-runtime.service.in
+++ b/packaging/systemd/ori-runtime.service.in
@@ -8,6 +8,7 @@ After=network.target
 [Service]
 Type=simple
 @ORI_USER_DIRECTIVE@
+@ORI_DEVICE_GROUPS@
 WorkingDirectory=@ORI_DATA_DIR@
 EnvironmentFile=-@ORI_ENV_FILE@
 ExecStart=@ORI_ROOT@/current/venv/bin/python -m ori.runtime --config @ORI_CONFIG@

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -33,6 +33,7 @@ from ori.installer.linux import (
     SystemdServiceProfile,
     apply_system_service_permissions,
     ensure_service_account,
+    host_device_groups,
     install_composed_release,
     install_release,
     provision_runtime_config,
@@ -2269,6 +2270,192 @@ def test_system_permissions_allow_only_configured_runtime_socket(
         finally:
             health_socket.close()
             unexpected_socket.close()
+
+
+def test_a_system_unit_grants_the_device_groups_the_host_defines() -> None:
+    """The service account cannot open a gpiochip without the owning group."""
+    rendered = render_systemd_unit(
+        _service_template(),
+        profile=SystemdServiceProfile.system(),
+        root=Path("/opt/ori"),
+        data_dir=Path("/opt/ori/data"),
+        config_path=Path("/opt/ori/data/ori.yaml"),
+        env_file=Path("/etc/ori/runtime.env"),
+        device_groups=("gpio", "i2c"),
+    )
+    assert "SupplementaryGroups=gpio i2c" in rendered
+
+
+def test_a_host_without_those_groups_gets_no_directive() -> None:
+    """systemd refuses to start a unit naming a group that does not exist."""
+    rendered = render_systemd_unit(
+        _service_template(),
+        profile=SystemdServiceProfile.system(),
+        root=Path("/opt/ori"),
+        data_dir=Path("/opt/ori/data"),
+        config_path=Path("/opt/ori/data/ori.yaml"),
+        env_file=Path("/etc/ori/runtime.env"),
+        device_groups=(),
+    )
+    assert "SupplementaryGroups" not in rendered
+
+
+def test_a_user_unit_names_no_supplementary_groups() -> None:
+    """A user unit runs as someone who already has their own groups."""
+    rendered = render_systemd_unit(
+        _service_template(),
+        profile=SystemdServiceProfile.user(),
+        root=Path("/opt/ori"),
+        data_dir=Path("/opt/ori/data"),
+        config_path=Path("/opt/ori/data/ori.yaml"),
+        env_file=Path("/etc/ori/runtime.env"),
+        device_groups=("gpio", "i2c"),
+    )
+    assert "SupplementaryGroups" not in rendered
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "gpio\nExecStartPre=/bin/sh",  # the value lands in a unit file
+        "wheel",  # a real group, but not a device group
+        "docker",
+        "",
+    ],
+)
+def test_a_group_that_is_not_a_device_group_is_refused(name: str) -> None:
+    """The allowlist is the constant, not the shape of the name."""
+    with pytest.raises(LinuxInstallError, match="not a device group"):
+        render_systemd_unit(
+            _service_template(),
+            profile=SystemdServiceProfile.system(),
+            root=Path("/opt/ori"),
+            data_dir=Path("/opt/ori/data"),
+            config_path=Path("/opt/ori/data/ori.yaml"),
+            env_file=Path("/etc/ori/runtime.env"),
+            device_groups=(name,),
+        )
+
+
+def test_host_device_groups_reports_only_what_the_host_defines() -> None:
+    defined = {"gpio"}
+
+    def resolver(name: str) -> object:
+        if name in defined:
+            return object()
+        raise KeyError(name)
+
+    assert host_device_groups(resolver) == ("gpio",)
+    assert host_device_groups(_raise_key) == ()
+
+
+def test_a_composed_system_install_writes_the_grant_into_the_unit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An upgrade renders through this same call, so it regains the grant too."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    written: list[str] = []
+
+    class Preparer:
+        def prepare(self, release: Path) -> None:
+            interpreter = release / "venv" / "bin" / "python"
+            interpreter.parent.mkdir(parents=True)
+            interpreter.write_bytes(b"python")
+            interpreter.chmod(0o700)
+
+        def validate(self, _release: Path) -> None:
+            return None
+
+    class Health:
+        def verify(self, _release: Path) -> dict[str, object]:
+            return {"device_id": "ori-01", "critical": False}
+
+    class Manager:
+        def install_unit(self, rendered: str) -> Callable[[], None]:
+            written.append(rendered)
+            return lambda: None
+
+        def restart(self) -> None:
+            return None
+
+        def stop(self) -> None:
+            return None
+
+        def enable(self) -> BootPersistence:
+            return BootPersistence(True, "enabled")
+
+        def boot_persistence(self) -> BootPersistence:
+            return BootPersistence(True, "enabled")
+
+    monkeypatch.setattr(
+        "ori.installer.linux.provision_runtime_config",
+        lambda **_kwargs: lambda: None,
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux.apply_system_service_permissions",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        "ori.installer.linux.grp.getgrnam",
+        lambda name: object() if name in {"gpio", "i2c"} else _raise_key(name),
+    )
+    install_composed_release(
+        layout=layout,
+        bundle=ExtractedReleaseBundle(
+            tmp_path, "2.3.0", "linux-aarch64-python3.12", "3.12", 1
+        ),
+        values=InstallerConfigInput("ori-01", "Office", "Lagos"),
+        service_profile=SystemdServiceProfile.system(),
+        service_manager=Manager(),  # type: ignore[arg-type]
+        unit_template=_service_template(),
+        env_file=layout.data / "runtime.env",
+        preparer=Preparer(),  # type: ignore[arg-type]
+        health_verifier=Health(),  # type: ignore[arg-type]
+    )
+    assert written and "SupplementaryGroups=gpio i2c" in written[0]
+
+
+def _raise_key(name: str) -> object:
+    raise KeyError(name)
+
+
+def test_a_user_unit_carrying_device_groups_is_refused_at_install(
+    tmp_path: Path,
+) -> None:
+    """The renderer is not the only thing that decides what the unit may grant."""
+    unit = (tmp_path / "units" / "ori-runtime.service").resolve()
+    manager = SystemdServiceManager(
+        profile=SystemdServiceProfile.user(),
+        unit_path=unit,
+        runner=lambda command: subprocess.CompletedProcess(command, 0, "", ""),
+        effective_uid=1001,
+    )
+    rendered = _rendered_unit(tmp_path, SystemdServiceProfile.user()).replace(
+        "[Service]", "[Service]\nSupplementaryGroups=gpio i2c", 1
+    )
+    with pytest.raises(LinuxInstallError, match="outside a system profile"):
+        manager.install_unit(rendered)
+    assert not unit.exists()
+
+
+@pytest.mark.parametrize("named", ["gpio ../../root", "wheel", "gpio wheel"])
+def test_a_system_unit_naming_a_non_device_group_is_refused_at_install(
+    named: str, tmp_path: Path
+) -> None:
+    """A unit reaching the installer from anywhere is held to the same list."""
+    unit = (tmp_path / "units" / "ori-runtime.service").resolve()
+    manager = SystemdServiceManager(
+        profile=SystemdServiceProfile.system(),
+        unit_path=unit,
+        runner=lambda command: subprocess.CompletedProcess(command, 0, "", ""),
+        effective_uid=0,
+    )
+    rendered = _rendered_unit(tmp_path, SystemdServiceProfile.system()).replace(
+        "[Service]", f"[Service]\nSupplementaryGroups={named}", 1
+    )
+    with pytest.raises(LinuxInstallError, match="not a device group"):
+        manager.install_unit(rendered)
+    assert not unit.exists()
 
 
 def test_system_upgrade_preserves_access_and_reapplies_permissions(


### PR DESCRIPTION
## What does this PR do?

A system-scope install runs the runtime as its own dedicated service account. On the certified Trixie 64-bit image the device nodes a runtime drives are group-owned and mode 0660, so that account can open neither of them, and nothing in the install says so. The failure surfaces much later and somewhere else: a runtime that cannot reach hardware it was configured for, on a device where the install reported success.

The grant belongs to the unit, not to the account. The installer deliberately adopts an existing service account exactly as found, and a group added with `usermod -aG` would outlive both the unit and the uninstall — a standing privilege that nothing in the install transaction owns, and that removing Ori would leave behind. A system unit therefore renders `SupplementaryGroups`, and a user unit never does, because a user unit already runs as someone with their own groups.

Only groups the host's group database actually defines are named. systemd refuses to start a unit naming a group that does not exist, so naming them unconditionally would turn a working install on a host without those groups into a service that cannot start.

`DEVICE_GROUPS` is the allowlist, and membership in it — not the shape of the name — is what both the renderer and the install-time unit validator check. A group that exists and looks entirely plausible is still refused unless it is one of those groups, so the constant is the boundary rather than a comment describing one. The validator holds a unit reaching the installer from any source to the same list, and refuses a user unit that carries the directive at all.

`DeviceAllow=` is not added. The unit sets neither `PrivateDevices=` nor a closed device policy, so `DeviceAllow=` on its own narrows nothing and is not the missing POSIX credential grant; it belongs to a device-cgroup hardening design with its own proof.

Rendering happens inside the composed install transaction, which an upgrade runs against an existing root, so an upgraded install gains the grant rather than keeping a unit that predates it.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — the change is confined to `ori/installer/`, which the capability guard does not watch and which declares no runtime capability. No action, tier, executor or registry entry is added or altered, and the runtime's behaviour once started is unchanged; what changes is the credential the service process is started with.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D code path is added. `grp` is in the standard library.

## Related issue

Closes #553
Refs #556

## Testing notes

Proven on the bench Pi, isolating the unit directive as the cause. A throwaway account belonging to no device group was denied both nodes by a transient unit, and opened both when the same unit carried the directive — including under `NoNewPrivileges=true` and `ProtectSystem=strict`, which do not narrow device authority already granted. The existing service account could not have shown this, because it carries the groups from an earlier manual grant. `systemd-analyze verify` accepts the rendered unit, and the unit rendered from this branch is byte-identical to the one verified on the device. The probe account was removed and no existing account was modified.

`/dev/gpiochip0` on that image also carries an ACL for the desktop login user. That entry does not cover the service account, so a `getfacl` line naming a human is not evidence the service can open the chip — the documentation says so, and the verification steps now check the identity that actually runs rather than passing under `sudo`.

Every boundary was mutation-checked and each mutation is refused by the test named for that property: the grant removed, the directive rendered for an empty set, a user unit granted the same groups, either allowlist check dropped or weakened to a truthiness test, the validator ignoring the directive or checking only the first name, the host lookup skipped, and the composed install ceasing to pass the host groups.

The grant is standing and wider than the installed configuration needs. The installer writes `relay.enabled: false` with no pin and no sensors, so nothing at install time declares which devices a deployment will drive, and a group grant covers every node those groups own rather than the two named. Narrowing it needs a transition that re-renders the unit once commissioning states which pin and which bus are real, which is a change to when the unit is written rather than to how it is rendered. That is #556, and `docs/RASPBERRY_PI_SUPPORT.md` states the breadth plainly rather than implying the grant tracks hardware.

A live cutover on the bench Pi — installing a release carrying this unit, restarting under observation, confirming the service process holds the expected groups, and only then removing the earlier manual account membership — is deliberately left as a separate supervised hardware step. The installed service on that device declares no `gpio_pin`, holds no commissioning binding and has no gpio or i2c descriptor open, so it drives nothing today.
