### PR TITLE
fix(config): resolve a relative store path against its own configuration

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -109,6 +109,35 @@ candidate or release is cut.
   hostile document is refused rather than raising out of the loader, a repeated
   key is refused, and a document nested past the recursion limit cannot stop the
   runtime.
+- A relative `database.path` resolves against the directory holding the
+  configuration that declared it, rather than against the working directory of
+  whatever process loaded it. Every generated configuration declares
+  `ori_state.db` relative, so the runtime, the commissioning bridge and the
+  production encrypted-storage check previously each answered according to
+  where they were started: a ceremony command run from outside the data
+  directory reported that the device held no state store while the store and
+  its binding sat intact beside the configuration, and the requirement that
+  `database.path` live under `state.encryption.encrypted_path_prefixes` could
+  be satisfied or defeated by standing in the right directory. An installed
+  deployment is unaffected, because its unit sets `WorkingDirectory` to the
+  data directory that holds its configuration. A deployment that relied on the
+  working directory to select its store, or to satisfy that posture check, now
+  resolves and is judged against the configuration instead. Where a store
+  exists only where the working directory would have found one, config load
+  reports both paths, since opening the resolved store creates it and the
+  device would otherwise come up on an empty one while its commissioned
+  binding sits in the other. That is reported and not refused: a file of that
+  name in the working directory is a coincidence as often as it is the
+  device's store. An absolute `database.path` is taken exactly as declared,
+  and `:memory:` names no file so it is not resolved.
+- `state action-log` and `state history` take `--path` and read the store the
+  named installation declares. They previously opened `ori_state.db` beside the
+  caller and read no configuration at all, so they could not reach a deployment
+  that declared any other `database.path`, and a read in a directory with no
+  store created an empty one and reported an empty action log — a device that
+  appeared to have taken no actions rather than a lookup that went elsewhere.
+  An absent store is now refused and named, and a refusal distinguishes a store
+  that is missing from a path that is not a file.
 - `SECURITY.md` names Raspberry Pi OS Trixie as the production-supported Pi
   platform and Bookworm as a published bundle that is not a certified target,
   which is what `docs/linux-install.md` and the capability matrix already said.

--- a/ori/cli_bridge.py
+++ b/ori/cli_bridge.py
@@ -61,7 +61,6 @@ from ori.utils.bool_utils import is_truthy
 
 _SCHEMA_VERSION = 1
 _DEFAULT_HEALTH_TIMEOUT_MS = 3000
-_DEFAULT_STATE_DB_PATH = "ori_state.db"
 _MAX_STATE_LIMIT = 1000
 _LOOPBACK_HOSTS = {"localhost", "127.0.0.1", "::1"}
 _LEGACY_COMMANDS = {
@@ -738,13 +737,14 @@ async def _read_health_snapshot(socket_path: str, timeout_ms: int) -> dict[str, 
 
 
 async def _read_state_action_log(args: list[str]) -> list[dict[str, Any]]:
+    config, args = _state_config(args, command="state action-log")
     filters = _parse_state_filters(
         args,
         command="state action-log",
         allowed={"limit"},
     )
     limit = _state_limit(filters.get("limit"), default=50)
-    store = _state_store_from_default_path()
+    store = _state_store_from_config(config)
     await store.open()
     try:
         return await store.get_action_log(limit=limit)
@@ -753,6 +753,7 @@ async def _read_state_action_log(args: list[str]) -> list[dict[str, Any]]:
 
 
 async def _read_state_history(args: list[str]) -> list[dict[str, Any]]:
+    config, args = _state_config(args, command="state history")
     filters = _parse_state_filters(
         args,
         command="state history",
@@ -765,13 +766,20 @@ async def _read_state_history(args: list[str]) -> list[dict[str, Any]]:
             "state history requires sensor_id",
         )
     limit = _state_limit(filters.get("limit"), default=100)
-    store = _state_store_from_default_path()
+    store = _state_store_from_config(config)
     await store.open()
     try:
         readings = await store.get_history(sensor_id=sensor_id, limit=limit)
     finally:
         await store.close()
     return [_sensor_reading_to_dict(reading) for reading in readings]
+
+
+def _state_config(args: list[str], *, command: str) -> tuple[Config, list[str]]:
+    """The installation a state read names, and the filters left after it."""
+    path = _required_option(args, "--path", command)
+    index = args.index("--path")
+    return Config.load(path), args[:index] + args[index + 2 :]
 
 
 def _parse_state_filters(
@@ -829,8 +837,7 @@ def _state_limit(raw: str | None, *, default: int) -> int:
 
 def _commissioning_store(config: Config) -> StateStore:
     """The store the runtime itself opens, resolved the way the runtime does."""
-    db_path = str(config.raw.get("database", {}).get("path", _DEFAULT_STATE_DB_PATH))
-    return StateStore(db_path=db_path)
+    return StateStore(db_path=config.database_path)
 
 
 def _declared_actuators(config: Config) -> list[dict[str, Any]]:
@@ -862,9 +869,7 @@ async def _in_force_binding(config: Config) -> AcceptedBinding | None:
     loader reads it; reporting it here would let a producer chain a revision
     onto a document this device never accepted.
     """
-    db_path = Path(
-        str(config.raw.get("database", {}).get("path", _DEFAULT_STATE_DB_PATH))
-    )
+    db_path = Path(config.database_path)
     if not db_path.is_file():
         # A device that has never started has no store, and asking it a
         # question must not build one. Opening the store applies the DDL, so
@@ -1013,12 +1018,14 @@ async def _commissioning_deliver(
 
 
 async def _proof_state(config: Config):
-    """The provisional and in-force bindings this device holds, and its posture."""
-    db_path = Path(
-        str(config.raw.get("database", {}).get("path", _DEFAULT_STATE_DB_PATH))
-    )
+    """The provisional and in-force bindings this device holds."""
+    db_path = Path(config.database_path)
     if not db_path.is_file():
-        return None, None, None
+        raise BridgeError(
+            "no_provisional_binding",
+            f"no state store at {db_path}, so this device holds no "
+            "provisional binding there",
+        )
     store = _commissioning_store(config)
     await store.open()
     try:
@@ -1032,7 +1039,7 @@ async def _proof_state(config: Config):
             return None
         return accepted_from_row(row)
 
-    return held(provisional_row), held(in_force_row), db_path
+    return held(provisional_row), held(in_force_row)
 
 
 async def _commissioning_prove_command(
@@ -1056,12 +1063,7 @@ async def _commissioning_prove_command(
     )
 
     config = Config.load(config_path)
-    provisional, in_force, db_path = await _proof_state(config)
-    if db_path is None:
-        raise BridgeError(
-            "no_provisional_binding",
-            "this device has no state store, so it holds no provisional binding.",
-        )
+    provisional, in_force = await _proof_state(config)
     store = _commissioning_store(config)
     await store.open()
     try:
@@ -1120,12 +1122,7 @@ async def _commissioning_proof_export(config_path: str) -> dict[str, Any]:
     )
 
     config = Config.load(config_path)
-    provisional, _, db_path = await _proof_state(config)
-    if db_path is None:
-        raise BridgeError(
-            "no_provisional_binding",
-            "this device has no state store, so it holds no provisional binding.",
-        )
+    provisional, _ = await _proof_state(config)
     store = _commissioning_store(config)
     await store.open()
     try:
@@ -1197,17 +1194,23 @@ def _write_staged_binding(target: Path, payload: bytes) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _state_store_from_default_path() -> StateStore:
-    path = Path(_DEFAULT_STATE_DB_PATH)
+def _state_store_from_config(config: Config) -> StateStore:
+    """The store the named installation declares, refused rather than created.
+
+    A read that opened a missing store would apply the DDL and answer from the
+    empty database it had just built, which reads as a device that has recorded
+    nothing rather than as a lookup that went somewhere else.
+    """
+    path = Path(config.database_path)
     if not path.exists():
         raise BridgeError(
             "state_store_unavailable",
-            f"state database does not exist: {_DEFAULT_STATE_DB_PATH}",
+            f"state database does not exist: {path}",
         )
     if not path.is_file():
         raise BridgeError(
             "state_store_unavailable",
-            f"state database path is not a file: {_DEFAULT_STATE_DB_PATH}",
+            f"state database path is not a file: {path}",
         )
     return StateStore(str(path))
 

--- a/ori/config.py
+++ b/ori/config.py
@@ -747,7 +747,9 @@ class Config:
         os_sandbox = _parse_os_sandbox(data.get("os_sandbox"))
         state_cfg = _parse_state(data.get("state"))
         evidence_cfg = _parse_evidence(data.get("evidence"))
-        database_path = _parse_database_path(data.get("database"))
+        database_path = _resolve_database_path(
+            _parse_database_path(data.get("database")), path
+        )
         logging_cfg = _parse_logging(data.get("logging"))
         _validate_coap_sensor_allowlist(sensors, actions.coap)
         _warn_gateway_network_posture(gateway)
@@ -3120,6 +3122,11 @@ def _parse_state_encryption(data: dict[str, Any]) -> StateEncryptionConfig:
     )
 
 
+#: SQLite's private in-memory database. It names no file, so it is not a path
+#: to resolve.
+_IN_MEMORY_STORE = ":memory:"
+
+
 def _parse_database_path(data: Any) -> str:
     if data is None:
         return "ori_state.db"
@@ -3129,6 +3136,39 @@ def _parse_database_path(data: Any) -> str:
     if not path:
         raise ConfigValidationError("database.path must not be empty.")
     return path
+
+
+def _resolve_database_path(declared: str, config_path: str) -> str:
+    """Resolve a relative store path against the configuration that declared it.
+
+    A relative path otherwise resolves against the caller's working directory,
+    which makes both the store a command opens and the production
+    encrypted-storage check a property of where a process was started.
+    """
+    if declared == _IN_MEMORY_STORE:
+        return declared
+    candidate = Path(declared).expanduser()
+    if candidate.is_absolute():
+        return str(candidate)
+    home = Path(config_path).expanduser().resolve(strict=False).parent
+    resolved = Path(os.path.normpath(home / candidate))
+    legacy = Path(declared)
+    if legacy.is_file() and not resolved.exists():
+        # Opening the resolved store creates it, so a deployment that relied on
+        # the working directory would come up on an empty one. A file of that
+        # name in the working directory is a coincidence as often as it is that
+        # deployment, so this reports rather than refuses.
+        logger.warning(
+            "[config] database.path %r resolves to %s, which does not exist, "
+            "while a file of that name exists at %s. A relative database.path "
+            "is resolved against the directory holding the configuration, not "
+            "the working directory. If that file is this device's store, move "
+            "it beside the configuration or declare database.path absolutely.",
+            declared,
+            resolved,
+            legacy.resolve(strict=False),
+        )
+    return str(resolved)
 
 
 def _parse_logging(data: Any) -> LoggingConfig:

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -689,8 +689,7 @@ class OriRuntime:
             self._status_indicator = status_indicator
 
         # ── Step B: Open StateStore ───────────────────────────────────────────
-        db_path: str = config.raw.get("database", {}).get("path", "ori_state.db")
-        self._state_store = StateStore(db_path=db_path)
+        self._state_store = StateStore(db_path=config.database_path)
         await self._state_store.open()
         await self._load_remote_command_lockout_state()
 

--- a/tests/commissioning/test_proof_operation.py
+++ b/tests/commissioning/test_proof_operation.py
@@ -839,7 +839,7 @@ def test_only_a_matched_attestation_is_reported_as_a_success(
     from ori import cli_bridge
 
     async def fake_state(config: Any) -> Any:
-        return object(), None, Path("present")
+        return object(), None
 
     for attestation, expected_ok, expected_code in (
         ("matched", True, None),

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -103,7 +103,7 @@ def _read_stdout_json(capsys) -> dict:
     return json.loads(captured.out)
 
 
-async def _seed_state_store(path: Path) -> None:
+async def _seed_state_store(path: Path, action: str = "trip_relay") -> None:
     store = StateStore(str(path))
     await store.open()
     try:
@@ -123,7 +123,7 @@ async def _seed_state_store(path: Path) -> None:
         )
         await store.log_action_for_event(
             ActionResult(
-                action_name="trip_relay",
+                action_name=action,
                 tier="D",
                 executed=True,
                 approved=None,
@@ -267,10 +267,11 @@ def test_cli_bridge_health_snapshot_preserves_device_policy_caps(monkeypatch, ca
 
 
 def test_cli_bridge_state_action_log_reads_runtime_store(tmp_path, monkeypatch, capsys):
+    config_path = _relative_store_config(tmp_path / "data")
+    asyncio.run(_seed_state_store(tmp_path / "data" / "ori_state.db"))
     monkeypatch.chdir(tmp_path)
-    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
 
-    rc = cli_bridge.main(["state", "action-log", "limit=5"])
+    rc = cli_bridge.main(["state", "action-log", "--path", str(config_path), "limit=5"])
 
     payload = _read_stdout_json(capsys)
     assert rc == 0
@@ -283,10 +284,11 @@ def test_cli_bridge_state_action_log_reads_runtime_store(tmp_path, monkeypatch, 
 
 
 def test_cli_bridge_state_history_requires_sensor_id(tmp_path, monkeypatch, capsys):
+    config_path = _relative_store_config(tmp_path / "data")
+    asyncio.run(_seed_state_store(tmp_path / "data" / "ori_state.db"))
     monkeypatch.chdir(tmp_path)
-    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
 
-    rc = cli_bridge.main(["state", "history", "limit=5"])
+    rc = cli_bridge.main(["state", "history", "--path", str(config_path), "limit=5"])
 
     payload = _read_stdout_json(capsys)
     assert rc == 2
@@ -299,10 +301,20 @@ def test_cli_bridge_state_history_requires_sensor_id(tmp_path, monkeypatch, caps
 def test_cli_bridge_state_history_reads_bounded_sensor_history(
     tmp_path, monkeypatch, capsys
 ):
+    config_path = _relative_store_config(tmp_path / "data")
+    asyncio.run(_seed_state_store(tmp_path / "data" / "ori_state.db"))
     monkeypatch.chdir(tmp_path)
-    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
 
-    rc = cli_bridge.main(["state", "history", "sensor_id=pir_01", "limit=5"])
+    rc = cli_bridge.main(
+        [
+            "state",
+            "history",
+            "--path",
+            str(config_path),
+            "sensor_id=pir_01",
+            "limit=5",
+        ]
+    )
 
     payload = _read_stdout_json(capsys)
     assert rc == 0
@@ -322,10 +334,13 @@ def test_cli_bridge_state_history_reads_bounded_sensor_history(
 
 
 def test_cli_bridge_state_rejects_unknown_filter(tmp_path, monkeypatch, capsys):
+    config_path = _relative_store_config(tmp_path / "data")
+    asyncio.run(_seed_state_store(tmp_path / "data" / "ori_state.db"))
     monkeypatch.chdir(tmp_path)
-    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
 
-    rc = cli_bridge.main(["state", "action-log", "table=sensor_history"])
+    rc = cli_bridge.main(
+        ["state", "action-log", "--path", str(config_path), "table=sensor_history"]
+    )
 
     payload = _read_stdout_json(capsys)
     assert rc == 2
@@ -335,15 +350,70 @@ def test_cli_bridge_state_rejects_unknown_filter(tmp_path, monkeypatch, capsys):
 
 
 def test_cli_bridge_state_rejects_missing_database(tmp_path, monkeypatch, capsys):
+    """A read must refuse an absent store, not build one and answer from it."""
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    monkeypatch.chdir(tmp_path)
+
+    rc = cli_bridge.main(["state", "action-log", "--path", str(config_path)])
+
+    payload = _read_stdout_json(capsys)
+    assert rc == 2
+    assert payload["ok"] is False
+    assert payload["error"]["code"] == "state_store_unavailable"
+    assert "does not exist" in payload["error"]["detail"]
+    assert str(home / "ori_state.db") in payload["error"]["detail"]
+    assert not (home / "ori_state.db").exists()
+    assert not (tmp_path / "ori_state.db").exists()
+
+
+def test_cli_bridge_state_separates_an_absent_store_from_one_that_is_not_a_file(
+    tmp_path, monkeypatch, capsys
+):
+    """A directory in the store's place is a wrong path, not a fresh device."""
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    (home / "ori_state.db").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    cli_bridge.main(["state", "action-log", "--path", str(config_path)])
+
+    detail = _read_stdout_json(capsys)["error"]["detail"]
+    assert "is not a file" in detail
+    assert "does not exist" not in detail
+
+
+def test_cli_bridge_state_read_requires_the_installation_it_reads(
+    tmp_path, monkeypatch, capsys
+):
+    """Without a configuration the command cannot know whose store it opened."""
+    asyncio.run(_seed_state_store(tmp_path / "ori_state.db"))
     monkeypatch.chdir(tmp_path)
 
     rc = cli_bridge.main(["state", "action-log"])
 
     payload = _read_stdout_json(capsys)
     assert rc == 2
-    assert payload["ok"] is False
-    assert payload["error"]["code"] == "state_store_unavailable"
-    assert not (tmp_path / "ori_state.db").exists()
+    assert payload["error"]["code"] == "invalid_arguments"
+    assert "--path" in payload["error"]["detail"]
+
+
+def test_cli_bridge_state_reads_the_store_the_config_names_not_the_cwd(
+    tmp_path, monkeypatch, capsys
+):
+    """A store sitting in the caller's directory must not answer for another."""
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    asyncio.run(_seed_state_store(home / "ori_state.db"))
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    asyncio.run(_seed_state_store(elsewhere / "ori_state.db", action="close_gas_valve"))
+    monkeypatch.chdir(elsewhere)
+
+    cli_bridge.main(["state", "action-log", "--path", str(config_path)])
+
+    payload = _read_stdout_json(capsys)
+    assert payload["result"][0]["action_name"] == "trip_relay"
 
 
 def test_cli_bridge_skills_validate_reports_invalid_skill(tmp_path, capsys):
@@ -783,6 +853,130 @@ def _anchor(monkeypatch, seed: str | None = None) -> None:
     from tests.commissioning.signing import EPHEMERAL_SEED, public_key_b64
 
     monkeypatch.setenv(COMMISSIONING_ANCHOR_ENV, public_key_b64(seed or EPHEMERAL_SEED))
+
+
+def _relative_store_config(home: Path) -> Path:
+    """A configuration declaring its store the way every generated one does."""
+    home.mkdir(parents=True, exist_ok=True)
+    body = textwrap.dedent("""\
+        device:
+          id: bench-01
+          name: Bench
+          location: Test Lab
+          deployment_profile: development
+        sensors:
+          - id: load-current
+            type: cpu_percent
+            protocol: psutil
+            poll_interval_ms: 1000
+        skills: []
+        reasoning:
+          default_tier: rule
+        actions:
+          relay:
+            enabled: false
+            gpio_pin: 26
+        database:
+          path: ori_state.db
+        logging:
+          level: INFO
+          file: ori.log
+        """)
+    config_path = home / "ori.yaml"
+    config_path.write_text(body, encoding="utf-8")
+    return config_path
+
+
+def test_the_bridge_looks_for_the_store_beside_the_config_not_the_caller(
+    tmp_path, monkeypatch, capsys
+):
+    """`--path` names an installation, so the answer cannot depend on the cwd."""
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    rc = cli_bridge.main(["commissioning", "proof-export", "--path", str(config_path)])
+
+    error = _read_stdout_json(capsys)["error"]
+    assert rc != 0
+    assert error["code"] == "no_provisional_binding"
+    assert str(home / "ori_state.db") in error["detail"]
+    assert str(elsewhere) not in error["detail"]
+
+
+def test_a_store_beside_the_config_is_found_from_any_directory(
+    tmp_path, monkeypatch, capsys
+):
+    """A present store stops the refusal, and no second store is created."""
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    (home / "ori_state.db").write_bytes(b"")
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    cli_bridge.main(["commissioning", "proof-export", "--path", str(config_path)])
+
+    error = _read_stdout_json(capsys)["error"]
+    assert "no state store" not in error["detail"]
+    # Opening a store applies the DDL, so a store materialising here is the
+    # command having built the runtime's durable state in the wrong place.
+    assert not (elsewhere / "ori_state.db").exists()
+
+
+async def _retain_own_binding(config_path: Path) -> None:
+    """An in-force binding this device itself holds."""
+    from ori.config import Config
+
+    config = Config.load(str(config_path))
+    store = cli_bridge._commissioning_store(config)
+    await store.open()
+    try:
+        await store.retain_commissioned_binding(
+            binding_seq=3,
+            canonical_hash="sha256:" + "b" * 64,
+            device_id=config.device.id,
+            inventory_generation=1,
+            signer_id="commissioning-test",
+            supersedes=None,
+            canonical_json="{}",
+            signature="ed25519:" + base64.b64encode(b"\x00" * 64).decode(),
+            zones_json=json.dumps(
+                [
+                    {
+                        **_legacy_zone(),
+                        "control_proof_method": "commanded_and_observed",
+                        "control_proof_performed_at_ms": 1800000000000,
+                    }
+                ]
+            ),
+        )
+    finally:
+        await store.close()
+
+
+def test_inventory_reads_the_binding_beside_the_config_from_any_directory(
+    tmp_path, monkeypatch, capsys
+):
+    """The baseline a producer chains onto cannot depend on the caller's cwd.
+
+    Reporting no accepted binding when one is held invites a first-sequence
+    document over a device that already holds one.
+    """
+    home = tmp_path / "data"
+    config_path = _relative_store_config(home)
+    asyncio.run(_retain_own_binding(config_path))
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    cli_bridge.main(["commissioning", "inventory", "--path", str(config_path)])
+
+    result = _read_stdout_json(capsys)["result"]
+    assert result["accepted_binding_seq"] == 3
+    assert result["accepted_binding_hash"] == "sha256:" + "b" * 64
 
 
 def test_cli_bridge_commissioning_inventory_reports_the_candidate_set(tmp_path, capsys):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 
 import ast
 import base64
+import logging
 import os
 import pathlib
 import subprocess
@@ -1326,6 +1327,236 @@ class TestLoadExample:
         )
 
         with pytest.raises(ConfigValidationError, match="require_signed"):
+            Config.load(yaml_path)
+
+    def test_the_in_memory_store_is_not_a_path_to_resolve(self, tmp_path):
+        """SQLite's private database names no file."""
+        yaml_path = _write_yaml(
+            tmp_path,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ":memory:"
+            """,
+        )
+
+        assert Config.load(yaml_path).database_path == ":memory:"
+
+    def test_a_store_only_the_working_directory_could_find_is_reported(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Coming up on an empty store would strand the binding in the old one.
+
+        Reported and not refused: a file of that name in the working directory
+        is a coincidence as often as it is this device's store.
+        """
+        home = tmp_path / "data"
+        home.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "ori_state.db").write_bytes(b"")
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        with caplog.at_level(logging.WARNING, logger="ori.config"):
+            cfg = Config.load(yaml_path)
+
+        assert cfg.database_path == str(home / "ori_state.db")
+        warned = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert str(elsewhere / "ori_state.db") in warned
+        assert str(home / "ori_state.db") in warned
+
+    def test_a_store_beside_the_config_is_used_without_complaint(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """The report fires on ambiguity alone, not on every relative path."""
+        home = tmp_path / "data"
+        home.mkdir()
+        (home / "ori_state.db").write_bytes(b"")
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        (elsewhere / "ori_state.db").write_bytes(b"")
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        with caplog.at_level(logging.WARNING, logger="ori.config"):
+            cfg = Config.load(yaml_path)
+
+        assert cfg.database_path == str(home / "ori_state.db")
+        assert not [r for r in caplog.records if "database.path" in r.getMessage()]
+
+    def test_a_relative_store_path_resolves_beside_the_config(
+        self, tmp_path, monkeypatch
+    ):
+        """Otherwise the store a command opens depends on where it was run."""
+        home = tmp_path / "data"
+        home.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        assert Config.load(yaml_path).database_path == str(home / "ori_state.db")
+
+    def test_an_absolute_store_path_is_taken_exactly_as_declared(self, tmp_path):
+        """An absolute path is the operator's own, and is not rewritten."""
+        elsewhere = tmp_path / "mount" / ".." / "mount" / "ori_state.db"
+        yaml_path = _write_yaml(
+            tmp_path,
+            f"""
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {{}}
+            gateway: {{}}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: {elsewhere}
+            """,
+        )
+
+        assert Config.load(yaml_path).database_path == str(elsewhere)
+
+    def _encrypted_posture_config(self, home, prefix, monkeypatch):
+        private_key, public_key_b64 = _ed25519_keypair()
+        monkeypatch.setenv("ORI_CONFIG_TRUST_ANCHOR_PUBLIC_KEY_B64", public_key_b64)
+        return _write_yaml(
+            home,
+            _sign_config_yaml(
+                f"""
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+              deployment_profile: production
+            sensors: []
+            skills: []
+            reasoning: {{}}
+            gateway: {{}}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            security:
+              enforce_production_posture: true
+              config_signature:
+                require_signed: true
+              skills:
+                require_signed: true
+            state:
+              encryption:
+                mode: filesystem_required
+                encrypted_path_prefixes:
+                  - "{prefix}"
+            database:
+              path: ori_state.db
+            """,
+                private_key,
+            ),
+        )
+
+    def test_the_encrypted_store_requirement_is_met_from_any_directory(
+        self, tmp_path, monkeypatch
+    ):
+        """A config inside the encrypted prefix declares an encrypted store."""
+        encrypted_dir = tmp_path / "encrypted"
+        encrypted_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        yaml_path = self._encrypted_posture_config(
+            encrypted_dir, encrypted_dir, monkeypatch
+        )
+        monkeypatch.chdir(outside)
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.database_path == str(encrypted_dir / "ori_state.db")
+
+    def test_standing_in_the_encrypted_directory_does_not_satisfy_the_requirement(
+        self, tmp_path, monkeypatch
+    ):
+        """The gate is a fact about the declared store, not about the caller."""
+        encrypted_dir = tmp_path / "encrypted"
+        encrypted_dir.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        yaml_path = self._encrypted_posture_config(outside, encrypted_dir, monkeypatch)
+        monkeypatch.chdir(encrypted_dir)
+
+        with pytest.raises(ConfigValidationError, match="encrypted_path_prefixes"):
             Config.load(yaml_path)
 
     def test_production_posture_allows_loopback_gateway_without_site_tls(

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1161,6 +1161,69 @@ def minimal_config(tmp_path: Path) -> Path:
     return cfg
 
 
+@pytest.mark.asyncio
+async def test_the_runtime_opens_the_store_beside_its_config(tmp_path, monkeypatch):
+    """The runtime and the commissioning bridge must open the same store.
+
+    A relative path is what every generated configuration declares, so a
+    runtime resolving it against its working directory would build its durable
+    state somewhere the ceremony commands do not read.
+    """
+    _patch_external(monkeypatch)
+    home = tmp_path / "data"
+    (home / "skills").mkdir(parents=True)
+    (home / "ori.yaml").write_text(
+        textwrap.dedent(f"""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors:
+              - id: cpu-sensor
+                type: cpu_percent
+                protocol: psutil
+                poll_interval_ms: 100
+            skills: []
+            reasoning:
+              default_tier: rule
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+              relay:
+                enabled: false
+            skills_dir: {str(home / "skills")}
+            database:
+              path: ori_state.db
+        """),
+        encoding="utf-8",
+    )
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    runtime = OriRuntime(config_path=str(home / "ori.yaml"))
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and not (home / "ori_state.db").exists():
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+        assert (home / "ori_state.db").exists(), (
+            "the runtime never opened a store beside its configuration: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+        assert not (elsewhere / "ori_state.db").exists()
+    finally:
+        await _stop_and_join(runtime, start_task)
+
+
 def _patch_external(monkeypatch):
     """Patch all external I/O so tests run without hardware or credentials."""
     monkeypatch.setattr(


### PR DESCRIPTION
## What does this PR do?

A relative `database.path` resolved against the working directory of whatever process loaded the configuration. Every generated configuration declares `ori_state.db` relative, so the store a command opened was a property of where it was started rather than of the installation it was handed. On the bench this surfaced as a commissioning ceremony command reporting that the device held no state store, from one directory, while the store and its provisional binding sat intact beside the configuration that `--path` named. The command had looked somewhere else, and its message made a claim about the device rather than about the lookup.

The same value decides a security question, which is the part that makes this more than an ergonomics defect. The production posture check resolves `database.path` to decide whether the store lives under `state.encryption.encrypted_path_prefixes`. With a relative path that resolution used the caller's working directory, so for one configuration the encrypted-storage requirement could be satisfied by starting inside the encrypted mount and failed by starting outside it. The requirement is now a fact about the declared installation. Nothing newly passes: every location admitted now was already admitted when the process was launched from the configuration directory, and what is removed is admission that depended on where the process stood.

`Config` is the single place the path is resolved. A relative value resolves against the directory holding the configuration, an absolute value is taken exactly as declared, and `:memory:` names no file so it is not a path to resolve. Consumers read the resolved field rather than re-deriving it from the raw document — the runtime, the commissioning store, the in-force binding lookup, and the proof state, which now raises naming the path it examined instead of discarding it precisely when a caller needs it. Re-derivation is what allowed the runtime and the bridge to disagree about which store belongs to one configuration, so removing it is the fix rather than a tidy-up alongside it.

Opening a store applies the DDL and creates it, so a deployment that relied on the working directory would come up on an empty store while its commissioned binding sat in the other one. Where a store exists only where the working directory would have found one, config load reports both paths. That is reported and not refused: a file of that name in the working directory is a coincidence as often as it is the device's store, and an installed deployment cannot be in that shape at all, because the rendered unit sets `WorkingDirectory` to the data directory that holds the configuration and unit rendering already refuses a configuration outside it.

`state action-log` and `state history` read no configuration at all and opened `ori_state.db` beside the caller, so they could not reach a deployment that declared any other `database.path`, and a read in a directory with no store created an empty one and reported an empty action log — a device that appeared to have taken no actions rather than a lookup that had gone elsewhere. Both now take `--path` and read the store the named installation declares, and an absent store is refused rather than built, distinguishing a store that is missing from a path that is not a file.

Requiring `--path` on those two reads changes their argument surface. Nothing outside this repository calls them: the CLI has not implemented state queries, and the shared contract already designates the runtime bridge as the source of truth for these semantics rather than specifying them independently. The contract's description of the two commands is brought in line separately.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes. No action, tier, executor or registry entry is added or altered, and no capability gains or loses a path. What changes is which file on disk a already-permitted read or write resolves to.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D code path is added.

## Related issue

Closes #554
Closes #558

## Testing notes

Fourteen tests, each driven through a real entry point rather than the resolver: `Config.load`, `cli_bridge.main`, and a runtime actually started from a foreign directory to observe where its store lands. The bridge tests assert both halves — that the refusal names the store beside the configuration and not the one beside the caller, and that no store materialises in the caller's directory, since opening one is how a wrong lookup becomes a confident wrong answer.

The two posture tests are the ones that carry the security claim. A configuration inside the encrypted prefix loads from a directory outside it, and a configuration outside the prefix is refused while the caller stands inside it — so the requirement can no longer be met by choosing where to stand.

Every boundary was mutation-checked, and each mutation is refused by the test named for that property: the resolution reverted to the working directory, skipped entirely at load, or applied to an absolute path; the in-memory sentinel treated as a path; the ambiguity report suppressed, fired unconditionally, or naming only one of the two stores; the commissioning store, the in-force lookup and the runtime each reading the raw document again; the state reads falling back to a caller-relative default or accepting no installation; and an absent store built instead of refused, or refused without naming what was examined.

Two of those mutations initially survived for a reason worth recording: the harness anchor for a twelve-space line also matched inside a sixteen-space line, so it mutated a different function and the named test passed for the wrong reason. Both kill once anchored uniquely.

An earlier revision of the ambiguity check refused the load instead of reporting it, which failed 165 tests. A file named `ori_state.db` in the working directory is common on any host where the runtime has been run from a shell, and a refusal makes every unrelated configuration on that host unloadable, so the check reports and the load proceeds.
