### PR TITLE
fix(installer): keep a runtime's working directory out of the install root

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -150,7 +150,11 @@ candidate or release is cut.
   one from an earlier release says which file to remove rather than sending an
   operator looking. That refusal is also what keeps a pipe from stalling an
   install indefinitely: the permission walk opens each file it plans to change,
-  and opening a pipe waits for a writer that never comes.
+  and opening a pipe waits for a writer that never comes, so it opens
+  non-blocking and checks what it opened. Both halves are needed. An inode
+  number is reused immediately after `unlink` on the filesystems these installs
+  run on, so a regular file the walk validated and a pipe that replaced it
+  carry the same number, and only the file type says anything changed.
 - A device endpoint must name an absolute path, or a URL where its transport
   can open one. `sensors[*].port` on `protocol: serial` and
   `actions.sms.gsm.port` are opened with `Serial()`, which takes a port name,

--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -138,6 +138,70 @@ candidate or release is cut.
   appeared to have taken no actions rather than a lookup that went elsewhere.
   An absent store is now refused and named, and a refusal distinguishes a store
   that is missing from a path that is not a file.
+- The service works in a runtime directory of its own rather than in the
+  directory it keeps state in. A GPIO library creates its notification pipe in
+  the working directory and never removes it, and the install root admits
+  regular files only, so a device that had driven GPIO refused its own
+  reinstall with `special files are forbidden` and no indication of what had
+  been found or where. systemd creates the runtime directory and removes it
+  when the service stops, so an artefact any library leaves there is gone by
+  the time an installer looks, whichever library and whichever platform. A
+  refusal now names the offending path and its file type, so a device carrying
+  one from an earlier release says which file to remove rather than sending an
+  operator looking. That refusal is also what keeps a pipe from stalling an
+  install indefinitely: the permission walk opens each file it plans to change,
+  and opening a pipe waits for a writer that never comes.
+- A device endpoint must name an absolute path, or a URL where its transport
+  can open one. `sensors[*].port` on `protocol: serial` and
+  `actions.sms.gsm.port` are opened with `Serial()`, which takes a port name,
+  so neither accepts a URL; `sensors[*].device_path` on `protocol: usb_serial`
+  is handed to `serial_for_url` and still accepts `socket://` and the other
+  forms that reaches. `sensors[*].device` on `protocol: smart` reaches
+  `smartctl` as an argument, so it must be absolute too, which also keeps a
+  value beginning with `-` from arriving there as an option. A device path is not anchored to the configuration the
+  way a data file is, because it names a node the host owns rather than a file
+  beside the document; left relative it would follow the working directory,
+  which is now a runtime directory systemd empties on every stop. This is a
+  deliberate compatibility change, not the tightening of something that could
+  never have worked: a relative name does reach a device through a symlink in
+  the working directory, and a deployment doing that must now name the device
+  absolutely. The refusal happens at config load and names the field, rather
+  than surfacing as a failed read later.
+- `ORI_AUTOLOAD_DOTENV` is refused under staging or production posture, and
+  under a development deployment that has opted into hardened posture. A
+  configuration signature covers the document before `${VAR}` fields are
+  expanded, so a `.env` in the data directory the service can write would
+  decide what a signed field holds while the signature still verified. A
+  hardened deployment's environment belongs in the unit's `EnvironmentFile`,
+  which the service cannot write. The posture is read from the document
+  directly, since the decision has to be made before the configuration that
+  would answer it is loaded, and a document that cannot be read is treated as
+  hardened. A posture field that is itself expanded is treated as hardened too:
+  unexpanded it says nothing about the posture, while what it expands to is
+  exactly what is being decided. Startup then confirms that decision against
+  the posture the loaded document declares, and refuses when a `.env` was
+  loaded before a document that turns out to be hardened.
+- `ORI_AUTOLOAD_DOTENV` otherwise reads a `.env` beside the configuration only.
+  It also read one beside the process, which the unit now points at a runtime directory
+  systemd empties on every stop; those values are expanded into the
+  configuration the runtime then trusts, so a file found next to the process is
+  not this installation's environment. A development workflow that ran
+  `--config /elsewhere/ori.yaml` while relying on a `.env` in the current
+  directory must move that file beside the configuration or export the
+  variables; an installed service is unaffected, since its unit reads
+  `EnvironmentFile`.
+- `health_socket.path`, `reasoning.model_path` and the `gateway.tls` material
+  resolve against the directory holding the configuration when declared
+  relative, as the store, log, evidence and skills paths do. A socket bound in
+  the working directory would be unreachable at the path an operator was told
+  to use, and TLS material resolved there would not be found at all. The
+  firmware provisioning socket and CA paths already had to be absolute when
+  that section is enabled, and still do.
+- `logging.file`, `evidence.db_path` and `evidence.key_path` resolve against
+  the directory holding the configuration, as `database.path` and the skills
+  directory already do. The evidence key is sealed on first use, so a runtime
+  reading one configuration from two working directories would seal two device
+  identities for one device.
 - `SECURITY.md` names Raspberry Pi OS Trixie as the production-supported Pi
   platform and Bookworm as a published bundle that is not a certified target,
   which is what `docs/linux-install.md` and the capability matrix already said.

--- a/ori/config.py
+++ b/ori/config.py
@@ -7,7 +7,7 @@ import math
 import os
 import re
 import stat
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
 from ipaddress import ip_network
 from pathlib import Path
@@ -751,6 +751,71 @@ class Config:
             _parse_database_path(data.get("database")), path
         )
         logging_cfg = _parse_logging(data.get("logging"))
+        # The runtime writes these, so where they land must be the installation
+        # the configuration describes rather than wherever it was started. The
+        # evidence key is sealed on first use, so a second working directory
+        # would seal a second device identity for one device.
+        logging_cfg = replace(
+            logging_cfg, file=anchor_to_config(logging_cfg.file, path)
+        )
+        evidence_cfg = replace(
+            evidence_cfg,
+            db_path=anchor_to_config(evidence_cfg.db_path, path),
+            key_path=anchor_to_config(evidence_cfg.key_path, path),
+        )
+        reasoning = replace(
+            reasoning, model_path=anchor_to_config(reasoning.model_path, path)
+        )
+        for section, keys in (
+            (health_socket, ("path",)),
+            (gateway.tls, ("ca_certfile", "certfile", "keyfile")),
+        ):
+            if not isinstance(section, dict):
+                continue
+            for key in keys:
+                declared = section.get(key)
+                if isinstance(declared, str):
+                    # An empty value means unset, and the anchor returns it
+                    # unchanged rather than resolving to the config directory.
+                    section[key] = anchor_to_config(declared, path)
+
+        # A sensor carries its own transport material and device endpoint.
+        # The schema canonicalises every deprecated TLS spelling into
+        # `mqtt.tls.*` before this runs, so anchoring the canonical name covers
+        # each of them; a sweep over the aliases as well anchored nothing.
+        for sensor in sensors:
+            mqtt_cfg = sensor.metadata.get("mqtt")
+            tls = mqtt_cfg.get("tls") if isinstance(mqtt_cfg, dict) else None
+            if isinstance(tls, dict):
+                for key in ("ca_certfile", "certfile", "keyfile"):
+                    declared = tls.get(key)
+                    if isinstance(declared, str):
+                        tls[key] = anchor_to_config(declared, path)
+
+            # `usb_serial` opens a URL through `serial_for_url`; `serial` does
+            # not, so what each may name is checked against its own consumer.
+            endpoint = {
+                "serial": "port",
+                "usb_serial": "device_path",
+                # Passed verbatim as an argv element to `smartctl`, which takes
+                # a device path and no URL form. Requiring it absolute also
+                # keeps a value that begins with `-` from arriving as an option.
+                "smart": "device",
+            }.get(sensor.protocol)
+            declared = sensor.metadata.get(endpoint) if endpoint else None
+            if endpoint and isinstance(declared, str):
+                sensor.metadata[endpoint] = _checked_device_endpoint(
+                    declared,
+                    f"sensors[{sensor.id}].{endpoint}",
+                    urls_supported=sensor.protocol == "usb_serial",
+                )
+
+        gsm = actions.sms.get("gsm") if isinstance(actions.sms, dict) else None
+        if isinstance(gsm, dict) and isinstance(gsm.get("port"), str):
+            # The modem is opened with `Serial()`, which takes a port name.
+            gsm["port"] = _checked_device_endpoint(
+                gsm["port"], "actions.sms.gsm.port", urls_supported=False
+            )
         _validate_coap_sensor_allowlist(sensors, actions.coap)
         _warn_gateway_network_posture(gateway)
         _validate_production_security_posture(
@@ -2491,6 +2556,42 @@ def _parse_security(data: Any) -> dict:
     return out
 
 
+def hardened_posture_declared(config_path: str) -> bool:
+    """Whether a document asks for hardened posture, read before it is expanded.
+
+    Anything that must decide before `Config.load` cannot ask the loaded
+    configuration what posture it is in, because the values that expansion
+    depends on are supplied by exactly the decisions being made. The document
+    is admitted through the same reader the loader uses and read for the two
+    fields that settle it. A document that cannot be read is treated as
+    hardened: the caller is choosing whether to widen its own trust, and an
+    unreadable answer is not a reason to widen it.
+    """
+    try:
+        raw = _load_config_document(_read_config_text(config_path), config_path)
+    except Exception:
+        return True
+    if not isinstance(raw, dict):
+        return True
+    device = raw.get("device")
+    security = raw.get("security")
+    profile = ""
+    if isinstance(device, dict):
+        profile = str(device.get("deployment_profile", "") or "").strip().lower()
+    enforce_raw = ""
+    enforce = False
+    if isinstance(security, dict):
+        enforce = security.get("enforce_production_posture") is True
+        enforce_raw = str(security.get("enforce_production_posture", "") or "")
+    # A field that is itself expanded says nothing yet about the posture, and
+    # what it expands to is exactly what the caller is deciding whether to
+    # supply. Read unexpanded, `${ORI_POSTURE}` is neither staging nor
+    # production, so it would answer no to the question it decides.
+    if "${" in profile or "${" in enforce_raw:
+        return True
+    return profile in {"staging", "production"} or enforce
+
+
 def requires_production_posture(
     *, device: DeviceConfig, security: dict[str, Any]
 ) -> bool:
@@ -3138,6 +3239,48 @@ def _parse_database_path(data: Any) -> str:
     return path
 
 
+def _checked_device_endpoint(value: str, field: str, *, urls_supported: bool) -> str:
+    """Refuse a device endpoint that names neither a node nor a reachable URL.
+
+    A device path is not resolved against the configuration the way a data file
+    is: it names something the host owns, and there is no directory it would be
+    relative to. Left relative it would follow the working directory, which the
+    unit points at a runtime directory systemd empties on every stop.
+
+    Whether a URL is accepted is the consumer's own rule rather than a shared
+    one. `usb_serial` hands anything containing `://` to `serial_for_url`, so
+    it can reach a bridge; `serial` and the GSM modem call `Serial()` directly,
+    which takes a port name only. Admitting a URL where it cannot be opened
+    would move the failure from config load to the first read.
+    """
+    if not value:
+        return value
+    if urls_supported and "://" in value:
+        return value
+    if not Path(value).expanduser().is_absolute():
+        supported = " or a URL its transport can open" if urls_supported else ""
+        raise ConfigValidationError(
+            f"{field} must be an absolute device path{supported}: {value!r}"
+        )
+    return value
+
+
+def anchor_to_config(declared: str, config_path: str) -> str:
+    """Anchor a relative path to the directory holding the configuration.
+
+    A relative path otherwise resolves against the working directory of
+    whatever process loaded the configuration, so the file a deployment reads
+    or writes would be a property of where it was started.
+    """
+    if not declared:
+        return declared
+    candidate = Path(declared).expanduser()
+    if candidate.is_absolute():
+        return str(candidate)
+    home = Path(config_path).expanduser().resolve(strict=False).parent
+    return str(Path(os.path.normpath(home / candidate)))
+
+
 def _resolve_database_path(declared: str, config_path: str) -> str:
     """Resolve a relative store path against the configuration that declared it.
 
@@ -3147,11 +3290,9 @@ def _resolve_database_path(declared: str, config_path: str) -> str:
     """
     if declared == _IN_MEMORY_STORE:
         return declared
-    candidate = Path(declared).expanduser()
-    if candidate.is_absolute():
-        return str(candidate)
-    home = Path(config_path).expanduser().resolve(strict=False).parent
-    resolved = Path(os.path.normpath(home / candidate))
+    if Path(declared).expanduser().is_absolute():
+        return anchor_to_config(declared, config_path)
+    resolved = Path(anchor_to_config(declared, config_path))
     legacy = Path(declared)
     if legacy.is_file() and not resolved.exists():
         # Opening the resolved store creates it, so a deployment that relied on

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -2026,12 +2026,18 @@ def _set_owned_mode(change: _PermissionChange, uid: int, gid: int, mode: int) ->
     # O_NONBLOCK because the service owns this tree and is still running: a
     # regular file validated during planning can be a pipe by the time it is
     # opened, and opening a pipe for reading waits for a writer that never
-    # comes. The identity check below is what refuses the substitution; without
-    # this flag it is unreachable and the installer stalls as root.
+    # comes. The checks below are what refuse the substitution; without this
+    # flag they are unreachable and the installer stalls as root.
     flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
     descriptor = os.open(change.path, flags)
     try:
         current = os.fstat(descriptor)
+        # Both checks are needed, and neither subsumes the other. An inode
+        # number is reused immediately after unlink on the filesystems Linux
+        # installs run on, so a regular file replaced by a pipe keeps the
+        # number the plan recorded and only the type says it changed.
+        if not (stat.S_ISREG(current.st_mode) or stat.S_ISDIR(current.st_mode)):
+            raise OSError("permission target is no longer a regular file")
         if current.st_dev != change.device or current.st_ino != change.inode:
             raise OSError("permission target changed after validation")
         try:

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -658,6 +658,26 @@ def _has_control_character(value: str) -> bool:
     return any(ord(character) < 32 or ord(character) == 127 for character in value)
 
 
+_FILE_KINDS: tuple[tuple[Callable[[int], bool], str], ...] = (
+    (stat.S_ISFIFO, "named pipe"),
+    (stat.S_ISSOCK, "socket"),
+    (stat.S_ISCHR, "character device"),
+    (stat.S_ISBLK, "block device"),
+    (stat.S_ISDIR, "directory"),
+)
+
+
+def _describe_special_file(path: Path, mode: int) -> str:
+    """Name what was found and where, without letting the name speak for itself.
+
+    A refusal an operator cannot act on sends them looking, and the likeliest
+    causes are artefacts of the runtime having run. The name is repr-quoted
+    because it reaches a terminal and a path is not this installer's to trust.
+    """
+    kind = next((label for test, label in _FILE_KINDS if test(mode)), "special file")
+    return f"{kind} {str(path)!r}"
+
+
 def _unsafe_unit_value(value: str) -> bool:
     return (
         any(character.isspace() for character in value) or "%" in value or "@" in value
@@ -1901,7 +1921,11 @@ def _owned_tree_plan(
                 continue
             if not path.is_file():
                 raise LinuxInstallError(
-                    "unsafe_install_root", "special files are forbidden"
+                    "unsafe_install_root",
+                    "special files are forbidden in the install root: "
+                    f"{_describe_special_file(path, path_stat.st_mode)}. "
+                    "Stop the service, remove that file, and run this again: "
+                    "a running runtime recreates the ones it made.",
                 )
             existing_mode = path_stat.st_mode
             mode = executable_mode if existing_mode & 0o100 else regular_mode
@@ -1999,7 +2023,12 @@ def _apply_permission_plan(plan: Sequence[_PermissionChange]) -> None:
 
 
 def _set_owned_mode(change: _PermissionChange, uid: int, gid: int, mode: int) -> None:
-    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW
+    # O_NONBLOCK because the service owns this tree and is still running: a
+    # regular file validated during planning can be a pipe by the time it is
+    # opened, and opening a pipe for reading waits for a writer that never
+    # comes. The identity check below is what refuses the substitution; without
+    # this flag it is unreachable and the installer stalls as root.
+    flags = os.O_RDONLY | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
     descriptor = os.open(change.path, flags)
     try:
         current = os.fstat(descriptor)

--- a/ori/runtime.py
+++ b/ori/runtime.py
@@ -46,6 +46,8 @@ from ori.config import (
     Config,
     ConfigValidationError,
     SensorConfig,
+    anchor_to_config,
+    hardened_posture_declared,
     requires_production_posture,
 )
 from ori.firmware_mqtt_operator import (
@@ -392,8 +394,14 @@ class OriRuntime:
             current working directory.
     """
 
-    def __init__(self, config_path: str = "ori.yaml") -> None:
+    def __init__(
+        self, config_path: str = "ori.yaml", *, dotenv_loaded: bool = False
+    ) -> None:
         self._config_path = config_path
+        #: Whether a `.env` was autoloaded before this configuration could be
+        #: read. The decision had to be made first; startup confirms it against
+        #: the posture the document turns out to declare.
+        self._dotenv_loaded = dotenv_loaded
         self._config: Config | None = None
         self._shutdown_event: asyncio.Event = asyncio.Event()
         self._adapters: list[BaseAdapter] = []
@@ -512,6 +520,7 @@ class OriRuntime:
             skills_dir = self._skills_dir or str(
                 Path(self._config_path).parent / "skills"
             )
+            skills_dir = anchor_to_config(skills_dir, self._config_path)
             loaded = self._skill_loader.load_all(skills_dir)
 
             # Safety-first fallback: do not replace a working handler graph
@@ -595,6 +604,18 @@ class OriRuntime:
         # ── Step A: Load and validate config ─────────────────────────────────
         try:
             config = Config.load(self._config_path)
+            # The autoload had to decide before this document could be read, so
+            # its answer is confirmed against the posture the document turns
+            # out to declare. This closes a document whose posture is itself
+            # expanded, and one replaced between the two reads.
+            if self._dotenv_loaded and requires_production_posture(
+                device=config.device, security=config.security
+            ):
+                raise ConfigValidationError(
+                    "a .env was loaded through ORI_AUTOLOAD_DOTENV before this "
+                    "configuration declared hardened posture; its values may "
+                    "have supplied signed fields. Use the unit's EnvironmentFile."
+                )
             _validate_required_runtime_capabilities(config, self._config_path)
         except ConfigValidationError:
             logger.exception("[runtime] config validation failed — aborting")
@@ -1256,9 +1277,18 @@ class OriRuntime:
         self._deduplicator = EventDeduplicator()
 
         # ── Step F: Load skills and register handlers ─────────────────────────
-        skills_dir: str = config.raw.get(
-            "skills_dir",
-            str(Path(self._config_path).parent / "skills"),
+        # A relative value would otherwise resolve against the working
+        # directory, which the unit points at a runtime directory systemd
+        # empties on every stop. Skills that vanish take their triggers with
+        # them, and a skill can carry Tier D coverage.
+        skills_dir: str = anchor_to_config(
+            str(
+                config.raw.get(
+                    "skills_dir",
+                    str(Path(self._config_path).parent / "skills"),
+                )
+            ),
+            self._config_path,
         )
         self._skills_dir = skills_dir
         skills_security = config.security.get("skills")
@@ -5288,14 +5318,27 @@ def _sync_power_state_from_reading(indicator: LEDIndicator, reading: Any) -> Non
         indicator.set_power_state(PowerState.MAINS)
 
 
-def _maybe_autoload_dotenv(config_path: str) -> None:
+def _maybe_autoload_dotenv(config_path: str) -> bool:
     """Load .env when explicitly enabled via ORI_AUTOLOAD_DOTENV=true.
 
     This is a development convenience toggle. Production remains explicit-env
     by default (no implicit .env loading).
     """
     if not is_truthy(os.environ.get("ORI_AUTOLOAD_DOTENV", "")):
-        return
+        return False
+
+    # A signature covers the document before expansion, so a file that supplies
+    # what `${VAR}` fields expand to decides the value of a signed field
+    # without invalidating the signature. The data directory is writable by the
+    # service; the unit's EnvironmentFile is not, which is where a hardened
+    # deployment's environment belongs.
+    if hardened_posture_declared(config_path):
+        logger.warning(
+            "[runtime] ORI_AUTOLOAD_DOTENV is refused under staging or "
+            "production posture: a .env beside the configuration would supply "
+            "values for signed fields. Use the unit's EnvironmentFile."
+        )
+        return False
 
     try:
         from dotenv import load_dotenv
@@ -5303,27 +5346,22 @@ def _maybe_autoload_dotenv(config_path: str) -> None:
         logger.warning(
             "[runtime] ORI_AUTOLOAD_DOTENV is enabled but python-dotenv is not installed"
         )
-        return
+        return False
 
-    config_dir = Path(config_path).resolve().parent
-    candidates = [config_dir / ".env", Path.cwd() / ".env"]
-    loaded_any = False
-    seen: set[str] = set()
-
-    for candidate in candidates:
-        key = str(candidate.resolve())
-        if key in seen:
-            continue
-        seen.add(key)
-        if candidate.is_file():
-            load_dotenv(dotenv_path=candidate, override=False)
-            loaded_any = True
-            logger.info("[runtime] loaded environment from %s", candidate)
-
-    if not loaded_any:
-        logger.info(
-            "[runtime] ORI_AUTOLOAD_DOTENV enabled but no .env file found near config/cwd"
-        )
+    # Beside the configuration only. The unit works in a runtime directory
+    # systemd empties on every stop, so a file found there is not this
+    # installation's environment, and these values are expanded into the
+    # configuration the runtime then trusts.
+    candidate = Path(config_path).resolve().parent / ".env"
+    if candidate.is_file():
+        load_dotenv(dotenv_path=candidate, override=False)
+        logger.info("[runtime] loaded environment from %s", candidate)
+        return True
+    logger.info(
+        "[runtime] ORI_AUTOLOAD_DOTENV enabled but no .env file beside %s",
+        config_path,
+    )
+    return False
 
 
 def _local_llm_requested(reasoning_cfg: Any) -> bool:
@@ -6531,9 +6569,9 @@ def main() -> None:
         datefmt="%Y-%m-%dT%H:%M:%S",
     )
 
-    _maybe_autoload_dotenv(args.config)
+    dotenv_loaded = _maybe_autoload_dotenv(args.config)
 
-    runtime = OriRuntime(config_path=args.config)
+    runtime = OriRuntime(config_path=args.config, dotenv_loaded=dotenv_loaded)
     asyncio.run(runtime.start())
 
 

--- a/packaging/systemd/ori-runtime.service.in
+++ b/packaging/systemd/ori-runtime.service.in
@@ -9,7 +9,9 @@ After=network.target
 Type=simple
 @ORI_USER_DIRECTIVE@
 @ORI_DEVICE_GROUPS@
-WorkingDirectory=@ORI_DATA_DIR@
+RuntimeDirectory=ori
+RuntimeDirectoryMode=0700
+WorkingDirectory=%t/ori
 EnvironmentFile=-@ORI_ENV_FILE@
 ExecStart=@ORI_ROOT@/current/venv/bin/python -m ori.runtime --config @ORI_CONFIG@
 Restart=on-failure

--- a/pyright-baseline.json
+++ b/pyright-baseline.json
@@ -1,11 +1,5 @@
 {
-  "total": 478,
-  "by_area": {
-    "tests": 334,
-    "tests/commissioning": 14,
-    "tests/evidence": 6,
-    "tests/firmware": 86,
-    "tests/remote_commands": 38
-  },
+  "total": 0,
+  "by_area": {},
   "note": "pyright error count over the trees pyright analyses (ori, tests, scripts; skills/ is outside its include). Lower it whenever the real count falls. Raising it needs --allow-raise and is a decision, not a step. `pyright ori/ scripts/` is separately gated at zero, so a rise there cannot be absorbed by a fall in tests/. The count depends on pythonPlatform and pythonVersion, both pinned in pyproject.toml."
 }

--- a/tests/commissioning/test_actuator.py
+++ b/tests/commissioning/test_actuator.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from ori.actions.commissioned_actuator import CommissionedActuator
@@ -35,6 +37,10 @@ class _Driver:
     @property
     def is_active(self) -> bool:
         return self.energised
+
+
+#: Structural double for the declared parameter type.
+_driver: Any = _Driver
 
 
 def _zone(*, active_high: bool, open_outcome: str) -> AcceptedZone:
@@ -74,7 +80,7 @@ async def test_outcomes_resolve_through_the_mapping_not_a_convention(
 ) -> None:
     """Two zones with opposite mappings drive opposite coil operations for
     the same outcome; a seam that assumed 'trip energises' fails one of them."""
-    driver = _Driver()
+    driver = _driver()
     actuator = CommissionedActuator(
         driver=driver,
         zone=_zone(active_high=True, open_outcome=open_outcome),
@@ -100,7 +106,7 @@ def test_the_level_follows_the_commissioned_polarity(
     active_high: bool, coil_state: str, level: str
 ) -> None:
     actuator = CommissionedActuator(
-        driver=_Driver(),
+        driver=_driver(),
         zone=_zone(active_high=active_high, open_outcome="de_energised"),
         binding_seq=1,
     )
@@ -110,7 +116,7 @@ def test_the_level_follows_the_commissioned_polarity(
 async def test_startup_commands_de_energised_explicitly() -> None:
     """The coil is commanded, not assumed: a release is issued whatever the
     platform default level would have been."""
-    driver = _Driver()
+    driver = _driver()
     driver.energised = True  # whatever the platform left the pin at
     actuator = CommissionedActuator(
         driver=driver,
@@ -131,7 +137,7 @@ async def test_startup_commands_de_energised_explicitly() -> None:
 
 
 async def test_a_driver_failure_is_reported_not_hidden() -> None:
-    driver = _Driver(fail=True)
+    driver = _driver(fail=True)
     actuator = CommissionedActuator(
         driver=driver,
         zone=_zone(active_high=True, open_outcome="energised"),
@@ -143,7 +149,7 @@ async def test_a_driver_failure_is_reported_not_hidden() -> None:
 
 def test_only_protected_circuit_outcomes_and_coil_states_are_accepted() -> None:
     actuator = CommissionedActuator(
-        driver=_Driver(),
+        driver=_driver(),
         zone=_zone(active_high=True, open_outcome="energised"),
         binding_seq=1,
     )
@@ -158,12 +164,12 @@ def test_only_protected_circuit_outcomes_and_coil_states_are_accepted() -> None:
         }
     )
     with pytest.raises(ValueError):
-        CommissionedActuator(driver=_Driver(), zone=firmware, binding_seq=1)
+        CommissionedActuator(driver=_driver(), zone=firmware, binding_seq=1)
 
 
 async def test_an_unknown_coil_state_is_refused() -> None:
     actuator = CommissionedActuator(
-        driver=_Driver(),
+        driver=_driver(),
         zone=_zone(active_high=True, open_outcome="energised"),
         binding_seq=1,
     )

--- a/tests/commissioning/test_loader.py
+++ b/tests/commissioning/test_loader.py
@@ -399,12 +399,12 @@ async def _seed_row(store: StateStore, table: str, zones_json: str) -> None:
             "supersedes, canonical_json, signature, zones_json, verified_at_ms) "
             "VALUES (1, 3, ?, ?, 1, 's', NULL, '{}', 'ed25519:x', ?, 1000)"
         )
+    conn = store._conn
+    assert conn is not None
     await store._run_write(
         lambda: (
-            store._conn.execute(
-                sql, ("sha256:" + "e" * 64, CTX["device_id"], zones_json)
-            ),
-            store._conn.commit(),
+            conn.execute(sql, ("sha256:" + "e" * 64, CTX["device_id"], zones_json)),
+            conn.commit(),
         )
     )
 

--- a/tests/commissioning/test_proof_operation.py
+++ b/tests/commissioning/test_proof_operation.py
@@ -15,7 +15,7 @@ import base64
 import json
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 
@@ -954,7 +954,7 @@ async def test_only_the_proof_operation_moves_a_pin_through_the_bridge(
 
     op = proof_operation.ProofOperation(
         store=_NullProofStore(),
-        driver=object(),
+        driver=cast(Any, object()),
         provisional=_accepted(),
         in_force=None,
         hardened=False,
@@ -1319,7 +1319,7 @@ async def test_a_late_failure_keeps_the_observation_the_operator_gave(
     import sqlite3
 
     flaky = Flaky(store)
-    op, driver, _ = _operation(flaky, monkeypatch)
+    op, driver, _ = _operation(cast(Any, flaky), monkeypatch)
     with pytest.raises(sqlite3.OperationalError):
         await _run(op, outcome="open_protected_circuit")
 
@@ -1445,7 +1445,7 @@ def test_the_terminal_is_never_acquired_only_used(
     def recording(path: str, flags: int, *args: object) -> int:
         if path == proof_operation.TTY_PATH:
             opened.append(flags)
-        return real_open(path, flags, *args)
+        return real_open(path, flags, *args)  # type: ignore[arg-type]
 
     master, slave = pty.openpty()
     monkeypatch.setattr(proof_operation, "TTY_PATH", os.ttyname(slave))

--- a/tests/commissioning/test_runtime_startup.py
+++ b/tests/commissioning/test_runtime_startup.py
@@ -494,9 +494,11 @@ async def test_a_retained_binding_with_an_unproven_leg_is_retired_on_load(
     await store.open()
     runtime._state_store = store
     try:
+        conn = store._conn
+        assert conn is not None
         await store._run_write(
             lambda: (
-                store._conn.execute(
+                conn.execute(
                     "INSERT INTO commissioned_binding (binding_seq, canonical_hash, "
                     "device_id, inventory_generation, signer_id, supersedes, "
                     "canonical_json, signature, zones_json, accepted_at_ms, "
@@ -536,7 +538,7 @@ async def test_a_retained_binding_with_an_unproven_leg_is_retired_on_load(
                         ),
                     ),
                 ),
-                store._conn.commit(),
+                conn.commit(),
             )
         )
         await runtime._load_commissioning(

--- a/tests/evidence/test_disclosure.py
+++ b/tests/evidence/test_disclosure.py
@@ -40,7 +40,7 @@ import re
 import subprocess
 import tomllib
 import zipfile
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 
 import pytest
 
@@ -882,7 +882,7 @@ _TEXT_SCAN_SUFFIXES = {
 }
 
 
-def _text_scan_paths() -> list[pathlib.Path]:
+def _text_scan_paths() -> Iterator[pathlib.Path]:
     for root in ("ori", "tests", "docs", "scripts"):
         base = REPO_ROOT / root
         if not base.is_dir():

--- a/tests/evidence/test_harness.py
+++ b/tests/evidence/test_harness.py
@@ -794,11 +794,15 @@ def test_the_runbook_derives_the_filenames_the_builder_writes() -> None:
     builder = ARTIFACT_BUILDER.read_text(encoding="utf-8")
     runbook = _runbook()
 
-    produced = re.search(r'ARTIFACT_NAME="([^"]+)"', builder).group(1)
+    produced_match = re.search(r'ARTIFACT_NAME="([^"]+)"', builder)
+    assert produced_match is not None
+    produced = produced_match.group(1)
     assert produced.replace("$RELEASE_VERSION", "$VERSION") in runbook, (
         f"the runbook does not derive the artifact name the builder writes: {produced}"
     )
-    registry = re.search(r'"\$OUTDIR/(release-keys[^"]*)"', builder).group(1)
+    registry_match = re.search(r'"\$OUTDIR/(release-keys[^"]*)"', builder)
+    assert registry_match is not None
+    registry = registry_match.group(1)
     assert registry in runbook, "the runbook names a registry the builder never writes"
 
 

--- a/tests/evidence/test_ingest.py
+++ b/tests/evidence/test_ingest.py
@@ -16,6 +16,7 @@ import hashlib
 import hmac
 import json
 import pathlib
+from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -436,7 +437,7 @@ def _custody_case(name: str):
 
 
 def _verify_custody(artifact, **overrides):
-    kwargs = {
+    kwargs: dict[str, Any] = {
         "device_id": DEVICE,
         "custody_keys": _custody_registry(),
         "expected_digest": artifact["envelope_digest"],
@@ -696,7 +697,9 @@ def test_an_unrecognised_version_is_rejected_before_anything_is_trusted(
     artifact = dict(case(name, "valid")["artifact"])
     artifact["v"] = 2
     with pytest.raises(IngestRejectedError) as raised:
-        verifier(artifact, device_id=DEVICE, registry=registry, **kwargs)
+        verifier(  # type: ignore[arg-type]
+            artifact, device_id=DEVICE, registry=registry, **kwargs
+        )
     assert raised.value.reason == REJECT_UNRECOGNISED_VERSION
 
 
@@ -715,7 +718,12 @@ def test_an_undefined_field_is_rejected(registry, name):
         else verify_epoch_confirmation
     )
     with pytest.raises(IngestRejectedError):
-        verifier(artifact, device_id=DEVICE, registry=registry, **kwargs)
+        verifier(
+            artifact,
+            device_id=DEVICE,
+            registry=registry,
+            **kwargs,  # type: ignore[arg-type]
+        )
 
 
 def test_a_free_text_rejection_reason_cannot_be_constructed():

--- a/tests/firmware/test_command_egress.py
+++ b/tests/firmware/test_command_egress.py
@@ -7,6 +7,7 @@ import base64
 import json
 import secrets
 from pathlib import Path
+from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -97,6 +98,7 @@ async def _register_device(store: StateStore, *, approve: bool = True) -> str:
         from ori.utils.time_utils import now_ms
 
         dev = await store.get_firmware_device(manifest["device_id"])
+        assert dev is not None
         await store.resolve_firmware_confirmation(
             manifest["device_id"],
             dev["anchor_epoch_id"],
@@ -168,7 +170,7 @@ def test_provisioning_approval_reproduces_shared_golden_vectors(case: dict) -> N
 
 
 def test_provisioning_approval_rejects_noncanonical_inputs() -> None:
-    good = dict(
+    good: dict[str, Any] = dict(
         capability_hash="sha256:" + "ab" * 32,
         device_id="ori-fw-7c9f2b3a",
         posture="sealed_flash",

--- a/tests/firmware/test_commands.py
+++ b/tests/firmware/test_commands.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -63,7 +64,7 @@ class TestGoldenCommandVectors:
 
 class TestFailClosedBuild:
     def test_rejects_what_the_device_would_refuse(self) -> None:
-        good = dict(
+        good: dict[str, Any] = dict(
             action="relay_open",
             capability_hash="sha256:" + "ab" * 32,
             channel="relay0",

--- a/tests/firmware/test_confirmation_reconciliation.py
+++ b/tests/firmware/test_confirmation_reconciliation.py
@@ -19,6 +19,7 @@ missing was something to call it again.
 from __future__ import annotations
 
 import asyncio
+from typing import Any, cast
 
 import pytest
 
@@ -244,7 +245,7 @@ def _subscriber_with_hook(on_connected):
     """A subscriber built without touching MQTT or the network."""
     from ori.gateway.firmware_telemetry import MqttFirmwareTelemetrySubscriber
 
-    subscriber = object.__new__(MqttFirmwareTelemetrySubscriber)
+    subscriber: Any = object.__new__(MqttFirmwareTelemetrySubscriber)
     subscriber._topic = "ori/fw/+/telemetry"
     subscriber._qos = 1
     subscriber._on_connected = on_connected
@@ -263,7 +264,7 @@ class _Client:
 def test_successful_connect_schedules_the_hook_on_the_loop():
     """`_on_connect` runs on the MQTT client's thread, never the event loop."""
     calls: list[int] = []
-    subscriber = _subscriber_with_hook(lambda: calls.append(1))
+    subscriber: Any = _subscriber_with_hook(lambda: calls.append(1))
     client = _Client()
 
     subscriber._on_connect(client, None, None, 0)
@@ -278,7 +279,7 @@ def test_successful_connect_schedules_the_hook_on_the_loop():
 def test_failed_connect_does_not_schedule_the_hook():
     """A refused connection is not a restored link."""
     calls: list[int] = []
-    subscriber = _subscriber_with_hook(lambda: calls.append(1))
+    subscriber: Any = _subscriber_with_hook(lambda: calls.append(1))
     client = _Client()
 
     subscriber._on_connect(client, None, None, 5)
@@ -289,7 +290,7 @@ def test_failed_connect_does_not_schedule_the_hook():
 
 
 def test_connect_without_a_hook_is_harmless():
-    subscriber = _subscriber_with_hook(None)
+    subscriber: Any = _subscriber_with_hook(None)
     client = _Client()
     subscriber._on_connect(client, None, None, 0)
     assert client.subscribed == [("ori/fw/+/telemetry", 1)]
@@ -334,7 +335,7 @@ def test_liveness_stack_forwards_the_callback_to_the_subscriber():
     try:
         sentinel = object()
         runtime_module._build_firmware_liveness_stack(
-            _StubConfig(), None, None, None, sentinel
+            _stubconfig(), cast(Any, None), cast(Any, None), None, cast(Any, sentinel)
         )
     finally:
         runtime_module._build_firmware_telemetry_subscriber = original
@@ -350,6 +351,10 @@ class _StubGatewayCfg:
 
 class _StubConfig:
     gateway = _StubGatewayCfg()
+
+
+#: Structural double for the declared parameter type.
+_stubconfig: Any = _StubConfig
 
 
 # --- the configured interval reaches the worker ----------------------------

--- a/tests/firmware/test_liveness.py
+++ b/tests/firmware/test_liveness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import base64
 import json
 import secrets
+from typing import Any, cast
 
 import pytest
 
@@ -83,7 +84,10 @@ def test_runtime_seq_zero_and_out_of_range_refused(runtime_seq: object) -> None:
     # liveness message is only meaningful in a strictly increasing series.
     with pytest.raises(FirmwareLivenessError):
         build_liveness_bytes(
-            boot_id=1, capability_hash=HASH, device_id=DEVICE, runtime_seq=runtime_seq
+            boot_id=1,
+            capability_hash=HASH,
+            device_id=DEVICE,
+            runtime_seq=cast(Any, runtime_seq),
         )
 
 
@@ -91,7 +95,10 @@ def test_runtime_seq_zero_and_out_of_range_refused(runtime_seq: object) -> None:
 def test_boot_id_zero_and_out_of_range_refused(boot_id: object) -> None:
     with pytest.raises(FirmwareLivenessError):
         build_liveness_bytes(
-            boot_id=boot_id, capability_hash=HASH, device_id=DEVICE, runtime_seq=1
+            boot_id=cast(Any, boot_id),
+            capability_hash=HASH,
+            device_id=DEVICE,
+            runtime_seq=1,
         )
 
 

--- a/tests/firmware/test_liveness_composition.py
+++ b/tests/firmware/test_liveness_composition.py
@@ -21,6 +21,7 @@ import copy
 import json
 import secrets
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -129,12 +130,19 @@ class _Cfg:
         self.device = _Cfg._Device()
 
 
+#: Structural double for the declared parameter type.
+_cfg: Any = _Cfg
+
+#: Structural double for the declared parameter type.
+_fakebus: Any = _FakeBus
+
+
 RUNTIME_KEY_ENV = "ORI_TEST_RUNTIME_COMMAND_SEED"
 PROVISIONER_KEY_ENV = "ORI_TEST_PROVISIONER_SEED"
 
 
-def _command_cfg() -> _Cfg:
-    return _Cfg(
+def _command_cfg() -> Any:
+    return _cfg(
         {
             "enabled": True,
             "runtime_command_key_env": RUNTIME_KEY_ENV,
@@ -167,7 +175,7 @@ def test_builder_passes_the_supervisor_through_to_the_subscriber(store) -> None:
     """Object identity, not merely 'a supervisor exists'."""
     shared = FirmwareLivenessSupervisor()
     subscriber = _build_firmware_telemetry_subscriber(
-        _Cfg(), _FakeBus(), store, None, shared
+        _cfg(), _fakebus(), store, None, shared
     )
     assert subscriber is not None
     assert subscriber._liveness_supervisor is shared
@@ -181,7 +189,7 @@ async def test_accepted_telemetry_through_the_subscriber_enables_signing(
     arriving on the subscriber makes the service able to sign."""
     shared = FirmwareLivenessSupervisor()
     subscriber = _build_firmware_telemetry_subscriber(
-        _Cfg(), _FakeBus(), store, None, shared
+        _cfg(), _fakebus(), store, None, shared
     )
     assert subscriber is not None
 
@@ -204,7 +212,7 @@ async def test_rejected_telemetry_does_not_establish_supervision(store) -> None:
     backstop suppressed by asserting supervision no runtime provides."""
     shared = FirmwareLivenessSupervisor()
     subscriber = _build_firmware_telemetry_subscriber(
-        _Cfg(), _FakeBus(), store, None, shared
+        _cfg(), _fakebus(), store, None, shared
     )
     assert subscriber is not None
     # Provision first: otherwise this passes because the device is
@@ -265,7 +273,7 @@ def test_composition_root_gives_both_halves_one_supervisor(store, command_keys) 
     """
     cfg = _command_cfg()
     supervisor, subscriber, pair, _scheduler = _build_firmware_liveness_stack(
-        cfg, _FakeBus(), store, None
+        cfg, _fakebus(), store, None
     )
     assert subscriber is not None and pair is not None
     _, service = pair
@@ -285,7 +293,7 @@ def test_both_builders_receive_the_same_supervisor(store, command_keys) -> None:
     """
     shared = FirmwareLivenessSupervisor()
     subscriber = _build_firmware_telemetry_subscriber(
-        _Cfg(), _FakeBus(), store, None, shared
+        _cfg(), _fakebus(), store, None, shared
     )
     pair = _build_firmware_command_service(_command_cfg(), store, shared)
     assert subscriber is not None and pair is not None
@@ -313,7 +321,7 @@ async def test_service_signs_only_after_the_shared_supervisor_is_populated(
 
     shared = FirmwareLivenessSupervisor()
     subscriber = _build_firmware_telemetry_subscriber(
-        _Cfg(), _FakeBus(), store, None, shared
+        _cfg(), _fakebus(), store, None, shared
     )
     pair = _build_firmware_command_service(_command_cfg(), store, shared)
     assert subscriber is not None and pair is not None
@@ -362,7 +370,7 @@ def test_command_service_cannot_be_built_without_a_supervisor(store) -> None:
         client_factory=lambda **_: _FakeClient(),
     )
     with pytest.raises(TypeError, match="liveness_supervisor"):
-        FirmwareCommandService(
+        FirmwareCommandService(  # type: ignore[call-arg]
             store=store,
             publisher=publisher,
             runtime_command_key_bytes=_RUNTIME_SEED,
@@ -372,10 +380,10 @@ def test_command_service_cannot_be_built_without_a_supervisor(store) -> None:
 
 def test_telemetry_subscriber_cannot_be_built_without_a_supervisor(store) -> None:
     with pytest.raises(TypeError, match="liveness_supervisor"):
-        MqttFirmwareTelemetrySubscriber(
+        MqttFirmwareTelemetrySubscriber(  # type: ignore[call-arg]
             broker_url="mqtt://localhost",
             telemetry_gate=FirmwareTelemetryGate(store),
-            event_bus=_FakeBus(),
+            event_bus=_fakebus(),
             state_store=store,
             runtime_device_id="runtime-01",
         )
@@ -388,7 +396,7 @@ def test_telemetry_subscriber_rejects_a_wrongly_typed_supervisor(store) -> None:
         MqttFirmwareTelemetrySubscriber(
             broker_url="mqtt://localhost",
             telemetry_gate=FirmwareTelemetryGate(store),
-            event_bus=_FakeBus(),
+            event_bus=_fakebus(),
             state_store=store,
             runtime_device_id="runtime-01",
             liveness_supervisor=object(),  # type: ignore[arg-type]
@@ -400,7 +408,7 @@ def test_signer_cannot_be_built_without_a_supervisor(store) -> None:
     the two the review named. Left alone it would have re-created the
     private-instance hazard inside any future direct signer caller."""
     with pytest.raises(TypeError, match="supervisor"):
-        FirmwareLivenessSigner(store, _RUNTIME_SEED)
+        FirmwareLivenessSigner(store, _RUNTIME_SEED)  # type: ignore[call-arg]
 
     with pytest.raises(FirmwareLivenessError, match="supervisor must be"):
         FirmwareLivenessSigner(
@@ -420,7 +428,7 @@ def test_the_stack_builds_a_scheduler_bound_to_the_command_service(
     the assertion that fails if the scheduler is ever built but not
     returned, or returned but built against the wrong object."""
     _supervisor, _subscriber, pair, scheduler = _build_firmware_liveness_stack(
-        _command_cfg(), _FakeBus(), store, None
+        _command_cfg(), _fakebus(), store, None
     )
     assert pair is not None and scheduler is not None
     assert scheduler._service is pair[1]
@@ -431,7 +439,7 @@ def test_no_command_egress_means_no_scheduler(store) -> None:
     """Without the command service there is no key and no publisher, so a
     loop would have nothing to say and no way to say it."""
     _supervisor, _subscriber, pair, scheduler = _build_firmware_liveness_stack(
-        _Cfg(), _FakeBus(), store, None
+        _cfg(), _fakebus(), store, None
     )
     assert pair is None
     assert scheduler is None
@@ -443,7 +451,7 @@ def test_the_configured_interval_reaches_the_scheduler(store, command_keys) -> N
     cfg = _command_cfg()
     cfg.gateway.firmware_commands["liveness_interval_s"] = 5.0
     _supervisor, _subscriber, _pair, scheduler = _build_firmware_liveness_stack(
-        cfg, _FakeBus(), store, None
+        cfg, _fakebus(), store, None
     )
     assert scheduler is not None
     assert scheduler.interval_s == 5.0
@@ -463,7 +471,7 @@ async def test_scheduler_publishes_only_for_telemetry_established_devices(
     )
 
     _supervisor, subscriber, pair, scheduler = _build_firmware_liveness_stack(
-        _command_cfg(), _FakeBus(), store, None
+        _command_cfg(), _fakebus(), store, None
     )
     assert subscriber is not None and pair is not None and scheduler is not None
     publisher, _service = pair
@@ -497,7 +505,7 @@ def test_a_configured_interval_above_the_contract_ceiling_fails_startup(
     cfg = _command_cfg()
     cfg.gateway.firmware_commands["liveness_interval_s"] = 30.0
     with pytest.raises(ValueError, match="at most"):
-        _build_firmware_liveness_stack(cfg, _FakeBus(), store, None)
+        _build_firmware_liveness_stack(cfg, _fakebus(), store, None)
 
 
 # --- The health snapshot derives the degradation reason ---

--- a/tests/firmware/test_liveness_publisher.py
+++ b/tests/firmware/test_liveness_publisher.py
@@ -567,6 +567,7 @@ async def test_a_stalled_publication_is_abandoned_not_waited_on() -> None:
     class _HangingService(_FakeService):
         async def publish_runtime_liveness(self, **kwargs) -> bytes:
             await asyncio.Event().wait()
+            raise AssertionError("unreachable: the wait never returns")
 
     service = _HangingService([_device("ori-fw-a")])
     scheduler = FirmwareLivenessScheduler(service, per_device_timeout_s=0.05)

--- a/tests/firmware/test_mqtt.py
+++ b/tests/firmware/test_mqtt.py
@@ -4,6 +4,7 @@
 import asyncio
 import json
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -64,6 +65,13 @@ class _FakeStore:
         self.history.append(event)
 
 
+#: Structural double for the declared parameter type.
+_fakefirmwaregate: Any = _FakeFirmwareGate
+
+#: Structural double for the declared parameter type.
+_fakestore: Any = _FakeStore
+
+
 class _FakeClient:
     def __init__(self, payloads: list[dict] | None = None) -> None:
         self.payloads = payloads or []
@@ -111,9 +119,9 @@ def _subscriber(*, payloads: list[dict] | None = None, gate=None, store=None, bu
     return (
         firmware_mqtt_module.MqttFirmwareTelemetrySubscriber(
             broker_url="mqtt://localhost",
-            telemetry_gate=gate or _FakeFirmwareGate(),
+            telemetry_gate=gate or _fakefirmwaregate(),
             event_bus=bus or EventBus(),
-            state_store=store or _FakeStore(),
+            state_store=store or _fakestore(),
             runtime_device_id="runtime-01",
             liveness_supervisor=FirmwareLivenessSupervisor(),
             client_factory=lambda **_: fake_client,
@@ -140,8 +148,8 @@ async def test_serve_until_subscribes_to_firmware_topic():
 
 
 async def test_signed_telemetry_payload_publishes_accepted_readings_to_event_bus():
-    gate = _FakeFirmwareGate()
-    store = _FakeStore()
+    gate = _fakefirmwaregate()
+    store = _fakestore()
     bus = EventBus()
     delivered = []
 
@@ -174,8 +182,8 @@ async def test_signed_telemetry_payload_publishes_accepted_readings_to_event_bus
 
 
 async def test_signed_fault_payload_is_recorded_without_event_bus_publish():
-    gate = _FakeFirmwareGate()
-    store = _FakeStore()
+    gate = _fakefirmwaregate()
+    store = _fakestore()
     bus = EventBus(strict_exceptions=True)
     delivered = []
 
@@ -208,9 +216,9 @@ def test_paho_unavailable_raises():
             mp.setattr(firmware_mqtt_module, "_PAHO_AVAILABLE", False)
             firmware_mqtt_module.MqttFirmwareTelemetrySubscriber(
                 broker_url="mqtt://localhost",
-                telemetry_gate=_FakeFirmwareGate(),
+                telemetry_gate=_fakefirmwaregate(),
                 event_bus=EventBus(),
-                state_store=_FakeStore(),
+                state_store=_fakestore(),
                 runtime_device_id="runtime-01",
                 liveness_supervisor=FirmwareLivenessSupervisor(),
             )

--- a/tests/firmware/test_mqtt_certificate_workflow.py
+++ b/tests/firmware/test_mqtt_certificate_workflow.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import json
 from datetime import UTC, datetime, timedelta
+from typing import Any, cast
 
 import pytest
 from cryptography import x509
@@ -61,8 +62,8 @@ def _ca_material(
                 key_agreement=False,
                 key_cert_sign=is_ca,
                 crl_sign=is_ca,
-                encipher_only=None,
-                decipher_only=None,
+                encipher_only=cast(Any, None),
+                decipher_only=cast(Any, None),
             ),
             True,
         )
@@ -249,7 +250,7 @@ async def test_workflow_issues_minimal_client_certificate_and_install_request(
         client_ca_key.public_key().verify(
             certificate.signature,
             certificate.tbs_certificate_bytes,
-            ec.ECDSA(certificate.signature_hash_algorithm),
+            ec.ECDSA(cast(Any, certificate.signature_hash_algorithm)),
         )
         assert (
             certificate.subject.get_attributes_for_oid(NameOID.COMMON_NAME)[0].value
@@ -267,7 +268,7 @@ async def test_workflow_issues_minimal_client_certificate_and_install_request(
         assert certificate.public_key().public_bytes(
             serialization.Encoding.DER,
             serialization.PublicFormat.SubjectPublicKeyInfo,
-        ) == transport_key.public_key().public_bytes(
+        ) == cast(Any, transport_key).public_key().public_bytes(
             serialization.Encoding.DER,
             serialization.PublicFormat.SubjectPublicKeyInfo,
         )

--- a/tests/firmware/test_mqtt_operator.py
+++ b/tests/firmware/test_mqtt_operator.py
@@ -13,6 +13,7 @@ import secrets
 import socket
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from cryptography import x509
@@ -63,8 +64,8 @@ def _ca_material(common_name: str) -> tuple[bytes, bytes]:
                 key_agreement=False,
                 key_cert_sign=True,
                 crl_sign=True,
-                encipher_only=None,
-                decipher_only=None,
+                encipher_only=cast(Any, None),
+                decipher_only=cast(Any, None),
             ),
             True,
         )
@@ -424,7 +425,7 @@ async def test_runtime_starts_operator_with_runtime_owned_material(
     runtime._state_store = StateStore(db_path=":memory:")
     await runtime._state_store.open()
     socket_path = f"/tmp/ori-op-{os.getpid()}-{id(runtime)}.sock"
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         firmware_mqtt_provisioning={
             "enabled": True,
             "socket_path": socket_path,
@@ -463,7 +464,7 @@ async def test_runtime_refuses_a_different_command_provisioning_root(
     runtime = OriRuntime(config_path="unused.yaml")
     runtime._state_store = StateStore(db_path=":memory:")
     await runtime._state_store.open()
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         firmware_mqtt_provisioning={
             "enabled": True,
             "provisioner_key_env": "ORI_TEST_MQTT_PA",

--- a/tests/firmware/test_provisioner.py
+++ b/tests/firmware/test_provisioner.py
@@ -167,6 +167,7 @@ def _confirm(bench, device_id="ori-fw-bench0001"):
         await store.open()
         try:
             dev = await store.get_firmware_device(device_id)
+            assert dev is not None
             await store.resolve_firmware_confirmation(
                 device_id, dev["anchor_epoch_id"], status="confirmed", at_ms=now_ms()
             )

--- a/tests/firmware/test_telemetry.py
+++ b/tests/firmware/test_telemetry.py
@@ -18,6 +18,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+from typing import Any
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -101,7 +102,7 @@ def signed_fault_message(
 def verify(case_name: str, **overrides):
     case = CASES[case_name]
     envelope = case["input"]
-    kwargs = {
+    kwargs: dict[str, Any] = {
         "anchor_device_id": envelope["device_id"],
         "anchor_public_key_b64": PUBLIC_KEY_B64,
         "anchor_posture": envelope["posture"],
@@ -412,7 +413,9 @@ class TestGoldenFaultVectors:
         # can hold is not a shape the firmware could have emitted; the
         # receiver must refuse it rather than accept a wider contract.
         result = verify_fault_message(
-            signed_fault_message(**{field: "x" * (FAULT_TOKEN_MAX_LEN + 1)}),
+            signed_fault_message(
+                **{field: "x" * (FAULT_TOKEN_MAX_LEN + 1)}  # type: ignore[arg-type]
+            ),
             anchor_device_id=SEALED_DEVICE,
             anchor_public_key_b64=PUBLIC_KEY_B64,
             anchor_posture="sealed_flash",
@@ -427,7 +430,7 @@ class TestGoldenFaultVectors:
     @pytest.mark.parametrize("bad", ["relay/0", "bad token", "relay:0", "réf"])
     def test_token_outside_fleet_alphabet_rejected(self, field: str, bad: str) -> None:
         result = verify_fault_message(
-            signed_fault_message(**{field: bad}),
+            signed_fault_message(**{field: bad}),  # type: ignore[arg-type]
             anchor_device_id=SEALED_DEVICE,
             anchor_public_key_b64=PUBLIC_KEY_B64,
             anchor_posture="sealed_flash",
@@ -442,7 +445,8 @@ class TestGoldenFaultVectors:
     def test_token_at_max_length_accepted(self, field: str) -> None:
         result = verify_fault_message(
             signed_fault_message(
-                code="sensor_fault", **{field: "x" * FAULT_TOKEN_MAX_LEN}
+                code="sensor_fault",
+                **{field: "x" * FAULT_TOKEN_MAX_LEN},  # type: ignore[arg-type]
             ),
             anchor_device_id=SEALED_DEVICE,
             anchor_public_key_b64=PUBLIC_KEY_B64,
@@ -1276,6 +1280,7 @@ class TestLifecycleMigration:
         await store.open()
         try:
             row = await store.get_firmware_device("ori-fw-legacy01")
+            assert row is not None
             assert row["anchor_epoch_id"].startswith("sha256:")
             assert row["key_epoch_id"].startswith("sha256:")
             # Approval and freshness are preserved by the migration.
@@ -1283,6 +1288,7 @@ class TestLifecycleMigration:
             assert row["last_seq"] == 500
 
             history = await store.list_firmware_anchor_history("ori-fw-legacy01")
+            assert history is not None
             assert len(history) == 1
             assert history[0]["state"] == "active"
             assert history[0]["anchor_epoch_id"] == row["anchor_epoch_id"]

--- a/tests/remote_commands/test_commands.py
+++ b/tests/remote_commands/test_commands.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -27,6 +28,12 @@ from ori.security.remote_commands.policy import (
     command_result,
 )
 from ori.state.store import StateStore
+
+
+def _await_args(mock: Any) -> Any:
+    """The call a mock recorded, narrowed for the type checker."""
+    assert mock.await_args is not None
+    return mock.await_args
 
 
 @pytest.fixture
@@ -519,7 +526,7 @@ async def test_sms_handler_invokes_runtime_command_handler(store, fixed_now):
 
     assert ok is True
     handler.assert_awaited_once()
-    handled = handler.await_args.args[0]
+    handled = _await_args(handler).args[0]
     assert handled.command_id == "sms-handler"
     assert handled.command == "UPDATE_CONFIG"
 
@@ -548,7 +555,7 @@ async def test_sms_handler_sends_execution_feedback(store, fixed_now):
 
     assert ok is True
     action.send.assert_awaited_once()
-    message, to_number = action.send.await_args.args
+    message, to_number = _await_args(action.send).args
     assert to_number == "+2348012345678"
     assert "executed" in message
     assert "sms-exec" in message
@@ -583,7 +590,7 @@ async def test_sms_handler_sends_dry_run_feedback(store, fixed_now):
     )
 
     assert ok is True
-    message, to_number = action.send.await_args.args
+    message, to_number = _await_args(action.send).args
     assert to_number == "+2348012345678"
     assert "DRY RUN" in message
     assert "sms-dry-run" in message
@@ -613,7 +620,7 @@ async def test_sms_handler_sends_precondition_feedback(store, fixed_now):
     )
 
     assert ok is True
-    message, _to_number = action.send.await_args.args
+    message, _to_number = _await_args(action.send).args
     assert "precondition failed" in message
     assert "sms-precondition" in message
 
@@ -641,7 +648,7 @@ async def test_sms_handler_sends_audit_only_feedback(store, fixed_now):
     )
 
     assert ok is True
-    message, _to_number = action.send.await_args.args
+    message, _to_number = _await_args(action.send).args
     assert "audit-only" in message
 
 
@@ -660,7 +667,7 @@ async def test_sms_handler_sends_generic_rejection_feedback(store, fixed_now):
 
     assert ok is False
     action.send.assert_awaited_once()
-    message, to_number = action.send.await_args.args
+    message, to_number = _await_args(action.send).args
     assert to_number == "+2348012345678"
     assert "rejected" in message
     assert "missing_signature" not in message
@@ -693,7 +700,7 @@ async def test_sms_rejection_feedback_is_throttled_after_repeated_failures(
     assert ok is False
     action.send.assert_not_awaited()
     incident_handler.assert_awaited_once()
-    decision = incident_handler.await_args.args[0]
+    decision = _await_args(incident_handler).args[0]
     assert decision.channel == "sms"
     assert decision.from_number == from_number
     assert decision.rejection_count == 6
@@ -936,7 +943,7 @@ async def test_sms_rejection_feedback_still_sends_at_threshold_boundary(
     assert ok is False
     action.send.assert_awaited_once()
     assert await store.get_remote_command_security_incidents() == []
-    message, to_number = action.send.await_args.args
+    message, to_number = _await_args(action.send).args
     assert to_number == from_number
     assert "rejected" in message
     assert (
@@ -983,7 +990,7 @@ async def test_accepted_sms_command_feedback_is_not_rejection_throttled(
 
     assert ok is True
     action.send.assert_awaited_once()
-    message, to_number = action.send.await_args.args
+    message, to_number = _await_args(action.send).args
     assert to_number == from_number
     assert "executed" in message
     assert "sms-accepted-throttle" in message
@@ -1107,7 +1114,7 @@ async def test_whatsapp_invokes_runtime_command_handler(store, fixed_now):
 
     assert reply == "NO"
     handler.assert_awaited_once()
-    handled = handler.await_args.args[0]
+    handled = _await_args(handler).args[0]
     assert handled.command_id == "wa-handler"
     assert handled.channel == "whatsapp"
 

--- a/tests/remote_commands/test_execution.py
+++ b/tests/remote_commands/test_execution.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -69,7 +70,7 @@ def test_command_requests_dry_run_from_args():
 
 
 async def test_audit_only_command_is_logged_without_execution(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -88,7 +89,7 @@ async def test_audit_only_command_is_logged_without_execution(store):
 
 
 async def test_audit_only_command_with_dry_run_stays_audit_only(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -104,7 +105,7 @@ async def test_audit_only_command_with_dry_run_stays_audit_only(store):
 
 
 async def test_unsupported_command_with_dry_run_stays_unsupported(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -120,7 +121,7 @@ async def test_unsupported_command_with_dry_run_stays_unsupported(store):
 
 
 async def test_refresh_policy_requires_enabled_device_policy(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": False})
     runtime._dispatcher = object()
@@ -136,7 +137,7 @@ async def test_refresh_policy_requires_enabled_device_policy(store):
 
 
 async def test_refresh_policy_executes_existing_verified_policy_path(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -154,7 +155,7 @@ async def test_refresh_policy_executes_existing_verified_policy_path(store):
 
 
 async def test_refresh_policy_dry_run_is_logged_without_refresh(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -175,7 +176,7 @@ async def test_refresh_policy_dry_run_is_logged_without_refresh(store):
 
 
 async def test_lockout_risk_does_not_block_when_enforcement_disabled(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -209,7 +210,7 @@ async def test_lockout_risk_does_not_block_when_enforcement_disabled(store):
 
 
 async def test_lockout_enforcement_blocks_critical_sender(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -248,7 +249,7 @@ async def test_lockout_enforcement_blocks_critical_sender(store):
 
 
 async def test_unsupported_command_is_logged_without_execution(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -268,7 +269,7 @@ async def test_unsupported_command_is_logged_without_execution(store):
 async def test_executable_policy_without_handler_is_logged_as_mismatch(
     store, monkeypatch
 ):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(device_policy={"enabled": True})
     runtime._dispatcher = object()
@@ -289,7 +290,7 @@ async def test_executable_policy_without_handler_is_logged_as_mismatch(
 
 
 async def test_apply_policy_requires_reference_args(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -343,7 +344,7 @@ def _make_skill(
 
 
 def _runtime_with_skill(skill: Skill, store: StateStore) -> OriRuntime:
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -766,7 +767,7 @@ async def test_set_threshold_complex_tier_d_condition_fails_closed(store):
 
 
 async def test_apply_policy_fetches_hash_verifies_and_applies(store, monkeypatch):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -824,7 +825,7 @@ async def test_apply_policy_fetches_hash_verifies_and_applies(store, monkeypatch
 
 
 async def test_apply_policy_dry_run_does_not_fetch_or_apply(store, monkeypatch):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -865,7 +866,7 @@ async def test_apply_policy_dry_run_does_not_fetch_or_apply(store, monkeypatch):
 
 
 async def test_apply_policy_dry_run_validates_reference_args(store, monkeypatch):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -904,7 +905,7 @@ async def test_apply_policy_dry_run_validates_reference_args(store, monkeypatch)
 
 
 async def test_apply_policy_hash_mismatch_is_rejected_and_logged(store, monkeypatch):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
@@ -953,7 +954,7 @@ async def test_apply_policy_hash_mismatch_is_rejected_and_logged(store, monkeypa
 
 
 async def test_apply_policy_requires_device_policy_enabled(store):
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     runtime._state_store = store
     runtime._config = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),

--- a/tests/test_circuit_breaker.py
+++ b/tests/test_circuit_breaker.py
@@ -59,6 +59,7 @@ def test_open_blocks_reads():
     cb._record_failure()
     assert cb.state == CircuitState.OPEN
     # Patch monotonic so time has NOT elapsed
+    assert cb.opened_at is not None
     with patch("ori.hal.base.time.monotonic", return_value=cb.opened_at + 10):
         assert cb._allow_read() is False
 
@@ -68,6 +69,7 @@ def test_open_to_half_open_after_timeout():
     cb._record_failure()
     assert cb.state == CircuitState.OPEN
     # Advance monotonic past the recovery timeout
+    assert cb.opened_at is not None
     with patch("ori.hal.base.time.monotonic", return_value=cb.opened_at + 61):
         allowed = cb._allow_read()
     assert allowed is True

--- a/tests/test_cli_bridge.py
+++ b/tests/test_cli_bridge.py
@@ -1483,9 +1483,11 @@ async def _retain_legacy_binding(config_path: Path) -> None:
     store = cli_bridge._commissioning_store(config)
     await store.open()
     try:
+        conn = store._conn
+        assert conn is not None
         await store._run_write(
             lambda: (
-                store._conn.execute(
+                conn.execute(
                     "INSERT INTO commissioned_binding (binding_seq, canonical_hash, "
                     "device_id, inventory_generation, signer_id, supersedes, "
                     "canonical_json, signature, zones_json, accepted_at_ms, "
@@ -1497,7 +1499,7 @@ async def _retain_legacy_binding(config_path: Path) -> None:
                         json.dumps([_legacy_zone()]),
                     ),
                 ),
-                store._conn.commit(),
+                conn.commit(),
             )
         )
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 
 import ast
 import base64
+import json
 import logging
 import os
 import pathlib
@@ -1328,6 +1329,346 @@ class TestLoadExample:
 
         with pytest.raises(ConfigValidationError, match="require_signed"):
             Config.load(yaml_path)
+
+    def test_the_log_and_evidence_paths_anchor_to_the_config(
+        self, tmp_path, monkeypatch
+    ):
+        """The service works in a runtime directory, not where it keeps state.
+
+        The evidence key is sealed on first use, so a second working directory
+        would seal a second device identity for one device.
+        """
+        home = tmp_path / "data"
+        home.mkdir()
+        elsewhere = tmp_path / "elsewhere"
+        elsewhere.mkdir()
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            logging:
+              file: ori.log
+            evidence:
+              enabled: false
+              db_path: ori_evidence.db
+              key_path: ori_evidence.key
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.logging.file == str(home / "ori.log")
+        assert cfg.evidence.db_path == str(home / "ori_evidence.db")
+        assert cfg.evidence.key_path == str(home / "ori_evidence.key")
+
+    def test_absolute_log_and_evidence_paths_are_left_alone(self, tmp_path):
+        mount = tmp_path / "mount"
+        yaml_path = _write_yaml(
+            tmp_path,
+            f"""
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {{}}
+            gateway: {{}}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            logging:
+              file: {mount / "ori.log"}
+            evidence:
+              enabled: false
+              key_path: {mount / "ori_evidence.key"}
+            """,
+        )
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.logging.file == str(mount / "ori.log")
+        assert cfg.evidence.key_path == str(mount / "ori_evidence.key")
+
+    def test_every_relative_filesystem_setting_anchors_to_the_config(
+        self, tmp_path, monkeypatch
+    ):
+        """The unit works in a runtime directory systemd empties on every stop.
+
+        A health socket bound there is unreachable, and a TLS material path
+        resolved there is a file the broker connection will not find.
+        """
+        home = tmp_path / "data"
+        home.mkdir()
+        elsewhere = tmp_path / "runtime-dir"
+        elsewhere.mkdir()
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: rule
+              model_path: models
+            gateway:
+              enabled: false
+              broker_url: ""
+              tls:
+                enabled: false
+                ca_certfile: tls/ca.pem
+                certfile: tls/client.pem
+                keyfile: tls/client.key
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            health_socket:
+              enabled: true
+              path: health.sock
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.health_socket["path"] == str(home / "health.sock")
+        assert cfg.gateway.tls["ca_certfile"] == str(home / "tls" / "ca.pem")
+        assert cfg.gateway.tls["certfile"] == str(home / "tls" / "client.pem")
+        assert cfg.gateway.tls["keyfile"] == str(home / "tls" / "client.key")
+        assert cfg.reasoning.model_path == str(home / "models")
+
+    def test_absolute_filesystem_settings_are_left_alone(self, tmp_path):
+        mount = tmp_path / "mount"
+        yaml_path = _write_yaml(
+            tmp_path,
+            f"""
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: rule
+              model_path: {mount / "models"}
+            gateway: {{}}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            health_socket:
+              enabled: true
+              path: {mount / "health.sock"}
+            """,
+        )
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.health_socket["path"] == str(mount / "health.sock")
+        assert cfg.reasoning.model_path == str(mount / "models")
+
+    def _device_config(self, home, *, sensors: str = "", gsm: str = "") -> str:
+        home.mkdir(exist_ok=True)
+        return _write_yaml(
+            home,
+            f"""
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors:{sensors or " []"}
+            skills: []
+            reasoning: {{}}
+            gateway: {{}}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+{gsm}
+            """,
+        )
+
+    def test_a_relative_serial_port_is_refused(self, tmp_path, monkeypatch):
+        """It names a node the host owns, not a file beside the config.
+
+        Anchoring it would invent a device path; leaving it relative would make
+        it follow a runtime directory systemd empties on every stop.
+        """
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: meter
+                type: energy
+                protocol: serial
+                poll_interval_ms: 1000
+                port: ttyUSB0""",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(ConfigValidationError, match="absolute device path"):
+            Config.load(yaml_path)
+
+    def test_a_serial_port_may_not_be_a_url(self, tmp_path):
+        """`serial` opens with `Serial()`, which takes a port name only.
+
+        Admitting one here would move the failure to the first read.
+        """
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: meter
+                type: energy
+                protocol: serial
+                poll_interval_ms: 1000
+                port: socket://127.0.0.1:7000""",
+        )
+
+        with pytest.raises(ConfigValidationError, match="absolute device path"):
+            Config.load(yaml_path)
+
+    def test_a_usb_serial_device_path_may_be_a_url(self, tmp_path):
+        """`usb_serial` hands anything with a scheme to `serial_for_url`."""
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: meter
+                type: energy
+                protocol: usb_serial
+                poll_interval_ms: 1000
+                device_path: socket://127.0.0.1:7000""",
+        )
+
+        cfg = Config.load(yaml_path)
+
+        assert cfg.sensors[0].metadata["device_path"] == "socket://127.0.0.1:7000"
+
+    def test_an_absolute_device_path_is_taken_as_declared(self, tmp_path):
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: meter
+                type: energy
+                protocol: serial
+                poll_interval_ms: 1000
+                port: /dev/ttyUSB0""",
+        )
+
+        assert Config.load(yaml_path).sensors[0].metadata["port"] == "/dev/ttyUSB0"
+
+    def test_a_relative_gsm_modem_port_is_refused(self, tmp_path, monkeypatch):
+        """The modem is opened with `Serial()` too."""
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            gsm="""                transport: gsm
+                gsm:
+                  enabled: true
+                  port: ttyAMA0""",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(ConfigValidationError, match="absolute device path"):
+            Config.load(yaml_path)
+
+    def test_a_relative_smart_device_is_refused(self, tmp_path, monkeypatch):
+        """It reaches `smartctl` as an argv element, which takes a path."""
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: disk
+                type: disk_health
+                protocol: smart
+                poll_interval_ms: 60000
+                device: disk0""",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(ConfigValidationError, match="absolute device path"):
+            Config.load(yaml_path)
+
+    def test_a_smart_device_that_would_arrive_as_an_option_is_refused(self, tmp_path):
+        """`smartctl` would read a leading dash as one of its own flags."""
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: disk
+                type: disk_health
+                protocol: smart
+                poll_interval_ms: 60000
+                device: -d""",
+        )
+
+        with pytest.raises(ConfigValidationError, match="absolute device path"):
+            Config.load(yaml_path)
+
+    def test_an_absolute_smart_device_is_taken_as_declared(self, tmp_path):
+        yaml_path = self._device_config(
+            tmp_path / "data",
+            sensors="""
+              - id: disk
+                type: disk_health
+                protocol: smart
+                poll_interval_ms: 60000
+                device: /dev/sda""",
+        )
+
+        assert Config.load(yaml_path).sensors[0].metadata["device"] == "/dev/sda"
+
+    @pytest.mark.parametrize(
+        "placement",
+        [
+            "                mqtt:\n                  tls:\n                    ca_certfile: tls/ca.pem",
+            "                mqtt_tls_ca_certfile: tls/ca.pem",
+            "                tls_ca_certfile: tls/ca.pem",
+            "                mqtt:\n                  mqtt_tls_ca_certfile: tls/ca.pem",
+            "                mqtt:\n                  tls_ca_certfile: tls/ca.pem",
+        ],
+    )
+    def test_every_accepted_tls_spelling_anchors(
+        self, placement: str, tmp_path, monkeypatch
+    ):
+        """Whichever spelling an operator used, the value must be anchored.
+
+        The schema canonicalises the deprecated spellings into `mqtt.tls.*`
+        before the anchoring runs. This holds that path end to end, so a change
+        that stopped canonicalising would surface here rather than as material
+        resolved against a runtime directory systemd empties on every stop.
+        """
+        home = tmp_path / "data"
+        yaml_path = self._device_config(
+            home,
+            sensors=f"""
+              - id: broker
+                type: temperature
+                protocol: mqtt
+                poll_interval_ms: 1000
+                broker_host: 127.0.0.1
+                topic: sensors/temp
+{placement}""",
+        )
+        monkeypatch.chdir(tmp_path)
+
+        cfg = Config.load(yaml_path)
+
+        found = json.dumps(cfg.sensors[0].metadata)
+        assert str(home / "tls" / "ca.pem") in found
+        assert '"tls/ca.pem"' not in found
 
     def test_the_in_memory_store_is_not_a_path_to_resolve(self, tmp_path):
         """SQLite's private database names no file."""

--- a/tests/test_device_lifecycle_vectors.py
+++ b/tests/test_device_lifecycle_vectors.py
@@ -185,14 +185,15 @@ async def run_step(store: StateStore, step: dict) -> None:
 
     if op == "register":
         outcome = await store.upsert_firmware_device_anchor(
-            device_id=DEVICE_ID, **anchor_call_fields(step["anchor"])
+            device_id=DEVICE_ID,
+            **anchor_call_fields(step["anchor"]),  # type: ignore[arg-type]  # type: ignore[arg-type]
         )
     elif op == "reprovision":
         outcome = await store.reprovision_firmware_device(
             device_id=DEVICE_ID,
             actor=ACTOR,
             reason=REASON,
-            **anchor_call_fields(step["anchor"]),
+            **anchor_call_fields(step["anchor"]),  # type: ignore[arg-type]
         )
     elif op == "promote":
         outcome = await store.approve_firmware_device(
@@ -214,6 +215,7 @@ async def run_step(store: StateStore, step: dict) -> None:
         outcome = await store.allocate_firmware_command_seq(DEVICE_ID)
     elif op == "assert_active":
         row = await store.get_firmware_device(DEVICE_ID)
+        assert row is not None
         expected = anchor_epoch_id(device_id=DEVICE_ID, **_epoch_input(step["anchor"]))
         assert row["anchor_epoch_id"] == expected, (
             f"active anchor should still be {step['anchor']}"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -13,7 +13,7 @@ import stat
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Sequence
+from typing import Any, Sequence
 
 import pytest
 
@@ -682,10 +682,12 @@ def test_mode_evaluation_uses_the_owner_class_first() -> None:
         st_uid = 1000
         st_gid = 50
 
+    _stat: Any = _Stat
+
     service = doctor.ServiceIdentity("svc", 1000, frozenset({50}))
-    assert doctor._mode_allows(_Stat(), service, doctor.READ) is False
+    assert doctor._mode_allows(_stat(), service, doctor.READ) is False
     other = doctor.ServiceIdentity("other", 1001, frozenset({50}))
-    assert doctor._mode_allows(_Stat(), other, doctor.READ) is True
+    assert doctor._mode_allows(_stat(), other, doctor.READ) is True
 
 
 # --- classification and reporting ----------------------------------------

--- a/tests/test_elevator.py
+++ b/tests/test_elevator.py
@@ -5,6 +5,7 @@ import asyncio
 import logging
 import time
 from dataclasses import dataclass, field
+from typing import Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -67,6 +68,7 @@ class FakeSkill:
     prompts: dict = field(default_factory=dict)
     _actions: dict = field(default_factory=dict)
     actions: dict = field(default_factory=dict)
+    hooks: Any = None
 
     def get_default_actions(self, sensor_type: str) -> list[str]:
         return self._actions.get(sensor_type, [])
@@ -958,7 +960,7 @@ class TestReason:
 
     def test_sanitize_prompt_input_coerces_float_to_string(self):
         elevator = IntelligenceElevator()
-        assert elevator._sanitize_prompt_input(12.5) == "12.5"
+        assert elevator._sanitize_prompt_input(cast(Any, 12.5)) == "12.5"
 
     async def test_rule_engine_result_has_empty_prompt(self):
         """Rule engine (Tier D, bypass_llm=True) must leave prompt as empty string."""
@@ -1484,8 +1486,10 @@ class TestReasonAndDispatch:
             )
 
             actions = await store.get_action_log()
+            conn = store._conn
+            assert conn is not None
             row = await store._run(
-                lambda: store._conn.execute(
+                lambda: conn.execute(
                     "SELECT correlation_id FROM reasoning_log"
                 ).fetchone()
             )
@@ -1550,8 +1554,10 @@ class TestReasonAndDispatch:
 
             actions = await store.get_action_log()
             correlations = {row["correlation_id"] for row in actions}
+            conn = store._conn
+            assert conn is not None
             row = await store._run(
-                lambda: store._conn.execute(
+                lambda: conn.execute(
                     "SELECT reasoning_status, response, correlation_id FROM reasoning_log"
                 ).fetchone()
             )
@@ -1614,8 +1620,10 @@ class TestReasonAndDispatch:
             action_correlation_ids = {
                 row["correlation_id"] for row in by_action.values()
             }
+            conn = store._conn
+            assert conn is not None
             row = await store._run(
-                lambda: store._conn.execute(
+                lambda: conn.execute(
                     "SELECT reasoning_status, response, model, correlation_id FROM reasoning_log"
                 ).fetchone()
             )
@@ -1671,8 +1679,10 @@ class TestReasonAndDispatch:
             action_correlation_ids = {
                 row["correlation_id"] for row in by_action.values()
             }
+            conn = store._conn
+            assert conn is not None
             row = await store._run(
-                lambda: store._conn.execute(
+                lambda: conn.execute(
                     "SELECT reasoning_status, response, correlation_id FROM reasoning_log"
                 ).fetchone()
             )

--- a/tests/test_energy_throttle.py
+++ b/tests/test_energy_throttle.py
@@ -3,6 +3,7 @@
 
 import time
 from dataclasses import dataclass, field
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -100,7 +101,7 @@ def _skill_tier_d() -> FakeSkill:
     )
 
 
-def _cfg(enabled: bool = True) -> object:
+def _cfg(enabled: bool = True) -> Any:
     return type(
         "C",
         (object,),
@@ -176,6 +177,7 @@ class TestEnergyAwareThrottle:
             tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
         assert tier == "rule"
         emit.assert_awaited_once()
+        assert emit.await_args is not None
         assert emit.await_args.kwargs["level"] == "low"
 
     @pytest.mark.asyncio
@@ -186,6 +188,7 @@ class TestEnergyAwareThrottle:
             tier = await elevator.select_tier(_event(), _skill_tier_a(), store)
         assert tier == "rule"
         emit.assert_awaited_once()
+        assert emit.await_args is not None
         assert emit.await_args.kwargs["level"] == "critical"
 
     @pytest.mark.asyncio

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import time
+from typing import Any, cast
 
 import pytest
 
@@ -88,7 +89,7 @@ class TestSubscribe:
 
         bus = EventBus()
         with caplog.at_level(logging.WARNING, logger="ori.network.event_bus"):
-            bus.subscribe("current_clamp", sync_handler)
+            bus.subscribe("current_clamp", cast(Any, sync_handler))
 
         assert any("not async" in r.message for r in caplog.records)
 
@@ -108,7 +109,7 @@ class TestSubscribe:
 
         bus = EventBus()
         with caplog.at_level(logging.WARNING, logger="ori.network.event_bus"):
-            bus.subscribe("current_clamp", sync_handler)
+            bus.subscribe("current_clamp", cast(Any, sync_handler))
 
         assert bus.subscriber_count("current_clamp") == 1
 

--- a/tests/test_gateway_export.py
+++ b/tests/test_gateway_export.py
@@ -557,6 +557,7 @@ async def test_mqtt_server_subscribes_to_device_request_topic(store):
 
         def connect(self, host, port, keepalive):
             self.connected = (host, port, keepalive)
+            assert self.on_connect is not None
             self.on_connect(self, None, None, 0)
 
         def loop_start(self):

--- a/tests/test_gateway_heartbeat.py
+++ b/tests/test_gateway_heartbeat.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -34,6 +35,10 @@ class _FakePostureTracker:
         self.recorded.append(timestamp_ms if timestamp_ms is not None else 0)
 
 
+#: Structural double for the declared parameter type.
+_fakeposturetracker: Any = _FakePostureTracker
+
+
 def _auth(
     *, max_skew_ms: int = 5_000, replay_ttl_ms: int = 5_000
 ) -> GatewayMessageAuthenticator:
@@ -56,7 +61,7 @@ def _subscriber(
 ):
     return MqttGatewayHeartbeatSubscriber(
         broker_url=broker_url,
-        posture_tracker=posture_tracker or _FakePostureTracker(),
+        posture_tracker=posture_tracker or _fakeposturetracker(),
         device_id=device_id,
         authenticator=authenticator,
         client_factory=client_factory or (lambda **_: _FakeClient()),
@@ -129,7 +134,7 @@ class _FakeClient:
 
 
 async def test_valid_heartbeat_calls_record_gateway_heartbeat():
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -142,7 +147,7 @@ async def test_valid_heartbeat_calls_record_gateway_heartbeat():
 
 async def test_degraded_status_still_updates_posture():
     """A gateway reporting 'degraded' is still alive — posture must be updated."""
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -154,7 +159,7 @@ async def test_degraded_status_still_updates_posture():
 
 async def test_unknown_status_still_updates_posture():
     """Forward-compatibility: unknown status values must not suppress posture update."""
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -172,7 +177,7 @@ async def test_missing_timestamp_ms_falls_back_to_now(monkeypatch):
     """When timestamp_ms is absent the subscriber uses the local clock."""
     monkeypatch.setattr(heartbeat_module, "now_ms", lambda: 42_000)
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -186,7 +191,7 @@ async def test_missing_timestamp_ms_falls_back_to_now(monkeypatch):
 async def test_non_numeric_timestamp_ms_falls_back_to_now(monkeypatch):
     monkeypatch.setattr(heartbeat_module, "now_ms", lambda: 99_000)
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -198,7 +203,7 @@ async def test_non_numeric_timestamp_ms_falls_back_to_now(monkeypatch):
 
 
 async def test_malformed_json_silently_discarded():
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -210,7 +215,7 @@ async def test_malformed_json_silently_discarded():
 
 async def test_non_dict_json_silently_discarded():
     """A JSON array or scalar must be discarded — only objects are valid."""
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -223,7 +228,7 @@ async def test_non_dict_json_silently_discarded():
 
 
 async def test_empty_payload_silently_discarded():
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker)
     sub._loop = asyncio.get_running_loop()
 
@@ -249,7 +254,7 @@ def test_message_before_loop_set_logs_warning(caplog):
 
 async def test_auth_disabled_accepts_unsigned_heartbeat():
     """No authenticator set → unsigned heartbeats update posture without auth block."""
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=None)
     sub._loop = asyncio.get_running_loop()
 
@@ -267,7 +272,7 @@ async def test_auth_enabled_accepts_valid_signed_heartbeat():
         raw, message_type=_HEARTBEAT_MESSAGE_TYPE, signed_at_ms=_now_ms()
     )
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=_auth())
     sub._loop = asyncio.get_running_loop()
 
@@ -279,7 +284,7 @@ async def test_auth_enabled_accepts_valid_signed_heartbeat():
 
 async def test_auth_enabled_rejects_unsigned_heartbeat(caplog):
     """Auth enabled but no auth block in payload → discarded with WARNING."""
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=_auth())
     sub._loop = asyncio.get_running_loop()
 
@@ -300,7 +305,7 @@ async def test_auth_enabled_rejects_tampered_payload(caplog):
     )
     signed["uptime_s"] = 9999.0  # tamper after signing
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=_auth())
     sub._loop = asyncio.get_running_loop()
 
@@ -322,7 +327,7 @@ async def test_auth_enabled_rejects_replayed_heartbeat(caplog):
     )
     signed_bytes = json.dumps(signed).encode()
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=authenticator)
     sub._loop = asyncio.get_running_loop()
 
@@ -347,7 +352,7 @@ async def test_auth_enabled_rejects_stale_heartbeat(caplog):
         raw, message_type=_HEARTBEAT_MESSAGE_TYPE, signed_at_ms=0
     )
 
-    tracker = _FakePostureTracker()
+    tracker = _fakeposturetracker()
     sub = _subscriber(tracker, authenticator=authenticator)
     sub._loop = asyncio.get_running_loop()
 
@@ -414,11 +419,11 @@ async def test_serve_until_tls_applies_context():
         tls_contexts.append(ctx)
         original_tls_set(ctx)
 
-    fake.tls_set_context = _capture_tls
+    cast(Any, fake).tls_set_context = _capture_tls
 
     sub = MqttGatewayHeartbeatSubscriber(
         broker_url="mqtts://localhost",
-        posture_tracker=_FakePostureTracker(),
+        posture_tracker=_fakeposturetracker(),
         device_id="dev-01",
         client_factory=lambda **_: fake,
     )
@@ -474,6 +479,6 @@ def test_paho_unavailable_raises():
         with pytest.raises(RuntimeError, match="paho-mqtt is not installed"):
             MqttGatewayHeartbeatSubscriber(
                 broker_url="mqtt://localhost",
-                posture_tracker=_FakePostureTracker(),
+                posture_tracker=_fakeposturetracker(),
                 device_id="dev-01",
             )

--- a/tests/test_gateway_reasoning.py
+++ b/tests/test_gateway_reasoning.py
@@ -69,6 +69,7 @@ class _FakeClient:
 
     def loop_start(self):
         self.loop_started = True
+        assert self.on_connect is not None
         self.on_connect(self, None, None, 0)
 
     def subscribe(self, topic):
@@ -78,6 +79,7 @@ class _FakeClient:
         decoded = json.loads(payload.decode("utf-8"))
         self.published.append((topic, decoded, qos, retain))
         if self.response_builder is not None:
+            assert self.on_message is not None
             self.on_message(self, None, _Message(self.response_builder(decoded)))
 
     def loop_stop(self):

--- a/tests/test_gpio_actuation_guard.py
+++ b/tests/test_gpio_actuation_guard.py
@@ -11,6 +11,8 @@ reach a pin, so nothing there can prove a guard against reaching one.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from ori.actions.relay import RelayAction
@@ -58,7 +60,9 @@ async def test_actuating_a_relay_records_instead_of_driving() -> None:
     assert relay.is_active is True
     await relay.release()
     assert relay.is_active is False
-    assert relay._device.history == ["on", "off"]
+    device: Any = relay._device
+    assert device is not None
+    assert device.history == ["on", "off"]
 
 
 def test_the_opt_in_is_explicit(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_i2c_adapter.py
+++ b/tests/test_i2c_adapter.py
@@ -8,6 +8,7 @@ import math
 import os
 import time
 from pathlib import Path
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -762,7 +763,9 @@ class TestReadAds1115Current:
 
         assert reading.metadata["sensitivity_v_per_amp"] == pytest.approx(1 / 30)
         assert reading.metadata["mains_frequency_hz"] == 50.0
-        assert reading.metadata["sample_count"] >= adapter._window.min_samples
+        window = adapter._window
+        assert window is not None
+        assert reading.metadata["sample_count"] >= window.min_samples
         assert reading.metadata["window_ms"] > 0
         assert "bias_volts" in reading.metadata
 
@@ -791,6 +794,7 @@ class TestReadAds1115Current:
             try:
                 return next(slow)
             except StopIteration:
+                assert adapter._window is not None
                 time.sleep(adapter._window.nominal_seconds)
                 return 1.65
 
@@ -821,6 +825,7 @@ class TestReadAds1115Current:
 
         del original, reads
         rate = adapter._calibration["data_rate"]
+        assert adapter._window is not None
         expected = rate * adapter._window.nominal_seconds
         # Pacing bounds the count by the conversion rate. Without it the loop
         # takes thousands of reads in the same window.
@@ -956,7 +961,7 @@ class TestPiIntegration:
         await adapter.close()
         assert not adapter.is_connected
 
-    _ADS1115_GUARD = dict(
+    _ADS1115_GUARD: dict[str, Any] = dict(
         available=_ADS1115_AVAILABLE and _BLINKA_AVAILABLE,
         package=(
             "adafruit-circuitpython-ads1x15 and a blinka platform library "

--- a/tests/test_installer_activation.py
+++ b/tests/test_installer_activation.py
@@ -10,6 +10,7 @@ import os
 import pwd
 import subprocess
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
@@ -113,7 +114,7 @@ def test_the_installed_doctor_is_run_by_absolute_path(
     recorded: list[list[str]] = []
     real_run = subprocess.run
 
-    def _record(command: list[str], **kwargs: object) -> object:
+    def _record(command: list[str], **kwargs: object) -> Any:
         recorded.append(command)
         return real_run(command, **kwargs)  # type: ignore[arg-type]
 
@@ -807,7 +808,7 @@ def _install_release_for_real(root: Path, diagnose_as: str) -> tuple[Path, objec
     return release, identity
 
 
-def _as_reported(checks: list[object]) -> list[dict[str, object]]:
+def _as_reported(checks: list[Any]) -> list[dict[str, object]]:
     """Render real DoctorCheck objects the way doctor's JSON report does."""
     return [
         {
@@ -833,7 +834,7 @@ def test_a_real_user_scope_install_passes_the_real_gate(tmp_path: Path) -> None:
     root = tmp_path / "ori"
     _release, identity = _install_release_for_real(root, "user")
 
-    reported = _as_reported(doctor.check_permissions(identity))
+    reported = _as_reported(doctor.check_permissions(cast(Any, identity)))
     code = next(c for c in reported if c["name"] == "permissions.code")
 
     assert code["status"] == "WARN"
@@ -858,7 +859,7 @@ def test_a_real_system_scope_install_is_blocked_when_code_is_writable(
     root = tmp_path / "ori"
     _release, identity = _install_release_for_real(root, "system")
 
-    reported = _as_reported(doctor.check_permissions(identity))
+    reported = _as_reported(doctor.check_permissions(cast(Any, identity)))
     code = next(c for c in reported if c["name"] == "permissions.code")
 
     assert code["status"] == "FAIL"

--- a/tests/test_installer_identity.py
+++ b/tests/test_installer_identity.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from ori.installer import identity
@@ -37,7 +39,7 @@ class _Operator:
         return "\n".join(self.prompts + self.messages)
 
 
-def _collect(operator: _Operator, **overrides: object) -> object:
+def _collect(operator: _Operator, **overrides: object) -> Any:
     options = InstallerInputOptions(**overrides)  # type: ignore[arg-type]
     return collect_installer_config(
         options, prompt=operator.prompt, write=operator.write
@@ -71,7 +73,9 @@ def test_a_stock_image_hostname_gets_a_suffix(hostname: str) -> None:
     assert suggestion is not None
     assert suggestion.generated_suffix is True
     assert suggestion.device_id != identity.normalise(hostname)
-    assert identity.suggest(hostname).device_id != suggestion.device_id
+    resuggested = identity.suggest(hostname)
+    assert resuggested is not None
+    assert resuggested.device_id != suggestion.device_id
 
 
 def test_a_suggested_id_always_satisfies_the_device_id_rules() -> None:

--- a/tests/test_installer_identity_continuity.py
+++ b/tests/test_installer_identity_continuity.py
@@ -27,6 +27,8 @@ identity on upgrade and starts reading it.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 import yaml
 
@@ -231,11 +233,12 @@ def test_no_installer_option_can_mutate_an_established_identity():
     test in this file.
     """
     installed = _installed()
-    for overrides in (
+    cases: tuple[dict[str, Any], ...] = (
         {"device_id": "other-id"},
         {"generate_device_id": True},
         {"device_id": "other-id", "generate_device_id": True},
-    ):
+    )
+    for overrides in cases:
         with pytest.raises(LinuxInstallError):
             collect_installer_config(
                 InstallerInputOptions(

--- a/tests/test_integration_rule_evaluation.py
+++ b/tests/test_integration_rule_evaluation.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -37,7 +38,7 @@ def _request(
     *,
     sensor_type: str = "current_clamp",
     unit: str = "ampere",
-    **kwargs: object,
+    **kwargs: Any,
 ) -> RuleEvaluationRequest:
     return RuleEvaluationRequest(
         sensor_id="main-circuit-current",

--- a/tests/test_inverter_profile_qualification.py
+++ b/tests/test_inverter_profile_qualification.py
@@ -42,7 +42,7 @@ def test_bundled_profile_vectors_decode_within_tolerance(profile_name):
 
     for vector in profile.vectors:
         decoded = decode_metric(profile, vector.metric, vector.raw_registers)
-        assert abs(decoded - vector.expected_value) <= vector.tolerance, (
+        assert abs(decoded - float(vector.expected_value)) <= vector.tolerance, (
             f"{profile_name}:{vector.metric} decoded {decoded}, expected "
             f"{vector.expected_value} +/- {vector.tolerance}"
         )

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -15,6 +15,7 @@ import tomllib
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest import mock
 
 import pytest
@@ -383,7 +384,7 @@ def test_creation_provenance_race_refuses_existing_entry_and_rolls_back_only_our
         *,
         dir_fd: int | None = None,
     ) -> None:
-        if Path(candidate) == layout.data:
+        if Path(cast(Any, candidate)) == layout.data:
             real_mkdir(candidate, mode, dir_fd=dir_fd)
             os.chmod(candidate, 0o775, dir_fd=dir_fd)
             raise FileExistsError(17, "simulated concurrent creation", str(candidate))
@@ -800,7 +801,7 @@ def test_composed_reinstall_integrates_config_dac_and_live_health_socket(
         bundle = ExtractedReleaseBundle(
             Path(root), "2.3.0", "linux-x86_64-python3.12", "3.12", 1
         )
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "layout": layout,
             "bundle": bundle,
             "values": InstallerConfigInput("ori-01", "Office", "Lagos"),
@@ -1283,7 +1284,7 @@ def test_same_version_is_idempotent_and_downgrade_requires_opt_in(
     tmp_path: Path,
 ) -> None:
     layout = InstallLayout.resolve(tmp_path / "ori")
-    kwargs = dict(
+    kwargs: dict[str, Any] = dict(
         layout=layout,
         prepare=_prepare,
         validate=_validate,
@@ -1333,7 +1334,7 @@ def test_noncanonical_version_is_rejected_with_stable_error(tmp_path: Path) -> N
 
 def test_prerelease_numeric_identifiers_use_semver_ordering(tmp_path: Path) -> None:
     layout = InstallLayout.resolve(tmp_path / "ori")
-    kwargs = dict(
+    kwargs: dict[str, Any] = dict(
         layout=layout,
         prepare=_prepare,
         validate=_validate,
@@ -2229,6 +2230,176 @@ def test_system_permissions_fail_closed_for_non_root_and_data_symlink(
             releases=[layout.release("2.3.0")],
         )
     assert layout.root.stat().st_mode & 0o777 == 0o755
+
+
+def test_a_file_that_becomes_a_pipe_after_validation_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The service owns this tree and is still running when the walk happens.
+
+    Without the non-blocking open the installer waits as root for a writer
+    that never comes, so the refusal below is never reached.
+    """
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.data.mkdir()
+    target = layout.data / "state.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+    monkeypatch.setattr("ori.installer.linux.os.fchmod", lambda *_args: None)
+
+    real_walk = os.walk
+
+    def swap_after_planning(*args: object, **kwargs: object):
+        for entry in real_walk(*args, **kwargs):  # type: ignore[arg-type]
+            yield entry
+        # Planning is complete and the plan holds a regular file. Replace it
+        # the way the running service could.
+        target.unlink()
+        os.mkfifo(target)
+
+    monkeypatch.setattr("ori.installer.linux.os.walk", swap_after_planning)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+
+    assert raised.value.code == "service_start_failed"
+
+
+def test_a_file_swapped_for_another_file_after_validation_is_refused(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A substitution that keeps the file type is still a different file."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.data.mkdir()
+    target = layout.data / "state.json"
+    target.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+    monkeypatch.setattr("ori.installer.linux.os.fchmod", lambda *_args: None)
+
+    real_walk = os.walk
+
+    def swap_after_planning(*args: object, **kwargs: object):
+        for entry in real_walk(*args, **kwargs):  # type: ignore[arg-type]
+            yield entry
+        target.unlink()
+        target.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr("ori.installer.linux.os.walk", swap_after_planning)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+
+    assert raised.value.code == "service_start_failed"
+
+
+def test_a_refused_special_file_is_named_with_its_kind(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The likeliest causes are artefacts of the runtime having run."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.data.mkdir()
+    fifo = layout.data / "unexpected.pipe"
+    os.mkfifo(fifo)
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+
+    assert "named pipe" in raised.value.detail
+    assert str(fifo) in raised.value.detail
+
+
+def test_a_refused_special_file_says_how_to_clear_it(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A live runtime recreates the artefacts it made, so naming is not enough."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.data.mkdir()
+    os.mkfifo(layout.data / "unexpected.pipe")
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+
+    assert "Stop the service" in raised.value.detail
+
+
+def test_a_refused_name_cannot_speak_for_itself(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The path reaches a terminal and is not the installer's to trust."""
+    layout = InstallLayout.resolve(tmp_path / "ori")
+    layout.releases.mkdir(parents=True)
+    layout.data.mkdir()
+    os.mkfifo(layout.data / "pipe\nExecStart=evil")
+    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
+    monkeypatch.setattr(
+        "ori.installer.linux.pwd.getpwnam",
+        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+    )
+    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
+
+    with pytest.raises(LinuxInstallError) as raised:
+        apply_system_service_permissions(layout, SystemdServiceProfile.system())
+
+    assert "\n" not in raised.value.detail
+    assert "\\n" in raised.value.detail
+
+
+def test_a_system_unit_works_outside_the_directory_it_must_not_litter(
+    tmp_path: Path,
+) -> None:
+    """GPIO drops a notification pipe in the working directory, and the install
+    root admits regular files only."""
+    rendered = render_systemd_unit(
+        _service_template(),
+        profile=SystemdServiceProfile.system(),
+        root=Path("/opt/ori"),
+        data_dir=Path("/opt/ori/data"),
+        config_path=Path("/opt/ori/data/ori.yaml"),
+        env_file=Path("/etc/ori/runtime.env"),
+    )
+    assert "RuntimeDirectory=ori" in rendered
+    assert "WorkingDirectory=%t/ori" in rendered
+    assert "WorkingDirectory=/opt/ori/data" not in rendered
+    # The data directory stays writable: it is where the runtime keeps state.
+    assert "ReadWritePaths=/opt/ori/data" in rendered
+
+
+def test_a_user_unit_also_works_outside_its_data_directory(tmp_path: Path) -> None:
+    """A user install writes into a home directory it must not litter either."""
+    rendered = _rendered_unit(tmp_path, SystemdServiceProfile.user())
+
+    working = [
+        line for line in rendered.splitlines() if line.startswith("WorkingDirectory=")
+    ]
+
+    assert "RuntimeDirectory=ori" in rendered
+    assert working == ["WorkingDirectory=%t/ori"]
 
 
 def test_system_permissions_allow_only_configured_runtime_socket(

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -2237,8 +2237,11 @@ def test_a_file_that_becomes_a_pipe_after_validation_is_refused(
 ) -> None:
     """The service owns this tree and is still running when the walk happens.
 
-    Without the non-blocking open the installer waits as root for a writer
-    that never comes, so the refusal below is never reached.
+    Two things have to hold for this to be caught. The open must not block,
+    or the installer waits as root for a writer that never comes. And the file
+    type must be checked, because an inode number is reused immediately after
+    unlink on the filesystems Linux installs run on, so the recorded inode
+    still matches and only the type says the file changed.
     """
     layout = InstallLayout.resolve(tmp_path / "ori")
     layout.releases.mkdir(parents=True)
@@ -2253,50 +2256,19 @@ def test_a_file_that_becomes_a_pipe_after_validation_is_refused(
     monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
     monkeypatch.setattr("ori.installer.linux.os.fchmod", lambda *_args: None)
 
-    real_walk = os.walk
+    real_apply = installer_linux._apply_permission_plan
 
-    def swap_after_planning(*args: object, **kwargs: object):
-        for entry in real_walk(*args, **kwargs):  # type: ignore[arg-type]
-            yield entry
-        # Planning is complete and the plan holds a regular file. Replace it
-        # the way the running service could.
+    def swap_between_planning_and_applying(plan):
+        # The plan holds a regular file it validated. Replace it the way
+        # the running service could, then let the apply proceed.
         target.unlink()
         os.mkfifo(target)
+        real_apply(plan)
 
-    monkeypatch.setattr("ori.installer.linux.os.walk", swap_after_planning)
-
-    with pytest.raises(LinuxInstallError) as raised:
-        apply_system_service_permissions(layout, SystemdServiceProfile.system())
-
-    assert raised.value.code == "service_start_failed"
-
-
-def test_a_file_swapped_for_another_file_after_validation_is_refused(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """A substitution that keeps the file type is still a different file."""
-    layout = InstallLayout.resolve(tmp_path / "ori")
-    layout.releases.mkdir(parents=True)
-    layout.data.mkdir()
-    target = layout.data / "state.json"
-    target.write_text("{}", encoding="utf-8")
-    monkeypatch.setattr("ori.installer.linux.os.geteuid", lambda: 0)
     monkeypatch.setattr(
-        "ori.installer.linux.pwd.getpwnam",
-        lambda _name: SimpleNamespace(pw_uid=1001, pw_gid=1002),
+        "ori.installer.linux._apply_permission_plan",
+        swap_between_planning_and_applying,
     )
-    monkeypatch.setattr("ori.installer.linux.os.fchown", lambda *_args: None)
-    monkeypatch.setattr("ori.installer.linux.os.fchmod", lambda *_args: None)
-
-    real_walk = os.walk
-
-    def swap_after_planning(*args: object, **kwargs: object):
-        for entry in real_walk(*args, **kwargs):  # type: ignore[arg-type]
-            yield entry
-        target.unlink()
-        target.write_text("{}", encoding="utf-8")
-
-    monkeypatch.setattr("ori.installer.linux.os.walk", swap_after_planning)
 
     with pytest.raises(LinuxInstallError) as raised:
         apply_system_service_permissions(layout, SystemdServiceProfile.system())

--- a/tests/test_offline_tokens.py
+++ b/tests/test_offline_tokens.py
@@ -4,6 +4,7 @@
 import base64
 import json
 import time
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -11,12 +12,16 @@ from ori.security.offline_tokens import OfflineTierCTokenVerifier
 from ori.skills.signing import canonical_signed_payload
 from ori.state.store import StateStore
 
-try:
+if TYPE_CHECKING:
     from cryptography.hazmat.primitives import serialization
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-except ImportError:  # pragma: no cover
-    Ed25519PrivateKey = None
-    serialization = None
+else:  # pragma: no cover - environment without cryptography support
+    try:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    except Exception:
+        Ed25519PrivateKey = None
+        serialization = None
 
 
 @pytest.mark.skipif(

--- a/tests/test_opcua_adapter.py
+++ b/tests/test_opcua_adapter.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Ori Nexus Systems LTD
 # SPDX-License-Identifier: Apache-2.0
 
+from typing import Any, cast
 from unittest.mock import patch
 
 import pytest
@@ -84,7 +85,7 @@ class TestOpcUaAdapter:
     @pytest.mark.asyncio
     async def test_connect_stores_config(self):
         adapter = OpcUaAdapter()
-        _FakeClient.default_node_value = 12.3
+        cast(Any, _FakeClient).default_node_value = 12.3
 
         with (
             patch("ori.hal.opcua_adapter._ASYNCUA_AVAILABLE", True),
@@ -107,7 +108,7 @@ class TestOpcUaAdapter:
     @pytest.mark.asyncio
     async def test_read_float_value(self):
         adapter = OpcUaAdapter()
-        _FakeClient.default_node_value = 42.75
+        cast(Any, _FakeClient).default_node_value = 42.75
 
         with (
             patch("ori.hal.opcua_adapter._ASYNCUA_AVAILABLE", True),
@@ -123,7 +124,7 @@ class TestOpcUaAdapter:
     @pytest.mark.asyncio
     async def test_read_int_value(self):
         adapter = OpcUaAdapter()
-        _FakeClient.default_node_value = _DataValue(123)
+        cast(Any, _FakeClient).default_node_value = _DataValue(123)
 
         with (
             patch("ori.hal.opcua_adapter._ASYNCUA_AVAILABLE", True),
@@ -137,7 +138,7 @@ class TestOpcUaAdapter:
     @pytest.mark.asyncio
     async def test_read_boolean(self):
         adapter = OpcUaAdapter()
-        _FakeClient.default_node_value = _DataValue(True)
+        cast(Any, _FakeClient).default_node_value = _DataValue(True)
 
         with (
             patch("ori.hal.opcua_adapter._ASYNCUA_AVAILABLE", True),
@@ -151,7 +152,7 @@ class TestOpcUaAdapter:
     @pytest.mark.asyncio
     async def test_circuit_breaker_integration(self):
         adapter = OpcUaAdapter()
-        _FakeClient.default_node_value = 10.0
+        cast(Any, _FakeClient).default_node_value = 10.0
 
         with (
             patch("ori.hal.opcua_adapter._ASYNCUA_AVAILABLE", True),

--- a/tests/test_ori_cli.py
+++ b/tests/test_ori_cli.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import tomllib
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -241,7 +242,7 @@ json.dump({"schema_version": 1, "ok": True, "status": "healthy",\n           "an
 
 
 def _args(**overrides: object) -> argparse.Namespace:
-    base = dict(
+    base: dict[str, Any] = dict(
         bundle="/b.tar.gz",
         signature="/b.sig",
         expected_version=None,

--- a/tests/test_pyright_ratchet.py
+++ b/tests/test_pyright_ratchet.py
@@ -92,8 +92,11 @@ def test_only_errors_are_counted() -> None:
 def test_the_committed_baseline_records_a_total_and_a_breakdown() -> None:
     baseline = json.loads(BASELINE.read_text())
     assert isinstance(baseline["total"], int) and baseline["total"] >= 0
-    assert baseline["by_area"]
     assert sum(baseline["by_area"].values()) == baseline["total"]
+    # A breakdown exists exactly when there is debt to break down. Requiring
+    # one unconditionally would mean a repository at zero could never record
+    # that it is at zero.
+    assert bool(baseline["by_area"]) == (baseline["total"] > 0)
     assert baseline["note"].strip()
 
 

--- a/tests/test_rejection_memory.py
+++ b/tests/test_rejection_memory.py
@@ -34,6 +34,12 @@ def _reading(
     )
 
 
+def _reading_of(event: OriEvent) -> SensorReading:
+    """The reading `_event` always sets, narrowed for the type checker."""
+    assert event.reading is not None
+    return event.reading
+
+
 def _event(value: float = 5.0, timestamp_ms: int | None = None) -> OriEvent:
     r = _reading(value=value)
     if timestamp_ms is not None:
@@ -178,10 +184,10 @@ class TestRejectionMemory:
         event = _event(value=5.0)
         skill = _FakeSkill()
         pattern_key = store._build_rejection_pattern_key(
-            event.reading.sensor_type,
+            _reading_of(event).sensor_type,
             "overcurrent_trip",
             "open_safety_circuit",
-            event.reading.value,
+            _reading_of(event).value,
             event.timestamp,
         )
         await store.store_rejection(
@@ -190,8 +196,8 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
             operator_response="scheduled overnight run",
             device_id=event.device_id,
-            sensor_type=event.reading.sensor_type,
-            value_bucket=round(event.reading.value * 2) / 2.0,
+            sensor_type=_reading_of(event).sensor_type,
+            value_bucket=round(_reading_of(event).value * 2) / 2.0,
             time_of_day_hour=2,
             day_of_week=3,
             expiry_days=30,
@@ -217,10 +223,10 @@ class TestRejectionMemory:
         event = _event(value=5.0)
         skill = _FakeSkill()
         pattern_key = store._build_rejection_pattern_key(
-            event.reading.sensor_type,
+            _reading_of(event).sensor_type,
             "overcurrent_trip",
             "open_safety_circuit",
-            event.reading.value,
+            _reading_of(event).value,
             event.timestamp,
         )
         await store.store_rejection(
@@ -229,8 +235,8 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
             operator_response="old rejection",
             device_id=event.device_id,
-            sensor_type=event.reading.sensor_type,
-            value_bucket=round(event.reading.value * 2) / 2.0,
+            sensor_type=_reading_of(event).sensor_type,
+            value_bucket=round(_reading_of(event).value * 2) / 2.0,
             time_of_day_hour=2,
             day_of_week=3,
             expiry_days=1,
@@ -257,10 +263,10 @@ class TestRejectionMemory:
     async def test_rejection_context_in_prompt(self, store, monkeypatch):
         event = _event(value=5.0)
         pattern_key = store._build_rejection_pattern_key(
-            event.reading.sensor_type,
+            _reading_of(event).sensor_type,
             "overcurrent_trip",
             "open_safety_circuit",
-            event.reading.value,
+            _reading_of(event).value,
             event.timestamp,
         )
         await store.store_rejection(
@@ -269,8 +275,8 @@ class TestRejectionMemory:
             proposed_action="open_safety_circuit",
             operator_response="scheduled run",
             device_id=event.device_id,
-            sensor_type=event.reading.sensor_type,
-            value_bucket=round(event.reading.value * 2) / 2.0,
+            sensor_type=_reading_of(event).sensor_type,
+            value_bucket=round(_reading_of(event).value * 2) / 2.0,
             time_of_day_hour=2,
             day_of_week=3,
             expiry_days=30,
@@ -364,10 +370,10 @@ class TestRejectionMemory:
             result=res,
         )
         key = store._build_rejection_pattern_key(
-            evt.reading.sensor_type,
+            _reading_of(evt).sensor_type,
             "overcurrent_trip",
             "open_safety_circuit",
-            evt.reading.value,
+            _reading_of(evt).value,
             evt.timestamp,
         )
         row = await store.lookup_rejection(key)

--- a/tests/test_release_bundle_build.py
+++ b/tests/test_release_bundle_build.py
@@ -15,6 +15,7 @@ import sys
 import tarfile
 import zipfile
 from pathlib import Path
+from typing import cast
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -167,7 +168,9 @@ def _explain_difference(first: Path, second: Path) -> str:
     left, right = _archive_fingerprint(first), _archive_fingerprint(second)
     differences = [key for key in left if left[key] != right[key]]
     lines = [f"bundles differ in: {differences or 'compressed bytes only'}"]
-    for member_a, member_b in zip(left["members"], right["members"]):
+    for member_a, member_b in zip(
+        cast(list, left["members"]), cast(list, right["members"])
+    ):
         if member_a != member_b:
             lines.append(f"  first  {member_a}")
             lines.append(f"  second {member_b}")

--- a/tests/test_release_identity.py
+++ b/tests/test_release_identity.py
@@ -243,6 +243,7 @@ def test_the_trigger_admits_tags_only_the_authority_can_refuse() -> None:
     handling here would be dead weight and should be revisited with it.
     """
     triggers = _workflow().get("on") or _workflow().get(True)
+    assert triggers is not None
     patterns = triggers["push"]["tags"]
 
     assert any("-" in pattern for pattern in patterns), (

--- a/tests/test_remote_policy_fetch.py
+++ b/tests/test_remote_policy_fetch.py
@@ -5,6 +5,7 @@ import base64
 import hashlib
 import json
 import time
+from typing import TYPE_CHECKING
 
 import pytest
 
@@ -16,13 +17,17 @@ from ori.policy.remote_fetch import (
 )
 from ori.skills.signing import canonical_signed_payload
 
-try:
+if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-except Exception:  # pragma: no cover - environment without cryptography support
-    Ed25519PrivateKey = None
-    Encoding = None
-    PublicFormat = None
+else:  # pragma: no cover - environment without cryptography support
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+        from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+    except Exception:
+        Ed25519PrivateKey = None
+        Encoding = None
+        PublicFormat = None
 
 
 def _base_config(public_key_b64: str) -> dict:

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -12,11 +12,12 @@ import base64
 import json
 import logging
 import os
+import sys
 import textwrap
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -70,13 +71,22 @@ from tests.conftest import (
     run_runtime_until,
 )
 
-try:
+if TYPE_CHECKING:
     from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-except Exception:  # pragma: no cover - environment without cryptography support
-    Ed25519PrivateKey = None
-    Encoding = None
-    PublicFormat = None
+else:  # pragma: no cover - environment without cryptography support
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            PublicFormat,
+        )
+    except Exception:
+        Ed25519PrivateKey = None
+        Encoding = None
+        PublicFormat = None
 
 
 async def _end_loop_once_warned(runtime, *, timeout: float = 15.0) -> None:
@@ -132,7 +142,7 @@ def _capability_config(
 
 def test_build_gateway_message_auth_uses_configured_env_secret(monkeypatch):
     monkeypatch.setenv("GATEWAY_SHARED_SECRET", "site-local-secret")
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -152,7 +162,7 @@ def test_build_gateway_message_auth_uses_configured_env_secret(monkeypatch):
 
 def test_remote_command_secret_env_names_are_not_logged(monkeypatch, caplog):
     monkeypatch.delenv("ORI_REMOTE_COMMAND_HMAC_SECRET", raising=False)
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(id="device-01"),
         security={
             "remote_commands": {
@@ -180,7 +190,7 @@ def test_resolve_setup_notification_channels_deduplicates_primary():
 
 
 def test_setup_success_message_is_bounded_and_notification_only():
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(
             id="phone-01",
             location="Temidayo Site",
@@ -210,7 +220,7 @@ def test_setup_success_message_is_bounded_and_notification_only():
 
 @pytest.mark.parametrize("location", ["", "   ", "\n\t"])
 def test_setup_success_message_falls_back_for_empty_location(location):
-    config = SimpleNamespace(device=SimpleNamespace(location=location))
+    config: Any = SimpleNamespace(device=SimpleNamespace(location=location))
 
     message = _setup_success_message(
         config=config,
@@ -225,7 +235,7 @@ def test_setup_success_message_falls_back_for_empty_location(location):
 
 
 def test_setup_success_message_truncates_only_normalized_location():
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(location="  Abuja\n" + "very-long-site " * 100)
     )
 
@@ -350,7 +360,7 @@ async def test_setup_success_notification_sends_enabled_channels():
     runtime._last_alert_timestamps_by_trigger = {}
     runtime._runtime_started_at_ms = 1_700_000_000_000
     sender = FakeAlertSender()
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(
             id="phone-01",
             location="Temidayo Site",
@@ -365,7 +375,7 @@ async def test_setup_success_notification_sends_enabled_channels():
         ),
     )
 
-    await runtime._send_setup_success_notifications(config, sender)
+    await runtime._send_setup_success_notifications(config, cast(Any, sender))
 
     assert [call["channel"] for call in sender.calls] == ["sms", "whatsapp"]
     assert all(call["to_number"] == "+2348000000000" for call in sender.calls)
@@ -386,7 +396,7 @@ async def test_setup_success_notification_queues_failed_delivery():
         async def send_exact(self, *, message, to_number, channel):
             return False
 
-    runtime = OriRuntime()
+    runtime: Any = OriRuntime()
     runtime._operator_contact = "+2348000000000"
     runtime._connected_sensor_ids = {"temperature-1"}
     runtime._loaded_skills = [
@@ -403,7 +413,7 @@ async def test_setup_success_notification_queues_failed_delivery():
         get_skill_state=AsyncMock(return_value=None),
         set_skill_state=AsyncMock(return_value=None),
     )
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(location="Abuja"),
         sensors=[SimpleNamespace(id="temperature-1", type="temperature")],
         actions=SimpleNamespace(
@@ -417,7 +427,7 @@ async def test_setup_success_notification_queues_failed_delivery():
     await runtime._send_setup_success_notifications(config, FailingAlertSender())
 
     runtime._state_store.enqueue_alert.assert_awaited_once()
-    queued = runtime._state_store.enqueue_alert.await_args.kwargs
+    queued = runtime._state_store.enqueue_alert.await_args.kwargs  # type: ignore[union-attr]
     assert queued["channel"] == "sms"
     assert queued["action_tier"] == "A"
     assert queued["trigger_name"] == "runtime_setup_complete"
@@ -444,7 +454,7 @@ async def test_start_telemetry_export_subscribes_wildcard_handler(monkeypatch):
     monkeypatch.setattr("ori.runtime.HttpTelemetryExporter", FakeExporter)
     runtime = OriRuntime()
     event_bus = EventBus()
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(id="phone-01"),
         telemetry_export=TelemetryExportConfig(
             enabled=True,
@@ -470,7 +480,7 @@ def _sms_webhook_posture_config(
     host: str,
     signature_mode: str = "token_only",
     allowed_source_cidrs: list[str] | None = None,
-) -> SimpleNamespace:
+) -> Any:
     return SimpleNamespace(
         actions=SimpleNamespace(
             sms={
@@ -520,7 +530,7 @@ def test_sms_webhook_security_posture_accepts_public_signed_allowlisted(caplog):
 def test_build_gateway_message_auth_accepts_previous_env_secret(monkeypatch):
     monkeypatch.setenv("GATEWAY_SHARED_SECRET", "current-secret")
     monkeypatch.setenv("GATEWAY_PREVIOUS_SHARED_SECRET", "previous-secret")
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -564,7 +574,7 @@ def test_build_gateway_message_auth_accepts_previous_env_secret(monkeypatch):
 
 def test_build_gateway_message_auth_rejects_missing_env_secret(monkeypatch):
     monkeypatch.delenv("GATEWAY_SHARED_SECRET", raising=False)
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -588,7 +598,7 @@ def test_build_gateway_message_auth_rejects_missing_env_secret(monkeypatch):
 def test_build_gateway_message_auth_redacts_previous_env_secret(monkeypatch, caplog):
     monkeypatch.setenv("GATEWAY_SHARED_SECRET", "current-secret")
     monkeypatch.delenv("GATEWAY_PREVIOUS_SHARED_SECRET", raising=False)
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -615,7 +625,7 @@ def test_build_gateway_message_auth_redacts_previous_env_secret(monkeypatch, cap
 def test_build_remote_command_verifier_passes_previous_env_secret(monkeypatch):
     monkeypatch.setenv("ORI_REMOTE_COMMAND_HMAC_SECRET", "current-secret")
     monkeypatch.setenv("ORI_REMOTE_COMMAND_PREVIOUS_HMAC_SECRET", "previous-secret")
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         device=SimpleNamespace(id="dev-01"),
         security={
             "remote_commands": {
@@ -636,7 +646,7 @@ def test_build_remote_command_verifier_passes_previous_env_secret(monkeypatch):
 
 def test_build_gateway_message_encryptor_uses_gateway_secret(monkeypatch):
     monkeypatch.setenv("GATEWAY_SHARED_SECRET", "site-local-secret")
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -655,7 +665,7 @@ def test_build_gateway_message_encryptor_uses_gateway_secret(monkeypatch):
 
 def test_build_gateway_message_encryptor_rejects_missing_env_secret(monkeypatch):
     monkeypatch.delenv("GATEWAY_SHARED_SECRET", raising=False)
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -676,7 +686,7 @@ def test_build_gateway_message_encryptor_rejects_missing_env_secret(monkeypatch)
 
 
 def test_build_gateway_message_encryptor_requires_auth_enabled():
-    config = SimpleNamespace(
+    config: Any = SimpleNamespace(
         gateway=GatewayConfig(
             enabled=True,
             broker_url="mqtt://broker.local",
@@ -708,7 +718,7 @@ async def _stop_and_join(runtime, start_task: asyncio.Task) -> None:
 @pytest.mark.asyncio
 async def test_a_failed_sensor_connect_does_not_take_the_runtime_down(
     minimal_config, monkeypatch
-):
+) -> Any:
     """A sensor that cannot connect is skipped; the runtime keeps running.
 
     This is the boundary a hardened refusal was briefly placed at, and the
@@ -1224,6 +1234,285 @@ async def test_the_runtime_opens_the_store_beside_its_config(tmp_path, monkeypat
         await _stop_and_join(runtime, start_task)
 
 
+@pytest.mark.asyncio
+async def test_a_relative_skills_dir_survives_a_runtime_working_directory(
+    tmp_path, monkeypatch
+):
+    """Skills that vanish take their triggers with them.
+
+    The unit points the working directory at a runtime directory systemd
+    empties on every stop, so a relative skills_dir resolved there would find
+    nothing and report a healthy runtime with no coverage.
+    """
+    _patch_external(monkeypatch)
+    home = tmp_path / "data"
+    skill_dir = home / "skills" / "test-skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "skill.yaml").write_text(
+        textwrap.dedent("""\
+            name: test-skill
+            version: 0.1.0
+            author: test
+            sensors_required:
+              - type: cpu_percent
+            triggers:
+              - name: high_cpu
+                condition: "value > 90"
+                action_tier: A
+                cooldown_seconds: 0
+                escalate_to: rule
+            actions:
+              available:
+                - name: alert_whatsapp
+                  tier: A
+              defaults:
+                high_cpu: [alert_whatsapp]
+        """),
+        encoding="utf-8",
+    )
+    (home / "ori.yaml").write_text(
+        textwrap.dedent("""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors:
+              - id: cpu-sensor
+                type: cpu_percent
+                protocol: psutil
+                poll_interval_ms: 100
+            skills:
+              - name: test-skill
+                version: "0.1.0"
+                config: {}
+            reasoning:
+              default_tier: rule
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+              relay:
+                enabled: false
+            skills_dir: skills
+            database:
+              path: ori_state.db
+        """),
+        encoding="utf-8",
+    )
+    elsewhere = tmp_path / "runtime-dir"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    runtime = OriRuntime(config_path=str(home / "ori.yaml"))
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and runtime._skills_dir is None:
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+        # The directory the loader was handed, taken from the running runtime
+        # rather than from the parsed configuration, because the seam that
+        # broke is between the two.
+        skills_dir = runtime._skills_dir
+        assert skills_dir is not None, (
+            "the runtime never resolved a skills directory: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+        assert skills_dir == str(home / "skills")
+        assert Path(skills_dir).is_dir()
+        assert (Path(skills_dir) / "test-skill" / "skill.yaml").is_file()
+    finally:
+        await _stop_and_join(runtime, start_task)
+
+
+@pytest.mark.asyncio
+async def test_startup_refuses_a_dotenv_loaded_before_a_hardened_document(
+    tmp_path, monkeypatch
+):
+    """The autoload decides before the document that settles it can be read.
+
+    A document can declare development, be replaced, and load as hardened; or
+    it can declare a posture that only expansion resolves. Either way the trust
+    was widened before the answer existed, so startup confirms it afterwards
+    rather than assuming the earlier answer held.
+    """
+    _patch_external(monkeypatch)
+    home = tmp_path / "data"
+    home.mkdir()
+    (home / "ori.yaml").write_text(
+        textwrap.dedent("""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: rule
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+        """),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "ori.runtime.requires_production_posture", lambda **_kwargs: True
+    )
+
+    runtime = OriRuntime(config_path=str(home / "ori.yaml"), dotenv_loaded=True)
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        # Bounded: a startup that does not refuse runs its loop forever, and an
+        # unbounded await would hang rather than report the missing refusal.
+        with pytest.raises(ConfigValidationError, match="ORI_AUTOLOAD_DOTENV"):
+            await asyncio.wait_for(start_task, timeout=10.0)
+    finally:
+        await _stop_and_join(runtime, start_task)
+
+
+@pytest.mark.asyncio
+async def test_startup_accepts_a_dotenv_under_a_document_that_stays_development(
+    tmp_path, monkeypatch
+):
+    """The confirmation must not refuse the deployments the toggle is for."""
+    _patch_external(monkeypatch)
+    home = tmp_path / "data"
+    home.mkdir()
+    (home / "ori.yaml").write_text(
+        textwrap.dedent("""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: rule
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+        """),
+        encoding="utf-8",
+    )
+    runtime = OriRuntime(config_path=str(home / "ori.yaml"), dotenv_loaded=True)
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and runtime._config is None:
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+        assert runtime._config is not None, (
+            "startup refused a development document: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+    finally:
+        await _stop_and_join(runtime, start_task)
+
+
+@pytest.mark.asyncio
+async def test_a_hardened_document_without_a_dotenv_still_starts(tmp_path, monkeypatch):
+    """The confirmation is about the .env, not about being hardened.
+
+    Refusing every hardened startup would make the check a posture gate, which
+    is not what it is for.
+    """
+    _patch_external(monkeypatch)
+    home = tmp_path / "data"
+    home.mkdir()
+    (home / "ori.yaml").write_text(
+        textwrap.dedent("""\
+            device:
+              id: test-device-01
+              name: Test Device
+              location: Test Lab
+            sensors: []
+            skills: []
+            reasoning:
+              default_tier: rule
+            gateway:
+              enabled: false
+              broker_url: ""
+            actions:
+              primary_alert_channel: sms
+              whatsapp:
+                enabled: false
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+        """),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(
+        "ori.runtime.requires_production_posture", lambda **_kwargs: True
+    )
+
+    runtime = OriRuntime(config_path=str(home / "ori.yaml"), dotenv_loaded=False)
+    start_task = asyncio.create_task(runtime.start())
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and runtime._config is None:
+            if start_task.done():
+                break
+            await asyncio.sleep(0.05)
+        assert runtime._config is not None, (
+            "startup refused a hardened document that loaded no .env: "
+            f"{start_task.exception() if start_task.done() else ''}"
+        )
+    finally:
+        await _stop_and_join(runtime, start_task)
+
+
+def test_main_carries_the_autoload_result_into_the_runtime(monkeypatch):
+    """The confirmation is only reachable if the entry point wires it through.
+
+    A default of False on the constructor means a caller that forgets it gets
+    a runtime that never confirms, and nothing else would say so.
+    """
+    from ori import runtime as runtime_module
+
+    captured: dict[str, object] = {}
+
+    class _Runtime:
+        def __init__(self, config_path: str, *, dotenv_loaded: bool = False) -> None:
+            captured["config_path"] = config_path
+            captured["dotenv_loaded"] = dotenv_loaded
+
+        async def start(self) -> None:
+            return None
+
+    monkeypatch.setattr(runtime_module, "OriRuntime", _Runtime)
+    monkeypatch.setattr(runtime_module, "_maybe_autoload_dotenv", lambda _path: True)
+    monkeypatch.setattr(sys, "argv", ["ori-runtime", "--config", "/tmp/ori.yaml"])
+
+    runtime_module.main()
+
+    assert captured == {"config_path": "/tmp/ori.yaml", "dotenv_loaded": True}
+
+
 def _patch_external(monkeypatch):
     """Patch all external I/O so tests run without hardware or credentials."""
     monkeypatch.setattr(
@@ -1503,7 +1792,7 @@ class TestLocalSLMWiring:
     def test_build_local_llm_returns_none_when_model_missing(self, tmp_path: Path):
         cfg_path = tmp_path / "ori.yaml"
         cfg_path.write_text("device: {}\n", encoding="utf-8")
-        reasoning_cfg = SimpleNamespace(
+        reasoning_cfg: Any = SimpleNamespace(
             local_model="missing-model",
             model_path=str(tmp_path / "models"),
             local_context_window=2048,
@@ -1522,7 +1811,7 @@ class TestLocalSLMWiring:
 
         cfg_path = tmp_path / "ori.yaml"
         cfg_path.write_text("device: {}\n", encoding="utf-8")
-        reasoning_cfg = SimpleNamespace(
+        reasoning_cfg: Any = SimpleNamespace(
             local_model="qwen2.5-0.5b-instruct-q4_k_m",
             model_path=str(model_dir),
             local_context_window=4096,
@@ -1579,7 +1868,7 @@ class TestLocalSLMWiring:
         assert captured["gateway_reasoner"] is None
 
     def test_build_gateway_reasoner_returns_none_when_gateway_disabled(self):
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             gateway=SimpleNamespace(enabled=False, broker_url="", reasoning={}),
             device=SimpleNamespace(id="test-device-01"),
         )
@@ -1606,7 +1895,7 @@ class TestLocalSLMWiring:
                 captured["message_auth"] = message_auth
 
         monkeypatch.setattr("ori.runtime.MqttGatewayReasoner", _FakeGatewayReasoner)
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             gateway=SimpleNamespace(
                 enabled=True,
                 broker_url="mqtt://broker.local:1884",
@@ -1628,7 +1917,7 @@ class TestLocalSLMWiring:
         }
 
     def test_build_runtime_node_heartbeat_returns_none_when_gateway_disabled(self):
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             gateway=SimpleNamespace(
                 enabled=False,
                 broker_url="",
@@ -1640,7 +1929,7 @@ class TestLocalSLMWiring:
         assert _build_runtime_node_heartbeat_publisher(cfg, lambda: {}) is None
 
     def test_build_runtime_node_heartbeat_returns_none_when_disabled(self):
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             gateway=SimpleNamespace(
                 enabled=True,
                 broker_url="mqtt://broker.local",
@@ -1679,7 +1968,7 @@ class TestLocalSLMWiring:
         def provider():
             return {"status": "healthy"}
 
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             gateway=SimpleNamespace(
                 enabled=True,
                 broker_url="mqtt://broker.local:1884",
@@ -1739,6 +2028,177 @@ class TestDotenvAutoload:
 
         _maybe_autoload_dotenv(str(cfg))
         assert os.environ.get("ORI_AUTOLOAD_SMOKE") == "already_set"
+
+    def test_a_dotenv_in_the_working_directory_is_ignored(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """The unit works in a runtime directory systemd empties on every stop.
+
+        These values are expanded into the configuration the runtime then
+        trusts, so a file found beside the process rather than beside the
+        configuration is not this installation's environment.
+        """
+        home = tmp_path / "data"
+        home.mkdir()
+        cfg = home / "ori.yaml"
+        cfg.write_text("device: {}\n", encoding="utf-8")
+        elsewhere = tmp_path / "runtime-dir"
+        elsewhere.mkdir()
+        (elsewhere / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_the_working_directory\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+        monkeypatch.chdir(elsewhere)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    @pytest.mark.parametrize(
+        "posture",
+        [
+            "  deployment_profile: production\n",
+            "  deployment_profile: staging\n",
+        ],
+    )
+    def test_a_hardened_document_refuses_the_autoload(
+        self, posture: str, tmp_path: Path, monkeypatch
+    ):
+        """A signature covers the document before the values are substituted.
+
+        A file the service can write would otherwise decide what a signed
+        `${VAR}` field holds, and the signature would still verify.
+        """
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text("device:\n" + posture, encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_an_opted_in_development_document_refuses_it_too(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """`enforce_production_posture` is how a development box opts in."""
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text(
+            "device:\n  deployment_profile: development\n"
+            "security:\n  enforce_production_posture: true\n",
+            encoding="utf-8",
+        )
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_a_document_that_is_not_a_mapping_refuses_it(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """It parses, so nothing raises, and it still declares no posture."""
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text("- not\n- a mapping\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_a_document_that_cannot_be_read_refuses_it(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """An unreadable answer is not a reason to widen what is trusted."""
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text("device: [not, a, mapping\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_an_expanded_posture_field_refuses_the_autoload(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """Read unexpanded, `${ORI_POSTURE}` is neither staging nor production.
+
+        It would answer no to the question it decides, and the `.env` would
+        then be what supplies production.
+        """
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text(
+            "device:\n  deployment_profile: ${ORI_POSTURE}\n", encoding="utf-8"
+        )
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\nORI_POSTURE=production\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_an_expanded_enforcement_flag_refuses_the_autoload(
+        self, tmp_path: Path, monkeypatch
+    ):
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text(
+            "device:\n  deployment_profile: development\n"
+            "security:\n  enforce_production_posture: ${ORI_ENFORCE}\n",
+            encoding="utf-8",
+        )
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        _maybe_autoload_dotenv(str(cfg))
+
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") is None
+
+    def test_a_development_document_still_loads_it(self, tmp_path: Path, monkeypatch):
+        """The refusals must not have made the toggle useless."""
+        cfg = tmp_path / "ori.yaml"
+        cfg.write_text("device:\n  deployment_profile: development\n", encoding="utf-8")
+        (tmp_path / ".env").write_text(
+            "ORI_AUTOLOAD_SMOKE=from_dotenv\n", encoding="utf-8"
+        )
+
+        monkeypatch.setenv("ORI_AUTOLOAD_DOTENV", "true")
+        monkeypatch.delenv("ORI_AUTOLOAD_SMOKE", raising=False)
+
+        assert _maybe_autoload_dotenv(str(cfg)) is True
+        assert os.environ.get("ORI_AUTOLOAD_SMOKE") == "from_dotenv"
+        # The return value is what startup confirms against the posture the
+        # document turns out to declare; nothing is left in the environment.
+        assert "_ORI_DOTENV_AUTOLOADED" not in os.environ
 
 
 class TestAdapterProtocol:
@@ -2130,6 +2590,7 @@ class TestSkillReload:
 
             assert runtime._event_bus is not None
             loader = runtime._skill_loader
+            assert loader is not None
             expected = len(runtime._skill_subscriptions)
             assert expected == 64, f"expected 8 x 8 handlers, got {expected}"
 
@@ -2247,7 +2708,7 @@ class TestShutdown:
     async def test_shutdown_drains_tier_d_tasks(self, minimal_config, monkeypatch):
         """Runtime must await dispatcher-tracked Tier D tasks before shutdown."""
         _patch_external(monkeypatch)
-        runtime = OriRuntime(config_path=str(minimal_config))
+        runtime: Any = OriRuntime(config_path=str(minimal_config))
         completed: list[bool] = []
 
         async def _tier_d_work():
@@ -2355,10 +2816,12 @@ class TestSensorPolling:
             async def read(self, sensor_id: str) -> SensorReading:
                 raise AssertionError("read() should not be called")
 
+        _nevercalledadapter: Any = _NeverCalledAdapter
+
         bus = AsyncMock()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
         with caplog.at_level(logging.ERROR):
-            await runtime._poll_sensor(_NeverCalledAdapter(), sensor_cfg, bus, "dev-01")
+            await runtime._poll_sensor(_nevercalledadapter(), sensor_cfg, bus, "dev-01")
         assert "state_store unavailable for sensor poll task" in caplog.text
 
     async def test_sensor_read_error_does_not_crash_runtime(
@@ -2442,9 +2905,9 @@ class TestSensorPolling:
                     f"I2CAdapter: refused a current window on '{sensor_id}': clipped"
                 )
 
-        sensor_cfg = SimpleNamespace(id="load-current", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="load-current", poll_interval_ms=1)
         await runtime._poll_sensor(
-            _RefusingAdapter(), sensor_cfg, AsyncMock(), "dev-01"
+            cast(Any, _RefusingAdapter()), sensor_cfg, AsyncMock(), "dev-01"
         )
 
         assert "load-current" in runtime._measurement_degraded
@@ -2509,9 +2972,9 @@ class TestSensorPolling:
                     runtime._shutdown_event.set()
                 raise MeasurementRefusedError("refused a current window: clipped")
 
-        sensor_cfg = SimpleNamespace(id="load-current", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="load-current", poll_interval_ms=1)
         await runtime._poll_sensor(
-            _RefusingAdapter(), sensor_cfg, AsyncMock(), "dev-01"
+            cast(Any, _RefusingAdapter()), sensor_cfg, AsyncMock(), "dev-01"
         )
 
         assert await store.get_measurement_degradation() == {"load-current": False}
@@ -2552,10 +3015,10 @@ class TestSensorPolling:
                     runtime._shutdown_event.set()
                 raise MeasurementRefusedError("refused a current window: clipped")
 
-        sensor_cfg = SimpleNamespace(id="load-current", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="load-current", poll_interval_ms=1)
         # Must return normally rather than propagating the store failure.
         await runtime._poll_sensor(
-            _RefusingAdapter(), sensor_cfg, AsyncMock(), "dev-01"
+            cast(Any, _RefusingAdapter()), sensor_cfg, AsyncMock(), "dev-01"
         )
         assert attempts >= MEASUREMENT_REFUSALS_BEFORE_DEGRADED + 2, (
             "polling stopped when persistence failed"
@@ -2631,8 +3094,10 @@ class TestSensorPolling:
                     runtime._shutdown_event.set()
                 raise AdapterReadError("I2CAdapter: bus read failed")
 
-        sensor_cfg = SimpleNamespace(id="load-current", poll_interval_ms=1)
-        await runtime._poll_sensor(_FailingAdapter(), sensor_cfg, AsyncMock(), "dev-01")
+        _failingadapter: Any = _FailingAdapter
+
+        sensor_cfg: Any = SimpleNamespace(id="load-current", poll_interval_ms=1)
+        await runtime._poll_sensor(_failingadapter(), sensor_cfg, AsyncMock(), "dev-01")
 
         assert runtime._measurement_degraded == set()
         assert runtime._measurement_refusals == {}
@@ -2658,8 +3123,10 @@ class TestSensorPolling:
                 return reading
 
         bus = AsyncMock()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
-        await runtime._poll_sensor(_OneShotAdapter(), sensor_cfg, bus, "dev-01")
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        await runtime._poll_sensor(
+            cast(Any, _OneShotAdapter()), sensor_cfg, bus, "dev-01"
+        )
 
         event = bus.publish.call_args.args[0]
         assert isinstance(event.fingerprint, str)
@@ -2686,13 +3153,13 @@ class TestSensorPolling:
                 return reading
 
         bus = AsyncMock()
-        sensor_cfg = SimpleNamespace(
+        sensor_cfg: Any = SimpleNamespace(
             id="cpu-sensor",
             poll_interval_ms=1,
             calibration={"min_value": 0.0, "max_value": 100.0},
         )
         await runtime._poll_sensor(
-            _OneShotAdapter(),
+            cast(Any, _OneShotAdapter()),
             sensor_cfg,
             bus,
             "dev-01",
@@ -2716,7 +3183,7 @@ class TestSensorPolling:
         runtime = OriRuntime(config_path="ori.yaml")
         runtime._state_store = AsyncMock()
         bus = AsyncMock()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
 
         async def _run_once(reading: SensorReading) -> OriEvent:
             runtime._shutdown_event = asyncio.Event()
@@ -2726,7 +3193,9 @@ class TestSensorPolling:
                     runtime._shutdown_event.set()
                     return reading
 
-            await runtime._poll_sensor(_OneShotAdapter(), sensor_cfg, bus, "dev-01")
+            await runtime._poll_sensor(
+                cast(Any, _OneShotAdapter()), sensor_cfg, bus, "dev-01"
+            )
             return bus.publish.call_args.args[0]
 
         first = await _run_once(
@@ -2774,13 +3243,13 @@ class TestSensorPolling:
         )
 
         runtime._send_or_queue_alert.assert_awaited_once()
-        kwargs = runtime._send_or_queue_alert.await_args.kwargs
+        kwargs = runtime._send_or_queue_alert.await_args.kwargs  # type: ignore[union-attr]
         assert kwargs["trigger_name"] == "sensor_stale_warning"
         assert kwargs["channel"] == "sms"
         assert "sensor-x" in kwargs["message"]
 
     async def test_deduplicator_suppresses_identical_readings_within_5_seconds(self):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._shutdown_event = asyncio.Event()
 
         class _Store:
@@ -2811,7 +3280,7 @@ class TestSensorPolling:
 
         runtime._state_store = _Store()
         bus = _Bus()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
         readings = [
             SensorReading(
                 sensor_id="cpu-sensor",
@@ -2846,7 +3315,7 @@ class TestSensorPolling:
         assert len(runtime._state_store.events) == 2
 
     async def test_deduplicator_allows_identical_readings_after_6_seconds(self):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._shutdown_event = asyncio.Event()
 
         class _Store:
@@ -2877,7 +3346,7 @@ class TestSensorPolling:
 
         runtime._state_store = _Store()
         bus = _Bus()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
         readings = [
             SensorReading(
                 sensor_id="cpu-sensor",
@@ -2971,7 +3440,7 @@ class TestSensorPolling:
                 return reading
 
         bus = _Bus()
-        sensor_cfg = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
+        sensor_cfg: Any = SimpleNamespace(id="cpu-sensor", poll_interval_ms=1)
         readings = [
             SensorReading(
                 sensor_id="cpu-sensor",
@@ -2996,9 +3465,9 @@ class TestSensorPolling:
         try:
             with patch("ori.network.deduplicator.now_ms", side_effect=[1_000, 2_000]):
                 await runtime._poll_sensor(
-                    _SequenceAdapter(readings),
+                    cast(Any, _SequenceAdapter(readings)),
                     sensor_cfg,
-                    bus,
+                    cast(Any, bus),
                     "dev-01",
                     EventDeduplicator(),
                 )
@@ -3021,6 +3490,8 @@ class TestCompactionLoop:
             def cleanup(self) -> None:
                 cleanup_calls["count"] += 1
 
+        _dedup: Any = _Dedup
+
         async def _compact(*_args, **_kwargs) -> None:
             runtime._shutdown_event.set()
 
@@ -3036,7 +3507,7 @@ class TestCompactionLoop:
             "ori.runtime.asyncio.wait_for",
             new=AsyncMock(side_effect=_fake_wait_for),
         ):
-            await runtime._compaction_loop(_Dedup())
+            await runtime._compaction_loop(_dedup())
 
         runtime._state_store.compact_history.assert_awaited_once_with(
             max_backward_skew_ms=3600000
@@ -3569,7 +4040,7 @@ class TestAlertOutbox:
             await runtime._state_store.close()
 
     async def test_send_or_queue_alert_never_caps_tier_d(self, tmp_path):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = StateStore(str(tmp_path / "alert-cap-tier-d.db"))
         await runtime._state_store.open()
         dispatcher = ActionDispatcher()
@@ -3609,7 +4080,7 @@ class TestAlertOutbox:
     async def test_send_or_queue_alert_ignores_alert_count_persistence_failure(
         self, tmp_path
     ):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = StateStore(str(tmp_path / "alert-count-failure.db"))
         await runtime._state_store.open()
         dispatcher = ActionDispatcher()
@@ -3650,7 +4121,7 @@ class TestAlertOutbox:
             await runtime._state_store.close()
 
     async def test_remote_command_incident_emits_tier_a_alert(self, tmp_path):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = StateStore(str(tmp_path / "remote-lockout.db"))
         await runtime._state_store.open()
         runtime._primary_alert_channel = "sms"
@@ -3681,7 +4152,7 @@ class TestAlertOutbox:
             await runtime._handle_remote_command_incident(decision)
 
             runtime._send_or_queue_alert.assert_awaited_once()
-            kwargs = runtime._send_or_queue_alert.await_args.kwargs
+            kwargs = runtime._send_or_queue_alert.await_args.kwargs  # type: ignore[union-attr]
             assert kwargs["channel"] == "sms"
             assert kwargs["recipient"] == "+2340000000000"
             assert kwargs["action_tier"] == "A"
@@ -3697,7 +4168,7 @@ class TestAlertOutbox:
     async def test_load_remote_command_lockout_state_from_persisted_incidents(
         self, tmp_path, monkeypatch
     ):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = StateStore(str(tmp_path / "remote-lockout-load.db"))
         await runtime._state_store.open()
         now = 1_780_000_000_000
@@ -3740,7 +4211,7 @@ class TestAlertOutbox:
             await runtime._state_store.close()
 
     def _bare_health_runtime(self, tmp_path) -> OriRuntime:
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._device_id = "dev-01"
         runtime._config = SimpleNamespace(
             gateway=SimpleNamespace(enabled=False, broker_url="", broker_posture={}),
@@ -3759,7 +4230,7 @@ class TestAlertOutbox:
         """`runtime-health/v2` types the field as an array and reads absence
         as unknown, so a device with no registry must omit the key rather than
         carry a null a consumer would iterate."""
-        runtime = self._bare_health_runtime(tmp_path)
+        runtime: Any = self._bare_health_runtime(tmp_path)
 
         snapshot = await runtime._build_health_snapshot()
 
@@ -3771,7 +4242,7 @@ class TestAlertOutbox:
         """An empty array is a device with no eligible pair, which is not the
         same statement as absence. The pairs themselves are produced and
         proven in `tests/safety/test_registry.py`; this is the wiring."""
-        runtime = self._bare_health_runtime(tmp_path)
+        runtime: Any = self._bare_health_runtime(tmp_path)
         runtime._safety_registry = SimpleNamespace(
             health_snapshot=lambda: {},
             safety_zones=lambda: [],
@@ -3797,7 +4268,7 @@ class TestAlertOutbox:
         undertaken to protect is not being protected — and commissioning
         problems already degrade for the same class of fact one step earlier.
         """
-        runtime = self._bare_health_runtime(tmp_path)
+        runtime: Any = self._bare_health_runtime(tmp_path)
         runtime._safety_registry = SimpleNamespace(
             health_snapshot=lambda: {},
             safety_zones=lambda: [self._zone("active", "unprotected")],
@@ -3811,7 +4282,7 @@ class TestAlertOutbox:
         assert snapshot.get("critical") is not True
 
     async def test_an_active_protected_pair_leaves_the_snapshot_healthy(self, tmp_path):
-        runtime = self._bare_health_runtime(tmp_path)
+        runtime: Any = self._bare_health_runtime(tmp_path)
         runtime._safety_registry = SimpleNamespace(
             health_snapshot=lambda: {},
             safety_zones=lambda: [self._zone("active", "protected")],
@@ -3835,7 +4306,7 @@ class TestAlertOutbox:
         Degrading on those would leave every device carrying a candidate
         profile permanently degraded — which is every device today.
         """
-        runtime = self._bare_health_runtime(tmp_path)
+        runtime: Any = self._bare_health_runtime(tmp_path)
         runtime._safety_registry = SimpleNamespace(
             health_snapshot=lambda: {},
             safety_zones=lambda: [self._zone(activation, "unprotected")],
@@ -3850,7 +4321,7 @@ class TestAlertOutbox:
     ):
         encrypted_dir = tmp_path / "encrypted"
         encrypted_dir.mkdir()
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._device_id = "dev-01"
         database_path = encrypted_dir / "ori_state.db"
         runtime._config = SimpleNamespace(
@@ -3882,7 +4353,7 @@ class TestAlertOutbox:
         assert str(encrypted_dir) not in json.dumps(posture)
 
     async def test_health_snapshot_reports_gateway_broker_posture(self):
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._device_id = "dev-01"
         runtime._config = SimpleNamespace(
             gateway=SimpleNamespace(
@@ -3927,7 +4398,7 @@ class TestAlertOutbox:
             ):
                 raise RuntimeError("incident query failed")
 
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = _FailingIncidentStore()
         runtime._remote_command_lockout_states["sms:+2348012345678"] = {
             "channel": "sms",
@@ -3954,7 +4425,7 @@ class TestAlertOutbox:
         now = 1_780_000_000_000
         monkeypatch.setattr("ori.runtime.now_ms", lambda: now)
         store = _CapturingIncidentStore()
-        runtime = OriRuntime(config_path="ori.yaml")
+        runtime: Any = OriRuntime(config_path="ori.yaml")
         runtime._state_store = store
         runtime._remote_command_lockout_config = {
             "risk_window_ms": 120_000,
@@ -4028,7 +4499,7 @@ class TestRemoteDevicePolicy:
             "ori.runtime.fetch_remote_device_policy_bundle", _fake_fetch
         )
 
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-01"),
             device_policy={
                 "enabled": True,
@@ -4070,7 +4541,7 @@ class TestRemoteDevicePolicy:
             "ori.runtime.fetch_remote_device_policy_bundle", _fake_fetch
         )
 
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-02"),
             device_policy={
                 "enabled": True,
@@ -4125,7 +4596,7 @@ class TestRemoteDevicePolicy:
             signature=str(payload["signature"]),
             raw_payload=raw_payload,
         )
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-cache-01"),
             device_policy={"public_key_b64": public_key_b64},
         )
@@ -4161,7 +4632,7 @@ class TestRemoteDevicePolicy:
             signature=str(payload["signature"]),
             raw_payload=raw_payload,
         )
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-cache-02"),
             device_policy={"public_key_b64": wrong_public_key_b64},
         )
@@ -4221,7 +4692,7 @@ class TestRemoteDevicePolicy:
             "ori.runtime.fetch_remote_device_policy_bundle",
             _fake_fetch,
         )
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-refresh-01"),
             device_policy={
                 "enabled": True,
@@ -4267,7 +4738,7 @@ class TestRemoteDevicePolicy:
             "ori.runtime.fetch_remote_device_policy_bundle",
             _fake_fetch,
         )
-        cfg = SimpleNamespace(
+        cfg: Any = SimpleNamespace(
             device=SimpleNamespace(id="dev-refresh-02"),
             device_policy={
                 "enabled": True,

--- a/tests/test_runtime_health_socket.py
+++ b/tests/test_runtime_health_socket.py
@@ -6,6 +6,7 @@ import json
 import os
 import socket
 from types import SimpleNamespace
+from typing import Any
 
 import pytest
 
@@ -106,7 +107,7 @@ async def test_health_socket_refuses_non_socket_existing_path(tmp_path):
 
 @pytest.mark.asyncio
 async def test_runtime_health_snapshot_shape():
-    runtime = OriRuntime(config_path="ori.yaml")
+    runtime: Any = OriRuntime(config_path="ori.yaml")
     now = now_ms()
     runtime._device_id = "dev-01"
     runtime._runtime_started_at_ms = now - 5_000

--- a/tests/test_skill_loader.py
+++ b/tests/test_skill_loader.py
@@ -5,6 +5,7 @@ import asyncio
 import base64
 import textwrap
 from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -22,15 +23,22 @@ from ori.skills.loader import (
 from ori.skills.sandbox import SkillSecurityError
 from ori.skills.signing import canonical_skill_payload
 
-try:
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import (
-        Ed25519PrivateKey,
-    )
+if TYPE_CHECKING:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
     from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
-except Exception:  # pragma: no cover - environment without cryptography support
-    Ed25519PrivateKey = None
-    Encoding = None
-    PublicFormat = None
+else:  # pragma: no cover - environment without cryptography support
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+            Ed25519PrivateKey,
+        )
+        from cryptography.hazmat.primitives.serialization import (
+            Encoding,
+            PublicFormat,
+        )
+    except Exception:
+        Ed25519PrivateKey = None
+        Encoding = None
+        PublicFormat = None
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 

--- a/tests/test_sms.py
+++ b/tests/test_sms.py
@@ -9,6 +9,7 @@ at the module level via monkeypatch so no live credentials are required.
 
 import sys
 import types
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -20,7 +21,7 @@ from ori.actions.sms import SMSAction
 
 def _make_at_stub(status: str = "Success") -> types.ModuleType:
     """Build a minimal africastalking module stub that returns *status*."""
-    stub = types.ModuleType("africastalking")
+    stub: Any = types.ModuleType("africastalking")
 
     class _SMS:
         @staticmethod
@@ -37,7 +38,7 @@ def _make_at_stub(status: str = "Success") -> types.ModuleType:
 
 
 def _make_at_stub_empty_recipients() -> types.ModuleType:
-    stub = types.ModuleType("africastalking")
+    stub: Any = types.ModuleType("africastalking")
     stub.SMS = type(
         "_SMS",
         (),
@@ -52,7 +53,7 @@ def _make_at_stub_empty_recipients() -> types.ModuleType:
 
 
 def _make_at_stub_raises() -> types.ModuleType:
-    stub = types.ModuleType("africastalking")
+    stub: Any = types.ModuleType("africastalking")
 
     class _SMS:
         @staticmethod
@@ -116,7 +117,7 @@ async def test_send_passes_message_and_number_to_sdk(monkeypatch):
     send_calls: list[tuple] = []
     init_calls: list[tuple] = []
 
-    stub = types.ModuleType("africastalking")
+    stub: Any = types.ModuleType("africastalking")
 
     class _SMS:
         @staticmethod
@@ -151,7 +152,7 @@ async def test_send_uses_at_sender_id_env_var(monkeypatch):
     monkeypatch.setenv("AT_SENDER_ID", "MYAPP")
     calls: list[str] = []
 
-    stub = types.ModuleType("africastalking")
+    stub: Any = types.ModuleType("africastalking")
 
     class _SMS:
         @staticmethod

--- a/tests/test_sms_webhook.py
+++ b/tests/test_sms_webhook.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -37,6 +38,10 @@ class _FakeWriter:
 
     async def wait_closed(self) -> None:
         return None
+
+
+#: Structural double for the declared parameter type.
+_fakewriter: Any = _FakeWriter
 
 
 @pytest.mark.asyncio
@@ -77,7 +82,7 @@ async def test_handle_client_rejects_disallowed_source_before_parsing():
     )
     server._read_request = AsyncMock()
     reader = asyncio.StreamReader()
-    writer = _FakeWriter(peername=("198.51.100.10", 12345))
+    writer = _fakewriter(peername=("198.51.100.10", 12345))
 
     await server._handle_client(reader, writer)
 
@@ -161,7 +166,7 @@ async def test_handle_client_returns_401_when_token_invalid():
         )
     )
     reader = asyncio.StreamReader()
-    writer = _FakeWriter()
+    writer = _fakewriter()
 
     await server._handle_client(reader, writer)
 
@@ -187,7 +192,7 @@ async def test_handle_client_returns_200_for_valid_request():
         )
     )
     reader = asyncio.StreamReader()
-    writer = _FakeWriter()
+    writer = _fakewriter()
 
     await server._handle_client(reader, writer)
 
@@ -215,7 +220,7 @@ async def test_handle_client_rejects_query_token_fallback():
         )
     )
     reader = asyncio.StreamReader()
-    writer = _FakeWriter()
+    writer = _fakewriter()
 
     await server._handle_client(reader, writer)
 
@@ -247,7 +252,7 @@ async def test_handle_client_rejects_unsigned_hmac_webhook_before_parsing():
         )
     )
     reader = asyncio.StreamReader()
-    writer = _FakeWriter()
+    writer = _fakewriter()
 
     await server._handle_client(reader, writer)
 
@@ -291,7 +296,7 @@ async def test_handle_client_accepts_signed_hmac_webhook():
         )
     )
     reader = asyncio.StreamReader()
-    writer = _FakeWriter()
+    writer = _fakewriter()
 
     await server._handle_client(reader, writer)
 

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -86,8 +86,10 @@ class TestLifecycle:
     async def test_open_creates_tables(self, tmp_path):
         s = StateStore(db_path=str(tmp_path / "lifecycle.db"))
         await s.open()
+        conn = s._conn
+        assert conn is not None
         tables = await s._run(
-            lambda: s._conn.execute(
+            lambda: conn.execute(
                 "SELECT name FROM sqlite_master WHERE type='table'"
             ).fetchall()
         )

--- a/tests/test_truthful_operator_output.py
+++ b/tests/test_truthful_operator_output.py
@@ -23,6 +23,7 @@ by command-level tests in tests/firmware/test_provisioner.py.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
 import yaml
@@ -73,6 +74,10 @@ class _StubConfig:
         self.gateway = _StubGateway(broker_url)
 
 
+#: Structural double for the declared parameter type.
+_stubconfig: Any = _StubConfig
+
+
 @pytest.mark.parametrize(
     "broker_url",
     [
@@ -90,7 +95,7 @@ def test_credentialed_loopback_broker_logs_no_security_error(broker_url, caplog)
     it matched no prefix and was reported as an unauthenticated public broker.
     """
     with caplog.at_level(logging.WARNING):
-        _warn_gateway_security_posture(_StubConfig(broker_url))
+        _warn_gateway_security_posture(_stubconfig(broker_url))
 
     errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
     assert errors == [], f"false security ERROR for loopback broker: {errors}"
@@ -99,7 +104,7 @@ def test_credentialed_loopback_broker_logs_no_security_error(broker_url, caplog)
 def test_non_loopback_broker_without_auth_still_logs_error(caplog):
     """The fix must not silence the alarm it exists to make accurate."""
     with caplog.at_level(logging.WARNING):
-        _warn_gateway_security_posture(_StubConfig("mqtt://user:pass@10.0.0.5:1883"))
+        _warn_gateway_security_posture(_stubconfig("mqtt://user:pass@10.0.0.5:1883"))
 
     errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
     assert errors, "a real public unauthenticated broker must still raise ERROR"

--- a/tests/test_whatsapp.py
+++ b/tests/test_whatsapp.py
@@ -8,6 +8,7 @@ All tests use a fake in-process provider — no Twilio credentials required.
 
 import sys
 import types
+from typing import Any, cast
 
 import pytest
 
@@ -298,7 +299,7 @@ async def test_twilio_provider_rate_limit_backoff_skips_immediate_repoll(monkeyp
             def list(**_kwargs):
                 return []
 
-    twilio_rest_mod.Client = _FakeClient
+    cast(Any, twilio_rest_mod).Client = _FakeClient
     monkeypatch.setitem(sys.modules, "twilio", twilio_mod)
     monkeypatch.setitem(sys.modules, "twilio.rest", twilio_rest_mod)
 


### PR DESCRIPTION
## What does this PR do?

A GPIO library creates its notification pipe in the process working directory and never removes it. The unit worked in the data directory, whose invariant is that it holds regular files only, so a device that had driven GPIO refused its own reinstall with `special files are forbidden` and no indication of what had been found or where. The devices most likely to meet it are exactly the ones that have been used.

The unit now declares a runtime directory of its own and works there. systemd creates it and removes it when the service stops, so an artefact any library leaves beside the process is gone by the time an installer looks — whichever library, whichever platform. The alternative was to tolerate the pipe by name, and that is worse: it keys the install root's invariant to one library's filename, and a device that had run under a different GPIO backend would still be refused. Prevention costs nothing that tolerance saves.

Moving the working directory changes what every relative path in the configuration means, and that is most of this change. Each is resolved against the directory holding the document that declared it, as the store and the skills directory already were: `logging.file`, `evidence.db_path`, `evidence.key_path`, `skills_dir`, `health_socket.path`, `reasoning.model_path`, and the gateway and sensor TLS material. Two of those matter beyond convenience. The evidence key is sealed on first use, so a runtime reading one configuration from two working directories would seal two device identities for one device. Skills resolved into a directory systemd empties would load nothing, and a runtime with no skills reports healthy while carrying none of their triggers.

A device endpoint is deliberately not anchored, because it names a node the host owns rather than a file beside the document; there is no directory it would be relative to. It must be absolute, or a URL where its transport can open one, and which of those applies is the consumer's own rule rather than a shared one. `sensors[*].port` on `protocol: serial` and `actions.sms.gsm.port` are opened with `Serial()`, which takes a port name, so a URL is refused rather than admitted and left to fail at the first read. `sensors[*].device_path` on `protocol: usb_serial` is handed to `serial_for_url`, so it still accepts `socket://` and every other form that reaches. `sensors[*].device` on `protocol: smart` arrives at `smartctl` as an argument, so requiring it absolute also keeps a value beginning with a dash from being read there as an option.

`ORI_AUTOLOAD_DOTENV` is refused under staging or production posture, and under a development deployment that has opted into it. A configuration signature covers the document before `${VAR}` fields are expanded, so a `.env` in the data directory the service can write would decide what a signed field holds while the signature still verified. The decision has to be made before the configuration that settles it can be read, so the posture is read from the document directly through the same admission path the loader uses; a field that is itself expanded is treated as hardened, since unexpanded it says nothing while what it expands to is exactly what is being decided; and startup then confirms the decision against the posture the loaded document declares, which is where the truth is finally known.

The refusal that started all this now names the offending path and its file type, and tells the operator to stop the service first, because a running runtime recreates what it made. The permission walk opens each file it plans to change, and opening a pipe waits for a writer that never comes, so it opens non-blocking: the service owns that tree and is still running during an upgrade, and a file validated during planning can be a pipe by the time it is opened.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes. No action, tier, executor or registry entry is added or altered, and no capability gains or loses a path. What changes is where a already-permitted read or write resolves to, and the credential the service process is started with.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D code path is added.

## Related issue

Closes #550
Refs #560

## Testing notes

Proven on the bench Pi with a real unit file rather than a transient one, because `systemd-run --property=` does not expand specifiers and `systemd-analyze verify` accepts the directive either way — so verification alone would have supported a claim that had not been tested. Under the old shape the pipe is created in the working directory and left there after the unit exits. Under the new shape the service reports `cwd=/run/oriprobe fifos_in_cwd=['.lgd-nfy0']`, that directory holds the pipe while the unit is up, and the whole directory is gone after `systemctl stop`. The install root is never touched, which means something only because the positive half shows the pipe was created somewhere.

The anchoring is proven on the same device against its own `/opt/ori/data/ori.yaml`, run from three working directories. The installed release resolves `ori_state.db`, `ori.log` and `ori_evidence.key` as bare relative names; this change resolves all of them under `/opt/ori/data` from `/`, from the data directory, and from a `/run` directory. That is what makes the working-directory move safe rather than destructive: without it the sealed evidence key would have landed on a tmpfs and been destroyed on every stop. The tree was staged under `/tmp`, driven by the installed venv's interpreter, and removed; the service was not restarted and its unit was not replaced.

Thirty-three tests, each driven through a real entry point — `Config.load`, `cli_bridge.main`, a runtime started from a foreign working directory, and `main()` itself, since the constructor's default would otherwise let a caller silently get a runtime that never confirms its dotenv decision. Every boundary is mutation-checked and each mutation is refused by the test named for that property, including one that can only be killed by blocking: removing the non-blocking open makes the installer wait for a writer that never comes, so that test fails by hanging rather than by asserting.

A tolerance keyed to one library's filename was built and then removed rather than shipped, because it would refuse a device that had run under a different GPIO backend.

The permission apply checks both what it opened and which inode it opened, and neither subsumes the other. That was found the hard way: the file-type check was added, then removed as unkillable on the reasoning that a different type necessarily has a different inode, and restored when CI failed on Linux. An inode number is reused immediately after `unlink` on the filesystems these installs run on — measured, a regular file replaced by a pipe keeps the same number — so the identity check alone cannot see that substitution, and only the type says it happened. The mutation that removes the type check survives on macOS and kills on Linux, which is why the installer suite is run in a Linux container rather than trusted from a developer machine. A substitution that preserves both type and inode is not detectable this way and is not claimed to be; the test asserting it was removed rather than left passing on one platform.

A relative device endpoint is a compatibility change, not the tightening of something that could never have worked — a relative name does reach a device through a symlink in the working directory. A development workflow that ran `--config /elsewhere/ori.yaml` while relying on a `.env` in the current directory must move that file beside the configuration or export the variables; an installed service is unaffected, since its unit reads `EnvironmentFile`.

Two things remain unproven on hardware and are deliberately left for the release cut: the real service running under this unit, and the upgrade path where a stale artefact triggers the named refusal. Both need an installer-built release and a supervised cutover rather than a hand-placed unit.

