### PR TITLE
fix(output): print no filesystem name an operator's terminal will obey

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -138,6 +138,31 @@ candidate or release is cut.
   appeared to have taken no actions rather than a lookup that went elsewhere.
   An absent store is now refused and named, and a refusal distinguishes a store
   that is missing from a path that is not a file.
+- Installer and doctor output no longer prints a filesystem name raw. A
+  refusal is produced when something about a path is already wrong, which is
+  when an operator reads most carefully and distrusts least, and the name in it
+  is not always one they chose: a walk over a path's parents reports whichever
+  component failed, and a directory listing reports whatever it found. An
+  escape sequence that erases the line it is printed on, a newline that forges
+  a second diagnostic, a carriage return that overwrites the first and a bidi
+  mark that reverses the rest all now arrive escaped.
+- An error `detail` stays one message rather than becoming two. It is prose
+  for an operator, not a machine-readable path field, so the path in it is
+  escaped in the JSON form too; a consumer recovering a path by parsing that
+  sentence was never reliable, which is the mistake `offending_path` made.
+- A remedy is quoted for a shell rather than escaped for a terminal, because it
+  is a command an operator copies and runs. A path containing a newline would
+  otherwise have ended that command and run what followed as the next one. The
+  path stays a single argument.
+- A configuration error names its path escaped as well. The loader wrote
+  `'{path}'`, which looks quoted and is not escaped, and `ori config validate`
+  appends that message to a line of its own, so escaping only the outer line
+  left the name it reports untouched. The same treatment reaches the config
+  installer, the firmware provisioner, the inverter profile doctor and the
+  phone doctor's report header.
+- `ori doctor` reports the offending release path whole. The machine-readable
+  `offending_path` was recovered by splitting the human sentence on its first
+  space, so any release path containing one was reported truncated.
 - The service works in a runtime directory of its own rather than in the
   directory it keeps state in. A GPIO library creates its notification pipe in
   the working directory and never removes it, and the install root admits

--- a/ori/cli.py
+++ b/ori/cli.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import IO, Any, Sequence
 
 from ori.utils import terminal
+from ori.utils.path_utils import shown
 
 
 def _version() -> str:
@@ -373,7 +374,8 @@ def _resolve(args: argparse.Namespace) -> tuple[Any, str] | int:
         # code did not anticipate, and a diagnostic command must report it
         # rather than end in a traceback.
         print(
-            f"ori: could not inspect the installation ({exc.filename or exc}): "
+            f"ori: could not inspect the installation "
+            f"({shown(exc.filename) if exc.filename else exc}): "
             f"{exc.strerror or exc}. Pass --scope user or --scope system "
             "explicitly.",
             file=sys.stderr,
@@ -420,7 +422,9 @@ def _run_config_validate(args: argparse.Namespace) -> int:
     stream = _out(args)
     if status == 0:
         _emit(
-            args, payload, terminal.success(f"Config is valid: {path}", stream=stream)
+            args,
+            payload,
+            terminal.success(f"Config is valid: {shown(path)}", stream=stream),
         )
         return EXIT_OK
     detail = payload.get("error", {})
@@ -428,7 +432,7 @@ def _run_config_validate(args: argparse.Namespace) -> int:
     _emit(
         args,
         payload,
-        terminal.failure(f"Config is not valid: {path}", stream=stream)
+        terminal.failure(f"Config is not valid: {shown(path)}", stream=stream)
         + f"\n  {message}",
     )
     return EXIT_FAILED

--- a/ori/config.py
+++ b/ori/config.py
@@ -35,7 +35,7 @@ from ori.security.remote_commands.commands import normalize_remote_command_sende
 from ori.security.remote_commands.lockout import normalize_remote_command_lockout_config
 from ori.utils.bool_utils import is_truthy
 from ori.utils.net_utils import is_loopback_host
-from ori.utils.path_utils import path_is_relative_to
+from ori.utils.path_utils import path_is_relative_to, shown
 
 logger = logging.getLogger(__name__)
 
@@ -312,13 +312,15 @@ def _load_config_document(text: str, path: str, *, expand_env: bool = False) -> 
         return yaml.load(text, Loader=loader)
     except _ConfigDocumentLimitError as exc:
         raise ConfigValidationError(
-            f"Config file '{path}' exceeds document limits: {exc}"
+            f"Config file {shown(path)} exceeds document limits: {exc}"
         ) from exc
     except yaml.YAMLError as exc:
-        raise ConfigValidationError(f"YAML parse error in '{path}': {exc}") from exc
+        raise ConfigValidationError(
+            f"YAML parse error in {shown(path)}: {exc}"
+        ) from exc
     except Exception as exc:
         raise ConfigValidationError(
-            f"Config file '{path}' could not be parsed: {type(exc).__name__}: {exc}"
+            f"Config file {shown(path)} could not be parsed: {type(exc).__name__}: {exc}"
         ) from exc
 
 
@@ -353,16 +355,18 @@ def read_config_bytes(path: str, *, max_bytes: int = _MAX_CONFIG_BYTES) -> bytes
     except OSError as exc:
         if exc.errno == errno.ELOOP:
             raise ConfigValidationError(
-                f"Config file '{path}' is a symbolic link, which is refused. "
+                f"Config file {shown(path)} is a symbolic link, which is refused. "
                 "Point the configuration path at the file itself."
             ) from exc
-        raise ConfigValidationError(f"Cannot read config file '{path}': {exc}") from exc
+        raise ConfigValidationError(
+            f"Cannot read config file {shown(path)}: {exc}"
+        ) from exc
 
     try:
         status = os.fstat(descriptor)
         if not stat.S_ISREG(status.st_mode):
             raise ConfigValidationError(
-                f"Config file '{path}' is not a regular file. A FIFO, device or "
+                f"Config file {shown(path)} is not a regular file. A FIFO, device or "
                 "directory cannot be a configuration document."
             )
         # Read one byte past the cap rather than trusting the size `fstat`
@@ -378,13 +382,15 @@ def read_config_bytes(path: str, *, max_bytes: int = _MAX_CONFIG_BYTES) -> bytes
             chunks.append(chunk)
             total += len(chunk)
     except OSError as exc:
-        raise ConfigValidationError(f"Cannot read config file '{path}': {exc}") from exc
+        raise ConfigValidationError(
+            f"Cannot read config file {shown(path)}: {exc}"
+        ) from exc
     finally:
         os.close(descriptor)
 
     if total > max_bytes:
         raise ConfigValidationError(
-            f"Config file '{path}' is larger than the {max_bytes} byte "
+            f"Config file {shown(path)} is larger than the {max_bytes} byte "
             "limit for a configuration document."
         )
     return b"".join(chunks)
@@ -403,7 +409,7 @@ def _read_config_text(path: str) -> str:
         return raw.decode("utf-8")
     except UnicodeDecodeError as exc:
         raise ConfigValidationError(
-            f"Config file '{path}' is not valid UTF-8: {exc}"
+            f"Config file {shown(path)} is not valid UTF-8: {exc}"
         ) from exc
 
 
@@ -674,7 +680,7 @@ class Config:
             raise
         except Exception as exc:
             raise ConfigValidationError(
-                f"Config file '{path}' could not be interpreted: "
+                f"Config file {shown(path)} could not be interpreted: "
                 f"{type(exc).__name__}: {exc}"
             ) from exc
 
@@ -686,7 +692,7 @@ class Config:
 
         if not isinstance(raw_unexpanded, dict):
             raise ConfigValidationError(
-                f"Config file '{path}' must be a YAML mapping at the top level."
+                f"Config file {shown(path)} must be a YAML mapping at the top level."
             )
 
         try:
@@ -710,7 +716,7 @@ class Config:
 
         if not isinstance(data, dict):
             raise ConfigValidationError(
-                f"Config file '{path}' must be a YAML mapping at the top level."
+                f"Config file {shown(path)} must be a YAML mapping at the top level."
             )
 
         device = _parse_device(data.get("device", {}))
@@ -3300,14 +3306,14 @@ def _resolve_database_path(declared: str, config_path: str) -> str:
         # name in the working directory is a coincidence as often as it is that
         # deployment, so this reports rather than refuses.
         logger.warning(
-            "[config] database.path %r resolves to %s, which does not exist, "
+            "[config] database.path %s resolves to %s, which does not exist, "
             "while a file of that name exists at %s. A relative database.path "
             "is resolved against the directory holding the configuration, not "
             "the working directory. If that file is this device's store, move "
             "it beside the configuration or declare database.path absolutely.",
-            declared,
-            resolved,
-            legacy.resolve(strict=False),
+            shown(declared),
+            shown(resolved),
+            shown(legacy.resolve(strict=False)),
         )
     return str(resolved)
 

--- a/ori/config_installer.py
+++ b/ori/config_installer.py
@@ -25,6 +25,7 @@ from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 from ori.config import Config, ConfigValidationError, read_config_bytes
+from ori.utils.path_utils import shown
 
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 # Named apart from `ori.config._MAX_SOURCE_CONFIG_BYTES`, which bounds the runtime's
@@ -172,7 +173,9 @@ def _read_source(
     try:
         return read_config_bytes(str(path), max_bytes=_MAX_SOURCE_CONFIG_BYTES)
     except ConfigValidationError as exc:
-        raise ConfigInstallError(f"cannot read generated config {path}: {exc}") from exc
+        raise ConfigInstallError(
+            f"cannot read generated config {shown(path)}: {exc}"
+        ) from exc
 
 
 def _fetch_https_source(
@@ -339,12 +342,12 @@ def main(argv: list[str] | None = None) -> int:
     elif result.dry_run:
         print(
             "Verified signed Ori config for "
-            f"{result.device_id}; dry run did not write {result.destination}."
+            f"{result.device_id}; dry run did not write {shown(result.destination)}."
         )
     else:
         print(
             "Installed signed Ori config for "
-            f"{result.device_id} at {result.destination}."
+            f"{result.device_id} at {shown(result.destination)}."
         )
     return 0
 

--- a/ori/doctor.py
+++ b/ori/doctor.py
@@ -25,9 +25,11 @@ import subprocess
 import sys
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
+from shlex import quote
 from typing import Any, Callable, Sequence
 
 from ori.utils import terminal
+from ori.utils.path_utils import shown
 
 PASS = terminal.PASS
 WARN = terminal.WARN
@@ -114,7 +116,7 @@ def assert_execution_allowed(identity: InstallIdentity) -> None:
     if identity.scope == "user":
         raise UnsafeExecutionError(
             "refusing to execute a user-scope installation as root: "
-            f"{identity.active_release} is writable by its owner. "
+            f"{shown(identity.active_release)} is writable by its owner. "
             "Re-run without sudo, as the user who owns the installation."
         )
     # A `system` label is a claim, not a guarantee: it can be supplied
@@ -175,7 +177,7 @@ def check_paths(identity: InstallIdentity) -> list[DoctorCheck]:
             status=PASS,
             message=(
                 f"Ori {identity.version} installed in {identity.scope} scope at "
-                f"{identity.install_root}"
+                f"{shown(identity.install_root)}"
             ),
             details=identity.as_dict(),
         )
@@ -189,7 +191,7 @@ def check_config(identity: InstallIdentity, runner: CommandRunner) -> list[Docto
             DoctorCheck(
                 name="config.present",
                 status=FAIL,
-                message=f"Config not found at {identity.config_path}",
+                message=f"Config not found at {shown(identity.config_path)}",
                 mandatory=True,
                 remedy="Reinstall, or restore the config from backup.",
             )
@@ -199,9 +201,9 @@ def check_config(identity: InstallIdentity, runner: CommandRunner) -> list[Docto
             DoctorCheck(
                 name="config.readable",
                 status=FAIL,
-                message=f"Config is not readable: {identity.config_path}",
+                message=f"Config is not readable: {shown(identity.config_path)}",
                 mandatory=True,
-                remedy=f"Check ownership and mode on {identity.config_path}.",
+                remedy=f"Check ownership and mode on {shown(identity.config_path)}.",
             )
         ]
     result = _run(
@@ -231,7 +233,7 @@ def check_config(identity: InstallIdentity, runner: CommandRunner) -> list[Docto
             status=FAIL,
             message="Config failed validation.",
             mandatory=True,
-            remedy=f"Run: ori config validate --path {identity.config_path}",
+            remedy=f"Run: ori config validate --path {quote(str(identity.config_path))}",
             details={"detail": _error_detail(result.stdout)},
         )
     ]
@@ -584,9 +586,11 @@ def _reachable(
         return DoctorCheck(
             name=name,
             status=FAIL,
-            message=(f"{service.name} cannot search {blocked} on the way to {target}."),
+            message=(
+                f"{service.name} cannot search {shown(blocked)} on the way to {shown(target)}."
+            ),
             mandatory=True,
-            remedy=f"Grant search access: chmod o+x {blocked}",
+            remedy=f"Grant search access: chmod o+x {quote(str(blocked))}",
             details={"blocked_at": str(blocked)},
         )
     missing = [
@@ -616,7 +620,7 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
             DoctorCheck(
                 name="permissions.data",
                 status=FAIL,
-                message=f"Data directory is missing: {identity.data_path}",
+                message=f"Data directory is missing: {shown(identity.data_path)}",
                 mandatory=True,
                 remedy="Reinstall to recreate it.",
             )
@@ -630,7 +634,7 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
                 status=FAIL,
                 message="Cannot resolve the account the service runs as.",
                 mandatory=True,
-                remedy=f"Check User= in {identity.unit_path} and that it exists.",
+                remedy=f"Check User= in {shown(identity.unit_path)} and that it exists.",
             )
         ]
     if identity.scope == "system" and service.uid == 0:
@@ -640,7 +644,7 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
                 status=FAIL,
                 message=f"System service runs as root ({service.name}).",
                 mandatory=True,
-                remedy=f"Set User=ori-runtime in {identity.unit_path}.",
+                remedy=f"Set User=ori-runtime in {shown(identity.unit_path)}.",
                 details={"service_user": service.name, "uid": service.uid},
             )
         ]
@@ -663,9 +667,9 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
             service,
             needs=EXECUTE,
             directory=True,
-            ok_message=f"{service.name} can reach {identity.install_root}.",
-            bad_message=f"{service.name} cannot search {identity.install_root}.",
-            remedy=f"Grant search access: chmod o+x {identity.install_root}",
+            ok_message=f"{service.name} can reach {shown(identity.install_root)}.",
+            bad_message=f"{service.name} cannot search {shown(identity.install_root)}.",
+            remedy=f"Grant search access: chmod o+x {quote(str(identity.install_root))}",
         ),
         _reachable(
             "permissions.config",
@@ -673,8 +677,8 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
             service,
             needs=READ,
             ok_message=f"{service.name} can read the config.",
-            bad_message=f"{service.name} cannot read {identity.config_path}.",
-            remedy=f"chown {service.name} {identity.config_path} and chmod 0640 it.",
+            bad_message=f"{service.name} cannot read {shown(identity.config_path)}.",
+            remedy=f"chown {service.name} {quote(str(identity.config_path))} and chmod 0640 it.",
         ),
         _reachable(
             "permissions.interpreter",
@@ -682,8 +686,8 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
             service,
             needs=READ | EXECUTE,
             ok_message=f"{service.name} can execute the release interpreter.",
-            bad_message=f"{service.name} cannot execute {interpreter}.",
-            remedy=f"Check mode on {interpreter}; it must be readable and executable.",
+            bad_message=f"{service.name} cannot execute {shown(interpreter)}.",
+            remedy=f"Check mode on {shown(interpreter)}; it must be readable and executable.",
         ),
         _reachable(
             "permissions.data",
@@ -692,8 +696,8 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
             needs=WRITE | EXECUTE,
             directory=True,
             ok_message=f"{service.name} can write its data directory.",
-            bad_message=f"{service.name} cannot write {identity.data_path}.",
-            remedy=f"chown -R {service.name} {identity.data_path} and chmod 0700 it.",
+            bad_message=f"{service.name} cannot write {shown(identity.data_path)}.",
+            remedy=f"chown -R {service.name} {quote(str(identity.data_path))} and chmod 0700 it.",
         ),
         _code_integrity(identity, service),
     ]
@@ -701,8 +705,13 @@ def check_permissions(identity: InstallIdentity) -> list[DoctorCheck]:
 
 def _integrity_violation(
     identity: InstallIdentity, service: ServiceIdentity
-) -> str | None:
-    """Return why the release is not immutable to ``service``, or None.
+) -> tuple[Path, str] | None:
+    """Return the path that is not immutable to ``service`` and why, or None.
+
+    The path is returned beside the reason rather than embedded in it. The
+    reported path was previously recovered by splitting the sentence on its
+    first space, which a path containing one would have broken, and which
+    escaping the name for the terminal would break too.
 
     Write permission lives on the inode being modified, so a read-only release
     directory says nothing about the files inside it: a 0666 module under a
@@ -721,7 +730,7 @@ def _integrity_violation(
     try:
         layout = InstallLayout.resolve(identity.install_root)
     except LinuxInstallError as exc:
-        return f"{identity.install_root} is not a usable install root ({exc})"
+        return identity.install_root, f"is not a usable install root ({exc})"
 
     stack = [identity.active_release]
     while stack:
@@ -729,12 +738,12 @@ def _integrity_violation(
         try:
             entries = sorted(current.iterdir())
         except OSError as exc:
-            return f"{current} could not be listed ({exc.strerror})"
+            return current, f"could not be listed ({exc.strerror})"
         for entry in entries:
             try:
                 info = entry.lstat()
             except OSError as exc:
-                return f"{entry} could not be inspected ({exc.strerror})"
+                return entry, f"could not be inspected ({exc.strerror})"
 
             if stat.S_ISLNK(info.st_mode):
                 # Symlinks carry no meaningful mode of their own; the installer
@@ -745,20 +754,20 @@ def _integrity_violation(
                         layout, entry, require_internal=entry.is_dir()
                     )
                 except LinuxInstallError as exc:
-                    return f"{entry} is not a permitted release symlink ({exc})"
+                    return entry, f"is not a permitted release symlink ({exc})"
                 continue
 
             if stat.S_ISDIR(info.st_mode):
                 if _mode_allows(info, service, WRITE):
-                    return f"{entry} is writable by {service.name}"
+                    return entry, f"is writable by {service.name}"
                 stack.append(entry)
                 continue
 
             if not stat.S_ISREG(info.st_mode):
-                return f"{entry} is a special file, which a release must not contain"
+                return entry, "is a special file, which a release must not contain"
 
             if _mode_allows(info, service, WRITE):
-                return f"{entry} is writable by {service.name}"
+                return entry, f"is writable by {service.name}"
     return None
 
 
@@ -798,10 +807,11 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
             details={"scope": identity.scope},
         )
 
+    release = quote(str(identity.active_release))
     remedy = (
         f"Make the release read-only to the service: "
-        f"chown -R root:root {identity.active_release} && "
-        f"chmod -R go-w {identity.active_release}"
+        f"chown -R root:root {release} && "
+        f"chmod -R go-w {release}"
     )
     if not service.groups_complete:
         return DoctorCheck(
@@ -809,7 +819,7 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
             status=FAIL,
             message=(
                 f"Could not establish that {service.name} is unable to modify "
-                f"{identity.active_release}: its supplementary group membership "
+                f"{shown(identity.active_release)}: its supplementary group membership "
                 "could not be resolved, and an unresolved group may grant write "
                 "access."
             ),
@@ -819,8 +829,9 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
         )
 
     if _mode_allows_path(identity.active_release, service, WRITE):
-        violation: str | None = (
-            f"{identity.active_release} is writable by {service.name}"
+        violation: tuple[Path, str] | None = (
+            identity.active_release,
+            f"is writable by {service.name}",
         )
     else:
         violation = _integrity_violation(identity, service)
@@ -834,16 +845,18 @@ def _code_integrity(identity: InstallIdentity, service: ServiceIdentity) -> Doct
             remedy=remedy,
             details={"release": str(identity.active_release)},
         )
+    offending, reason = violation
     return DoctorCheck(
         name="permissions.code",
         status=FAIL,
         message=(
             f"The verified release is not immutable to {service.name}: "
-            f"{violation}. The service could rewrite the code it executes."
+            f"{shown(offending)} {reason}. The service could rewrite the code "
+            "it executes."
         ),
         mandatory=True,
         remedy=remedy,
-        details={"offending_path": violation.split(" ", 1)[0]},
+        details={"offending_path": str(offending)},
     )
 
 
@@ -1168,7 +1181,10 @@ def run(
         # when something is already wrong; ending in a traceback makes it one
         # more thing that is wrong.
         print(
-            f"could not inspect the installation ({exc.filename or exc}): "
+            # `exc.filename` is the raw name; `str(exc)` would already be
+            # escaped, but this reads the attribute directly.
+            f"could not inspect the installation "
+            f"({shown(exc.filename) if exc.filename else exc}): "
             f"{exc.strerror or exc}. Pass --scope user or --scope system "
             "explicitly.",
             file=sys.stderr,

--- a/ori/firmware_provisioner.py
+++ b/ori/firmware_provisioner.py
@@ -68,6 +68,7 @@ from typing import Any
 from ori.security.firmware.commands import build_provisioning_approval_bytes
 from ori.security.firmware.telemetry import FirmwareVerificationError
 from ori.security.published_test_keys import is_published_seed
+from ori.utils.path_utils import shown
 
 # The shared corpus that ties these bytes to the C verifier in
 # ori-edge-firmware; the same bytes its test_provisioning.c accepts.
@@ -114,10 +115,10 @@ def _write_secret(path: Path, seed: bytes) -> None:
         fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     except FileExistsError as exc:
         raise ProvisionerError(
-            f"{path} already exists; refusing to overwrite an authority key"
+            f"{shown(path)} already exists; refusing to overwrite an authority key"
         ) from exc
     except OSError as exc:
-        raise ProvisionerError(f"cannot write {path}: {exc}") from exc
+        raise ProvisionerError(f"cannot write {shown(path)}: {exc}") from exc
     with os.fdopen(fd, "w", encoding="ascii") as fh:
         # Canonical base64: the form load_raw_ed25519_seed_from_env
         # reads. Writing hex here would generate keys the runtime cannot
@@ -129,12 +130,12 @@ def read_seed(path: Path, label: str) -> bytes:
     try:
         raw = path.read_text(encoding="ascii").strip()
     except OSError as exc:
-        raise ProvisionerError(f"cannot read {label} at {path}: {exc}") from exc
+        raise ProvisionerError(f"cannot read {label} at {shown(path)}: {exc}") from exc
     try:
         seed = base64.b64decode(raw.encode("ascii"), validate=True)
     except Exception as exc:
         raise ProvisionerError(
-            f"{label} at {path} must be canonical base64 (the form the runtime loads)"
+            f"{label} at {shown(path)} must be canonical base64 (the form the runtime loads)"
         ) from exc
     if len(seed) != 32:
         raise ProvisionerError(f"{label} must be 32 bytes ({len(seed)} found)")
@@ -142,12 +143,12 @@ def read_seed(path: Path, label: str) -> bytes:
         published = is_published_seed(seed)
     except Exception as exc:
         raise ProvisionerError(
-            f"{label} at {path} could not be checked against the published-key "
+            f"{label} at {shown(path)} could not be checked against the published-key "
             "set, so it is refused rather than trusted"
         ) from exc
     if published:
         raise ProvisionerError(
-            f"{label} at {path} holds a seed this repository publishes as test "
+            f"{label} at {shown(path)} holds a seed this repository publishes as test "
             "material, so anyone with a clone signs the same provisioning "
             "approvals. Generate a signing key that has never left the producer."
         )
@@ -198,8 +199,11 @@ def cmd_keygen(args: argparse.Namespace) -> int:
     _write_secret(out / "provisioner_seed.b64", seed_auth)
     _write_secret(out / "runtime_command_seed.b64", seed_rt)
 
-    print(f"authority seed      : {out / 'provisioner_seed.b64'}  (0600, keep offline)")
-    print(f"runtime command seed: {out / 'runtime_command_seed.b64'}  (0600)")
+    print(
+        f"authority seed      : {shown(out / 'provisioner_seed.b64')}"
+        "  (0600, keep offline)"
+    )
+    print(f"runtime command seed: {shown(out / 'runtime_command_seed.b64')}  (0600)")
     print()
     print("Load into the runtime environment (canonical base64):")
     print(
@@ -235,7 +239,9 @@ def _load_manifest_message(path: str) -> dict[str, Any]:
     try:
         message = json.loads(Path(path).read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise ProvisionerError(f"cannot read manifest message {path}: {exc}") from exc
+        raise ProvisionerError(
+            f"cannot read manifest message {shown(path)}: {exc}"
+        ) from exc
     if not isinstance(message, dict) or not isinstance(message.get("manifest"), dict):
         raise ProvisionerError("message has no manifest object")
     return message
@@ -436,7 +442,7 @@ def cmd_prepare_approval(args: argparse.Namespace) -> int:
     )
     if args.out:
         Path(args.out).write_bytes(message)
-        print(f"approval written to {args.out}")
+        print(f"approval written to {shown(args.out)}")
     else:
         sys.stdout.write(message.decode("utf-8") + "\n")
     print(

--- a/ori/installer/activation.py
+++ b/ori/installer/activation.py
@@ -27,6 +27,7 @@ from typing import Any, Callable
 
 from ori.installer import launcher
 from ori.installer.linux import LinuxInstallError
+from ori.utils.path_utils import shown
 
 DOCTOR_TIMEOUT_S = 120
 
@@ -80,7 +81,7 @@ def install_launcher(
     except launcher.LauncherConflictError as exc:
         return False, str(exc), _noop
     except OSError as exc:
-        return False, f"could not write {path}: {exc}", _noop
+        return False, f"could not write {shown(path)}: {exc}", _noop
 
     if previous is None:
 

--- a/ori/installer/identity.py
+++ b/ori/installer/identity.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ori.config import ConfigValidationError, read_config_document
+from ori.utils.path_utils import shown
 
 if TYPE_CHECKING:  # pragma: no cover - import cycle at runtime
     from ori.installer.linux import InstallLayout
@@ -148,7 +149,7 @@ def _exists(path: Path, description: str) -> bool:
         return path.exists() or path.is_symlink()
     except OSError as exc:
         raise InstalledConfigUnreadableError(
-            f"{description} at {path} could not be inspected, so whether this "
+            f"{description} at {shown(path)} could not be inspected, so whether this "
             f"root is in use cannot be determined: {exc}"
         ) from exc
 
@@ -167,7 +168,7 @@ def _entries(directory: Path, description: str) -> list[str]:
         return []
     except OSError as exc:
         raise InstalledConfigUnreadableError(
-            f"{description} at {directory} could not be inspected, so whether "
+            f"{description} at {shown(directory)} could not be inspected, so whether "
             f"this root is in use cannot be determined: {exc}"
         ) from exc
 
@@ -190,10 +191,10 @@ def _occupancy(layout: InstallLayout) -> list[str]:
     signs: list[str] = []
     current = layout.current
     if _exists(current, "the active release pointer"):
-        signs.append(f"an activated release at {current}")
+        signs.append(f"an activated release at {shown(current)}")
     releases = _entries(layout.releases, "the releases directory")
     if releases:
-        signs.append(f"managed releases ({', '.join(releases)})")
+        signs.append(f"managed releases ({', '.join(shown(r) for r in releases)})")
     data_entries = _entries(layout.data, "the data directory")
     if data_entries:
         signs.append(f"runtime state ({', '.join(data_entries)})")
@@ -232,7 +233,7 @@ def read_installed(layout: InstallLayout) -> InstalledIdentity | None:
         occupied = _occupancy(layout)
         if occupied:
             raise InstalledConfigUnreadableError(
-                f"{layout.root} already holds {', and '.join(occupied)}, but no "
+                f"{shown(layout.root)} already holds {', and '.join(occupied)}, but no "
                 "readable configuration, so the device it belongs to cannot be "
                 "identified. Deriving a new identity here would strand that "
                 "installation."
@@ -242,18 +243,18 @@ def read_installed(layout: InstallLayout) -> InstalledIdentity | None:
         document = read_config_document(str(config_path))
     except ConfigValidationError as exc:
         raise InstalledConfigUnreadableError(
-            f"an installation exists at {config_path} but its configuration "
+            f"an installation exists at {shown(config_path)} but its configuration "
             "could not be read"
         ) from exc
     device = document.get("device") if isinstance(document, dict) else None
     if not isinstance(device, dict):
         raise InstalledConfigUnreadableError(
-            f"an installation exists at {config_path} but declares no device section"
+            f"an installation exists at {shown(config_path)} but declares no device section"
         )
     device_id = str(device.get("id", "") or "").strip()
     if not device_id:
         raise InstalledConfigUnreadableError(
-            f"an installation exists at {config_path} but declares no device id"
+            f"an installation exists at {shown(config_path)} but declares no device id"
         )
     return InstalledIdentity(
         device_id=device_id,

--- a/ori/installer/launcher.py
+++ b/ori/installer/launcher.py
@@ -22,6 +22,9 @@ import tempfile
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from shlex import quote
+
+from ori.utils.path_utils import shown
 
 MARKER = "# ori-launcher: managed by Ori Runtime — do not edit"
 _MODE = 0o755
@@ -161,8 +164,8 @@ def _assert_replaceable(path: Path, install_root: Path, scope: str) -> None:
             # not. Swapping one for the other silently would change the
             # privilege policy of an installed command.
             raise LauncherConflictError(
-                f"{path} is the launcher for the {form.scope}-scope "
-                f"installation at {install_root}, and this is a {scope}-scope "
+                f"{shown(path)} is the launcher for the {form.scope}-scope "
+                f"installation at {shown(install_root)}, and this is a {scope}-scope "
                 "install. Changing scope is a migration: uninstall the "
                 f"{form.scope}-scope installation first."
             )
@@ -171,18 +174,18 @@ def _assert_replaceable(path: Path, install_root: Path, scope: str) -> None:
     identity = read_identity(path)
     if identity is not None and identity.schema not in supported_versions():
         raise LauncherConflictError(
-            f"{path} appears to have been written by a newer version of Ori "
+            f"{shown(path)} appears to have been written by a newer version of Ori "
             f"(launcher schema {identity.schema}; this release understands "
             f"{sorted(supported_versions())}). Use that version to change it."
         )
     if identity is not None and identity.install_root != str(install_root):
         raise LauncherConflictError(
-            f"{path} declares the Ori installation at {identity.install_root}, "
-            f"not {install_root}. Remove that installation first, or choose "
+            f"{shown(path)} declares the Ori installation at {shown(identity.install_root)}, "
+            f"not {shown(install_root)}. Remove that installation first, or choose "
             "another location for this one."
         )
     raise LauncherConflictError(
-        f"{path} already exists and is not a launcher this installer wrote, so "
+        f"{shown(path)} already exists and is not a launcher this installer wrote, so "
         "it will not be replaced. Move it aside, or choose another location "
         "for the ori command."
     )
@@ -321,9 +324,9 @@ def path_guidance(path: Path, path_entries: Sequence[str] | None = None) -> str 
     if directory in entries:
         return None
     return (
-        f"{directory} is not on your PATH, so the `ori` command will not be "
+        f"{shown(directory)} is not on your PATH, so the `ori` command will not be "
         f"found yet.\nAdd it for this shell:\n"
-        f'    export PATH="{directory}:$PATH"\n'
+        f'    export PATH={quote(directory)}:"$PATH"\n'
         f"To make it permanent, add that line to ~/.profile (or ~/.bashrc, or "
         f"~/.zshrc for zsh)."
     )

--- a/ori/installer/linux.py
+++ b/ori/installer/linux.py
@@ -27,6 +27,7 @@ import yaml
 from ori.installer import identity
 from ori.installer.trusted_paths import trust_failure
 from ori.security.release_bundles import ExtractedReleaseBundle, distribution_version
+from ori.utils.path_utils import shown
 
 _VERSION_RE = re.compile(
     r"^(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<patch>[0-9]+)"
@@ -2679,14 +2680,14 @@ def _repair_relocated_shebangs(staging: Path, destination: Path) -> None:
             if not stat.S_ISREG(info.st_mode):
                 raise LinuxInstallError(
                     "offline_install_failed",
-                    f"unexpected special file in release venv bin: {entry.name}",
+                    f"unexpected special file in release venv bin: {shown(entry.name)}",
                 )
             if not info.st_mode & 0o111:
                 continue
             data = entry.read_bytes()
         except OSError as exc:
             raise LinuxInstallError(
-                "offline_install_failed", f"cannot inspect {entry.name}"
+                "offline_install_failed", f"cannot inspect {shown(entry.name)}"
             ) from exc
 
         break_at = data.find(b"\n")
@@ -2697,7 +2698,7 @@ def _repair_relocated_shebangs(staging: Path, destination: Path) -> None:
             if staging_reference in data:
                 raise LinuxInstallError(
                     "offline_install_failed",
-                    f"{entry.name} references the staging path without a shebang",
+                    f"{shown(entry.name)} references the staging path without a shebang",
                 )
             continue
 
@@ -2711,7 +2712,7 @@ def _repair_relocated_shebangs(staging: Path, destination: Path) -> None:
             if staging_reference in data:
                 raise LinuxInstallError(
                     "offline_install_failed",
-                    f"{entry.name} points at an unexpected staging interpreter",
+                    f"{shown(entry.name)} points at an unexpected staging interpreter",
                 )
             continue
         _rewrite_preserving_mode(
@@ -2773,7 +2774,7 @@ def _rewrite_preserving_mode(path: Path, content: bytes, mode: int) -> None:
         os.replace(temporary, path)
     except OSError as exc:
         raise LinuxInstallError(
-            "offline_install_failed", f"cannot rebind {path.name}"
+            "offline_install_failed", f"cannot rebind {shown(path.name)}"
         ) from exc
     finally:
         if descriptor >= 0:
@@ -2822,12 +2823,12 @@ def _assert_no_staging_references(bin_dir: Path, staging_reference: bytes) -> No
             data = entry.read_bytes()
         except OSError as exc:
             raise LinuxInstallError(
-                "offline_install_failed", f"cannot reread {entry.name}"
+                "offline_install_failed", f"cannot reread {shown(entry.name)}"
             ) from exc
         if staging_reference in data:
             raise LinuxInstallError(
                 "offline_install_failed",
-                f"{entry.name} still references the staging directory",
+                f"{shown(entry.name)} still references the staging directory",
             )
 
 
@@ -3219,12 +3220,12 @@ def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
         info = os.fstat(descriptor)
         if not stat.S_ISDIR(info.st_mode):  # O_DIRECTORY also enforces this.
             raise LinuxInstallError(
-                "unsafe_install_root", f"{path.name} is not a directory"
+                "unsafe_install_root", f"{shown(path.name)} is not a directory"
             )
         descriptor_identity = (info.st_dev, info.st_ino)
         if created_identity is not None and descriptor_identity != created_identity:
             raise LinuxInstallError(
-                "unsafe_install_root", f"{path.name} changed during preparation"
+                "unsafe_install_root", f"{shown(path.name)} changed during preparation"
             )
 
         mode = stat.S_IMODE(info.st_mode)
@@ -3232,7 +3233,8 @@ def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
             # Never silently adopt a pre-existing directory another account
             # can modify. Its exact mode is evidence that entries are replaceable.
             raise LinuxInstallError(
-                "unsafe_install_root", f"{path.name} is writable by another account"
+                "unsafe_install_root",
+                f"{shown(path.name)} is writable by another account",
             )
         if created or mode & 0o007:
             # Pin created directories despite umask/default ACLs, and tighten
@@ -3241,13 +3243,14 @@ def _ensure_private_directory(path: Path) -> _CreatedDirectory | None:
             info = os.fstat(descriptor)
             if stat.S_IMODE(info.st_mode) != 0o700:
                 raise LinuxInstallError(
-                    "unsafe_install_root", f"{path.name} could not be made private"
+                    "unsafe_install_root",
+                    f"{shown(path.name)} could not be made private",
                 )
 
         current = os.stat(path, follow_symlinks=False)
         if (current.st_dev, current.st_ino) != descriptor_identity:
             raise LinuxInstallError(
-                "unsafe_install_root", f"{path.name} changed during preparation"
+                "unsafe_install_root", f"{shown(path.name)} changed during preparation"
             )
         completed = True
         if created:
@@ -3275,22 +3278,22 @@ def _private_directory_error_detail(
     """Explain a kernel refusal; pathname inspection here is diagnostic only."""
     if created and isinstance(error, PermissionError):
         return (
-            f"{path.name} was created but is not accessible; "
+            f"{shown(path.name)} was created but is not accessible; "
             "owner-stripping umasks are unsupported"
         )
     if created:
-        return f"{path.name} could not be verified after creation"
+        return f"{shown(path.name)} could not be verified after creation"
     try:
         info = os.stat(path, follow_symlinks=False)
     except FileNotFoundError:
-        return f"{path.name} parent is unavailable"
+        return f"{shown(path.name)} parent is unavailable"
     except OSError:
-        return f"{path.name} could not be prepared"
+        return f"{shown(path.name)} could not be prepared"
     if stat.S_ISLNK(info.st_mode):
-        return f"{path.name} must not be a symlink"
+        return f"{shown(path.name)} must not be a symlink"
     if not stat.S_ISDIR(info.st_mode):
-        return f"{path.name} is not a directory"
-    return f"{path.name} could not be prepared"
+        return f"{shown(path.name)} is not a directory"
+    return f"{shown(path.name)} could not be prepared"
 
 
 def _remove_created_directory(path: Path, identity: tuple[int, int] | None) -> None:

--- a/ori/installer/paths.py
+++ b/ori/installer/paths.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from ori.config import ConfigValidationError, read_config_document
 from ori.doctor import InstallIdentity
+from ori.utils.path_utils import shown
 
 SERVICE_NAME = "ori-runtime.service"
 SYSTEM_ROOT = Path("/opt/ori")
@@ -94,7 +95,7 @@ def detect_scope(root: Path | None = None) -> str:
 
     if user is _Presence.PRESENT and system is _Presence.PRESENT:
         raise AmbiguousScopeError(
-            f"installations exist at both {user_root()} and {SYSTEM_ROOT}; "
+            f"installations exist at both {shown(user_root())} and {shown(SYSTEM_ROOT)}; "
             "pass --scope user or --scope system"
         )
     # One installation is definitely here and the other cannot be read. The
@@ -107,7 +108,7 @@ def detect_scope(root: Path | None = None) -> str:
         return "system"
     if _Presence.INACCESSIBLE in (user, system):
         unreadable = " and ".join(
-            str(candidate)
+            shown(candidate)
             for candidate, presence in ((user_root(), user), (SYSTEM_ROOT, system))
             if presence is _Presence.INACCESSIBLE
         )
@@ -115,7 +116,9 @@ def detect_scope(root: Path | None = None) -> str:
             f"could not inspect {unreadable}, and no other installation was "
             "found; pass --scope user or --scope system explicitly"
         )
-    raise FileNotFoundError(f"no installation at {user_root()} or {SYSTEM_ROOT}")
+    raise FileNotFoundError(
+        f"no installation at {shown(user_root())} or {shown(SYSTEM_ROOT)}"
+    )
 
 
 def resolve_identity(
@@ -126,10 +129,10 @@ def resolve_identity(
     install_root = root or default_root(resolved_scope)
     current = install_root / "current"
     if not current.is_symlink() and not current.exists():
-        raise FileNotFoundError(f"no active release at {current}")
+        raise FileNotFoundError(f"no active release at {shown(current)}")
     active = current.resolve()
     if not active.is_dir():
-        raise FileNotFoundError(f"active release is unavailable: {active}")
+        raise FileNotFoundError(f"active release is unavailable: {shown(active)}")
     # `current` is a symlink, so its target is only as trustworthy as whoever
     # can write it. Callers execute the interpreter inside the active release,
     # so require a release this installer laid down rather than following the
@@ -137,8 +140,8 @@ def resolve_identity(
     releases = (install_root / "releases").resolve()
     if active.parent != releases:
         raise UnmanagedReleaseError(
-            f"{current} points outside the managed release directory: "
-            f"{active} is not a release in {releases}"
+            f"{shown(current)} points outside the managed release directory: "
+            f"{shown(active)} is not a release in {shown(releases)}"
         )
 
     data = install_root / "data"

--- a/ori/installer/trusted_paths.py
+++ b/ori/installer/trusted_paths.py
@@ -38,6 +38,8 @@ import os
 import stat
 from pathlib import Path
 
+from ori.utils.path_utils import shown
+
 # Deep enough for any legitimate interpreter chain — `python` to `python3` to
 # `python3.12` to the packaged binary is four — and shallow enough that a
 # hostile link tree ends quickly.
@@ -68,7 +70,10 @@ def trust_failure(
     if failure is None:
         return None
     component, reason = failure
-    return f"{component} {reason}"
+    # Escaped where the string is built, so both the installer refusal and the
+    # doctor check inherit it. The component is whichever parent of the path
+    # failed the walk, which is not always a name an operator chose.
+    return f"{shown(component)} {reason}"
 
 
 def _walk(

--- a/ori/installer/upgrade.py
+++ b/ori/installer/upgrade.py
@@ -37,6 +37,7 @@ from ori.security.release_bundles import (
     load_release_key_registry,
     verify_release_bundle,
 )
+from ori.utils.path_utils import shown
 
 
 class UpgradeError(Exception):
@@ -49,7 +50,7 @@ def install_from_bundle(args: argparse.Namespace) -> dict[str, Any]:
     signature = Path(args.signature).expanduser()
     for label, path in (("bundle", bundle), ("signature", signature)):
         if not path.is_file():
-            raise UpgradeError(f"{label} not found: {path}")
+            raise UpgradeError(f"{label} not found: {shown(path)}")
 
     registry_resource = resources.files("ori.installer").joinpath("release-keys.json")
     try:

--- a/ori/inverter_profile_doctor.py
+++ b/ori/inverter_profile_doctor.py
@@ -18,6 +18,7 @@ from ori.hal.inverter_profiles import (
     load_profile,
 )
 from ori.hal.inverter_vendor_targets import list_vendor_targets
+from ori.utils.path_utils import shown
 
 # Pre-release draft schema. No installer/customer evidence has been captured
 # against this contract yet, so breaking changes may still refine v1. Once the
@@ -148,13 +149,13 @@ def _read_evidence_bundle(path: Path) -> dict[str, Any]:
         raw = path.read_text(encoding="utf-8")
     except OSError as exc:
         raise InverterProfileError(
-            f"unable to read evidence file {path}: {exc}"
+            f"unable to read evidence file {shown(path)}: {exc}"
         ) from exc
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise InverterProfileError(
-            f"invalid JSON evidence file {path}: {exc.msg}"
+            f"invalid JSON evidence file {shown(path)}: {exc.msg}"
         ) from exc
     if not isinstance(data, dict):
         raise InverterProfileError("evidence file must contain a JSON object")
@@ -624,7 +625,7 @@ def _print_evidence(summary: dict[str, Any], json_output: bool) -> int:
         print(json.dumps(summary, indent=2, sort_keys=True))
         return 0 if summary["evidence_pass"] else 1
 
-    print(f"Evidence file: {summary['evidence_file']}")
+    print(f"Evidence file: {shown(summary['evidence_file'])}")
     print(f"Profile: {summary['profile']} ({summary['profile_status']})")
     identity = summary["identity"]
     print(

--- a/ori/phone_doctor.py
+++ b/ori/phone_doctor.py
@@ -22,6 +22,7 @@ from typing import Any
 from ori.config import Config, ConfigValidationError, read_config_document
 from ori.utils import terminal
 from ori.utils.bool_utils import is_truthy
+from ori.utils.path_utils import shown
 from ori.utils.termux import parse_termux_usb_output
 
 _DIRECT_SERIAL_GLOBS = ("/dev/ttyUSB*", "/dev/ttyACM*")
@@ -669,7 +670,7 @@ def _format_text(checks: list[DoctorCheck]) -> str:
         + c("  ORI  PHONE DOCTOR".center(width - 2), BOLD + WHITE)
         + c("║", BOLD + CYAN),
         c("║", BOLD + CYAN)
-        + c(f"  Config: {config_path}".center(width - 2), DIM)
+        + c(f"  Config: {shown(config_path)}".center(width - 2), DIM)
         + c("║", BOLD + CYAN),
         c("╚" + "═" * (width - 2) + "╝", BOLD + CYAN),
         "",

--- a/ori/utils/path_utils.py
+++ b/ori/utils/path_utils.py
@@ -11,3 +11,22 @@ def path_is_relative_to(path: Path, prefix: Path) -> bool:
         return True
     except ValueError:
         return False
+
+
+def shown(name: object) -> str:
+    """A filesystem name as operator output, quoted and escaped.
+
+    A refusal is produced when something about a path is already wrong, which
+    is when an operator reads most carefully and distrusts least. The name in
+    it is not always one they chose: a walk over a path's parents reports
+    whichever component failed, and a directory listing reports whatever it
+    found, so a name a less-privileged account created in a shared location
+    reaches a terminal intact.
+
+    `repr` of the string covers what that name can do there: an escape
+    sequence that erases the line it is printed on, a newline that forges a
+    second diagnostic, a carriage return that overwrites the first, a bidi
+    mark that reverses how the rest reads, and the surrogate escapes Python
+    uses for bytes that are not valid in the filesystem encoding.
+    """
+    return repr(str(name))

--- a/ori/utils/terminal.py
+++ b/ori/utils/terminal.py
@@ -17,6 +17,8 @@ import os
 import sys
 from typing import IO, Final
 
+from ori.utils.path_utils import shown
+
 # Bright variants (90-97) are universally supported by current terminals and
 # stay legible on both dark and light backgrounds. Plain white is deliberately
 # absent: bright white is close to invisible on a light background, so headings
@@ -74,7 +76,15 @@ def heading(text: str, *, stream: IO[str] | None = None) -> str:
 
 
 def path(text: str, *, stream: IO[str] | None = None) -> str:
-    return style(text, CYAN, stream=stream)
+    """Render a filesystem name for an operator, escaped as well as coloured.
+
+    This is the one boundary every path-shaped summary line already passes
+    through, so escaping here covers them together. A whole-message boundary
+    could not: prose carries newlines that are meant to be newlines, and only
+    the caller knows which fragment came from the filesystem. A path is that
+    fragment by construction.
+    """
+    return style(shown(text), CYAN, stream=stream)
 
 
 def warning(text: str, *, stream: IO[str] | None = None) -> str:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1738,6 +1738,96 @@ class TestLoadExample:
         assert str(elsewhere / "ori_state.db") in warned
         assert str(home / "ori_state.db") in warned
 
+    def test_the_ambiguity_warning_escapes_the_names_it_reports(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """This warning reaches a terminal and a log line like any refusal."""
+        home = tmp_path / "data"
+        home.mkdir()
+        elsewhere = tmp_path / "cwd\x1b[2K\nFORGED"
+        elsewhere.mkdir()
+        (elsewhere / "ori_state.db").write_bytes(b"")
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ori_state.db
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        with caplog.at_level(logging.WARNING, logger="ori.config"):
+            Config.load(yaml_path)
+
+        warned = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert "\x1b[2K" not in warned
+        assert "\nFORGED" not in warned
+        assert "\\x1b[2K" in warned
+
+    def test_each_name_the_ambiguity_warning_reports_is_escaped(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """One hostile argument cannot prove the other two are escaped.
+
+        The warning names the declared value, where it resolved to, and where a
+        file of that name was found. A regression limited to any one of them
+        would pass a test that made only another hostile.
+        """
+        home = tmp_path / "data\x1b[2KRESOLVED"
+        home.mkdir()
+        elsewhere = tmp_path / "cwd\x1b[2KLEGACY"
+        elsewhere.mkdir()
+        # YAML refuses a raw control character in a scalar, so the declared
+        # value reaches the loader the way it actually could: through
+        # expansion, where the document is clean and the environment is not.
+        declared = "store\x1b[2KDECLARED.db"
+        monkeypatch.setenv("ORI_TEST_DB_PATH", declared)
+        (elsewhere / declared).write_bytes(b"")
+        yaml_path = _write_yaml(
+            home,
+            """
+            device:
+              id: dev-01
+              name: Test
+              location: Lagos
+            sensors: []
+            skills: []
+            reasoning: {}
+            gateway: {}
+            actions:
+              primary_alert_channel: sms
+              sms:
+                enabled: false
+            database:
+              path: ${ORI_TEST_DB_PATH}
+            """,
+        )
+        monkeypatch.chdir(elsewhere)
+
+        with caplog.at_level(logging.WARNING, logger="ori.config"):
+            Config.load(yaml_path)
+
+        warned = "\n".join(
+            r.getMessage() for r in caplog.records if r.levelname == "WARNING"
+        )
+        assert "\x1b[2K" not in warned
+        for fragment in ("DECLARED", "RESOLVED", "LEGACY"):
+            assert f"\\x1b[2K{fragment}" in warned, fragment
+
     def test_a_store_beside_the_config_is_used_without_complaint(
         self, tmp_path, monkeypatch, caplog
     ):

--- a/tests/test_config_installer.py
+++ b/tests/test_config_installer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import base64
+import json
 import os
 import textwrap
 import threading
@@ -88,6 +89,57 @@ def _write_signed_config(tmp_path: Path, monkeypatch, *, device_id: str = "phone
         encoding="utf-8",
     )
     return source
+
+
+def test_the_human_output_escapes_the_destination_and_json_keeps_it(
+    tmp_path, monkeypatch, capsys
+):
+    """The two forms want different things from the same path.
+
+    An operator reads one in a terminal, where an escape sequence erases the
+    line it is printed on. A consumer reads the other and needs the name it
+    can open.
+    """
+    from ori import config_installer
+
+    hostile = tmp_path / "dest\x1b[2K\nFORGED" / "ori.yaml"
+    result = config_installer.ConfigInstallResult(
+        destination=hostile,
+        device_id="pi-01",
+        signer_id="product-provisioning",
+        signed_at_ms=1_800_000_000_000,
+    )
+    monkeypatch.setattr(
+        config_installer, "install_signed_config", lambda **_kwargs: result
+    )
+
+    assert config_installer.main(["--source", "http://x/c"]) == 0
+    human = capsys.readouterr().out
+    assert "\x1b[2K" not in human
+    assert "\nFORGED" not in human
+    assert "\\x1b[2K" in human
+
+    assert config_installer.main(["--source", "http://x/c", "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    # The machine field is the name a consumer can open.
+    assert payload["destination"] == str(hostile)
+
+    # The dry-run branch prints a line of its own, so it is escaped separately.
+    dry = config_installer.ConfigInstallResult(
+        destination=hostile,
+        device_id="pi-01",
+        signer_id="product-provisioning",
+        signed_at_ms=1_800_000_000_000,
+        dry_run=True,
+    )
+    monkeypatch.setattr(
+        config_installer, "install_signed_config", lambda **_kwargs: dry
+    )
+
+    assert config_installer.main(["--source", "http://x/c", "--dry-run"]) == 0
+    dry_human = capsys.readouterr().out
+    assert "\x1b[2K" not in dry_human
+    assert "\\x1b[2K" in dry_human
 
 
 def test_install_signed_config_writes_verified_config_atomically(tmp_path, monkeypatch):

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -5,9 +5,11 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import pwd
+import shlex
 import socket
 import stat
 import subprocess
@@ -153,6 +155,122 @@ def test_an_untrusted_component_is_named(tmp_path: Path, not_root: None) -> None
 
     assert failure is not None
     assert any(reason in failure for reason in _TRUST_REASONS), failure
+
+
+def test_an_untrusted_component_cannot_carry_control_characters(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The walk reports whichever parent failed, and any of them may be hostile.
+
+    A directory a less-privileged account created in a shared location is
+    named by this message, which an operator reads in a terminal at exactly
+    the moment something is already wrong with the path. Every other component
+    is made trustworthy so the hostile one is the component reported.
+    """
+    hostile = tmp_path / "stage\x1b[2K\nFAIL forged"
+
+    def lstat(path):
+        writable = str(path) == str(hostile)
+        return SimpleNamespace(
+            st_uid=0,
+            st_mode=stat.S_IFDIR | (0o775 if writable else 0o755),
+        )
+
+    monkeypatch.setattr(trusted_paths.os, "lstat", lstat)
+
+    failure = doctor._interpreter_trust_failure(hostile / "python")
+
+    assert failure is not None
+    assert "is writable by another account" in failure
+    assert "\x1b" not in failure
+    assert "\n" not in failure
+    assert "\\x1b" in failure and "\\n" in failure
+
+
+def test_the_inspection_backstop_escapes_the_name_it_reports(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`exc.filename` is the raw name, unlike `str(exc)` which is already escaped.
+
+    This is the path doctor takes when something is already wrong, which is
+    exactly when the name it prints is least likely to be one an operator
+    chose.
+    """
+    from ori.installer import paths as installer_paths
+
+    hostile = "/tmp/root\x1b[2K\nFAIL forged"
+
+    def explode(**_kwargs):
+        raise OSError(5, "Input/output error", hostile)
+
+    monkeypatch.setattr(installer_paths, "resolve_identity", explode)
+
+    assert doctor.run(scope=None, root=None) == 2
+
+    printed = capsys.readouterr().err
+    assert "\x1b[2K" not in printed
+    assert "\\x1b" in printed and "\\n" in printed
+
+
+def test_the_summary_header_escapes_the_paths_it_prints(tmp_path: Path) -> None:
+    """Every path-shaped summary line passes through one renderer.
+
+    The header prints six of them, and an install root is not always a name an
+    operator chose. Escaping in the renderer covers them together rather than
+    at each line.
+    """
+    hostile = tmp_path / "root\x1b[2K\nFAIL forged"
+
+    report = doctor.render_report([], _identity(hostile), stream=io.StringIO())
+
+    # Each fragment asserted on its own. A renderer that stripped the escape
+    # but left the newline would satisfy a weaker check, because the colour
+    # reset sits between the forged text and the line break.
+    assert "\x1b[2K" not in report
+    assert "\nFAIL forged" not in report
+    assert "\\x1b[2K" in report and "\\nFAIL forged" in report
+
+
+def test_a_remedy_command_cannot_be_broken_out_of(
+    tmp_path: Path, not_root: None
+) -> None:
+    """A remedy is pasted into a shell, which makes it the worse of the two.
+
+    Escaping for a terminal is not enough here. An operator copies this line
+    and runs it, so a newline in the path would end the command and run what
+    follows as the next one. Remedies are quoted for a shell, and the path
+    stays a single argument.
+    """
+    hostile = tmp_path / "data\nrm -rf ~"
+    identity = doctor.InstallIdentity(
+        scope="system",
+        version="2.3.1",
+        install_root=tmp_path,
+        active_release=tmp_path / "releases" / "2.3.1",
+        config_path=hostile / "ori.yaml",
+        data_path=hostile,
+        health_socket=hostile / "health.sock",
+        unit_path=tmp_path / "unit" / "ori-runtime.service",
+        service_user=pwd.getpwuid(os.getuid()).pw_name,
+    )
+    hostile.mkdir()
+
+    remedies = [
+        check.remedy
+        for check in doctor.check_permissions(identity)
+        if check.remedy and ("chown" in check.remedy or "chmod" in check.remedy)
+    ]
+
+    naming = [r for r in remedies if str(hostile) in r]
+
+    assert naming, "no remedy names the hostile path"
+    for remedy in naming:
+        words = shlex.split(remedy)
+        # The path is one argument. It still spans two printed lines, because
+        # a quoted newline is one, but nothing in it is a word the shell would
+        # run: unquoted it would have ended the command and started another.
+        assert any(str(hostile) in word for word in words), remedy
+        assert "rm" not in words, remedy
 
 
 def test_a_group_writable_component_is_untrusted(
@@ -358,6 +476,56 @@ def test_a_writable_file_under_a_read_only_release_fails(
         assert code.mandatory is True
         assert code.details["offending_path"] == str(payload)
         assert "not immutable" in code.message
+    finally:
+        _unseal(tmp_path)
+
+
+def test_a_control_character_in_a_release_name_reaches_no_terminal(
+    tmp_path: Path, not_root: None
+) -> None:
+    """The name is not always one an operator chose, and it reaches a terminal.
+
+    An escape sequence erases the line it is printed on, a newline forges what
+    reads as a separate diagnostic, and a bidi mark reverses the rest of the
+    message. Driven through the real check rather than the helper.
+    """
+    _layout(tmp_path)
+    hostile = _release(tmp_path) / "payload\x1b[2K\nFAIL forged\u202e.py"
+    hostile.write_text("# code\n")
+    _sealed(tmp_path)
+    hostile.chmod(0o666)
+    try:
+        code = _checks(tmp_path)["permissions.code"]
+        assert code.status == terminal.FAIL
+        # Nothing the name carries survives into the message.
+        assert "\x1b" not in code.message
+        assert "\n" not in code.message
+        assert "\u202e" not in code.message
+        assert "\\x1b" in code.message and "\\n" in code.message
+        # The structured field still carries the real name for a machine.
+        assert code.details["offending_path"] == str(hostile)
+    finally:
+        _unseal(tmp_path)
+
+
+def test_a_path_with_a_space_is_reported_whole(tmp_path: Path, not_root: None) -> None:
+    """The offending path is carried beside its reason, not split out of it.
+
+    Recovering it from the sentence by its first space truncated any release
+    path that contained one, in a field meant to be read by a machine.
+    """
+    _layout(tmp_path)
+    spaced = _release(tmp_path) / "a directory with spaces"
+    spaced.mkdir()
+    payload = spaced / "ori_payload.py"
+    payload.write_text("# code\n")
+    _sealed(tmp_path)
+    payload.chmod(0o666)
+    try:
+        code = _checks(tmp_path)["permissions.code"]
+        assert code.status == terminal.FAIL
+        assert code.details["offending_path"] == str(payload)
+        assert " " in code.details["offending_path"]
     finally:
         _unseal(tmp_path)
 

--- a/tests/test_linux_installer.py
+++ b/tests/test_linux_installer.py
@@ -392,7 +392,9 @@ def test_creation_provenance_race_refuses_existing_entry_and_rolls_back_only_our
 
     monkeypatch.setattr(installer_linux.os, "mkdir", mkdir_with_race)
 
-    with pytest.raises(LinuxInstallError, match="data is writable by another account"):
+    with pytest.raises(
+        LinuxInstallError, match="'data' is writable by another account"
+    ):
         install_release(
             layout=layout,
             version="2.3.0",

--- a/tests/test_ori_cli.py
+++ b/tests/test_ori_cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import shlex
 import subprocess
 import sys
 import tomllib
@@ -145,6 +146,87 @@ def test_json_mode_keeps_stdout_a_single_valid_document(
     assert cli.main(["config", "validate", "--path", str(config), "--json"]) == 0
     captured = capsys.readouterr()
     assert json.loads(captured.out) == {"result": {"valid": True}}
+
+
+def test_an_invalid_config_at_a_hostile_path_prints_nothing_a_terminal_obeys(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The outer line and the validation detail are separate producers.
+
+    Escaping the line the CLI writes is not enough: the detail comes from the
+    loader, through the bridge, and carries the path the loader was given.
+    Driven end to end with a real invalid config rather than a mocked detail,
+    because a benign mock cannot see that seam.
+    """
+    home = tmp_path / "root\x1b[2K\nFAIL forged"
+    home.mkdir()
+    config = home / "ori.yaml"
+    # Unparseable, so the loader's own message names the path. A document that
+    # merely fails validation produces a detail with no path in it, which
+    # would leave this proving only the line the CLI writes itself.
+    config.write_text("device: {\n", encoding="utf-8")
+
+    assert cli.main(["config", "validate", "--path", str(config)]) != 0
+
+    printed = capsys.readouterr()
+    human = printed.out + printed.err
+    assert "\x1b[2K" not in human
+    assert "\nFAIL forged" not in human
+    assert "\\x1b[2K" in human
+
+
+def test_the_json_detail_is_the_same_prose_the_terminal_gets(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """`detail` is a message, not a machine-readable path field.
+
+    A consumer that recovered a path by parsing this sentence was never
+    reliable, which is the same mistake `ori doctor` made with
+    `offending_path` and no longer makes. So the path in it is escaped for the
+    terminal in both forms rather than kept raw for one of them, and JSON
+    escaping is applied on top by the encoder.
+    """
+    home = tmp_path / "root\x1b[2Khidden"
+    home.mkdir()
+    config = home / "ori.yaml"
+    config.write_text("device: {\n", encoding="utf-8")
+
+    cli.main(["config", "validate", "--path", str(config), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    detail = payload["error"]["detail"]
+
+    cli.main(["config", "validate", "--path", str(config)])
+    human = capsys.readouterr().out
+
+    assert "\x1b" not in detail
+    assert "\\x1b" in detail
+    # The same sentence reaches both, rather than one being escaped for a
+    # terminal and the other kept raw for a reader that would have to parse it.
+    assert detail in human
+
+
+def test_the_provisioner_names_a_bad_seed_path_escaped(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The provisioner is an operator CLI and its refusals name a path.
+
+    A seed file is read from a location an operator passes, and the refusal
+    reaches a terminal through the top-level error printer.
+    """
+    from ori import firmware_provisioner
+
+    home = tmp_path / "keys\x1b[2K\nFAIL forged"
+    home.mkdir()
+    seed = home / "provisioner_seed.b64"
+    seed.write_text("not base64!!", encoding="ascii")
+
+    with pytest.raises(firmware_provisioner.ProvisionerError) as raised:
+        firmware_provisioner.read_seed(seed, "authority seed")
+
+    detail = str(raised.value)
+    assert "\x1b[2K" not in detail
+    assert "\nFAIL forged" not in detail
+    assert "\\x1b[2K" in detail
 
 
 def test_human_mode_prints_a_summary_not_json(
@@ -903,8 +985,33 @@ def test_path_guidance_gives_the_exact_export_command(tmp_path: Path) -> None:
     path = tmp_path / ".local" / "bin" / "ori"
     guidance = launcher.path_guidance(path, ["/usr/bin", "/bin"])
     assert guidance is not None
-    assert f'export PATH="{path.parent}:$PATH"' in guidance
+    # The directory is quoted and `$PATH` is not, so it still expands.
+    assert f'export PATH={path.parent}:"$PATH"' in guidance
     assert "~/.profile" in guidance
+
+
+def test_path_guidance_cannot_be_broken_out_of(tmp_path: Path) -> None:
+    """This line is copied into a shell, so the directory is quoted for one.
+
+    Quoting the whole `directory:$PATH` would stop `$PATH` expanding and leave
+    the operator with a PATH containing only this directory, so only the
+    directory is quoted.
+    """
+    hostile = tmp_path / 'bin";rm -rf ~;echo "'
+    guidance = launcher.path_guidance(hostile / "ori", ["/usr/bin"])
+
+    assert guidance is not None
+    export = next(
+        line for line in guidance.splitlines() if line.strip().startswith("export ")
+    )
+    words = shlex.split(export)
+
+    assert words[0] == "export"
+    assert "rm" not in words
+    assert words[1] == f"PATH={hostile}:$PATH"
+    # Quoting the whole assignment would give the same tokens and a dead
+    # expansion, so the expansion is asserted to sit outside the quotes.
+    assert ':"$PATH"' in export
 
 
 def test_no_path_guidance_when_the_command_will_already_resolve(

--- a/tests/test_phone_doctor.py
+++ b/tests/test_phone_doctor.py
@@ -160,6 +160,30 @@ def _dependency_finder(available):
     return find_spec
 
 
+def test_the_header_escapes_the_config_path_it_prints(tmp_path):
+    """The banner names the path an operator passed, in a terminal.
+
+    An escape sequence there erases the line it is printed on and a newline
+    forges another, in a report whose whole purpose is to be read when
+    something is already wrong.
+    """
+    hostile = str(tmp_path / "phone\x1b[2K\nFAIL forged" / "ori.yaml")
+    checks = [
+        phone_doctor.DoctorCheck(
+            name="config.load",
+            status="pass",
+            message="loaded",
+            details={"config_path": hostile},
+        )
+    ]
+
+    rendered = phone_doctor._format_text(checks)
+
+    assert "\x1b[2K" not in rendered
+    assert "\nFAIL forged" not in rendered
+    assert "\\x1b[2K" in rendered
+
+
 def test_phone_doctor_accepts_valid_phone_config_with_warnings(tmp_path, monkeypatch):
     config_path = _write_phone_config(tmp_path)
     monkeypatch.setattr(phone_doctor, "_find_direct_serial_devices", lambda: [])


### PR DESCRIPTION
## What does this PR do?

A refusal is produced when something about a path is already wrong, which is when an operator reads most carefully and distrusts least. The name in it is not always one they chose: a walk over a path's parents reports whichever component failed, and a directory listing reports whatever it found, so a directory a less-privileged account created in a shared location reached a terminal intact. An escape sequence erases the line it is printed on, a newline forges what reads as a separate diagnostic, a carriage return overwrites the first, and a bidi mark reverses how the rest reads.

Filesystem names now reach operator output through `shown`, which quotes and escapes them. The escaping is applied to the fragment rather than to the message, deliberately. A whole-message renderer would have been one choke point instead of many sites, but several messages carry newlines that are meant to be newlines, so such a boundary would either mangle those or leave the forgery case open; only the caller knows which part of a sentence came from the filesystem. Where a path-only boundary already existed — `terminal.path`, which every path-shaped summary line already passes through — escaping there covers them together, and that is the narrow version of the idea rather than the unsafe one.

A remedy is quoted for a shell rather than escaped for a terminal, because the two want different things from the same name. A remedy is a command an operator copies and runs, so a newline in a path would end that command and run what follows as the next one, and Python escapes are not shell escapes. The PATH guidance quotes the directory alone: quoting the expansion along with it would leave the operator with a PATH containing nothing but that directory.

Machine-read fields stay raw, and one of them was already broken. `ori doctor` reported its offending path by splitting the human sentence on its first space, so any release path containing one was truncated in a field meant to be read by a machine — escaping merely exposed it. The violation now carries the path beside its reason, and the message and the field each take what they need. An error `detail` is treated the other way: it is prose rather than a path field, so it is escaped in the JSON form too, because recovering a path by parsing that sentence was never reliable and was the same mistake.

The sweep reaches further than the two call sites the issue named. The configuration loader wrote `'{path}'`, which looks quoted and is not escaped, and `ori config validate` appends that message to a line of its own, so escaping only the outer line left the name it reports untouched. Beyond the installer and the doctor, the same treatment reaches the CLI, the config installer, the firmware provisioner, the inverter profile doctor and the phone doctor's report header.

## Type of change

- [x] `fix` — bug fix
- [x] `security` — touches a safety invariant (requires maintainer review even for skills)

## Checklist

### Required for all PRs

- [x] `pytest tests/ -v` passes with 0 failures
- [x] `ruff check --fix ori/ tests/ skills/` is clean
- [x] Every new `.py` file has the Apache-2.0 license header
- [x] If capability behavior changed, `docs/CAPABILITY_MATRIX.md` is updated in this PR
- [x] If capability-impacting files changed but matrix update is intentionally not needed, add `[skip-cap-matrix]` in PR body with rationale
- [x] PR description explains **why**, not just what

`[skip-cap-matrix]` — no capability changes. No action, tier, executor or registry entry is added or altered, and no capability gains or loses a path. What changes is how a name already being printed is rendered.

### If you used AI assistance

- [x] I can explain every line of AI-generated code in this PR
- [x] I have read and understood all files I am modifying
- [x] I am not submitting code I cannot defend in a review conversation

### If this touches `/ori/` (core runtime)

- [x] I opened an issue and discussed this change before writing code
- [x] Every new Tier D code path has test coverage
- [x] No new dependencies added without prior issue discussion

No Tier D code path is added.

## Related issue

Closes #555

## Testing notes

Fourteen tests, each driven through a real refusal or a real command rather than through the helper: the trust walk with a hostile component made the failing one, `render_report`, `check_permissions`, `path_guidance`, `read_seed`, the phone doctor's report, the config installer's two output forms, and `ori config validate` end to end. Every boundary is mutation-checked, in both directions — a mutation that escapes the machine-read `destination` fails, because escaping the wrong field is the error in the opposite direction.

Three of the tests were weaker than their names when first written, and each was corrected only because something else said so. The header test asserted the escape sequence was absent and that something was escaped, which a renderer stripping escapes while leaving newlines would have satisfied, since the colour reset sits between the forged text and the line break; it now asserts each fragment separately, and a mutation into exactly that half-measure is refused. The end-to-end CLI test used a document that fails validation rather than one that fails to parse, and that error carries no path, so it proved only the outer line the CLI writes itself while the producer seam went untested. The JSON test was named for a same-prose contract it never checked, because it only ever invoked the JSON form.

Two of the defects fixed here were introduced earlier in the same work. The doctor's `offending_path` was recovered by parsing prose, and the database ambiguity warning added in #554 logged its three paths raw.

One thing worth recording for whoever writes the next test in this area: YAML refuses a raw control character in a scalar, so a hostile `database.path` cannot arrive through the document at all. It arrives through `${VAR}` expansion, where the document is clean and the environment is not, and that is the route the test uses.
