### PR TITLE
docs(hal): state the accuracy floor under every ADS1115 current reading

### DIFF
--- a/docs/releases/unreleased.md
+++ b/docs/releases/unreleased.md
@@ -237,6 +237,19 @@ candidate or release is cut.
   The installer now recognises Trixie, so `detect_platform` no longer returns
   nothing on the platform the matrix certifies.
 
+- The accuracy floor of the ADS1115 current path is stated and held by test.
+  A sampling window is a fixed span of time rather than a whole number of
+  cycles — 860 samples a second does not divide a 50 Hz period, and the loop
+  stops on a deadline — so at the geometry the bench measured it runs slightly
+  past two cycles and carries about 2% worst-case error on correctly
+  configured hardware. A supply drifting within its band does not add to that
+  and can read better; declaring the wrong band does dominate it, at about 7%.
+  Every one of those errors is worse downward than upward, and an under-report
+  is a safety threshold reached late, so the bounds are not symmetric. No
+  behaviour changes: `mains_frequency_hz` was always a declared fact the
+  runtime cannot verify, and this says what it costs to get wrong and where
+  the floor sits underneath it.
+
 ## Fixed
 
 - Telemetry stops exporting to an endpoint that has refused this device. A

--- a/ori.yaml.example
+++ b/ori.yaml.example
@@ -64,7 +64,12 @@ sensors:
       # is a current-output type and needs a burden resistor, after which the
       # figure is the burden's volts per ampere.
       sensitivity_v_per_amp: 0.0333
-      # The supply frequency the sampling window is aligned to.
+      # The supply frequency, which sets the length of the sampling window.
+      # Nothing in the runtime can check it. Declaring the wrong band — 60 for
+      # a 50 Hz supply — reads up to about 7% low, and low is the direction
+      # that matters: an under-report is a safety threshold reached late or not
+      # at all. Declare what the supply actually is; a few hertz of drift
+      # within the right band is not what this is guarding against.
       mains_frequency_hz: 50
       # Optional deterministic gateway-escalation guardrails.
       # When gateway reasoning transport is available, readings outside these

--- a/ori/hal/ac_measurement.py
+++ b/ori/hal/ac_measurement.py
@@ -24,7 +24,44 @@ class WindowRefusedError(Exception):
 
 @dataclass(frozen=True)
 class WindowSpec:
-    """What a window must satisfy to be a measurement."""
+    """What a window must satisfy to be a measurement.
+
+    A window is a fixed span of time, not a whole number of cycles. The loop
+    paces at the conversion interval and stops on a deadline, and 860 samples
+    a second does not divide a 50 Hz period, so the window runs a little past
+    two cycles however correctly everything is configured. The mean is then
+    not quite the bias and the root mean square not quite the amplitude.
+
+    At the geometry the bench measured — 36 samples over 41.09 ms against a
+    40.00 ms nominal — that floor is about 2%, and it is under every reading
+    this path produces. `test_ac_measurement.py` holds it, along with the two
+    facts that make it easy to reason about wrongly:
+
+    - **A supply drifting inside its band does not add to it.** Where the
+      window stops relative to a cycle is what decides the error, so 47 Hz can
+      land closer to whole cycles than 50 Hz does and read better. Across
+      45–53 Hz the error stays under 5% and moves in both directions.
+    - **Declaring the wrong band does dominate it.** ``mains_frequency_hz`` is
+      a declared fact that nothing here can check, and it sets the window
+      length: two cycles at 60 Hz is 33 ms, which spans 1.67 cycles of a 50 Hz
+      supply. That reaches about 7%, several times the geometry's own floor,
+      and it is the only frequency error worth an operator's attention.
+
+    **Every one of these is worse downward than upward.** The worst case is an
+    under-report, which is a Tier D threshold reached later than it should be
+    or not at all, so these bounds are not symmetric and must not be quoted as
+    though they were.
+
+    Deriving the frequency from the samples would close the wrong-band case,
+    and is not done here yet. A matched filter over the two candidate bands
+    would classify reliably at the amplitudes involved; what is undecided is
+    what to do with a disagreement. Refusing the window removes protection to
+    correct a few percent, which is the wrong trade — accumulating disagreement
+    into the existing degraded-health and bounded-notice path removes none, and
+    is the option to weigh once a clamp on a live load has shown what the noise
+    actually looks like. Until then the declaration is a commissioning
+    obligation and this is what getting it wrong costs.
+    """
 
     mains_frequency_hz: float
     window_cycles: int

--- a/tests/test_ac_measurement.py
+++ b/tests/test_ac_measurement.py
@@ -107,6 +107,202 @@ def test_the_result_does_not_depend_on_where_sampling_began(phase: float) -> Non
     assert result.rms_volts == pytest.approx(1.0 / math.sqrt(2), rel=1e-3)
 
 
+# What the bench measured the paced loop actually delivering: 36 samples over
+# 41.09 ms against a 40.00 ms nominal, five trials identical
+# (docs/evidence/2026-09-03-pi4-ads1115-characterisation.md). The ratio matters
+# because the error below is decided by where the window stops relative to a
+# cycle, so a window modelled as exactly nominal measures a geometry the
+# hardware does not produce.
+_BENCH_OVERRUN = 1.027
+_DATA_RATE = 860
+_SAMPLE_INTERVAL = 1.0 / _DATA_RATE
+
+
+def _paced_window(*, declared_hz: float, cycles: int = 2) -> tuple[int, float]:
+    """Sample count and elapsed time, as `_read_ads1115_current` produces them.
+
+    The loop paces at the conversion interval and stops on a deadline, so the
+    count is whatever fits and the window ends mid-cycle unless the rate
+    happens to divide the period. At 860 SPS and 50 Hz it does not.
+    """
+    nominal = cycles / declared_hz
+    deadline = nominal * _BENCH_OVERRUN
+    count, elapsed = 0, 0.0
+    while elapsed < deadline:
+        count += 1
+        elapsed += _SAMPLE_INTERVAL
+    return count, nominal * _BENCH_OVERRUN
+
+
+def _worst_error_across_start_phases(
+    *, true_hz: float, declared_hz: float, amplitude: float = 0.5, bias: float = 1.65
+) -> float:
+    """The largest fractional RMS error over every phase the window can start at.
+
+    Swept rather than taken at one phase, because nothing aligns the window to
+    the waveform: the error is whatever the arbitrary start gives, so a single
+    phase reports one point of a spread.
+    """
+    count, elapsed = _paced_window(declared_hz=declared_hz)
+    spec = WindowSpec(
+        mains_frequency_hz=declared_hz,
+        window_cycles=2,
+        min_samples=16,
+        full_scale_volts=3.3,
+        clip_margin_volts=0.05,
+        overrun_tolerance=1.5,
+    )
+    true_rms = amplitude / math.sqrt(2)
+    worst = 0.0
+    for step in range(360):
+        phase = 2 * math.pi * step / 360
+        samples = [
+            bias
+            + amplitude
+            * math.sin(2 * math.pi * true_hz * (i * _SAMPLE_INTERVAL) + phase)
+            for i in range(count)
+        ]
+        measured = summarise_window(samples, elapsed, spec).rms_volts
+        worst = max(worst, abs(measured / true_rms - 1.0))
+    return worst
+
+
+def test_the_modelled_window_is_the_one_the_bench_measured() -> None:
+    """The bounds below are properties of a geometry, so the geometry is pinned.
+
+    Every error in this file is decided by where the window stops relative to
+    a cycle, so a model that is a sample or a millisecond out measures a
+    different machine. These two numbers come from five identical trials in
+    `docs/evidence/2026-09-03-pi4-ads1115-characterisation.md`; if the adapter's
+    pacing changes, this fails first and says so, rather than the bounds
+    drifting quietly to describe hardware nobody has run.
+    """
+    count, elapsed = _paced_window(declared_hz=50.0)
+
+    assert count == 36
+    assert elapsed == pytest.approx(0.04109, abs=0.0002)
+
+
+def test_even_a_correct_declaration_carries_a_bounded_error() -> None:
+    """The window does not span whole cycles, and the declaration cannot fix it.
+
+    860 samples a second does not divide a 50 Hz period, and the sampling loop
+    stops on a time deadline rather than at a zero crossing, so the window runs
+    a little past two cycles. The mean is then not quite the bias and the root
+    mean square not quite the amplitude. This is the floor under every reading
+    the path produces, present on correctly configured hardware, and it is
+    larger than what misdeclaring the frequency within a band costs.
+    """
+    inherent = _worst_error_across_start_phases(true_hz=50.0, declared_hz=50.0)
+    assert 0.015 < inherent < 0.03
+
+
+def test_declaring_the_wrong_band_costs_materially_more() -> None:
+    """The one case worth an operator's attention: 50 Hz declared as 60.
+
+    Two cycles at 60 Hz is 33 ms, which spans only 1.67 cycles of a 50 Hz
+    supply — a partial cycle far larger than the geometry's own, and the only
+    frequency error in this file that dominates it.
+    """
+    inherent = _worst_error_across_start_phases(true_hz=50.0, declared_hz=50.0)
+    misdeclared = _worst_error_across_start_phases(true_hz=50.0, declared_hz=60.0)
+
+    assert 0.04 < misdeclared < 0.09
+    assert misdeclared > inherent * 2
+
+
+def test_within_band_wander_is_bounded_and_not_always_worse() -> None:
+    """A supply that drifts changes the error rather than adding to it.
+
+    Where the window stops relative to a cycle is what decides the error, so a
+    supply a few hertz off can land closer to a whole number of cycles than the
+    nominal one does and read *better*. Stated because the opposite is the
+    intuitive assumption, and a bound derived from it would be wrong.
+    """
+    inherent = _worst_error_across_start_phases(true_hz=50.0, declared_hz=50.0)
+    across_band = {
+        hz: _worst_error_across_start_phases(true_hz=hz, declared_hz=50.0)
+        for hz in (45.0, 47.0, 49.0, 51.0, 53.0)
+    }
+
+    assert max(across_band.values()) < 0.05
+    # Both directions are present, which is also what stops this test passing
+    # while measuring nothing: a helper that ignored `true_hz` would put every
+    # entry equal to `inherent` and satisfy neither.
+    assert any(error > inherent for error in across_band.values())
+    assert any(error < inherent for error in across_band.values())
+
+
+def test_the_worst_case_is_always_an_under_report() -> None:
+    """The direction matters more than the magnitude.
+
+    A reading below the truth is a Tier D threshold reached later than it
+    should be, or not at all. #398 puts it plainly: a spurious trip is safe and
+    annoying, a missed trip is a fire. Every frequency error this file measures
+    is worse downward than upward, so the bounds above are not symmetric and
+    must not be quoted as though they were.
+    """
+    for true_hz, declared_hz in ((50.0, 50.0), (50.0, 60.0), (60.0, 50.0)):
+        count, elapsed = _paced_window(declared_hz=declared_hz)
+        spec = WindowSpec(
+            mains_frequency_hz=declared_hz,
+            window_cycles=2,
+            min_samples=16,
+            full_scale_volts=3.3,
+            clip_margin_volts=0.05,
+            overrun_tolerance=1.5,
+        )
+        true_rms = 0.5 / math.sqrt(2)
+        errors = []
+        for step in range(360):
+            phase = 2 * math.pi * step / 360
+            samples = [
+                1.65
+                + 0.5 * math.sin(2 * math.pi * true_hz * (i * _SAMPLE_INTERVAL) + phase)
+                for i in range(count)
+            ]
+            errors.append(
+                summarise_window(samples, elapsed, spec).rms_volts / true_rms - 1.0
+            )
+        assert abs(min(errors)) > max(errors), (
+            f"{true_hz} Hz declared {declared_hz} Hz reports high, not low"
+        )
+
+
+def test_the_overrun_budget_follows_the_declared_frequency() -> None:
+    """A 60 Hz window is shorter, so its allowance for running late is shorter.
+
+    The budget is `window_cycles / mains_frequency_hz` times the tolerance, and
+    always has been. Nothing held it: every other test here declares 50 Hz, so
+    a constant in place of the declared frequency changed no result, and a
+    60 Hz deployment would have inherited a 50 Hz allowance — a fifth more
+    slack than its window is entitled to — without a test noticing. The same
+    elapsed time is accepted at 50 Hz and refused at 60.
+    """
+    samples = _sine(amplitude=0.5, count=64)
+    elapsed = 0.055
+    at_50 = WindowSpec(
+        mains_frequency_hz=50.0,
+        window_cycles=2,
+        min_samples=16,
+        full_scale_volts=3.3,
+        clip_margin_volts=0.05,
+        overrun_tolerance=1.5,
+    )
+    at_60 = WindowSpec(
+        mains_frequency_hz=60.0,
+        window_cycles=2,
+        min_samples=16,
+        full_scale_volts=3.3,
+        clip_margin_volts=0.05,
+        overrun_tolerance=1.5,
+    )
+
+    summarise_window(samples, elapsed, at_50)
+    with pytest.raises(WindowRefusedError, match="against a nominal"):
+        summarise_window(samples, elapsed, at_60)
+
+
 def test_a_clipped_waveform_is_refused_rather_than_under_reported() -> None:
     """Clipping removes the peaks, so RMS reads low — an under-report.
 


### PR DESCRIPTION
## What does this PR do?

It records the accuracy the `ads1115_current` path actually has, which nothing did.

A sampling window is a fixed span of time, not a whole number of cycles. The loop paces at the conversion interval and stops on a deadline, and 860 samples a second does not divide a 50 Hz period, so the window runs a little past two cycles however correctly the deployment is configured. The mean is then not quite the bias, and the root mean square not quite the amplitude.

At the geometry the bench measured — 36 samples over 41.09 ms against a 40.00 ms nominal, five identical trials in `docs/evidence/2026-09-03-pi4-ads1115-characterisation.md` — **that floor is about 2% worst case, and it sits under every reading this path produces.**

Two things about it are easy to reason about wrongly, so both are held by test rather than left to intuition:

- **A supply drifting inside its band does not add to the floor, and can read better.** Where the window stops relative to a cycle is what decides the error, so 47 Hz lands closer to whole cycles than 50 Hz does. Across 45–53 Hz the error stays under 5% and moves in both directions. The intuitive assumption is the opposite, and a bound derived from it would have been wrong.
- **Declaring the wrong band does dominate it.** `mains_frequency_hz` is a declared fact nothing in the runtime can check, and it sets the window length: two cycles at 60 Hz is 33 ms, which spans 1.67 cycles of a 50 Hz supply. That reaches about 7%, several times the geometry's own floor, and it is the only frequency error worth an operator's attention.

**Every one of these errors is worse downward than upward.** An under-report is a Tier D threshold reached later than it should be, or not at all — #398's own framing is that a spurious trip is safe and annoying while a missed trip is a fire. So the bounds are not symmetric, and a test now fails if any case ever reports high instead of low.

## Why the model is pinned to the bench rather than to nominal timing

The bounds are properties of a geometry, and the error is acutely sensitive to the sample count because the rate does not divide the period. A window modelled as exactly nominal gives 35 samples and a 0.87% floor; the hardware delivers 36 and 2.17%. So the modelled count and elapsed time are asserted directly against the evidence file. If the adapter's pacing changes, that assertion fails first and says so, rather than the bounds drifting quietly to describe hardware nobody has run.

## What is not done, and why it is recorded as open

Deriving the frequency from the samples would close the wrong-band case. What is undecided is not whether it can be detected — a matched filter over two candidate bands would classify reliably at these amplitudes — but what to do with a disagreement. Refusing the window removes protection to correct a few percent, which is the wrong trade in a path Tier D is evaluated against. Accumulating disagreement into the existing degraded-health and bounded-notice path removes none, and is the option to weigh once a clamp on a live load has shown what the noise actually looks like.

The docstring records that as the open question rather than implying it is settled.

## Type of change

- [x] `docs` — documentation only
- [x] `test` — tests only

## What this does not change

Any production behaviour. The AST of `ori/hal/ac_measurement.py` with docstrings stripped is byte-identical to the parent commit; `ori.yaml.example` is comment-only. `mains_frequency_hz` was always a declared fact the runtime cannot verify.

## Verification

- Full suite 5846 passed / 30 skipped; `ruff`, `ruff format --check`, `mypy ori/`, pyright 0 against a baseline of 0.
- Eight mutations, all killed — including four that target the test machinery rather than the code, because a bound is worthless if the model behind it has stopped measuring: a window modelled as nominal instead of as the bench measured it, a loop count that ignores the declared frequency, a generator that ignores the true supply frequency, and samples spread over elapsed time instead of paced at the conversion interval.
- The figures were derived twice, independently, before being written down.

## Known remaining work on #398

`Refs` rather than `Closes`. Two contract items still need the bench, and one needs a decision:

- The high-rail `clip_margin_volts`, which needs only a jumper from A0 to 3.3 V.
- A real RMS proof through a clamp and bias network on a live load.
- Contract item 10, "behaviour when frequency or timing cannot be trusted". Documenting a bound is not behaviour, so this does not close it; closing it needs either the accumulate-and-notice mechanism above or a recorded decision that the documented floor is the answer.

Refs #398
