### PR TITLE
docs(decisions): record that the tier letter is two decisions, and where a licence comes from

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1986,3 +1986,88 @@ This decision stands on its own and does not close
 `ori-platform/ori-runtime#510`, whose remaining scope is the pair-scoped
 supervision mechanism, its health and evidence state, the reset qualification
 boundary, and the connect-time contention case.
+
+## 2026-09-12 — The tier letter is two decisions, and reading it as one scale produced defects
+
+`A` through `D` looks like a severity scale, and the framework was reasoned
+about as one for long enough to produce three defects. It is not a scale. Each
+letter is a pair drawn from two independent axes.
+
+**Consequence class** — `informational`, `soft`, `hard` — is what the action
+does to the world. Whether opening a circuit is reversible is a fact about site
+wiring, established per channel at commissioning, so no skill author is in a
+position to hold it and the runtime registry owns it. That reason is stronger
+than "the manifest is untrusted input": it holds for a scrupulous author with
+no intent to overreach, which is why the boundary does not move when signing
+improves.
+
+**Authority basis** — `autonomous`, `operator_approval`, `safety_condition` —
+is what licenses one dispatch. The letters are the pairs that exist: A is
+informational and autonomous; B is soft, autonomous or approved per deployment;
+C is hard and approved; D is hard under a release-owned safety condition,
+pre-authorised because no human is reachable in the time the condition allows.
+
+Three consequences follow, and each corrects something that had already gone
+wrong:
+
+- **A and D are both autonomous, so a maximum over tiers is not conservative.**
+  A dispatch rule taking the greatest tier in a set granted Tier D to every
+  non-informational action alongside a trip, and would have let a notification
+  accompanying a cutoff inherit the cutoff's authority. On the two axes there is
+  nothing to exempt, because consequence class does not travel between actions.
+- **`requires_approval` moves a Tier B action along the authority axis** without
+  changing its letter. The letter alone therefore never decided whether a soft
+  action waits for a human, which is why reading the letter as the whole answer
+  kept producing surprises.
+- **A Tier D floor is a category error.** D is not more consequence than C; it
+  is the same consequence under a different licence, and no registry entry is in
+  a position to assert a licence. `emergency_cutoff` is registered at a hard
+  floor and reaches D only through a safety condition. That is the model
+  working, not a workaround for a registry that cannot express D.
+
+The axes are corrected into `skills-package/v3` in place rather than raised to a
+new contract version. A version exists to let implementations disagree about
+which one they follow; there is no implementation of the preceding version to
+protect, so a new number would record a disagreement nobody is having while
+leaving the wrong reasoning standing as the current contract.
+
+## 2026-09-12 — An action's licence is captured when the row is written, never derived at sealing
+
+`evidence/v2` requires every attested `runtime_action` to name what permitted
+it. The value cannot be built at sealing time. Attestation reconciliation runs
+after a restart and seals from the stored row alone, and the skill, profile or
+binding loaded by then may not be the one that licensed the action — frequently
+it is not, because the restart is why the row is being reconciled. Anything
+derived from present state would be a different claim wearing the same field
+name.
+
+**So the complete typed licence is captured when the action row is first
+written, as canonical JSON, and replayed verbatim.** A snapshot rather than a
+set of columns because the kinds carry different fields — a proposal; a skill
+name, version and trigger; a profile, zone and binding sequence; a fixture hash
+— and columns would mean a migration per kind. The action log already holds
+exactly this shape for firmware registration input, for the same reason.
+
+**A row whose licence was never captured is refused, not sealed.** Historical
+rows migrate to null rather than to an empty object: there is nothing truthful
+to record, and a snapshot claiming something would be worse than one admitting
+nothing was recorded. Signing such a row anyway would consume a sequence number
+and read as evidence at a glance while being something a verifier must discount.
+The refusal is terminal and carries a closed reason, deliberately outside the
+selection the reconciliation loop retries — a transient failure must be retried
+and an unrecoverable one must not, or the loop logs the same row for the life of
+the device and buries the failures it exists to repair.
+
+**Grammatical validity is not truthfulness, and the two must both be checked.**
+A well-formed licence that belongs to a different tier is the harder case: a
+Tier D cutoff carrying a valid operator approval would seal a claim, under the
+device key, that a human approved a trip nobody was asked about. Tier C admits
+only an operator approval; Tier D admits only the safety-condition kinds; any
+other tier carries no licence on the evidence path at all. The check runs before
+the chain is touched, so a refusal allocates no sequence number and leaves no
+gap a verifier reads as a missing row.
+
+**Where the snapshot and a query column name the same fact they must agree.** A
+disagreement means one of them was written from something other than the
+decision being sealed, and publishing either would assert a licence the row does
+not support.


### PR DESCRIPTION
## What does this PR do?

Two decisions settled over the last stretch reached `CLAUDE.md` and the contracts but never reached `DECISIONS.md`, which is the record a future reader consults before reopening a settled question. Without an entry, the reasoning survives only in merged diffs and PR bodies, and the next person to look at the Action Tier Framework finds the corrected shape with no account of what it replaced or why.

**The tier letter is two decisions, not one scale.** `A` through `D` reads as increasing severity, and the framework was reasoned about that way for long enough to produce three defects. Each letter is a pair drawn from consequence class — what the action does to the world, runtime-owned because whether opening a circuit is reversible is a fact about site wiring established per channel at commissioning — and authority basis, what licenses one dispatch. That reason is stronger than "the manifest is untrusted input": it holds for a scrupulous author, which is why the boundary does not move when signing improves.

The entry records the three consequences and the defect behind each. A dispatch rule taking the greatest tier in a set granted Tier D to every non-informational action beside a trip, so a notification would have inherited the cutoff's authority. `requires_approval` moves a Tier B action along the authority axis without changing its letter, which is why the letter alone never decided whether a soft action waits for a human. And a Tier D registry floor is a category error: D is the same consequence as C under a different licence, and no registry entry is in a position to assert a licence. It also states why the axes were corrected into the skills-package contract in place rather than raised to a new version — there is no implementation of the preceding version to protect, so a new number would record a disagreement nobody is having while leaving the wrong reasoning standing as current.

**Where an action's licence comes from.** Attestation reconciliation runs after a restart and seals from the stored row alone, and the skill, profile or binding loaded by then may not be the one that licensed the action — frequently it is not, because the restart is why the row is being reconciled. Anything derived from present state would be a different claim wearing the same field name. So the licence is captured when the row is written and replayed verbatim, as a snapshot rather than columns because the kinds carry different fields.

The entry records why a row with no captured licence is refused rather than sealed, why that refusal is terminal and sits outside the selection the reconciliation loop retries, and why a well-formed licence belonging to another tier is the harder case than a malformed one — a Tier D cutoff carrying a valid operator approval would seal a claim, under the device key, that a human approved a trip nobody was asked about.

## Type of change

- [x] `docs` — documentation only

## Checklist

- [x] Documentation only; no runtime code changed, so no capability behaviour moved and the matrix is unaffected
- [x] Every load-bearing claim verified against merged code rather than recalled: the reconciliation query selects `pending` and `failed` so a refusal is genuinely terminal, the tier-to-kind map admits operator approval at C and the three safety-condition kinds at D, `authority_json` is nullable with no default, `emergency_cutoff` is registered at a hard floor, and the skills-package contract carries the axes at the vendored pin
- [x] No issue numbers in the prose, per the convention for code and docs
- [x] PR description explains **why**, not just what

## Proof level

Documentation of decisions already implemented and merged. It asserts nothing new about the runtime's behaviour, and it makes no claim that any of it has run on a device — the authority work behind both entries is host-tested conformance to a contract.
